### PR TITLE
Support packaging other namespaces

### DIFF
--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -220,7 +220,7 @@ fn determine_timestamps(
     index: &mut [ExtendedPackageInfo],
 ) -> anyhow::Result<()> {
     // Check if git is installed on the system.
-    let has_git = Command::new("git").arg("--version").status().is_ok();
+    let has_git = Command::new("git").arg("--version").output().is_ok();
 
     // Determine timestamp via Git. Do this in parallel because it is pretty
     // slow.

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -1,4 +1,3 @@
-use core::time;
 use std::collections::HashMap;
 use std::env::args;
 use std::fs;


### PR DESCRIPTION
Change the bundler to package every subdirectory of `packages` instead of only preview. Multiple indices are generated.