### PR TITLE
xarrow:0.3.1

### DIFF
--- a/packages/preview/xarrow/0.3.1/LICENSE
+++ b/packages/preview/xarrow/0.3.1/LICENSE
@@ -1,0 +1,14 @@
+xarrow: variable-length arrows in typst.
+Copyright (C) 2023-2024 Lucas Tabary-Maujean
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/packages/preview/xarrow/0.3.1/README.md
+++ b/packages/preview/xarrow/0.3.1/README.md
@@ -1,0 +1,85 @@
+# typst-xarrow
+
+Variable-length arrows in Typst, fitting the width of a given content.
+
+## Usage
+
+This library mainly provides the `xarrow` function. This function takes one
+positional argument, which is the content to display on top of the arrow.
+Additionally, the library provides the following arrow styles:
+
+- `xarrowDashed` using arrow `sym.arrow.dashed`.
+- `xarrowDouble` using arrow `sym.arrow.double.long`;
+- `xarrowHook` using arrow `sym.arrow.hook`;
+- `xarrowSquiggly` using arrow `sym.arrow.long.squiggly`;
+- `xarrowTwoHead` using arrow `sym.arrow.twohead`;
+- ...
+
+These names use camlCase in order to be simply called from math mode. This may
+change in the future, if it becomes possible to have the function names
+mirror the dot-separated name of the symbols themselves.
+
+### Arguments
+
+Users can provide the following arguments to any of the previously-mentioned
+functions:
+
+- `width` defines the width of the arrow. It defaults to `auto`, which makes the
+  arrow adapt to the size of the body.
+- `margins` defines the spacing on each side of the `body` argument. Ignored when
+  `width` is not `auto`.
+- `position` defines whether the main `body` argument will be set above or below
+  the arrow. Default is `top`; the only other accepted value is `bottom`.
+- `opposite` sets the content that is displayed on the other, non-default side
+  of the arrow. Default is `none`.
+
+### Example
+
+```
+#import "@preview/xarrow:0.3.0": xarrow, xarrowSquiggly, xarrowTwoHead
+
+$
+  a xarrow(sym: <--, QQ\, 1 + 1^4) b \
+  c xarrowSquiggly("very long boi") d \
+  c / ( a xarrowTwoHead("NP" limits(sum)^*) b times 4)
+$
+```
+
+## Customisation
+
+The `xarrow` function has several named arguments which serve to create new
+arrow designs:
+
+- `sym` is the base symbol.
+- `sections` defines the way the symbol is divided. Drawing an arrow consists of
+  drawing its tail, then repeating a central part that is defined by `sections`,
+  then drawing the head. This is the parameter that has to be tweaked if
+  observing artefacts. `sections` are given as two ratios, delimiting
+  respectively the beginning and the end of the central, repeated part of the
+  symbol.
+- `partial_repeats` indicates whether the central part of the symbol can be
+  partially repeated at the end in order to match the exact desired width. This
+  has to be disabled when the repeated part has a clear period (like the
+  squiggly arrow).
+
+### Example
+
+```
+#let xarrowSquigglyBottom = xarrow.with(
+  sym: sym.arrow.long.squiggly,
+  sections: (20%, 45%),
+  partial_repeats: false,
+  position: bottom,
+)
+```
+
+## Limitations
+
+- The predefined arrows are tweaked with the Computer Modern Math font in mind.
+  With different glyphs, more sophisticated arrows will require manual
+  modifications (of the `sections` argument) to be rendered correctly.
+- The `width` argument cannot be given ratio/fractions like other shapes. This
+  would be a nice feature to have, in order to be able to create an arrow that
+  takes 50% of the available line width for instance.
+- I would like to make a proper manual for this library in the future, using
+  something cool like [mantys](https://github.com/jneug/typst-mantys).

--- a/packages/preview/xarrow/0.3.1/lib.typ
+++ b/packages/preview/xarrow/0.3.1/lib.typ
@@ -1,0 +1,98 @@
+// Create a longer arrow, almost the way TeX does it. That is, repeating a truncated version
+// of the symbol. This is arguably less elegant than using the scale function, but
+// will look better with most renderers.
+// The symbol is divided in three parts, as defined by the section parameter.
+// Please adjust this parameter and/or use longer versions of the given arrows
+// if artefacts occur.
+#let xarrow(
+  sym: sym.arrow.long, // the arrow symbol to use
+  margin: 0.15em, // margins surrounding body over the symbol on each side
+  width: auto, // override variable width 
+  sections: (40%, 60%), // delimiting the symbol in three parts, the central one is repeated
+  partial_repeats: true, // whether the central part can be partially repeated
+  position: top, // default position of the main argument
+  opposite: none, // content on the opposite, non-default side of the arrow
+  body
+) = math.class("relation", context {
+  assert(type(sym) == symbol, message: "xarrow: input symbol must be of type `symbol`")
+
+  // put the symbol in a barebone equation block in order to
+  // measure and lay it out correctly
+  let sym = math.equation(block: true, numbering: none, sym)
+
+  let (begin, end) = sections
+  assert(begin > 0%, message: "xarrow: middle section must start within the symbol")
+  assert(begin < end, message: "xarrow: sections must be given in increasing order")
+  assert(end < 100%, message: "xarrow: middle section must end within the symbol")
+
+  let (top_content, bottom_content) = if position == top {
+    (body, opposite)
+  } else if position == bottom {
+    (opposite, body)
+  } else {
+    panic("xarrow: incorrect body position `" + repr(position) + "`")
+  }
+  
+  let (body_width, _) = measure($limits("") ^#top_content _#bottom_content$).values()
+  let (sym_w, sym_h) = measure(sym).values()
+
+  let margin_absolute = measure(line(length: margin)).width
+  let repeated_width = body_width + 2 * margin_absolute - (100% - end + begin) * sym_w
+
+  if type(width) == length {
+    let width = measure(line(length: width)).width
+    repeated_width = width - (100% - end + begin) * sym_w
+  } else if width != auto {
+    panic("xarrow: unsupported width type `" + repr(type(width)) + "`")
+  }
+  
+  // Repeat the body to fit the given width
+  let fit_width(width, partial_repeats, body) = {
+    let (body_width, body_height) = measure(body).values()
+    if partial_repeats {
+      let repeats = calc.floor(width / body_width)
+      let remainder = width - repeats * body_width
+      body * repeats
+      block(height: body_height, width: remainder, clip: true, body)
+    } else {
+      let repeats = calc.ceil(width / body_width)
+      body * repeats
+    }
+  }
+
+  math.attach(
+    math.limits({
+      if repeated_width < (end - begin) * sym_w {
+        sym
+      } else {
+        // The contents in the blocks are centered, using `place` to center the view
+        // on the desired sections. Cannot use `align` because it doesn't affect `block`s.
+        block(width: begin * sym_w, height: sym_h, clip: true,
+          place(dx: (100% - begin) / 2 * sym_w, sym)
+        )
+        
+        fit_width(repeated_width, partial_repeats,
+          block(height: sym_h, width: (end - begin) * sym_w, clip: true,
+            place(dx: (100% - begin - end) / 2 * sym_w, sym)
+          )
+        )
+          
+        block(width: (100% - end) * sym_w, height: sym_h, clip: true,
+          place(dx: - end / 2 * sym_w, sym)
+        )
+      }
+    }),
+    t: top_content,
+    b: bottom_content,
+  )
+})
+
+// Some alternative arrow styles.
+#let xarrowDashed = xarrow.with(sym: sym.arrow.dashed, sections: (20%, 51%), partial_repeats: false)
+#let xarrowDouble = xarrow.with(sym: sym.arrow.double.long)
+#let xarrowHook = xarrow.with(sym: sym.arrow.hook)
+#let xarrowLeftRight = xarrow.with(sym: sym.arrow.l.r, sections: (33%, 66%))
+#let xarrowLeftRightDouble = xarrow.with(sym: sym.arrow.l.r.double, sections: (40%, 60%))
+#let xarrowSquiggly = xarrow.with(sym: sym.arrow.long.squiggly, sections: (20%, 45%), partial_repeats: false)
+#let xarrowTwoHead = xarrow.with(sym: sym.arrow.twohead, sections: (10%, 20%), partial_repeats: false)
+

--- a/packages/preview/xarrow/0.3.1/typst.toml
+++ b/packages/preview/xarrow/0.3.1/typst.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xarrow"
+version = "0.3.1"
+entrypoint = "lib.typ"
+authors = ["loutr"]
+license = "GPL-3.0-only"
+description = "Variable-length arrows in Typst."
+repository = "https://codeberg.org/loutr/typst-xarrow/"
+compiler = "0.11.0"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

This version of xarrow fixes the bug introduced by version 0.11 of the typst compiler which caused arrows to be rendered with an extra, undesired space after them.