### PR TITLE
gloss-awe:0.0.4

### DIFF
--- a/packages/preview/gloss-awe-0.0.4/LICENSE
+++ b/packages/preview/gloss-awe-0.0.4/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/preview/gloss-awe-0.0.4/README.md
+++ b/packages/preview/gloss-awe-0.0.4/README.md
@@ -1,0 +1,257 @@
+# gloss-awe
+
+Automatically create a glossary in [typst](https://typst.app/).
+
+This typst component creates a glossary page from a given pool of potential glossary
+entries using only those entries, that are marked with the `gls` or `gls-add` functions in
+the document.
+
+⚠️ Typst is in beta and evolving, and this package evolves with it. As a result, no
+backward compatibility is guaranteed yet. Also, the package itself is under development
+and fine-tuning.
+
+## Table of Contents
+
+* [Usage](#usage)
+  * [Marking the Entries](#marking-the-entries)
+  * [Controlling the Show](#controlling-the-show)
+  * [Hiding Entries from the Glossary Page](#hiding-entries-from-the-glossary-page)
+  * [Pool of Entries](#pool-of-entries)
+  * [Unknown Entries](#unknown-entries)
+  * [Creating the glossary page](#creating-the-glossary-page)
+* [Changelog](#changelog)
+  * [v0.0.4](#v004)
+  * [v0.0.3](#v003)
+  * [v0.0.2](#v002)
+
+## Usage
+
+### Marking the Entries
+
+To include a term into the glossary, it can be marked with the `gls` function. The
+simplest form is like this:
+
+```typ
+This is how to mark something for the glossary in #gls[Typst].
+```
+
+The function will render as defined with the specified show rule (see below!).
+
+### Controlling the Show
+
+To control, how the markers are rendered in the document, a show rule has to be defined.
+It usually looks like the following:
+
+```typ
+// marker display : this rule makes the glossary marker in the document visible.
+#show figure.where(kind: "jkrb_glossary"): it => {it.body}
+```
+
+### Hiding Entries from the Glossary Page
+
+It is also possible to hide entries (temporarily) from the generated glossary page without
+removing any markers for them from the document.
+
+The following sample will hide the entries for "Amaranth" and "Butterscotch" from the
+glossary, even if it is marked with `gls[...]` or `gls-add[...]` somewhere in the
+document.
+
+```typ
+    #let hidden-entries = (
+        "Amaranth",
+        "Butterscotch"
+    )
+
+    #make-glossary(glossary-pool, excluded: hidden-entries)
+```
+
+### Pool of Entries
+
+A "pool of entries" is a typst dictionary. It can be read from a file or may be the result
+of other operations.
+
+One or more pool(s) are then given to the `make-glossary()` function. This will create a
+glossary page of all referenced entries. If given more than one pool, the order pools are
+searched in the order they are given to the method. The first match wins. This can be used
+to have a global pool to be used in different documents, and another one for local usage
+only.
+
+The pool consists of a dictionary of definition entries. The key of an entry is the term.
+Note, that it is case-sensitive. Each entry itself is also a dictionary, and its main key
+is `description`. This is the content for the term. There may be other keys in an entry in
+the future. For now, it supports:
+
+- description
+- link
+
+An entry in the pool for the term "Engine" file may look like this:
+
+```typ
+    Engine: (
+        description: [
+
+            In the context of software, an engine...
+
+        ],
+        link: [
+
+            (1) Software engine - Wikipedia.
+            https://en.wikipedia.org/wiki/Software_engine
+            (13.5.2023).
+
+        ]
+    ),
+```
+
+### Unknown Entries
+
+If the document marks a term that is not contained in the pool, an entry will be generated
+anyway, but it will be visually marked as missing. This is convenient for the workflow,
+where one can mark the desired entries while writing the document, and provide missing
+entries later.
+
+There is a parameter for the `make-glossary()` function named `missing`, where a function
+can be provided to format or even suppress the missing entries.
+
+### Creating the Glossary Page
+
+To create the glossary page, provide the pool of potential entries to the make-glossary
+function. The following listing shows a complete sample document with a glossary. The
+sample glossary pool is contained in the main document as well:
+
+```typ
+    #import "@preview/gloss-awe:0.0.4": *
+
+    // Text settings
+    #set text(font: ("Arial", "Trebuchet MS"), size: 12pt)
+
+    // Defining the Glossary Pool with definitions.
+    #let glossary-pool = (
+        Cloud: (
+            description: [
+
+                Cloud computing is a model where computer resources are made available
+                over the internet. Such resources can be assigned on demand in a very short
+                time, and only as long as they are required by the user.
+
+            ]
+        ),
+
+        Marker: (
+            description: [
+
+                A Marker in `gloss-awe` is a typst function to mark a word or phrase to appear
+                in the documents glossary. The marker is also linked to the glossary section
+                by referencing the label `<Glossary>`.
+
+            ]
+        ),
+
+        Glossary: (
+            description: [
+
+                A glossary is a list of terms and their definitions that are specific to a
+                particular subject or field. It is used to define the intended meaning of
+                terms used in a document and to agree on a common definition of those terms. A
+                well-defined glossary can be very helpful in documents where very specific
+                meanings of certain terms are used.
+
+            ]
+        ),
+
+        "Glossary Pool": (
+            description: [
+
+                A glossary pool is a collection of glossary entries. An automated tool can
+                pull needed definitions from this pool to create the glossary pages for a
+                specific context.
+
+            ]
+        ),
+
+        REST: (
+            description: [
+
+                Representational State Transfer (abgekürzt REST) ist ein Paradigma für die
+                Softwarearchitektur von verteilten Systemen, insbesondere für Webservices.
+                REST ist eine Abstraktion der Struktur und des Verhaltens des World Wide
+                Web. REST hat das Ziel, einen Architekturstil zu schaffen, der den
+                Anforderungen des modernen Web besser genügt.
+
+            ]
+        ),
+
+        XML: (
+            description: [
+
+                XML stands for `'eXtensible Markup Language'`.
+
+            ],
+            link: [https://www.w3.org/XML]
+        ),
+    )
+
+    // Defining, how marked glossary entries in the document appear
+    #show figure.where(kind: "jkrb_glossary"): it => {it.body}
+
+    // This alternate rule, creates links to the glossary for marked entries.
+    // #show figure.where(kind: "jkrb_glossary"): it => [#link(<Glossar>)[#it.body]]
+
+    = My Sample Document with `gloss-awe`
+
+    In this document the usage of the `gloss-awe` package is demonstrated to create a glossary
+    with the help of a simple and small sample glossary pool. We have defined the pool in a
+    dictionary named #gls[Glossary Pool] above. It contains the definitions the `gloss-awe`
+    can use to build the glossary in the #gls[Glossary] section of this document. The pool
+    could also come from external files, like #gls[JSON] or #gls[XML] or other sources. Only
+    those definitions are shown in the glossary, that are marked in this document with one of
+    the #gls(entry: "Marker")[marker] functions `gloss-awe` provides.
+
+    If a Word is marked, that is not in the Glossary Pool, it gets a special markup in the
+    resulting glossary, making it easy for the Author to spot the missing information an
+    providing a definition. In this sample, there is no definition for "JSON" provided,
+    resulting in an Entry with a red remark "#text(fill: red)[No~glossary~entry]".
+
+    There is also a way to include Entries in the glossary for Words that are not contained in
+    the documents text:
+
+    #gls-add("Cloud")
+    #gls-add("REST")
+
+
+    = Glossary <Glossary>
+
+    This section contains the generated Glossary, in a nice two-column-layout. It also bears a
+    label, to enable the linking from marked words to the glossary.
+
+    #line(length: 100%)
+    #set text(font: ("Arial", "Trebuchet MS"), size: 10pt)
+    #columns(2)[
+        #make-glossary(glossary-pool)
+    ]
+
+```
+
+More usage samples are shown in the document `sample-usage.typ` on
+[gloss-awe´s GitHub]([Title](https://github.com/RolfBremer/typst-glossary)).
+
+A more complex sample PDF is available there as well.
+
+</span>
+
+## Changelog
+
+### v0.0.4
+
+* Breaking: Renamed the main file from `glossary.typ` to `gloss-awe.typ` to match package.
+* Added support for hidden glossary entries.
+* Added a Changelog to this readme.
+
+### v0.0.3
+
+* Added support for package manager in Typst.
+* Add `gls-add[...]` function for entries that are not in the document.
+
+### v.0.0.2
+
+* Moved version to Github.

--- a/packages/preview/gloss-awe-0.0.4/gloss-awe.typ
+++ b/packages/preview/gloss-awe-0.0.4/gloss-awe.typ
@@ -1,0 +1,98 @@
+// Copyright 2023 Rolf Bremer, Jutta Klebe
+
+// gls[term]: Marks a term in the document as referenced.
+// gls(glossary-term)[term]: Marks a term in the document as referenced with a
+// different expression ("glossary-term") in the glossary.
+
+// To ensure that the marked entries are displayed properly, it is also required
+// to use a show rule, like the following:
+// #show figure.where(kind: "jkrb_glossary"): it => {it.body}
+
+// We use a figure element to store the marked text and an optional
+// reference to be used to map to the glossary. If the latter is empty, we use the body
+// for the mapping.
+#let gls(entry: none, display) = figure(display, caption: entry, numbering: none, kind: "jkrb_glossary")
+
+// Add a keyword to the glossary, even if it is not in the documents content.
+#let gls-add(entry) = figure([], caption: entry, numbering: none, kind: "jkrb_glossary")
+
+// This function creates a glossary page with entries for every term
+// in the document marked with `gls[term]`.
+#let make-glossary(
+    // Indicate missing entries.
+    missing: text(fill: red, weight: "bold")[ No glossary entry ],
+
+    // Function to format the Header of the entry.
+    heading: it => { heading(level: 2, numbering: none, outlined: false, it)},
+
+    // This array contains entry titles to exclude from the generated glossary page.
+    excluded: (),
+
+    // The glossary data.
+    ..glossaries
+
+    ) = {
+
+    let figure-title(figure) = {
+        let ct = ""
+        if figure.caption == none {
+            if figure.body.has("text") {
+                ct = figure.body.text
+            }
+            else {
+                for cc in figure.body.children {
+                    if cc.has("text") {
+                        ct += cc.text
+                    }
+                }
+            }
+        }
+        else{
+            ct = figure.caption.text
+        }
+        return ct
+    }
+
+    let lookup(key, glossaries) = {
+        let entry = none
+        for glossary in glossaries.pos() {
+            if glossary.keys().contains(key) {
+                let entry = glossary.at(key)
+                return entry
+            }
+        }
+        return entry
+    }
+
+    locate(loc => {
+        let words = ()  //empty array
+
+        // find all marked elements
+        let all-elements = query(figure.where(kind: "jkrb_glossary"), loc)
+
+        // only use the not hidden elements
+        let elements = ()
+        for e in all-elements {
+            if figure-title(e) not in excluded {
+                elements.push(e)
+            }
+        }
+
+        // extract the titles
+        let titles = elements.map(e => figure-title(e)).sorted()
+        for t in titles {
+            if words.contains(t) { continue }
+            words.push(t)
+            heading(t)
+            let e = lookup(t, glossaries)
+            if e != none {
+                e.description
+                if e.keys().contains("link") {
+                    e.link
+                }
+            } else {
+                missing
+            }
+        }
+    })
+}

--- a/packages/preview/gloss-awe-0.0.4/typst.toml
+++ b/packages/preview/gloss-awe-0.0.4/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gloss-awe"
+version = "0.0.4"
+authors = ["JKRB <https://github.com/RolfBremer>"]
+license = "Apache-2.0"
+description = "Awesome Glossary for Typst."
+entrypoint = "gloss-awe.typ"
+repository = "https://github.com/RolfBremer/typst-glossary"


### PR DESCRIPTION
Add support for hidden glossary entries.
Renamed main file (entry point) to match package name.

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name in conformance with the guidelines
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] ensured that my submission does not infringe upon the rights of a third party
- [x] tested my package locally on my system and it worked
- [x] named this PR as `name:version` of the submitted package
- [x] agree that my package will not be removed without good reason

<!--
Please add a brief description of your package below and explain why you think it is useful to others.
-->

Description: This typst component creates a glossary page from a given pool of potential glossary
entries using only those entries, that are marked with the `gls` or `gls-add` functions in
the document. See the `README.md` for examples and usage.
