### PR TITLE
use caption body to avoid "Agorithm 1: Algorithm 1"

### DIFF
--- a/packages/preview/lovelace/0.1.0/lib.typ
+++ b/packages/preview/lovelace/0.1.0/lib.typ
@@ -115,7 +115,7 @@
               counter(figure.where(kind: "lovelace")).display(it.numbering)
               [: ]
             })
-            it.caption
+            it.caption.body
           }
 
         )


### PR DESCRIPTION


<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [ x ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Since the caption by default also uses the supplement, the current code shows double "Algorithm n". Using only the caption body fixes the issue
