### PR TITLE
Fix GitHub handle parsing and use better email address validation

### DIFF
--- a/bundler/Cargo.lock
+++ b/bundler/Cargo.lock
@@ -53,6 +53,7 @@ name = "bundler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "email_address",
  "flate2",
  "ignore",
  "rayon",
@@ -112,6 +113,12 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
 
 [[package]]
 name = "equivalent"

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = "1"
+email_address = { version = "0.2.4", default-features = false }
 flate2 = "1"
 ignore = "0.4"
 rayon = "1.0"


### PR DESCRIPTION
This PR switches out the email address validation especially in order to support SMTPUTF8. It uses a small crate for that because it is implemented as described in the RFCs.