### PR TITLE
syntree:0.2.0

### DIFF
--- a/packages/preview/syntree/0.2.0/LICENSE
+++ b/packages/preview/syntree/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Lynn <https://github.com/lynn>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/syntree/0.2.0/README.md
+++ b/packages/preview/syntree/0.2.0/README.md
@@ -1,0 +1,57 @@
+# typst-syntree
+
+**syntree** is a typst package for rendering syntax trees / parse trees (the kind linguists use).
+
+The name and syntax are inspired by Miles Shang's [syntree](https://github.com/mshang/syntree). Here's an example to get started:
+
+<table>
+<tr>
+<td>
+
+```typ
+#import "@preview/syntree:0.2.0": syntree
+
+#syntree(
+  nonterminal: (font: "Linux Biolinum"),
+  terminal: (fill: blue),
+  child-spacing: 3em, // default 1em
+  layer-spacing: 2em, // default 2.3em
+  "[S [NP This] [VP [V is] [^NP a wug]]]"
+)
+```
+
+</td>
+<td>
+
+![Output tree for "This is a wug"](https://github.com/lynn/typst-syntree/assets/16232127/d0c680b2-4fd0-420f-b350-9e9c96ac37f3)
+
+</td>
+</tr>
+</table>
+
+
+There's limited support for formulas inside nodes; try `#syntree("[DP$zws_i$ this]")` or `#syntree("[C $diameter$]")`.
+
+For more flexible tree-drawing, use `tree`:
+
+<table>
+<tr>
+<td>
+
+```typ
+#import "@preview/syntree:0.2.0": tree
+
+#let bx(col) = box(fill: col, width: 1em, height: 1em)
+#tree("colors",
+  tree("warm", bx(red), bx(orange)),
+  tree("cool", bx(blue), bx(teal)))
+```
+
+</td>
+<td>
+
+![Output tree of colors](https://github.com/lynn/typst-syntree/assets/16232127/bc979614-e2ce-4616-97d1-1584788fc71f)
+
+</td>
+</tr>
+</table>

--- a/packages/preview/syntree/0.2.0/example.typ
+++ b/packages/preview/syntree/0.2.0/example.typ
@@ -1,0 +1,11 @@
+#import "@local/syntree:0.2.0": syntree
+
+#figure(
+  caption: "Example of a syntax tree.",
+  gap: 2em,
+  syntree(
+    nonterminal: (fill: blue),
+    terminal: (style: "italic"),
+    "[S [NP [Det the] [Nom [Adj little] [N bear]]] [VP [VP [V saw] [NP [Det the] [Nom [Adj fine] [Adj fat] [N trout]]]] [PP [P in] [^NP the brook]]]]"
+  )
+)

--- a/packages/preview/syntree/0.2.0/lib.typ
+++ b/packages/preview/syntree/0.2.0/lib.typ
@@ -1,0 +1,59 @@
+#let tree(tag, ..children, child-spacing: 1em, layer-spacing: 2.3em, roof: false, stroke: 0.75pt) = {
+  let tag_text = text(tag)
+  style(sty => {
+    let child_widths = children.pos().map(c => measure(c, sty).width)
+    let child_xs = ()
+    let acc = 0pt
+    for width in child_widths {
+      child_xs.push(acc)
+      acc += width + child-spacing
+    }
+
+    let children_width = acc - child-spacing
+
+    let child_nodes = children.pos().enumerate().map(t => {
+      let (i, child) = t
+      let child_width = measure(child, sty).width
+      let x0 = child_xs.at(i) + child_width / 2
+      let hi = -layer-spacing + 0.3em
+      let lo = -0.3em
+      if roof {
+        place(polygon(stroke: stroke, (0pt + child_width/2, hi), (children_width - x0 + child_width/2, lo), (-x0+ child_width/2, lo)))
+      } else {
+        place(line(stroke: stroke, start: (0pt+ child_width/2, lo), end: (children_width / 2 - x0+ child_width/2, hi)))
+      }
+      child
+    })
+
+    let child_stack = stack(dir: ltr, spacing: child-spacing, ..child_nodes)
+    let layer_stack = stack(dir: ttb, spacing: layer-spacing, tag_text, child_stack)
+    block(align(center, layer_stack))
+  })
+}
+
+#let syntree(code, terminal: (:), nonterminal: (:), child-spacing: 1em, layer-spacing: 2.3em) = {
+  let stack = ((),)
+  let roof_stack = (false,)
+  for token in code.matches(regex(`(\\\[|\\\]|[^\[\]\s])+|\[|\]`.text)) {
+    if token.text == "[" {
+      stack.push(())
+      roof_stack.push(false)
+    } else if token.text == "]" {
+      let (tag, ..children) = stack.pop()
+      let roof = roof_stack.pop()
+      if roof {
+        children = (text(..terminal, children.join([ ])),)
+      }
+      stack.last().push(tree(tag, ..children, child-spacing: child-spacing, layer-spacing: layer-spacing, roof: roof))
+    } else {
+      let sty = if stack.last().len() == 0 { nonterminal } else { terminal }
+      let t = token.text
+      if t.starts-with("^") {
+        t = t.slice(1)
+        roof_stack.last() = true
+      }
+      stack.last().push(text(..sty, eval("[" + t + "]")))
+    }
+  }
+  stack.last().last()
+}

--- a/packages/preview/syntree/0.2.0/typst.toml
+++ b/packages/preview/syntree/0.2.0/typst.toml
@@ -1,0 +1,9 @@
+[package]
+name = "syntree"
+version = "0.2.0"
+repository = "https://github.com/lynn/typst-syntree"
+entrypoint = "lib.typ"
+authors = ["Lynn <https://github.com/lynn>"]
+license = "MIT"
+description = "Linguistics syntax/parse tree rendering"
+


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Description: **syntree** is a typst package for rendering syntax trees / parse trees (the kind linguists use). Version 0.2.0 fixes the rendering to work with Typst 0.7.0+.

(Thank you to @crd2333 and @jocap for writing and applying a fix! https://github.com/lynn/typst-syntree/pull/3)