### PR TITLE
Fix typo and add typo checking to submission guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ are detailed below:
   least briefly) what the package does and all definitions intended for usage by
   downstream users. Examples in the README should show how to use the package
   through an `@preview` import. If you have images in your README, you might
-  want to check whether they also work in dark mode.
+  want to check whether they also work in dark mode. Also consider running
+  [`typos`][typos] through your package before release.
 - **Style:** No specific code style is mandated, but two spaces of indent and
   kebab-case for variable and function names are recommended.
 - **License:** Packages must be licensed under the terms of an
@@ -162,3 +163,4 @@ respective license.
 [SemVer]: https://semver.org/
 [OSI]: https://opensource.org/licenses/
 [template-packages]: https://github.com/typst/typst/issues/2432
+[typos]: https://github.com/crate-ci/typos

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ are relative to the file they are used in.
 This repository contains a collection of published packages. Due to its early
 and experimental nature, all packages in this repository are scoped in a
 `preview` namespace. A package that is stored in
-`packages/preview/{name}/{version}` in this repository will become availabe in
+`packages/preview/{name}/{version}` in this repository will become available in
 Typst as `#import "@preview/{name}:{version}"`. You must always specify the full
 package version.
 


### PR DESCRIPTION
(deleted template as listed in it, since this is not a package submission)

Fixes a typo in `README.md` I ran across while looking up on how to install local packages.

It might also be useful to add running [`typos`](https://github.com/crate-ci/typos) (can also be used as an installed binary without GH actions) to the submission guidelines since there are quite a few typos in the packages, too, on the other hand I'm not sure if you're fine with that, so I left it out.