### PR TITLE
commute:0.2.0

### DIFF
--- a/packages/preview/commute/0.2.0/LICENSE
+++ b/packages/preview/commute/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Giacomo Gallina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/commute/0.2.0/README.md
+++ b/packages/preview/commute/0.2.0/README.md
@@ -30,7 +30,7 @@ You can clone this repo and import `lib.typ`:
 ```
 Or directly use the builtin package manager:
 ```
-#import "@preview/commute:0.1.0": node, arr, commutative-diagram
+#import "@preview/commute:0.2.0": node, arr, commutative-diagram
 ```
 
 ## `commutative-diagram`

--- a/packages/preview/commute/0.2.0/README.md
+++ b/packages/preview/commute/0.2.0/README.md
@@ -1,0 +1,115 @@
+# Commute
+Proof-of-concept commutative diagrams library for [typst](https://typst.app/home)
+
+See [EricWay1024/tikzcd-editor][https://github.com/EricWay1024/tikzcd-editor]
+for a web-based visual diagram editor for this library!
+
+# Example
+```
+#import "@preview/commute:0.2.0": node, arr, commutative-diagram
+
+#align(center)[#commutative-diagram(
+  node((0, 0), $X$),
+  node((0, 1), $Y$),
+  node((1, 0), $X \/ "ker"(f)$, "quot"),
+  arr($X$, $Y$, $f$),
+  arr("quot", (0, 1), $tilde(f)$, label-pos: right, "dashed", "inj"),
+  arr($X$, "quot", $pi$),
+)]
+```
+
+![screenshot](https://github.com/typst/packages/assets/20535498/71eb8d47-b6f9-43fa-a1fd-7ff58b8d0025)
+   
+For more usage examples look at `example.typ`
+
+# Usage
+The library provides 3 functions: `node`, `arr`, and `commutative-diagram`.
+You can clone this repo and import `lib.typ`:
+```
+#import "path/to/commute/lib.typ": node, arr, commutative-diagram
+```
+Or directly use the builtin package manager:
+```
+#import "@preview/commute:0.1.0": node, arr, commutative-diagram
+```
+
+## `commutative-diagram`
+```
+commutative-diagram(
+  node-padding: (70pt, 70pt),
+  arr-clearance: 0.7em,
+  padding: 1.5em,
+  debug: false,
+  ..entities
+)
+```
+`commutative-diagram` returns a rectangular region containing the
+nodes and arrows.
+All the unnamed arguments passed to `commutative-diagram` are treated as
+nodes or arrows of the diagram. These can be constructed using the
+`node` and `arr` functions explained below.
+The other arguments are as follows:
+- `node-padding`: `(length, length)`. The space to leave between adjacent nodes. It's a
+  tuple, `(h, v)`, containing the horizontal and vertical spacing respectively.
+- `arr-clearance`: `length`. The default space between arrows' base/tip and the diagram's nodes. 
+- `padding`: `length`. The padding around the whole diagram
+- `debug`: `bool`. Whether or not to display debug information. 
+
+## `node`
+```
+node(
+  pos,
+  label,
+  id: label,
+)
+```
+Creates a new diagram node. Has the following positional arguments:
+- `pos`: `(integer, integer)`. The position of the node in `(row, column)` format.
+  Must be integers, but can be negative, the only thing that counts is the
+  difference between the coordinares of the variuos nodes in the diagram.
+- `label`: `content`. The node's label.
+- `id`: `any`. The node's id, defaults to its label if not specified.
+
+## `arr`
+```
+arr(
+  start,
+  end,
+  label,
+  start-space: none,
+  end-space: none,
+  label-pos: left,
+  curve: 0deg,
+  stroke: 0.45pt,
+  ..options
+)
+```
+Creates an arrow. Has the following arguments:
+- `start`: `(integer, integer)` or `any`. The position of the node from which the arrow starts,
+  in `(row, column)` format, or its id.
+- `end`: `(integer, integer)` or `any`. The position of the node where the arrow ends,
+  in `(row, column)` format, or its id.
+- `label`: `content`. The label to put on the arrow.
+- `start-space`: `length`. The space between the start node and the beginning of the arrow.
+  You can pass `none` to leave a sensible default, customizable using the
+  `arr-clearance` parameter of the `commutative-diagram` function.
+- `end-space`: `length`. Similar to the above.
+- `label-pos`: `length` or `left` or `right`. Where to position the arrow's label relative to the arrow.
+  A positive length means that, when looking towards the tip of the arrow,
+  the label is on the left. `left` and `right` measure the label to automatically get a reasonable
+  length. If set to `0` (`0` the number, which is different from `0pt` or `0em`)
+  then the label is placed on top of the arrow, with a white background to help
+  with legibility.
+- `curve`: `angle`. The difference in orientation between the start and the end of the arrow.
+  If positive, the arrow curves to the right, when looking towards the tip.
+- `stroke`: `stroke`. The thickness and color of the arrows. The default should probably be fine.
+- `options`: `string`s. After the mandatory positional arguments `start`, `end` and `label`,
+  any remaining unnamed argument is treated as an extra option. Recognized options are:
+  - `"inj"`, gives the arrow a hook at the start, used for injective functions
+  - `"surj"`, gives the arrow a double tip, used for surjective functions
+  - `"bij"`, gives the arrow a tip also at the start, used for bijective functions
+  - `"def"`, gives the arrow a bar at the start, used for function definitions
+  - `"nat"`, gives the arrow a double stem, used for natural transformations
+  - All the options supported by the `dash` parameter of Typst's `stroke` type, such as
+    `"dashed"`, `"densely-dotted"`, etc. These change the appearance of the arrow's stem
+

--- a/packages/preview/commute/0.2.0/example.typ
+++ b/packages/preview/commute/0.2.0/example.typ
@@ -1,0 +1,62 @@
+#import "@preview/commute:0.2.0": node, arr, commutative-diagram
+// #import "lib.typ": node, arr, commutative-diagram
+
+#set text(font: "New Computer Modern")
+
+A minimal diagram
+#align(center, commutative-diagram(
+  node((0, 0), $X$),
+  node((0, 1), $Y$),
+  node((1, 0), $X \/ "ker"(f)$, "quot"),
+  arr($X$, $Y$, $f$),
+  arr("quot", $Y$, $tilde(f)$, label-pos: right, "dashed", "inj"),
+  arr($X$, "quot", $pi$),
+))
+
+A more complicated diagram, with various kinds of arrows
+(plz don't report me to the math police, i know this diagram is wrong, it's just to show all the different arrows)
+#align(center, commutative-diagram(//debug: true, 
+  node((0, 0), $pi_1(X sect Y)$),
+  node((0, 1), $pi_1(Y)$),
+  node((1, 0), $pi_1(X)$),
+  node((1, 1), $pi_1(Y) ast.op_(pi_1(X sect Y)) pi_1(X)$),
+  arr((0, 0), (0, 1), $i_1$, label-pos: right, "inj"),
+  arr((0, 0), (1, 0), $i_2$, "nat"),
+  arr((1, 0), (2, 2), $j_1$, curve: -15deg, "surj", "dotted"),
+  arr((0, 1), (2, 2), $j_2$, curve: 20deg, "nat", "bij"),
+  arr((1, 1), (2, 2), $k$, label-pos: 0, "dashed", "bij"),
+  arr((1, 0), (1, 1), [], "dashed", "inj", "surj"),
+  arr((0, 1), (1, 1), [], "def"),
+  node((2, 2), $pi_1(X union Y)$)
+))
+
+
+A diagram with `debug` enabled
+#align(center, commutative-diagram(debug: true,
+  node((0, 0), $A$),
+  node((0, 1), $B$),
+  node((0, 2), $C$),
+  node((0, 3), $D$),
+  node((0, 4), $E$),
+  node((1, 0), $A'$),
+  node((1, 1), $B'$),
+  node((1, 2), $C'$),
+  node((1, 3), $D'$),
+  node((1, 4), $E'$),
+  arr((0, 0), (0, 1), $a$),
+  arr((0, 1), (0, 2), $b$),
+  arr((0, 2), (0, 3), $c$),
+  arr((0, 3), (0, 4), $d$),
+  arr((1, 0), (1, 1), $a'$),
+  arr((1, 1), (1, 2), $b'$),
+  arr((1, 2), (1, 3), $c'$),
+  arr((1, 3), (1, 4), $d'$),
+  arr((0, 0), (1, 0), $alpha$),
+  arr((0, 1), (1, 1), $beta$),
+  arr((0, 2), (1, 2), $gamma$),
+  arr((0, 3), (1, 3), $delta$),
+  arr((0, 4), (1, 4), $epsilon$),
+  arr((0, 2), (1, 3), [wow!], "dash-dotted"),
+))
+
+

--- a/packages/preview/commute/0.2.0/lib.typ
+++ b/packages/preview/commute/0.2.0/lib.typ
@@ -1,0 +1,340 @@
+#let node(pos, label, ..opts) = (
+  kind: "node",
+  pos: pos,
+  label: label,
+  id: repr(opts.pos().at(0, default: label)),
+)
+
+#let arr(start, end, label,
+         start-space: none, end-space: none,
+         label-pos: left, curve: 0deg, stroke: 0.05em, ..options) = {
+  (
+    kind: "arrow",
+    start: start,
+    end: end,
+    label: label,
+    start-space: start-space,
+    end-space: end-space,
+    label-pos: label-pos,
+    curve: curve,
+    stroke: stroke,
+    options: options.pos(),
+  )
+}
+
+#let commutative-diagram(
+  node-padding: (70pt, 70pt),
+  arr-clearance: 0.7em,
+  padding: 1.5em,
+  debug: false,
+  ..entities
+) = {
+  style(styles => {
+
+    // useful utility function
+    let _center(c) = {
+      let m = measure(c, styles)
+      place(dx: -0.5*m.width, dy: -0.5*m.height, c)
+    }
+  
+    // get nodes and arrows from the function arguments
+    let entities = entities.pos()
+    let nodes = entities.filter(e => e.kind == "node")
+    let arrows = entities.filter(e => e.kind == "arrow")
+    let pos-from-id = (:)
+  
+    // adjust node and arrow coordinates so that the min is (0, 0)
+    let min-row = calc.min(..nodes.map(node => node.pos.at(0)))
+    let min-col = calc.min(..nodes.map(node => node.pos.at(1)))
+    let max-row = calc.max(..nodes.map(node => node.pos.at(0)))
+    let max-col = calc.max(..nodes.map(node => node.pos.at(1)))
+  
+    for i in range(nodes.len()) {
+      nodes.at(i).pos.at(0) -= min-row
+      nodes.at(i).pos.at(1) -= min-col
+      pos-from-id.insert(nodes.at(i).id, nodes.at(i).pos)
+    }
+  
+    arrows = arrows.map(arr => {
+      if type(arr.start) == "array" {
+        arr.start.at(0) -= min-row
+        arr.start.at(1) -= min-col
+      } else if repr(arr.start) in pos-from-id {
+        arr.start = pos-from-id.at(repr(arr.start), default: none)
+      } else {
+        panic("Error while processing arrow from " +
+              repr(arr.start) + " to " + repr(arr.end) +
+              ": can't find a node with id = " + repr(arr.start))
+      }
+      if type(arr.end) == "array" {
+        arr.end.at(0) -= min-row
+        arr.end.at(1) -= min-col
+      } else if repr(arr.end) in pos-from-id {
+        arr.end = pos-from-id.at(repr(arr.end), default: none)
+      } else {
+        panic("Error while processing arrow from " +
+              repr(arr.start) + " to " + repr(arr.end) +
+              ": can't find a node with id = " + repr(arr.end))
+      }
+      arr
+    })
+  
+    max-row -= min-row
+    max-col -= min-col
+    min-col = 0
+    min-row = 0
+  
+    // measure the size of the various rows and columns
+    let col-sizes = ()
+    let row-sizes = ()
+    for r in range(0, max-row+1) {
+      row-sizes.push(0pt)
+    }
+    for c in range(0, max-col+1) {
+      col-sizes.push(0pt)
+    }
+    for node in nodes {
+      let m = measure(node.label, styles)
+      if m.width > col-sizes.at(node.pos.at(1)) {
+        col-sizes.at(node.pos.at(1)) = m.width
+      }
+      if m.height > row-sizes.at(node.pos.at(0)) {
+        row-sizes.at(node.pos.at(0)) = m.height
+      }
+    }
+    let row-pos = row-sizes
+    let col-pos = col-sizes
+    row-pos.at(0) /= 2
+    col-pos.at(0) /= 2
+    for r in range(1, max-row+1) {
+      row-pos.at(r) += row-pos.at(r - 1) + node-padding.at(1)
+    }
+    for c in range(1, max-col+1) {
+      col-pos.at(c) += col-pos.at(c - 1) + node-padding.at(0)
+    }
+  
+    // total diagram dimensions
+    let height = row-sizes.fold(-node-padding.at(1), (x, y) =>
+                                x+y+node-padding.at(1))
+    let width = col-sizes.fold(-node-padding.at(0), (x, y) =>
+                                x+y+node-padding.at(0))
+
+    // useful functions used many times later
+    let coords(pos) = (
+      col-pos.at(pos.at(1)), row-pos.at(pos.at(0))
+    )
+  
+    let size-at(pos) = {
+      for node in nodes {
+        if node.pos == pos {
+          return measure(node.label, styles)
+        }
+      }
+      return (width: 0pt, height: 0pt)
+    }
+  
+    // units conversion
+    let pt-per-em = measure(rect(width: 1em), styles).width
+    let to-abs(l) = l.abs + l.em * pt-per-em
+
+    // various vector utility functions
+    let v-add(a, b) = (a.at(0) + b.at(0), a.at(1) + b.at(1))
+    let v-sub(a, b) = (a.at(0) - b.at(0), a.at(1) - b.at(1))
+    let v-mul(a, x) = (a.at(0) * x, a.at(1) * x)
+    let v-dir(a, l) = v-mul((calc.cos(a), calc.sin(a)), l)
+    let v-add-dir(p, a, l) = v-add(p, v-dir(a, l))
+    let v-length(vv) = calc.sqrt(calc.pow(to-abs(vv.at(0))/1mm, 2) +
+                                 calc.pow(to-abs(vv.at(1))/1mm, 2))*1mm
+  
+    // measures the length of a segment starting in the center
+    // of a rectangle and ending on one of the rectangle's edges,
+    // given the angle of the segment
+    let measure-at-angle(m, a, padding) = {
+      if calc.sin(a) == 0 {
+        m.width / 2 + padding
+      } else if calc.cos(a) == 0 {
+        m.height / 2 + padding
+      } else {
+        calc.min(
+          (m.width / 2 + padding) / calc.abs(calc.cos(a)), 
+          (m.height / 2 + padding) / calc.abs(calc.sin(a)),
+          calc.max(m.width, m.height) / 2 + padding,
+        )
+      }
+    }
+  
+    // the box where all the diagram's elements are
+    box(
+      width: width + 2*padding, height: height + 2*padding,
+      stroke: if debug { 0.5pt + red } else { none },
+      inset: padding,
+      {
+
+      for arr in arrows {
+        let start = coords(arr.start)
+        let end = coords(arr.end)
+        // arrow angle measured clockwise from the right
+        // i know that clockwise is disgusting, but rotate rotates clockwise
+        let angle = calc.atan2((end.at(0) - start.at(0)) / 1pt,
+                               (end.at(1) - start.at(1)) / 1pt)
+        let curve-angle = arr.curve
+        let start-space = arr.start-space
+        let end-space = arr.end-space
+        if start-space == none {
+          start-space = measure-at-angle(size-at(arr.start),
+                                         angle - curve-angle,
+                                         to-abs(arr-clearance))
+        }
+        if end-space == none {
+          end-space = measure-at-angle(size-at(arr.end),
+                                       angle + curve-angle,
+                                       to-abs(arr-clearance))
+        }
+        let astart = v-add-dir(start, angle - curve-angle, start-space)
+        let aend = v-add-dir(end, angle + 180deg + curve-angle, end-space)
+      
+        // draw the arrow's tip
+        place(dx: aend.at(0), dy: aend.at(1),
+          rotate(angle + curve-angle + 90deg, origin: top+left,
+            if "surj" in arr.options {
+              move(dy: 0.21em, _center(
+                box(clip:true, height: 0.42em, $arrow.t.twohead$)
+              ))
+              aend = v-add-dir(aend, angle + curve-angle, -0.42em)
+            } else if "nat" in arr.options {
+              move(dy: 0.18em, _center(
+                box(clip:true, height: 0.36em, $arrow.t.double$)
+              ))
+              aend = v-add-dir(aend, angle + curve-angle, -0.36em)
+            } else {
+              move(dy: 0.15em, _center(
+                box(clip:true, height: 0.3em, $arrow.t$)
+              ))
+              aend = v-add-dir(aend, angle + curve-angle, -0.3em)
+            }
+          )
+        )
+
+        // draw the arrow's start
+        place(dx: astart.at(0), dy: astart.at(1),
+          rotate(angle - curve-angle - 90deg, origin: top+left, 
+            if "bij" in arr.options {
+              if "nat" in arr.options {
+                move(dy: 0.18em, _center(
+                  box(clip:true, height: 0.36em, $arrow.t.double$)
+                ))
+                astart = v-add-dir(astart, angle - curve-angle, 0.36em)
+              } else {
+                move(dy: 0.15em, _center(
+                  box(clip: true, height: 0.3em, $arrow.t$)
+                ))
+                astart = v-add-dir(astart, angle - curve-angle, 0.3em)
+              }
+            } else if "inj" in arr.options {
+              path(stroke: (thickness: arr.stroke, cap: "round"),
+                (0em, 0.15em), ((0.15em, 0em), (-0.15em, 0em)), (0.3em, 0.15em)
+              )
+              astart = v-add-dir(astart, angle - curve-angle, 0.15em)
+            } else if "def" in arr.options {
+              place(dx: -0.2em, line(stroke: (thickness: arr.stroke, cap: "round"),
+                                     length: 0.4em))
+            }  
+          )
+        )
+
+        // find the dash style
+        let dash = arr.options
+          .filter(opt => opt not in ("inj", "surj", "bij", "def", "nat"))
+          .at(0, default: none)
+
+        // draw the arrow's stem
+        
+        // this should be, up to a good approximation (due to different
+        // start and end tips), a parabola. See https://en.wikipedia.org/wiki/Bézier_curve
+        let ctrl-length = - (v-length(v-sub(astart, aend)) / 3
+                             / calc.cos(curve-angle))
+        if "nat" in arr.options {
+          let sep = 0.095em
+          place(path(stroke: (thickness: arr.stroke, dash: dash, cap: "round"),
+            (v-add-dir(astart, angle - curve-angle + 90deg, -sep),
+             v-dir(angle - curve-angle, ctrl-length)),
+            (v-add-dir(aend, angle + curve-angle + 90deg, -sep),
+             v-dir(angle + curve-angle, ctrl-length)),
+          ))
+          place(path(stroke: (thickness: arr.stroke, dash: dash, cap: "round"),
+            (v-add-dir(astart, angle - curve-angle + 90deg, sep),
+             v-dir(angle - curve-angle, ctrl-length)),
+            (v-add-dir(aend, angle + curve-angle + 90deg, sep),
+             v-dir(angle + curve-angle, ctrl-length)),
+          ))
+        } else {
+          place(path(stroke: (thickness: arr.stroke, dash: dash, cap: "round"),
+            (astart, v-dir(angle - curve-angle, ctrl-length)),
+            (aend, v-dir(angle + curve-angle, ctrl-length)),
+          ))
+        }
+      
+        // draw the arrow's label
+        let normal = (- aend.at(1) + astart.at(1), aend.at(0) - astart.at(0))
+        let middle = v-add(v-mul(v-add(astart, aend), 0.5),
+                           v-mul(normal, -calc.tan(curve-angle)/4))
+      
+        let m = measure(arr.label, styles)
+        let l = (
+          (
+            if arr.label-pos == right { -0.5 }
+            else if arr.label-pos == left { 0.5 }
+            else { 0 }
+          ) * (
+            0.5em +
+            calc.abs(calc.sin(angle)) * m.width +
+            calc.abs(calc.cos(angle)) * (m.height + 0.3em)
+          ) + (
+            if type(arr.label-pos) == "length" { arr.label-pos }
+            else { 0pt }
+          )
+        )
+        let lpos = v-add-dir(middle, angle - 90deg, l)
+        if arr.label-pos == 0 {
+          place(dx: lpos.at(0), dy: lpos.at(1), _center(
+            rect(width: m.width + 0.1em, height: m.height + 0.3em, fill: white)
+          ))
+        }
+        if debug {
+          place(dx: lpos.at(0), dy: lpos.at(1), _center(
+            rect(width: m.width + 0.5em, height: m.height + 0.8em,
+                 radius: 0.25em, stroke: 0.5pt + red)
+          ))
+        }
+        place(dx: lpos.at(0), dy: lpos.at(1), _center(arr.label))
+      }
+  
+      for node in nodes {
+        let coords = coords(node.pos)
+        place(
+          dx: coords.at(0),
+          dy: coords.at(1),
+          _center(node.label)
+        )
+        if debug {
+          let m = measure(node.label, styles)
+          place(
+            dx: coords.at(0),
+            dy: coords.at(1),
+            _center(rect(width: m.width + 2 * arr-clearance,
+                         height: m.height + 2 * arr-clearance,
+                         stroke: 0.5pt+red)),
+          )
+          place(
+            dx: coords.at(0),
+            dy: coords.at(1),
+            _center(circle(
+              radius: calc.max(m.width, m.height) / 2 + arr-clearance,
+              stroke: 0.5pt+red
+            )),
+          )
+        }
+      }
+    })
+  })
+}

--- a/packages/preview/commute/0.2.0/typst.toml
+++ b/packages/preview/commute/0.2.0/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "commute"
+version = "0.2.0"
+entrypoint = "lib.typ"
+authors = ["giacomogallina <https://gitlab.com/giacomogallina>"]
+license = "MIT"
+description = "A proof of concept library for commutative diagrams."
+repository = "https://gitlab.com/giacomogallina/commute"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [X] an update for a package

I added support for double arrows, named nodes, and in general fixed a lot of hacky stuff that was now easy to do in idiomatic typst

Description: A proof-of-concept library for commutative diagrams

