### PR TITLE
idwtet:0.2.0

### DIFF
--- a/packages/preview/idwtet/0.2.0/LICENSE
+++ b/packages/preview/idwtet/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ludwig Austermann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/idwtet/0.2.0/README.md
+++ b/packages/preview/idwtet/0.2.0/README.md
@@ -1,0 +1,58 @@
+# Package IDWTET
+The name `idwtet` stands for "I Don't Wanna Type Everything Twice". It provides a `typst-ex` and a `typst-ex-code` codeblock, which *shows **and** executes* typst code.
+
+It is meant for code demonstration, e.g. when publishing a package, and provides some niceties:
+- the code should always be correct in the examples: As the example code is used for the code block, but also for evaluation, there is no need to write it twice
+- easy configuration with simple, uniform and good look
+
+However, there are some limitations:
+- Every code block has its own local scope and the default behaviour is that variables are not reachable from outside. A similar restriction lies on import statements. That is why, there is the `eval-scope` argument, which captures variables and simulates global variables. Additionally, a `typst` codeblock is provided for a consistent look.
+- Locality can be displayed to the users by automatically wrapping code in `typst-ex-code`, but `typst-ex` does not provide such functionality. It might thus be difficult for users to understand code examples this way.
+- The page width has to be defined in absolute terms. It is quite nice, for a showcase, to take the least possible space, but tracking the widths of all boxes and then setting the page width accordingly is not (yet) possible.
+
+## Usage
+Only one function is defined,
+`init(body, bcolor: luma(210), inset: 5pt, border: 2pt, radius: 2pt, content-font: "linux libertine", code-font-size: 9pt, content-font-size: 11pt, code-return-box: true, wrap-code: false, eval-scope: (:), escape-bracket: "%")`,
+which is supposed to be used with a show rule. Then raw codeblocks (with `block=true`) of the languages `typst`, `typst-ex`, `typst-code` and `typst-ex-code` are modified. The main feature of this package are `typst-ex` and `typst-ex-code`.
+
+The parameters of `init` are:
+- `body`: for usage with show rule, hence the whole document.
+- `bcolor`: the background- (and border-) color of the blocks
+- `inset`: inset param of code and content blocks, should be ≥ 2pt
+- `border`: border thickness
+- `radius`: block radius
+- `content-font`: The font used in the previewed content / result.
+- `code-font-size`: The fontsize used in the code blocks.
+- `content-font-size`: The fontsize used in the preview content / result.
+- `code-return-box`: If to show the code return type on `typst-ex-code` blocks.
+- `wrap-code`: If to wrap the code in `#{` and `}`, to symbolize local scope.
+- `eval-scope`: A dictionary with the keys as the variable names and the values as another dictionary with keys `value` and `code`, both of these are optional. The former has the defined value, the latter the code recreate the variable, for usage in the code blocks.
+- `escape-bracket`: The text to wrap a variable with, to access the `code` part of a `eval-scope` variable.
+
+## Example
+````typst
+#set page(margin: 0.5cm, width: 14cm, height: auto)
+#import "@preview/idwtet:0.1.0"
+#show: idwtet.init.with(eval-scope: (
+  ouset: (
+    value: {import "@preview/ouset:0.1.1": ouset; ouset},
+    code: "#import \"@preview/ouset:0.1.1\": ouset"
+  )
+))
+
+== ouset package #text(gray)[(v0.1.1)]
+```typst-ex
+%ouset%
+$
+"Expression 1" ouset(&, <==>, "Theorem 1") "Expression 2"\
+               ouset(&, ==>,, "Theorem 7") "Expression 3"
+$
+```
+Or something like
+```typst-ex-code
+let a = range(10)
+a
+```
+````
+
+Further examples are given in the repo example folder.

--- a/packages/preview/idwtet/0.2.0/idwtet.typ
+++ b/packages/preview/idwtet/0.2.0/idwtet.typ
@@ -1,0 +1,133 @@
+#let init(
+  body,
+  bcolor: luma(210),
+  inset: 5pt,
+  border: 2pt,
+  radius: 2pt,
+  content-font: "linux libertine",
+  code-font-size: 9pt,
+  content-font-size: 11pt,
+  code-return-box: true,
+  wrap-code: false,
+  eval-scope: (:),
+  escape-bracket: "%"
+) = {  
+  let eval-scope-values = (:)
+  let eval-scope-codes = (:)
+   for (k, v) in eval-scope.pairs() {
+    if type(v) == "dictionary" {
+      if v.keys().contains("value") {
+        eval-scope-values.insert(k, v.value)
+      }
+      if v.keys().contains("code") {
+        eval-scope-codes.insert(k, v.code)
+      }
+    } else {
+      panic("Argument `eval-scope` accepts only a (value?: ..., code?: ...) dictionary for each variable!")
+    }
+  }
+
+  let substitute-remove-code(text) = eval-scope-codes.pairs().fold(
+    (text, text), (s, a) => (
+      s.at(0).replace(
+        escape-bracket + a.at(0) + escape-bracket,
+        a.at(1)
+      ),
+      s.at(1).replace(
+        escape-bracket + a.at(0) + escape-bracket,
+        ""
+      )
+    )
+  )
+  
+  show raw.where(block: true, lang: "typst-ex"): it => {
+    let (substituted-text, removed-text) = substitute-remove-code(it.text)
+    
+    set text(code-font-size)
+    let code = block(
+      width: 100%,
+      fill: bcolor,
+      stroke: border + bcolor,
+      inset: inset,
+      radius: (top: 4pt),
+      raw(lang: "typst", substituted-text)
+    )
+    
+    let result = eval(
+      removed-text,
+      mode: "markup",
+      scope: eval-scope-values
+    )
+    let result-content = block(
+      width: 100%,
+      stroke: border + bcolor,
+      inset: inset,
+      radius: (bottom: radius),
+      text(font: content-font, content-font-size, result)
+    )
+
+    grid(
+      code,
+      result-content
+    )
+  }
+
+  show raw.where(block: true, lang: "typst-ex-code"): it => {
+    let (substituted-text, removed-text) = substitute-remove-code(it.text)
+    
+    set text(code-font-size)
+    let code = block(
+      width: 100%,
+      fill: bcolor,
+      stroke: border + bcolor,
+      inset: inset,
+      radius: (top: 4pt),
+      if wrap-code { raw(lang: "typst", "#{\n" + substituted-text + "\n}") } else { raw(lang: "typc", substituted-text) }
+    )
+    
+    let result = eval(removed-text, scope: eval-scope-values)
+    let type-box = box(inset: 2pt, radius: 1pt, fill: white, text(code-font-size, "return type: " + raw(type(result))))
+    let result-content = block(
+      width: 100%,
+      stroke: border + bcolor,
+      inset: inset,
+      radius: (bottom: radius),
+      text(font: content-font, content-font-size, {
+        if code-return-box {
+          style(sty => place(
+            type-box,
+            dx: inset - 1pt,
+            dy: - inset - measure(type-box, sty).height - 1pt,
+            right
+          ))
+        }
+        [ #result ]
+      })
+    )
+
+    grid(
+      code,
+      result-content
+    )
+  }
+
+  show raw.where(block: true, lang: "typst"): it => block(
+    width: 100%,
+    fill: bcolor,
+    stroke: border + bcolor,
+    inset: inset,
+    radius: radius,
+    text(code-font-size, raw(lang: "typst", it.text))
+  )
+
+  show raw.where(block: true, lang: "typst-code"): it => block(
+    width: 100%,
+    fill: bcolor,
+    stroke: border + bcolor,
+    inset: inset,
+    radius: radius,
+    text(code-font-size, raw(lang: "typc", it.text))
+  )
+
+  body
+}

--- a/packages/preview/idwtet/0.2.0/typst.toml
+++ b/packages/preview/idwtet/0.2.0/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "idwtet"
+version = "0.2.0"
+entrypoint = "idwtet.typ"
+authors = ["Ludwig Austermann"]
+license = "MIT"
+description = "Package for uniform, correct and simplified typst code demonstration."
+repository = "https://github.com/ludwig-austermann/typst-idwtet"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name in conformance with the guidelines
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] ensured that my submission does not infringe upon the rights of a third party
- [x] tested my package locally on my system and it worked
- [x] named this PR as `name:version` of the submitted package
- [x] agree that my package will not be removed without good reason

<!--
Please add a brief description of your package below and explain why you think it is useful to others.
-->

Description: This package lets developers write better demonstration code, as it adds special code blocks typst-ex, which highlights and displays itself as typst code blocks, but also evaluates itself. By this, examples should never be out of date and gain additionally unified design.

This package was already proposed to be added in #31, but main functionality relied on a bug in the typst compiler. This version uses eval scopes from typst 0.7 and has therefore a different interface, which resolves earlier problems.
