### PR TITLE
drafting:0.1.1

### DIFF
--- a/packages/preview/drafting/0.1.1/LICENSE
+++ b/packages/preview/drafting/0.1.1/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/packages/preview/drafting/0.1.1/README.md
+++ b/packages/preview/drafting/0.1.1/README.md
@@ -1,0 +1,7 @@
+# Drafting
+
+This package hosts several utilities that are useful for drafting documents, namely margin notes and precise positioning
+helpers. Over time, hopefully more utilities will be contributed. A quick, comprehensive overview is provided by the
+[example document](https://github.com/ntjess/typst-drafting/blob/v0.1.1/docs/main.pdf):
+
+![](https://github.com/ntjess/typst-drafting/raw/v0.1.1/docs/main.png)

--- a/packages/preview/drafting/0.1.1/drafting.typ
+++ b/packages/preview/drafting/0.1.1/drafting.typ
@@ -1,0 +1,390 @@
+/// Default properties for margin notes. These can be overridden per function call, or
+/// globally by calling `set-margin-note-defaults`. Available options are:
+/// - `margin-right` (length): Size of the right margin
+/// - `margin-left` (length): Size of the left margin
+/// - `page-width` (length): Width of the page/container. This is automatically
+///   inferrable when using `set-page-properties`
+/// - `page-offset-x` (length): Horizontal offset of the page/container. This is
+///   generally only useful if margin notes are applied inside a box/rect; at the page
+///   level this can remain unspecified
+/// - `stroke` (paint): Stroke to use for the margin note's border and connecting line
+/// - `rect` (function): Function to use for drawing the margin note's border. This
+///   function must accept positional `content` and keyword `width` arguments.
+/// - `side` (side): Which side of the page to place the margin note on. Must be `left`
+///   or `right`
+/// - `hidden` (bool): Whether to hide the margin note. This is useful for temporarily
+///   disabling margin notes without removing them from the code
+#let margin-note-defaults = state(
+  "margin-note-defaults",
+  (
+    margin-right: 0in,
+    margin-left: 0in,
+    page-width: none,
+    page-offset-x: 0in,
+    stroke: red,
+    rect: rect,
+    side: right,
+    hidden: false,
+  )
+)
+#let note-descent = state("note-descent", (:))
+
+#let _run-func-on-first-loc(func, label-name: "loc-tracker") = {
+  // Some placements are determined by locations relative to a fixed point. However, typst
+  // will automatically re-evaluate that computation several times, since the usage
+  // of that computation will change where an element is placed (and therefore update its
+  // location, and so on). Get around this with a state that only checks for the first
+  // update, then ignores all subsequent updates
+  let lbl = label(label-name)
+  [#metadata(label-name)#lbl]
+  locate(loc => {
+    let use-loc = query(selector(lbl).before(loc), loc).last().location()
+    func(use-loc)
+  })
+}
+
+/// Place content at a specific location on the page relative to the top left corner
+/// of the page, regardless of margins, current container, etc.
+/// -> content
+#let absolute-place(dx: 0em, dy: 0em, content) = {
+  _run-func-on-first-loc(loc => {
+    let pos = loc.position()
+    place(dx: -pos.x + dx, dy: -pos.y + dy, content)
+  })
+}
+
+#let _calc-text-resize-ratio(width, spacing, styles) = {
+  // Add extra margin to ensure reasonable separation between two adjacent lines
+  let size = measure(text[#width], styles).width * 120%
+  spacing / size * 100%
+}
+
+#let rule-grid(
+  dx: 0pt,
+  dy: 0pt,
+  stroke: black,
+  width: 100cm,
+  height: 100cm,
+  spacing: none,
+  divisions: none,
+  square: false,
+  relative: true,
+) = {
+  // Unfortunately an int cannot be constructed from a length, so get it through a
+  // hacky method of converting to a string then an int
+  if spacing == none and divisions == none {
+    panic("Either `spacing` or `divisions` must be specified")
+  }
+  if spacing != none and divisions != none {
+    panic("Only one of `spacing` or `divisions` can be specified")
+  }
+  if divisions != none and type(divisions) != "array" {
+    divisions = (divisions, divisions)
+  }
+  if spacing != none and type(spacing) != "array" {
+    spacing = (spacing, spacing)
+  }
+
+  let place-func = if relative {place} else {absolute-place}
+  let global-dx = dx
+  let global-dy = dy
+  let to-int(amt) = int(amt.abs / 1pt)
+  let to-pt(amt) = amt * 1pt
+
+  let (divisions, spacing) = (divisions, spacing)
+
+  if divisions != none {
+    divisions = divisions.map(to-pt)
+    spacing = (width/divisions.at(0), height/divisions.at(1))
+    if square {
+      spacing = (calc.min(..spacing), calc.min(..spacing))
+    }
+    spacing = spacing.map(to-pt)
+  }
+  let (x-spacing, y-spacing) = spacing
+
+  let (width, height, step) = (width, height, x-spacing).map(to-int)
+  style(styles => {
+    // Assume text width is the limiting factor since a number will often be wider than
+    // tall. This works in the majority of cases
+    let scale-factor = _calc-text-resize-ratio(width, x-spacing, styles)
+
+    set line(stroke: stroke)
+    let dummy-line = line(stroke: stroke)
+    set text(size: 1em * scale-factor, fill: dummy-line.stroke.paint)
+    locate(loc => {
+      for (ii, dx) in range(0, width, step: step).enumerate() {
+        place-func(
+          dx: global-dx, dy: global-dy,
+          line(start: (dx * 1pt, 0pt), end: (dx * 1pt, height * 1pt))
+        )
+        place-func(
+          dx: global-dx + (dx * 1pt), dy: global-dy,
+          repr(ii * step)
+        )
+      }
+      let step = to-int(y-spacing)
+      for (ii, dy) in range(0, height, step: step).enumerate() {
+        place-func(
+          dx: global-dx, dy: global-dy,
+          line(start: (0pt, dy * 1pt), end: (width * 1pt, dy * 1pt))
+          )
+        place-func(
+          dy: global-dy + dy * 1pt, dx: global-dx,
+          repr(ii * step)
+        )
+      }
+    })
+  })
+}
+
+#let set-margin-note-defaults(..defaults) = {
+  defaults = defaults.named()
+  margin-note-defaults.update(old => {
+    if type(old) != "dictionary" {
+      old
+      panic("margin-note-defaults must be a dictionary")
+    }
+    if (old + defaults).len() != old.len() {
+      let allowed-keys = array(old.keys())
+      let violators = array(defaults.keys()).filter(key => key not in allowed-keys)
+      panic("margin-note-defaults can only contain the following keys: " + allowed-keys.join(", ") + ". Got: " + violators.join(", "))
+    }
+    let out = (:)
+    old + defaults
+  })
+}
+
+#let place-margin-rects(padding: 1%, ..rect-kwargs) = {
+  let rect-kwargs = rect-kwargs.named()
+  if "height" not in rect-kwargs {
+    rect-kwargs.insert("height", 100%)
+  }
+  locate(loc => {
+    let props = margin-note-defaults.at(loc)
+    let (page-width, r-width, l-width) = (
+      props.page-width,
+      props.margin-right,
+      props.margin-left,
+    )
+    let r(w) = rect(width: w, ..rect-kwargs)
+    absolute-place(r(l-width - padding))
+    absolute-place(dx: page-width + l-width + padding, r(r-width - padding))
+  })
+}
+
+#let set-page-properties(margin-right: 0pt, margin-left: 0pt, ..kwargs) = {
+  let kwargs = kwargs.named()
+  // Wrapping in "place" prevents a linebreak from adjusting
+  // the content
+  place(
+    layout(layout-size => {
+      set-margin-note-defaults(
+        margin-right: margin-right,
+        margin-left: margin-left,
+        page-width: layout-size.width,
+        ..kwargs
+      )
+    })
+  )
+}
+
+#let margin-lines(stroke: gray + 0.5pt) = {
+  locate(loc => {
+    let r-margin = margin-note-defaults.at(loc).margin-right
+    let l-margin = margin-note-defaults.at(loc).margin-left
+    place(dx: -2%, rect(height: 100%, width: 104%, stroke: (left: stroke, right: stroke)))
+
+    // absolute-place(dx: 100% - l-margin, line(end: (0%, 100%)))
+  })
+}
+
+#let _path-from-diffs(start: (0pt, 0pt), ..diffs) = {
+    let diffs = diffs.pos()
+    let out-path = (start, )
+    let next-pt = start
+    for diff in diffs {
+      next-pt = (next-pt.at(0) + diff.at(0), next-pt.at(1) + diff.at(1))
+      out-path.push(next-pt)
+    }
+    out-path
+}
+
+#let _get-page-pct(props) = {
+  let page-width = props.page-width
+  if page-width == none {
+    panic("drafting's default `page-width` must be specified and non-zero before creating a note")
+  }
+  page-width/100
+}
+
+#let _get-descent-at-page(loc, descents-dict: none) = {
+  if descents-dict == none {
+    descents-dict = note-descent.at(loc)
+  }
+  let page-cnt = str(counter(page).at(loc).first())
+  (page-cnt, descents-dict.at(page-cnt, default: (left: 0pt, right: 0pt)))
+}
+
+#let _update-descent(side, dy, anchor-y, note-rect) = {
+  style(styles => {
+    locate(loc => {
+      let height = measure(note-rect, styles).height
+      let dy = measure(v(dy + height), styles).height + anchor-y
+      note-descent.update(old => {
+        let (cnt, props) = _get-descent-at-page(loc, descents-dict: old)
+
+        props.insert(side, calc.max(dy, props.at(side)))
+        old.insert(cnt, props)
+        old
+      })
+    })
+  })
+}
+
+#let _margin-note-right(body, dy, anchor-x, anchor-y, ..props) = {
+  props = props.named()
+  let pct = _get-page-pct(props)
+  let dist-to-margin = 101*pct - anchor-x + props.margin-left
+  let text-offset = 0.5em
+  let right-width = props.margin-right - 4*pct
+
+  let path-pts = _path-from-diffs(
+    // make an upward line before coming back down to go all the way to
+    // the top of the lettering
+    (0pt, -1em),
+    (0pt, 1em + text-offset),
+    (dist-to-margin, 0pt),
+    (0pt, dy),
+    (1*pct + right-width / 2, 0pt)
+  )
+  dy += text-offset
+  let note-rect = props.at("rect")(
+    stroke: props.stroke, width: right-width, body
+  )
+  // Boxing prevents forced paragraph breaks
+  box[
+    #place(path(stroke: props.stroke, ..path-pts))
+    #place(dx: dist-to-margin + 1*pct, dy: dy, note-rect)
+  ]
+  _update-descent("right", dy, anchor-y, note-rect)
+}
+
+#let _margin-note-left(body, dy, anchor-x, anchor-y, ..props) = {
+  props = props.named()
+  let pct = _get-page-pct(props)
+  let dist-to-margin = -anchor-x + 1*pct
+  let text-offset = 0.4em
+  let box-width = props.margin-left - 4*pct
+  let path-pts = _path-from-diffs(
+    (0pt, -1em),
+    (0pt, 1em + text-offset),
+    (-anchor-x + props.margin-left + 1*pct, 0pt),
+    (-2*pct, 0pt),
+    (0pt, dy),
+    (-1*pct - box-width / 2, 0pt),
+  )
+  dy += text-offset
+  let note-rect = props.at("rect")(
+    stroke: props.stroke,  width: box-width, body
+  )
+  // Boxing prevents forced paragraph breaks
+  box[
+    #place(path(stroke: props.stroke, ..path-pts))
+    #place(dx: dist-to-margin + 1*pct, dy: dy, note-rect)
+  ]
+  _update-descent("left", dy, anchor-y, note-rect)
+}
+
+/// Places a boxed note in the left or right page margin.
+///
+/// - body (content): Margin note contents, usually text
+/// - dy (length): Vertical offset from the note's location -- negative values
+///   move the note up, positive values move the note down
+/// - ..kwargs (dictionary): Additional properties to apply to the note. Accepted values are keys from `margin-note-defaults`.
+#let margin-note(body, dy: auto, ..kwargs) = {
+  _run-func-on-first-loc(label-name: "margin-note", loc => {
+    let pos = loc.position()
+    let properties = margin-note-defaults.at(loc) + kwargs.named()
+    let (anchor-x, anchor-y) = (pos.x - properties.page-offset-x, pos.y)
+    
+    if properties.hidden {
+      return
+    }
+
+    // `let` assignment allows mutating argument
+    let dy = dy
+    if dy == auto {
+      let (cur-page, descents) = _get-descent-at-page(loc)
+      let cur-descent = descents.at(repr(properties.side))
+      dy = calc.max(0pt, cur-descent - loc.position().y)
+      // Notes at the beginning of a line misreport their y position, since immediately
+      // after they are placed, a new line is created which moves the note down.
+      // A hacky fix is to subtract a line's worth of space from the y position when
+      // detecting a note at the beginning of a line.
+      // TODO: When https://github.com/typst/typst/issues/763 is resolved,
+      // `get` this value from `par.leading` instead of hardcoding`
+      if anchor-x == properties.margin-left {
+        dy -= 0.65em
+      }
+    }
+
+    let margin-func = if properties.side == right {
+      _margin-note-right
+    } else {
+      _margin-note-left
+    }
+    margin-func(
+      body, dy, anchor-x, anchor-y, ..properties
+    )
+  })
+}
+
+/// Place a note inline with the text body.
+///
+/// - body (content): Margin note contents, usually text
+/// - par-break (bool): Whether to break the paragraph after the note, which places
+///   the note on its own line. Beware: inline notes with `par-break: false` cannot
+///   have a fill and will behave strangely when oversized content is present.
+/// - ..kwargs (dictionary): Additional properties to apply to the note.
+///
+#let inline-note(body, par-break: true, ..kwargs) = {
+  locate(loc => {
+    let properties = margin-note-defaults.at(loc) + kwargs.named()
+    if properties.hidden {
+      return
+    }
+
+    let rect-func = properties.at("rect")
+    if par-break {
+      return rect-func(body, stroke: properties.stroke)
+    }
+    // else
+    let dummy-rect = rect-func(stroke: properties.stroke)[Dummy content]
+    let s = dummy-rect.stroke
+    // Underline/overline stroke should inherit their properties from when users
+    // specify `set rect(stroke: ...)` which is accomplished by grabbing defaults
+    // from a dummy rect.
+    let stroke-props = (
+      paint: s.paint,
+      thickness: s.thickness,
+      cap: s.cap,
+      miter-limit: s.miter-limit,
+      dash: s.dash,
+    )
+    let bottom = 0.5em
+    let top = 1em
+    set text(top-edge: "ascender", bottom-edge: "descender")
+    let cap-line = {
+      let t = s.thickness / 2
+      show "|": it => box(height: top, outset: (bottom: bottom + t, top: t), stroke: s)
+      [|]
+    }
+    let new-body = underline(stroke: stroke-props, [ #body ], offset: bottom)
+    new-body = [
+      #underline([#cap-line#new-body#cap-line], stroke: stroke-props, offset: -top)
+    ]
+    new-body
+
+  })
+}

--- a/packages/preview/drafting/0.1.1/typst.toml
+++ b/packages/preview/drafting/0.1.1/typst.toml
@@ -1,0 +1,9 @@
+[package]
+name = "drafting"
+version = "0.1.1"
+entrypoint = "drafting.typ"
+authors = ["Nathan Jessurun"]
+license = "Unlicense"
+description = "Helpful functions for content positioning and margin comments/notes"
+repository = "https://github.com/ntjess/typst-drafting"
+keywords = ["comments", "notes", "margins", "positioning", "layout", "ruler"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name in conformance with the guidelines
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] ensured that my submission does not infringe upon the rights of a third party
- [x] tested my package locally on my system and it worked
- [x] named this PR as `name:version` of the submitted package
- [x] agree that my package will not be removed without good reason

<!--
Please add a brief description of your package below and explain why you think it is useful to others.
-->

Some helpful additions to note placement and positioning helpers:
- **Auto-move margin notes when they overlap** (the biggest reason for a version bump)
- Allow either global or local note hiding
- Allow totally-customized notes rather than only configuring stroke/fill
- Inline notes (https://github.com/ntjess/typst-drafting/issues/1)
- Different grid sizing in x vs. y direction in `rule-grid` + dx/dy offset
- Specify either `divisions` or `spacing` to define `rule-grid`'s spacing
- Improved documentation
