### PR TITLE
Added atmosphere to unit list

### DIFF
--- a/packages/preview/unify/0.4.3/units.csv
+++ b/packages/preview/unify/0.4.3/units.csv
@@ -45,4 +45,5 @@ sievert,Sv,upright("Sv"),true
 percent,%,percent,true
 decibel,dB,upright("dB"),true
 neper,Np,upright("Np"),true
-coulomb,C,"upright("C"),true
+coulomb,C,upright("C"),true
+atmosphere, atm, upright("atm"), true


### PR DESCRIPTION
Added atmosphere to unit list 

Commonly used in a lot of my thermodynamics homework so I thought it might be nice to have here ¯\\_(ツ)_/¯

Also removed the quote in the definition for coulomb that was preventing it from working. 