### PR TITLE
chordx:0.3.0

### DIFF
--- a/packages/preview/chordx/0.3.0/CHANGELOG.md
+++ b/packages/preview/chordx/0.3.0/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [v0.3.0](https://github.com/ljgago/typst-chords/compare/v0.2.0...v0.3.0) - 2024-03-01
+
+### Changed
+
+- Renamed `frets` parameter by `frets-amount`.
+- Renamed `fret-number` parameter by `fret`.
+- Renamed `color` parameter by `fill`.
+- Replaced `scale` parameter by `size`. You can use the same functionality using `em` units.
+- Replaced new types released in Typst v0.8.0.
+
+## [v0.2.0](https://github.com/ljgago/typst-chords/compare/v0.1.0...v0.2.0) - 2023-08-25
+
+### Added
+
+- New file structure.
+- New piano chords.
+- Options to scale the graphs.
+- New round style.
+
+### Changed
+
+- Renamed new-graph-chords to new-chart-chords.
+- Replaced array inputs by string inputs (thanks to `conchord` for the ideas).
+
+### Removed
+
+- Removed dependency of CeTZ, uses only native functions.
+
+## [v0.1.0](https://github.com/ljgago/typst-chords/compare/v0.1.0...v0.1.0) - 2023-07-16
+
+### Added
+
+- Added graph chords.
+- Added single chords.
+
+### Changed
+
+- The single chords show the chord name over a specific character or word.

--- a/packages/preview/chordx/0.3.0/LICENSE
+++ b/packages/preview/chordx/0.3.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Leonardo Javier Gago
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/chordx/0.3.0/README.md
+++ b/packages/preview/chordx/0.3.0/README.md
@@ -1,0 +1,141 @@
+# chordx
+
+A package to write song lyrics with chord diagrams in Typst.
+
+**Table of Contents**
+
+- [Introduction](#introduction)
+- [Usage](#usage)
+  - [Typst Packages](#typst-packages)
+  - [Local Packages](#local-packages)
+- [Documentation](#documentation)
+- [Examples](#examples)
+  - [Chart Chords](#chart-chords)
+  - [Piano Chords](#piano-chords)
+  - [Single Chords](#single-chords)
+- [Changelog](#changelog)
+- [License](#license)
+
+## Introduction
+
+With `chordx` you can easily generate song lyrics with chords for writing songbooks.
+
+`chordx` generates chord charts for stringed instruments (e.g. guitar, ukulele, etc.), piano chords (with diferent piano layouts) and single chords that are chords without charts used to write the chords over a word to write songbooks.
+
+## Usage
+
+`chordx` exports 3 functions that return others with default settings:
+
+- `new-chart-chords`: used to generate chart chords for stringed instruments.
+- `new-piano-chords`: used to generate piano chords.
+- `new-single-chords`: used to show the chord name over a word.
+
+### Typst Packages
+
+Typst added an experimental package repository and you can import `chordx` as follows:
+
+```typ
+#import "@preview/chordx:0.3.0": *
+```
+
+### Local Packages
+
+If the package hasn't been released yet, or if you just want to use it from this repository, you can use _*local-packages*_.
+
+You can read the documentation about typst [local-packages](https://github.com/typst/packages#local-packages) and learn about the path folders used in differents operating systems (Linux / MacOS / Windows).
+
+In Linux you can do:
+
+```sh
+git clone https://github.com/ljgago/typst-chords ~/.local/share/typst/packages/local/chordx/0.3.0
+```
+
+And import the package in your file:
+
+```typ
+#import "@local/chordx:0.3.0": *
+```
+
+## Documentation
+
+Here [chordx-docs](https://github.com/ljgago/typst-chords/blob/v0.3.0/docs/chordx-docs.pdf) you have the reference documentation that describes the functions and parameters used in this package. (_Generated with [tidy](https://github.com/Mc-Zen/tidy)_)
+
+## Examples:
+
+### Chart Chords
+
+```typ
+#import "@preview/chordx:0.3.0": *
+
+#let chart-chord = new-chart-chords(size: 18pt)
+#let chart-chord-round = new-chart-chords(style: "round", size: 1.5em)
+
+// Style "normal"
+#chart-chord(tabs: "x32o1o", fingers: "n32n1n")[C]
+#chart-chord(tabs: "ooo3", fingers: "ooo3")[C]
+
+// Style "round"
+#chart-chord-round(tabs: "xn332n", fingers: "o13421", fret: 3, capos: "115")[Cm]
+#chart-chord-round(tabs: "onnn", fingers: "n111", capos: "313")[Cm]
+```
+
+<h3 align="center">
+  <a href="https://github.com/ljgago/typst-chords/blob/v0.3.0/examples/chart-chords.typ">
+    <img
+      alt="Chart Chord"
+      src="https://github.com/ljgago/typst-chords/blob/v0.3.0/examples/chart-chords.svg"
+      style="max-width: 100%; width: 450pt;"
+    >
+  </a>
+</h3>
+
+### Piano Chords
+
+```typ
+#import "@preview/chordx:0.3.0": *
+
+#let piano-chord = new-piano-chords(layout: "F", size: 18pt)
+#let piano-chord-round = new-piano-chords(layout: "F", size: 1.5em, style: "round")
+
+#piano-chord(keys: "B1, D2#, F2#", fill: blue)[B]
+#piano-chord-round(keys: "B1, D2#, F2#", fill: red)[B]
+```
+
+<h3 align="center">
+  <a href="https://github.com/ljgago/typst-chords/blob/v0.3.0/examples/piano-chords.typ">
+    <img
+      alt="Piano Chord"
+      src="https://github.com/ljgago/typst-chords/blob/v0.3.0/examples/piano-chords.svg"
+      style="max-width: 100%; width: 450pt;"
+    >
+  </a>
+</h3>
+
+### Single Chords
+
+```typ
+#import "@preview/chordx:0.3.0": *
+
+#let chord = new-single-chords(style: "italic", weight: "semibold")
+
+#chord[Jingle][G][2] bells, jingle bells, jingle #chord[all][C][2] the #chord[way!][G][2] \
+#chord[Oh][C][] what fun it #chord[is][G][] to ride \
+In a #chord[one-horse][A7][2] open #chord[sleigh,][D7][3] hey!
+```
+
+<h2 align="center">
+  <a href="https://github.com/ljgago/typst-chords/blob/v0.3.0/examples/single-chords.typ">
+    <img
+      alt="Single Chord"
+      src="https://github.com/ljgago/typst-chords/blob/v0.3.0/examples/single-chords.svg"
+      style="max-width: 100%; width: 450pt;"
+    >
+  </a>
+</h2>
+
+## Changelog
+
+You can read the latest changes in [CHANGELOG.md](./CHANGELOG.md)
+
+## License
+[MIT License](./LICENSE)

--- a/packages/preview/chordx/0.3.0/lib.typ
+++ b/packages/preview/chordx/0.3.0/lib.typ
@@ -1,0 +1,3 @@
+#import "./src/chart.typ": new-chart-chords
+#import "./src/piano.typ": new-piano-chords
+#import "./src/single.typ": new-single-chords

--- a/packages/preview/chordx/0.3.0/src/chart.typ
+++ b/packages/preview/chordx/0.3.0/src/chart.typ
@@ -1,0 +1,310 @@
+#import "./utils.typ": size-to-scale, parse-input-string, top-border-normal, top-border-round
+
+// Draws a horizontal border that indicates the starting of the fretboard
+#let draw-nut(self) = {
+  let size = (
+    width: self.grid.width,
+    height: 1.2pt * self.scale
+  )
+
+  if self.fret in (none, 1) {
+    if self.style == "normal" {
+      top-border-normal(size, self.stroke, self.scale)
+    } else {
+      top-border-round(size, self.stroke, self.scale)
+    }
+  }
+}
+
+// Draws a grid with a width = (length of tabs) and height = (number of frets)
+#let draw-grid(self) = {
+  let radius = (bottom: 1pt * self.scale, top: 1pt * self.scale)
+  place(
+    rect(
+      width: self.grid.width,
+      height: self.grid.height,
+      radius: if self.style == "normal" {0pt} else {radius},
+      stroke: self.stroke
+    )
+  )
+
+  // draws the vertical lines
+  for i in range(self.grid.cols - 1) {
+    let x = (i + 1) * self.step
+    place(
+      line(
+        start: (x, 0pt),
+        end: (x, self.grid.height),
+        stroke: self.stroke
+      )
+    )
+  }
+
+  // draws the horizontal lines
+  for i in range(self.grid.rows - 1) {
+    let y = (i + 1) * self.step
+    place(
+      line(
+        start: (0pt, y),
+        end: (self.grid.width, y),
+        stroke: self.stroke
+      )
+    )
+  }
+}
+
+// Draws the tabs over the grid
+#let draw-tabs(self) = {
+  for (tab, col) in self.tabs.zip(range(self.tabs.len())) {
+    if type(tab) == "string" and lower(tab) == "x" {
+      let offset = col * self.step
+      place(
+        line(
+          start: (offset - 1.5pt * self.scale, -2.5pt * self.scale),
+          end: (offset + 1.5pt * self.scale, -5.5pt * self.scale),
+          stroke: self.stroke
+        )
+      )
+      place(
+        line(
+          start: (offset - 1.5pt * self.scale, -5.5pt * self.scale),
+          end: (offset + 1.5pt * self.scale, -2.5pt * self.scale),
+          stroke: self.stroke
+        )
+      )
+      continue
+    }
+    if (type(tab) == str and lower(tab) == "o") {
+      let radius = 1.7pt * self.scale
+      place(
+        dx: self.step * col - radius,
+        dy: -4pt * self.scale - radius,
+        circle(radius: radius, stroke: self.stroke)
+      )
+      continue
+    }
+    if type(tab) == int and tab > 0 and tab <= self.frets-amount {
+      let radius = 1.7pt * self.scale
+      place(
+        dx: self.step * col - radius,
+        dy: self.step * tab - radius - 2.5pt * self.scale,
+        circle(radius: radius, stroke: none, fill: black)
+      )
+      continue
+    }
+  }
+}
+
+// Draws a capo list
+//
+// capo = (fret, start, end)
+// fret: fret position
+// start: lowest starting string
+// end: highest ending string
+#let draw-capos(self) = {
+  let size = self.tabs.len()
+  for (fret, start, end, ..) in self.capos {
+    if start > size {
+      start = size
+    }
+    if end > size {
+      end = size
+    }
+    place(
+      dy: fret * self.step - 2.5pt * self.scale,
+      line(
+        start: ((size - start) * self.step, 0pt),
+        end: ((size - end) * self.step, 0pt),
+        stroke: (paint: black, thickness: 3.4pt * self.scale, cap: "round")
+      )
+    )
+  }
+}
+
+// Draws the finger numbers below the grid
+#let draw-fingers(self) = {
+  let size = self.tabs.len()
+  for (finger, col) in self.fingers.zip(range(size)) {
+    if type(finger) == int and finger > 0 and finger < 6 {
+      place(
+        left + top,
+        dx: col * self.step - 1.3pt * self.scale,
+        dy: self.grid.height + 1.5pt * self.scale,
+        text(6pt * self.scale)[#finger])
+    }
+  }
+}
+
+// Draws the fret start number that indicates the starting position of the fretboard
+#let draw-fret(self) = {
+  place(left + top,
+    dx: -3pt * self.scale,
+    dy: self.step / 2 - 0.2pt * self.scale,
+    place(right + horizon, text(8pt * self.scale)[#self.fret])
+  )
+}
+
+// Draws the chord name below the grid and finger numbers
+#let draw-name(self) = {
+  place(
+    dx: self.grid.width / 2,
+    dy: self.grid.height + self.vertical-gap-name,
+    place(center + horizon, text(12pt * self.scale)[#self.name])
+  )
+}
+
+// Render the chart
+#let render(self) = {
+  style(styles => {
+    let fret-number-size = measure(text(8pt * self.scale)[#self.fret], styles)
+    let chord-name-size = measure(text(12pt * self.scale)[#self.name], styles)
+
+    let tabs-height = if "o" in self.tabs or "x" in self.tabs {
+      -(4pt + 1.7pt) * self.scale
+    } else {
+      0pt
+    }
+
+    let graph = (
+      width: self.tabs.len() * self.step,
+      height: self.frets-amount * self.step
+    )
+
+    let chart = (
+      width: graph.width + fret-number-size.width + self.step / 2,
+      height: graph.height + chord-name-size.height / 2 + self.vertical-gap-name - tabs-height
+    )
+
+    let canvas = (
+      width: calc.max(graph.width / 2, chord-name-size.width / 2) + calc.max(chart.width / 2 + fret-number-size.width, chord-name-size.width / 2),
+      height: chart.height,
+      dx: calc.max((chord-name-size.width - graph.width) / 2 + self.step / 2, fret-number-size.width + self.step / 2),
+      dy: -(graph.height + chord-name-size.height / 2 + self.vertical-gap-name),
+    )
+
+    box(
+      width: canvas.width,
+      height: canvas.height,
+      place(
+        left + bottom,
+        dx: canvas.dx,
+        dy: canvas.dy, {
+          draw-nut(self)
+          draw-grid(self)
+          draw-tabs(self)
+          draw-capos(self)
+          draw-fingers(self)
+          draw-fret(self)
+          draw-name(self)
+        }
+      )
+    )
+  })
+}
+
+/// Return a new function with default parameters to generate chart chords for stringed instruments.
+///
+/// - frets-amount (integer): Presets the frets amount (the grid rows). *Optional*.
+/// - size (length): Presets the chart size. The default value is set to the chord name's font size. *Optional*.
+/// - style (string): Sets the chart style. *Optional*.
+///  - ```js "normal```: chart with right angles.
+///  - ```js "round```: chart with round angles.
+/// - font (string): Sets the name of the text font. *Optional*.
+/// -> function
+#let new-chart-chords(
+  frets-amount: 5,
+  size: 12pt,
+  style: "normal",
+  font: "Linux Libertine"
+) = {
+  /// Is the returned function by *new-chart-chords*.
+  ///
+  /// - tabs (string): Shows the tabs on the chart. *Optional*.
+  ///  - *x*: mute note.
+  ///  - *o*: air note.
+  ///  - *n*: without note.
+  ///  - *number*: note position on the fret.
+  ///
+  /// The string length of tabs defines the number of strings on the instrument.
+  ///  #parbreak() Example:
+  ///  - ```js "x32o1o"``` - (6 strings - C Guitar chord).
+  ///  - ```js "ooo3"``` - (4 strings - C Ukulele chord).
+  ///
+  /// - fingers (string): Shows the finger numbers. *Optional*.
+  ///  - *n*, *x*, *o*: without finger,
+  ///  - *number*: one finger
+  ///  #parbreak() Example: ```js "n32n1n"``` - (Fingers for guitar chord: C)
+  ///
+  /// - capos (string): Adds one or many capos on the chart. *Optional*.
+  ///  - 1#super[st] digit -- *fret*: fret position.
+  ///  - 2#super[nd] digit -- *start*: lowest starting string.
+  ///  - 3#super[rd] digit -- *end*: highest ending string.
+  ///  #parbreak() Example: ```js "115"``` $\u{2261}$ ```js "1,1,5"``` $=>$ ```js "fret,start,end"```
+  ///  #parbreak() With ```js "|"``` you can add capos:
+  ///  #parbreak() Example: ```js "115|312"``` $\u{2261}$ ```js "1,1,5|3,1,2"``` $=>$ ```js "fret,start,end|fret,start,end"```
+  ///
+  /// - fret (integer): Shows the fret number that indicates the starting position of the fretboard. *Optional*.
+  /// - frets-amount (integer): Sets the frets amount (the grid rows). *Optional*.
+  /// - size (length): Sets the chart size. The default value is set to the chord name's font size. *Optional*.
+  /// - name (string, content): Shows the chord name. *Required*.
+  /// -> content
+  let chart-chord(
+    tabs: "",
+    fingers: "",
+    capos: "",
+    fret: none,
+    frets-amount: frets-amount,
+    size: size,
+    name
+  ) = {
+    assert.eq(type(tabs), str)
+    assert.eq(type(fingers), str)
+    assert.eq(type(capos), str)
+    assert.eq(type(frets-amount), int)
+    assert.eq(type(size), length)
+    assert(type(fret) == int or fret == none, message: "type of 'fret' must to be 'int' or 'none'")
+    assert(type(name) in (str, content), message: "type of 'name' must to be 'str' or 'content'")
+    assert(style in ("normal", "round"), message: "'style' must to be '\"normal\"' or '\"round\"'")
+
+    let tabs = parse-input-string(tabs)
+    let fingers = parse-input-string(fingers)
+    let capos = parse-input-string(capos)
+    if capos.len() != 0 and type(capos.first()) != "array" {
+      capos = (capos,)
+    }
+
+    let scale = size-to-scale(size, 12pt)
+    let step = 5pt * scale
+    let stroke = black + 0.5pt * scale
+
+    let vertical-gap-name = 14pt * scale
+    if fingers.len() == 0 {
+      vertical-gap-name = 9pt * scale
+    }
+
+    set text(font: font)
+
+    let self = (
+      scale: scale,
+      step: step,
+      stroke: black + 0.5pt * scale,
+      vertical-gap-name: vertical-gap-name,
+      grid: (
+        width: (tabs.len() - 1) * step,
+        height: frets-amount * step,
+        rows: frets-amount,
+        cols: tabs.len() - 1,
+      ),
+      tabs: tabs,
+      fingers: fingers,
+      capos: capos,
+      frets-amount: frets-amount,
+      fret: fret,
+      style: style,
+      name: name,
+    )
+
+    render(self)
+  }
+  return chart-chord
+}

--- a/packages/preview/chordx/0.3.0/src/piano.typ
+++ b/packages/preview/chordx/0.3.0/src/piano.typ
@@ -1,0 +1,383 @@
+#import "./utils.typ": size-to-scale, parse-input-string, top-border-normal, top-border-round
+
+// A dictionary with the key names for the white-keys and their indices
+#let white-keys-dict = (
+  "C1": 0,
+  "D1": 1,
+  "E1": 2,
+  "F1": 3,
+  "G1": 4,
+  "A1": 5,
+  "B1": 6,  "C2b": 6,
+  "C2": 7,  "B1#": 7,
+  "D2": 8,
+  "E2": 9,  "F2b": 9,
+  "F2": 10, "E2#": 10,
+  "G2": 11,
+  "A2": 12,
+  "B2": 13, "C3b": 13,
+  "C3": 14, "B2#": 14,
+  "D3": 15,
+  "E3": 16, "F3b": 16,
+)
+
+// A dictionary with the key names for the black-keys and their indices
+#let black-keys-dict = (
+  "C1#": 1,  "D1b": 1,
+  "D1#": 2,  "E1b": 2,
+  "F1#": 4,  "G1b": 4,
+  "G1#": 5,  "A1b": 5,
+  "A1#": 6,  "B1b": 6,
+  "C2#": 8,  "D2b": 8,
+  "D2#": 9,  "E2b": 9,
+  "F2#": 11, "G2b": 11,
+  "G2#": 12, "A2b": 12,
+  "A2#": 13, "B2b": 13,
+  "C3#": 15, "D3b": 15,
+  "D3#": 16, "E3b": 16,
+)
+
+// Returns the indices of a key array of white-keys-dict or black-keys-dict
+#let keys-to-array-index(dict, key-array) = {
+  key-array
+    .map(k => dict.at(k, default: none))
+    .filter(k => k != none)
+}
+
+// Remove the number of the key name (C1# -> C#)
+#let normalize-key-name(key) = {
+  return key.replace(regex("\d+"), "").replace(regex("b$"), "\u{266D}")
+}
+
+// Gets the indices min and max of the layout
+#let piano-limits-from-layout(layout) = {
+  return if layout == "C" {
+    (min: 0, max: 9)
+  } else if (layout == "2C") {
+    (min: 0, max: 13)
+  } else if layout == "F" {
+    (min: 3, max: 13)
+  } else { // "2F"
+    (min: 3, max: 16)
+  }
+}
+
+// Returns the white-keys amount in the layout
+#let white-keys-amount-from-layout(layout) = {
+  return if layout == "C" {
+    10
+  } else if layout == "F" {
+    11
+  } else {
+    14
+  }
+}
+
+// Returns the black-keys amount in the layout
+#let black-keys-index-from-layout(layout) = {
+  return if layout in ("C", "2C") {
+    ( left: (1, 4, 8, 11), mid: (5, 12), right: (2, 6, 9, 13) )
+  } else {
+    ( left: (4, 8, 11, 15), mid: (5, 12), right: (6, 9, 13, 16) )
+  }
+}
+
+// Draws the piano
+#let draw-piano(self) = {
+  // draws the white-keys
+  for i in range(self.white-keys.amount) {
+    let key-pressed = i + self.limit.min
+    let fill-color = if key-pressed in self.tabs.white-keys-index {self.fill} else {white}
+    let x = i * self.white-keys.width
+
+    let radius-style = if self.style == "normal" {
+      0pt
+    } else {
+      if i == 0 {
+        (bottom: self.round, top-left: self.round)
+      } else if i == self.white-keys.amount - 1 {
+        (bottom: self.round, top-right: self.round)
+      } else {
+        (bottom: self.round)
+      }
+    }
+
+    place(
+      dx: x,
+      rect(
+        width: self.white-keys.width,
+        height: self.white-keys.height,
+        radius: radius-style,
+        stroke: self.stroke,
+        fill: fill-color
+      )
+    )
+  }
+
+  // draw the black-keys
+  for i in range(self.white-keys.amount) {
+    let key-pressed = i + self.limit.min
+    let fill-color = if key-pressed in self.tabs.black-keys-index {self.fill} else {black}
+    let base = i * self.white-keys.width - self.black-keys.width / 2
+    let x = 0pt
+
+    if key-pressed in self.black-keys.left {
+      x = base - self.black-keys.shift
+    } else if key-pressed in self.black-keys.mid {
+      x = base
+    } else if key-pressed in self.black-keys.right {
+      x = base + self.black-keys.shift
+    } else {
+      continue
+    }
+
+    place(
+      dx: x,
+      rect(
+        width: self.black-keys.width,
+        height: self.black-keys.height,
+        radius: if self.style == "normal" {0pt} else {(bottom: self.round)},
+        stroke: self.stroke,
+        fill: fill-color
+      )
+    )
+  }
+}
+
+// Draws border top
+#let draw-top-border(self) = {
+  let size = (
+    width: self.piano.width,
+    height: 1.2pt * self.scale
+  )
+
+  if self.style == "normal" {
+    top-border-normal(size, self.stroke, self.scale)
+  } else {
+    top-border-round(size, self.stroke, self.scale)
+  }
+}
+
+// Draws tabs or dots over the piano
+#let draw-tabs(self) = {
+  // draws tabs on white-keys chord
+  for i in self.tabs.white-keys-index {
+    if i < self.limit.min or i > self.limit.max {
+      continue
+    }
+
+    let radius = 1.7pt * self.scale
+    let x = (i - self.limit.min + 0.5) * self.white-keys.width - radius
+    let y = self.piano.height - 4pt * self.scale - radius
+
+    place(dx: x, dy: y, circle(radius: radius, stroke: none, fill: black))
+  }
+
+  // draws tabs on black-keys chord
+  for i in self.tabs.black-keys-index {
+    if i < self.limit.min or i > self.limit.max {
+      continue
+    }
+
+    let radius = 1.7pt * self.scale
+    let x = 0pt
+    let y = self.black-keys.height - 3.5pt * self.scale - radius
+    let base = (i - self.limit.min) * self.white-keys.width - radius
+
+    if i in self.black-keys.left {
+      x = base - self.black-keys.shift
+    } else if i in self.black-keys.mid {
+      x = base
+    } else if i in self.black-keys.right {
+      x = base + self.black-keys.shift
+    } else {
+      continue
+    }
+
+    place(dx: x, dy: y, circle(radius: radius, stroke: none, fill: black))
+  }
+}
+
+// Draws pressed note names
+#let draw-key-notes(self) = {
+  let gap-note = 1.8pt * self.scale
+
+  // white-keys
+  let white-keys = self.keys
+    .map(key => (white-keys-dict.at(key, default: none), normalize-key-name(key)) )
+    .filter(arr => arr.at(0) != none)
+
+  for (i, key-name) in white-keys {
+    if i < self.limit.min or i > self.limit.max {
+      continue
+    }
+
+    let x = (i - self.limit.min + 0.5) * self.white-keys.width
+    let y = self.piano.height + gap-note
+
+    place(dx: x, dy: y, place(center + top, text(6pt * self.scale)[#key-name]),
+    )
+  }
+
+  // black-keys
+  let black-keys = self.keys
+    .map(key => (black-keys-dict.at(key, default: none), normalize-key-name(key)) )
+    .filter(arr => arr.at(0) != none)
+
+  for (i, key-name) in black-keys {
+    if i < self.limit.min or i > self.limit.max {
+      continue
+    }
+
+    let x = 0pt
+    let y = -(self.top-border-height + gap-note)
+    let base = (i - self.limit.min) * self.white-keys.width
+
+    if i in self.black-keys.left {
+      x = base - self.black-keys.shift
+    } else if i in self.black-keys.mid {
+      x = base
+    } else if i in self.black-keys.right {
+      x = base + self.black-keys.shift
+    } else {
+      continue
+    }
+
+    place(dx: x, dy: y, place(center + bottom, text(6pt * self.scale)[#key-name]))
+  }
+}
+
+// Draws the chord name below the piano
+#let draw-name(self) = {
+  let x = self.piano.width / 2
+  let y = self.piano.height + self.vertical-gap-name
+  place(dx: x, dy: y, place(center + horizon, text(12pt * self.scale)[#self.name]))
+}
+
+// Render the piano
+#let render(self) = {
+  style(styles => {
+    let chord-name-size = measure(text(12pt * self.scale)[#self.name], styles)
+    let note-name-size = measure(text(6pt * self.scale)[#self.keys], styles)
+
+    let canvas = (
+      width: calc.max(self.piano.width, chord-name-size.width),
+      height: self.piano.height + self.vertical-gap-name + chord-name-size.height / 2 + note-name-size.height + self.top-border-height * 2,
+      dx: calc.max((chord-name-size.width - self.piano.width) / 2, 0pt),
+      dy: -(self.piano.height + self.vertical-gap-name + chord-name-size.height / 2)
+    )
+
+    box(
+      width: canvas.width,
+      height: canvas.height,
+      place(
+        left + bottom,
+        dx: canvas.dx,
+        dy: canvas.dy, {
+          draw-piano(self)
+          draw-top-border(self)
+          draw-tabs(self)
+          draw-key-notes(self)
+          draw-name(self)
+        }
+      )
+    )
+  })
+}
+
+/// Return a new function with default parameters to generate piano chords.
+///
+/// - layout (string): Presets the layout and size of the piano, ```js "C"```, ```js "2C"```, ```js "F"```, ```js "2F"```. *Optional*.
+///  - ```js "C"```: the piano layout starts from key *C1* to *E2* (17 keys).
+///  - ```js "2C"```: the piano layout starts from key *C1* to *B2* (24 keys, two octaves).
+///  - ```js "F"```: the piano layout starts from key *F1* to *B2* (19 keys).
+///  - ```js "2F"```: the piano layout stars from key *F1* to *E3* (24 keys, two octaves).
+/// - fill (color): Presets the fill color of the pressed key. *Optional*.
+/// - style (string): Sets the piano style. *Optional*.
+///  - ```js "normal```: piano with right angles.
+///  - ```js "round```: piano with round angles.
+/// - size (length): Presets the size. The default value is set to the chord name's font size. *Optional*.
+/// - font (string): Sets the name of the text font. *Optional*.
+/// -> function
+#let new-piano-chords(
+  layout: "C",
+  fill: gray,
+  style: "normal",
+  size: 12pt,
+  font: "Linux Libertine"
+) = {
+  /// Is the returned function by *new-piano-chords*.
+  ///
+  /// - keys (string): Keys chord notes from *C1* to *E3* (Depends on your layout). *Optional*.
+  /// #parbreak() Example: ```js "C1, E1b, G1"``` (Cm chord)
+  /// - fill (color): Sets the fill color of the pressed key. *Optional*.
+  /// - layout (string): Sets the layout and size of the piano, ```js "C"```, ```js "2C"```, ```js "F"```, ```js "2F"```. *Optional*.
+  ///  - ```js "C"```: the piano layout starts from key *C1* to *E2* (17 keys).
+  ///  - ```js "2C"```: the piano layout starts from key *C1* to *B2* (24 keys, two octaves).
+  ///  - ```js "F"```: the piano layout starts from key *F1* to *B2* (19 keys).
+  ///  - ```js "2F"```: the piano layout stars from key *F1* to *E3* (24 keys, two octaves).
+  /// - size (length): Sets the size. The default value is set to the chord name's font size. *Optional*.
+  /// - name (string, content): Shows the chord name. *Required*.
+  /// -> content
+  let piano-chord(
+    keys: "",
+    fill: fill,
+    layout: layout,
+    size: size,
+    name
+  ) = {
+    assert.eq(type(keys), str)
+    assert.eq(type(fill), color)
+    assert.eq(type(size), length)
+    assert(upper(layout) in ("C", "2C", "F", "2F"), message: "`layout` must to be \"C\", \"2C\", \"F\" or \"2F\"")
+    assert(style in ("normal", "round"), message: "`style` must to be \"normal\" or \"round\"")
+    assert(type(name) in (str, content), message: "type of `name` must to be `str` or `content`")
+
+    set text(font: font)
+
+    let scale = size-to-scale(size, 12pt)
+    let step = 7.5pt
+    let layout = upper(layout)
+    let white-keys-amount = white-keys-amount-from-layout(layout)
+    let black-keys-index = black-keys-index-from-layout(layout)
+    let piano-limits = piano-limits-from-layout(layout)
+    let keys = parse-input-string(keys)
+
+    let self = (
+      white-keys: (
+        width: step * scale,
+        height: 25pt * scale,
+        amount: white-keys-amount,
+      ),
+      black-keys: (
+        width: (step / 3) * scale * 2,
+        height: 17pt * scale,
+        shift: 1pt * scale,             // small shifting of the black-keys
+        left: black-keys-index.left,    // black-keys index with left shift
+        mid: black-keys-index.mid,      // black-keys index without shift
+        right: black-keys-index.right,  // black-keys index with right shift
+      ),
+      piano: (
+        width: white-keys-amount * step * scale,
+        height: 25pt * scale
+      ),
+      tabs: (
+        white-keys-index: keys-to-array-index(white-keys-dict, keys),
+        black-keys-index: keys-to-array-index(black-keys-dict, keys)
+      ),
+      round: 1pt * scale,
+      stroke: black + 0.5pt * scale,
+      vertical-gap-name: 14pt * scale,
+      top-border-height: 1.1pt * scale,
+      keys: keys,
+      scale: scale,
+      limit: piano-limits,
+      style: style,
+      fill: fill,
+      name: name,
+    )
+
+    render(self)
+  }
+  return piano-chord
+}

--- a/packages/preview/chordx/0.3.0/src/single.typ
+++ b/packages/preview/chordx/0.3.0/src/single.typ
@@ -1,0 +1,90 @@
+#import "./utils.typ": parse-content, has-number
+
+/// The single chords are chords without diagram used to show the chord name over a word.
+///
+/// - ..text-params (auto): Are the same parameters of *text* from the standard library of *typst*. *Required*.
+/// -> function
+#let new-single-chords(..text-params) = {
+  /// Is the returned function by *new-single-chords*.
+  ///
+  /// - body (content): Is the word or words where the chord goes. *Required*.
+  /// - name (content): Displays the chord name over the selected words in the body. *Required*.
+  /// - position (content): Positions the chord over a specific character in the body. *Required*.
+  ///  - ```typ []```: chord name centered on the body.
+  ///  - ```typ [number]```: the chord name starts over a specific body character. (First position ```js [1]```)
+  let single-chord(
+    body,
+    name,
+    position
+  ) = {
+    assert.eq(type(body), content)
+    assert.eq(type(name), content)
+    assert.eq(type(position), content)
+
+    style(styles => {
+      let horizontal-offset = 0pt
+      let vertical-offset = 1.2em
+      let anchor = center
+      let body-size = measure(body, styles)
+      let name-size = measure(text(..text-params)[#name], styles)
+      let body-array = parse-content(body)
+
+      if position.has("text") {
+        assert(has-number(position.at("text")) == true, message: "the \"position\" must to be a \"content\" with only numbers")
+
+        let body-chars-offset = 0pt
+        let pos = int(position.at("text")) - 1
+        let min-pos = 0
+        let max-pos = body-array.len() - 1
+        pos = calc.clamp(pos, min-pos, max-pos)
+
+        for i in range(pos) {
+          body-chars-offset += measure([#body-array.at(i)], styles).width
+        }
+
+        // gets the char-offset to center the first character of
+        // the chord with the selected character of the body
+        let chord-char = parse-content(name).at(0)
+        let chord-char-width = measure(text(..text-params)[#chord-char], styles).width
+        let body-char-width = measure([#body-array.at(pos)], styles).width
+        let char-offset = (chord-char-width - body-char-width) / 2
+
+        // final horizontal offset
+        horizontal-offset = body-chars-offset - char-offset
+        anchor = left
+      }
+
+      let canvas = (
+        width: 0pt,
+        height: body-size.height + name-size.height + 0.8em,
+        dx: horizontal-offset,
+        dy: -vertical-offset
+      )
+
+      if horizontal-offset > 0pt and name-size.width + horizontal-offset >= body-size.width {
+        canvas.width = name-size.width + horizontal-offset
+      } else if horizontal-offset <= 0pt and name-size.width >= body-size.width {
+        canvas.width = name-size.width
+      } else {
+        canvas.width = body-size.width
+      }
+
+      box(
+        width: canvas.width,
+        height: canvas.height, {
+          place(
+            anchor + bottom,
+            dx: canvas.dx,
+            dy: canvas.dy,
+            text(..text-params)[#name]
+          )
+          place(
+            anchor + bottom,
+            box(..body-size, body)
+          )
+        }
+      )
+    })
+  }
+  return single-chord
+}

--- a/packages/preview/chordx/0.3.0/src/utils.typ
+++ b/packages/preview/chordx/0.3.0/src/utils.typ
@@ -1,0 +1,98 @@
+// Gets the relative scale from a size of length type
+#let size-to-scale(size, default) = {
+  let length-type = repr(size).match(regex("pt|mm|cm|in|em")).text
+
+  if length-type == "em" {
+    size.em
+  } else {
+    size / default
+  }
+}
+
+// Gets the string from a content data
+#let parse-content(content-data) = {
+  if content-data.has("text") {
+    return content-data.at("text").codepoints()
+  }
+  if content-data.has("double") {
+    return (content-data,)
+  }
+  if content-data.has("children") {
+    for item in content-data.at("children") {
+      parse-content(item)
+    }
+  }
+  if content-data.has("body") {
+    parse-content(content-data.at("body"))
+  }
+  if content-data.has("base") {
+    parse-content(content-data.at("base"))
+  }
+  if content-data.has("equation") {
+    parse-content(content-data.at("equation"))
+  }
+}
+
+// Checks if the string contains only numbers
+#let has-number(string) = {
+  if string.trim().matches(regex("^\d+$")).len() != 0 {
+    true
+  } else {
+    false
+  }
+}
+
+// Parses different string inputs to array
+//
+// 123|234 == 1,2,3 | 2,3,4 => ((1,2,3), (2,3,4))
+// "x32o1o" == x,3,2,o,1,o => ("x",3,2,"o",1,"o")
+#let parse-input-string(string) = {
+  let to-int-or-ignore(s) = {
+    if s.matches(regex("^\d+$")).len() != 0 {int(s)} else {s}
+  }
+
+  string = string.trim().replace(regex("\s"), "")
+
+  if string.contains("|") {
+      string.split("|").map(parse-input-string)
+  } else if string.contains(",") {
+      string.split(",").map(to-int-or-ignore)
+  } else {
+      string.codepoints().map(to-int-or-ignore)
+  }
+}
+
+// Draws a border with right angles
+#let top-border-normal(size, stroke, scale) = {
+  place(
+    dy: -size.height,
+    rect(
+      width: size.width,
+      height: size.height,
+      stroke: stroke,
+      fill: black
+    )
+  )
+}
+
+// Draws a border with round angles
+#let top-border-round(size, stroke, scale) = {
+  let bezier-radius = 0.5519150244935105707435627pt * scale
+  let radius = 1pt * scale
+
+  place(
+    path(
+      fill: black,
+      stroke: stroke,
+      closed: true,
+      ((0pt, -0.2pt * scale), (0pt, bezier-radius)),
+      ((radius, -size.height), (-bezier-radius, 0pt)),
+      ((size.width - radius, -size.height), (-bezier-radius, 0pt)),
+      ((size.width, -0.2pt * scale), (0pt, -bezier-radius)),
+      ((size.width, radius), (0pt, bezier-radius)),
+      ((size.width - radius, 0pt), (bezier-radius, 0pt)),
+      ((radius, 0pt), (bezier-radius, 0pt)),
+      ((0pt, radius), (0pt, -bezier-radius)),
+    )
+  )
+}

--- a/packages/preview/chordx/0.3.0/typst.toml
+++ b/packages/preview/chordx/0.3.0/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "chordx"
+version = "0.3.0"
+entrypoint = "lib.typ"
+authors = ["Leonardo Gago <https://github.com/ljgago>"]
+license = "MIT"
+description = "A package to write song lyrics with chord diagrams in Typst."
+repository = "https://github.com/ljgago/typst-chords"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Changes since 0.2.0:
- Renamed `frets` parameter by `frets-amount`.
- Renamed `fret-number` parameter by `fret`.
- Renamed `color` parameter by `fill`.
- Replaced `scale` parameter by `size`. You can use the same functionality using `em` units.
- Replaced new types released in Typst v0.8.0.