### PR TITLE
Fail on unknown manifest keys + Add `[tool]` section for 3rd-party tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Optional:
   otherwise unnecessarily increase the bundle size. Don't exclude the README or
   the LICENSE.
 
-Thrid-party tools can add their own entry under the `[tool]` section to attach
+Third-party tools can add their own entry under the `[tool]` section to attach
 their own typst specific config to the manifest.
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Optional:
   otherwise unnecessarily increase the bundle size. Don't exclude the README or
   the LICENSE.
 
+Thrid-party tools can add their own entry under the `[tool]` section to attach
+their own typst specific config to the manifest.
+
+```toml
+[package]
+# ...
+
+[tool.mytool]
+foo = "bar"
+```
+
 Packages always live in folders named as `{name}/{version}`. The name and
 version in the folder name and manifest must match. Paths in a package are local
 to that package. Absolute paths start in the package root while relative paths

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Optional:
   the LICENSE.
 
 Third-party tools can add their own entry under the `[tool]` section to attach
-their own typst specific config to the manifest.
+their own Typst-specific configuration to the manifest.
 
 ```toml
 [package]

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -139,12 +139,12 @@ fn write_archive(info: &PackageInfo, buf: &[u8]) -> anyhow::Result<()> {
 }
 
 /// A parsed package manifest.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PackageManifest {
     package: PackageInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tool: Option<toml::Table>,
+    tool: Option<Tool>,
 }
 
 /// The `package` key in the manifest.
@@ -170,3 +170,7 @@ struct PackageInfo {
     #[serde(default)]
     exclude: Vec<String>,
 }
+
+/// The `tool` key in the manifest.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct Tool {}

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
 /// Create an archive for a package.
 fn process_package(path: &Path) -> anyhow::Result<PackageInfo> {
     println!("Bundling {}.", path.display());
-    let PackageManifest { package } =
+    let PackageManifest { package, .. } =
         parse_manifest(path).context("failed to parse package manifest")?;
     let buf = build_archive(path, &package.exclude).context("failed to build archive")?;
     validate_archive(&buf).context("failed to validate archive")?;
@@ -139,13 +139,17 @@ fn write_archive(info: &PackageInfo, buf: &[u8]) -> anyhow::Result<()> {
 }
 
 /// A parsed package manifest.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct PackageManifest {
     package: PackageInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool: Option<toml::Table>,
 }
 
 /// The `package` key in the manifest.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct PackageInfo {
     name: String,
     version: Version,


### PR DESCRIPTION
This PR denies unknown fields in both the package manifest and package section of the manifest, ensuring typos are caught by CI. To still allow external configuration, 3rd-party tools can use an entry in the `[tool]` section of the document.

This change is backwards compatible with all existing packages, one notable packages came up during testing, `drafting:0.1.2`, which already used `[tool]` without my prior knowledge.