### PR TITLE
Add a second, extended index file

### DIFF
--- a/bundler/Cargo.lock
+++ b/bundler/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "anyhow",
  "flate2",
  "ignore",
+ "rayon",
  "semver",
  "serde",
  "serde_json",
@@ -78,6 +79,37 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "equivalent"
@@ -220,6 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -8,9 +8,10 @@ publish = false
 anyhow = "1"
 flate2 = "1"
 ignore = "0.4"
+rayon = "1.0"
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-semver = { version = "1", features = ["serde"] }
 spdx = "0.10"
 tar = "0.4"
 toml = { version = "0.7.3", default-features = false, features = ["parse"] }

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -108,13 +108,6 @@ fn parse_manifest(path: &Path) -> anyhow::Result<PackageManifest> {
         bail!("package entry point is missing");
     }
 
-    if manifest.package.category.len() > 3 {
-        bail!(
-            "expected up to three categories, got {}",
-            manifest.package.category.len()
-        );
-    }
-
     Ok(manifest)
 }
 
@@ -284,56 +277,6 @@ struct PackageInfo {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     exclude: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    category: Vec<PackageCategory>,
-}
-
-/// Which kind of package is this?
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum PackageCategory {
-    /// Draw charts, plots, and figures.
-    DrawingPlots,
-    /// Icon packs.
-    Icons,
-    /// Utility functions for code.
-    Utility,
-    /// Frameworks and helpers for handling external data and user input and
-    /// templates that allow representing a lot of data.
-    Data,
-    /// Tools to handle multilingual documents.
-    Localization,
-    /// Layout building blocks and helpers.
-    Layout,
-    /// Packages and templates that help the user structure their document in a
-    /// logical manner.
-    Organization,
-    /// Presentation builders and templates.
-    Presentation,
-    /// Tools for processing and styling string and text-heavy content.
-    Text,
-    /// Packages that improve typesetting formulas and equations.
-    Mathematics,
-    /// Packages that help to build a comprehensive bibliography.
-    Bibliography,
-    /// Templates and packages to write scientific papers.
-    Paper,
-    /// Domain-specific tools for scientific disciplines.
-    Science,
-    /// Templates and primitives for Curricula Vitae.
-    #[serde(rename = "cv")]
-    CV,
-    /// University-specific templates.
-    University,
-    /// Templates for calendars and time management.
-    Calendar,
-    /// Templates and packages to create letters.
-    Letter,
-    /// Templates and packages to create reports.
-    Report,
-    /// Templates for grant and research proposals.
-    Proposal,
 }
 
 /// The `tool` key in the manifest.

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -324,6 +324,7 @@ enum PackageCategory {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ExtendedPackageInfo {
     /// The information from the package manifest.
     #[serde(flatten)]


### PR DESCRIPTION
The new index file contains the README, last and first update timestamps using Git and the archive size for the new package storefront.