### PR TITLE
quill:0.1.0 fix readme for dark mode

### DIFF
--- a/packages/preview/quill-0.1.0/README.md
+++ b/packages/preview/quill-0.1.0/README.md
@@ -37,6 +37,7 @@ Refer to the [user guide](https://github.com/Mc-Zen/quill/releases/download/v0.1
 <h3 align="center">
   <img alt="Gallery" src="https://github.com/Mc-Zen/packages/assets/52877387/fb9d887d-fab2-48dd-b5cb-02e120b76f30" style="background: white; padding: 10pt; box-sizing: border-box" />
 </h3>
+
 ## Examples
 
 Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview).

--- a/packages/preview/quill-0.1.0/README.md
+++ b/packages/preview/quill-0.1.0/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img alt="Quantum Circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/5d34c646-79a8-492b-8e49-9136d5881258" style="max-width: 100%; width: 300pt; padding: 10px 20px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt;box-sizing: border-box;">
+  <img alt="Quantum Circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/5d34c646-79a8-492b-8e49-9136d5881258" style="max-width: 100%; width: 300pt; padding: 10px 20px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt; box-sizing: border-box; background: white">
 </h1>
 
 
@@ -14,7 +14,7 @@ _Meanwhile, we suggest importing everything from the package in a local scope to
 
 ## Usage
 
-Create circuit diagrams by calling the function `quantum-circuit()` with any number of positional arguments — just like the built-in Typst functions `table()` or `grid()`. A variety of different gate and instructions commands are available and plain numbers can be used to produce any number of empty cells just filled with the current wire mode. A new wire is started by adding the content item `[\ ]`. 
+Create circuit diagrams by calling the function `quantum-circuit()` with any number of positional arguments — just like the built-in Typst functions `table()` or `grid()`. A variety of different gate and instruction commands are available and plain numbers can be used to produce any number of empty cells just filled with the current wire mode. A new wire is started by adding the content item `[\ ]`. 
 
 ```java
 #{
@@ -27,25 +27,26 @@ Create circuit diagrams by calling the function `quantum-circuit()` with any num
 ```
 
 <h3 align="center">
-  <img alt="Bell circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/0132e357-abeb-42b2-8b27-073e3d8b8063" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt">
+  <img alt="Bell circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/0132e357-abeb-42b2-8b27-073e3d8b8063" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt; background: white; box-sizing: border-box">
 </h3>
 
 Refer to the [user guide](https://github.com/Mc-Zen/quill/releases/download/v0.1.0/quill-guide.pdf) for full documentation.
 
 ## Gallery
 
-![gallery](https://github.com/Mc-Zen/packages/assets/52877387/fb9d887d-fab2-48dd-b5cb-02e120b76f30)
-
+<h3 align="center">
+  <img alt="Gallery" src="https://github.com/Mc-Zen/packages/assets/52877387/fb9d887d-fab2-48dd-b5cb-02e120b76f30" style="background: white; padding: 10pt; box-sizing: border-box" />
+</h3>
 ## Examples
 
 Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview).
 
 <h3 align="center">
-  <img alt="Quantum teleportation circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/c923c68a-63b2-4377-a362-dfa06ffe66f4" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt">
+  <img alt="Quantum teleportation circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/c923c68a-63b2-4377-a362-dfa06ffe66f4" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt; background: white; box-sizing: border-box">
 </h3>
 <h3 align="center">
-  <img alt="Quantum circuit for phase estimation" src="https://github.com/Mc-Zen/packages/assets/52877387/a875ac6f-9735-4136-96c0-99447a50695a" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt">
+  <img alt="Quantum circuit for phase estimation" src="https://github.com/Mc-Zen/packages/assets/52877387/a875ac6f-9735-4136-96c0-99447a50695a" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt; background: white; box-sizing: border-box">
 </h3>
 <h3 align="center">
-  <img alt="Quantum fourier transformation circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/a30ef089-e120-42bd-a698-dd6727d67e3c" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt">
+  <img alt="Quantum fourier transformation circuit" src="https://github.com/Mc-Zen/packages/assets/52877387/a30ef089-e120-42bd-a698-dd6727d67e3c" style="max-width: 100%; padding: 10px 10px; box-shadow: 1pt 1pt 10pt 0pt #AAAAAA; border-radius: 4pt; background: white; box-sizing: border-box">
 </h3>


### PR DESCRIPTION
This PR fixes the issue of the images in the readme not being readable in GitHubs darkmode due to them being transparent. 

It does not affect the package's code in any way. 