### PR TITLE
nth:1.0.0

### DIFF
--- a/packages/preview/nth/1.0.0/CHANGELOG.md
+++ b/packages/preview/nth/1.0.0/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0 - 2023-12-21
+
+### Changed
+* **Breaking** separated functionality, now `nth` only gives ordinals and `nths` gives ordinals in superscript (commit [eff87f3](https://github.com/extua/nth/commit/eff87f3f2a2a20cf05198fbd7d4e5fa2d30858d1), fixes [#1](https://github.com/extua/nth/issues/1) reported by [emilyyyylime](https://github.com/emilyyyylime)).
+
 ## 0.2.0 - 2023-10-02
 
 ### Fixed

--- a/packages/preview/nth/1.0.0/CHANGELOG.md
+++ b/packages/preview/nth/1.0.0/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 0.2.0 - 2023-10-02
+
+### Fixed
+* Added missing brace to if statement (commmit [bbe6251](https://github.com/typst/packages/commit/bbe6251c1511ff97d92988aeb55ff66470cbd0b9) in Typst repo) ([jeffa5](https://github.com/jeffa5))
+
+### Changed
+* Corrected a typo in the description in typst.toml (commit [2d5cbca](https://github.com/typst/packages/commit/2d5cbcada47a7fb1d00f2d3f7f67c11132e79429) in Typst repo) ([fnoaman](https://github.com/fnoaman))
+
+## 0.1.0 - 2023-09-15
+
+:seedling: Initial release.

--- a/packages/preview/nth/1.0.0/LICENSE
+++ b/packages/preview/nth/1.0.0/LICENSE
@@ -1,0 +1,7 @@
+MIT No Attribution
+
+Copyright 2023 Pierre Marshall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/nth/1.0.0/README.md
+++ b/packages/preview/nth/1.0.0/README.md
@@ -1,0 +1,25 @@
+# Nth
+
+Provides functions `#nth()` and `#nths()` which take a number and return it suffixed by an english ordinal.
+
+This package is named after the nth [LaTeX macro](https://ctan.org/pkg/nth) by Donald Arseneau.
+
+## Usage
+
+Include this line in your document to import the package.
+
+```typst
+#import "@preview/nth:1.0.0": *
+```
+
+Then, you can use `#nth()` to markup ordinal numbers in your document.
+
+For example, `#nth(1)` shows 1st,  
+`#nth(2)` shows 2nd,  
+`#nth(3)` shows 3rd,  
+`#nth(4)` shows 4th,  
+and `#nth(11)` shows 11th.
+
+If you want the ordinal to be in superscript, use `#nths` with an 's' at the end.
+
+For example, `#nths(1)` shows 1<sup>st</sup>.

--- a/packages/preview/nth/1.0.0/nth.typ
+++ b/packages/preview/nth/1.0.0/nth.typ
@@ -1,0 +1,31 @@
+#let nth(ordinal-num, sup: bool) = {
+  // Conditinally define ordinal-num, and if it's an integer change it to a string
+  let ordinal-str = if type(ordinal-num) == int {
+    str(ordinal-num)
+  } else {
+    ordinal-num
+  }
+  // Main if-else tree for this function
+  let ordinal-suffix = if ordinal-str.ends-with(regex("1[0-9]")) {
+    "th"
+  } else if ordinal-str.last() == "1" {
+    "st"
+  } else if ordinal-str.last() == "2" {
+    "nd"
+  } else if ordinal-str.last() == "3" {
+    "rd"
+  } else {
+    "th"
+  }
+  // Check whether sup attribute is set, and if so return suffix superscripted
+  if sup == true {
+    return ordinal-str + super(ordinal-suffix)
+  } else {
+    return ordinal-str + ordinal-suffix
+  }
+}
+
+// define nths function, which is just nth with sup attribute applied
+#let nths(ordinal) = {
+  nth(ordinal, sup: true)
+}

--- a/packages/preview/nth/1.0.0/typst.toml
+++ b/packages/preview/nth/1.0.0/typst.toml
@@ -7,4 +7,4 @@ license = "MIT-0"
 description = "Add english ordinals to numbers, eg. 1st, 2nd, 3rd, 4th."
 compiler = "0.8.0"
 repository = "https://github.com/extua/nth"
-exclude = "typstfmt.toml"
+exclude = ["typstfmt.toml"]

--- a/packages/preview/nth/1.0.0/typst.toml
+++ b/packages/preview/nth/1.0.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "nth"
+version = "1.0.0"
+entrypoint = "nth.typ"
+authors = ["Pierre Marshall <pierre.marshall@gmail.com>", "fnoaman", "Andrew Jeffery"]
+license = "MIT-0"
+description = "Add english ordinals to numbers, eg. 1st, 2nd, 3rd, 4th."
+compiler = "0.8.0"
+repository = "https://github.com/extua/nth"
+exclude = "typstfmt.toml"

--- a/packages/preview/nth/1.0.0/typstfmt.toml
+++ b/packages/preview/nth/1.0.0/typstfmt.toml
@@ -1,0 +1,4 @@
+indent_space = 2
+max_line_length = 80
+experimental_args_breaking_consecutive = false
+line_wrap = true


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Description:

Separated this into two functions, now nth just gives ordinals (with no superscript) and nths with an 's' gives ordinals in superscript (fixes https://github.com/extua/nth/issues/1 reported by [emilyyyylime](https://github.com/emilyyyylime)).