### PR TITLE
jurz:0.1.0

### DIFF
--- a/packages/preview/jurz/0.1.0/.gitignore
+++ b/packages/preview/jurz/0.1.0/.gitignore
@@ -1,0 +1,3 @@
+*.pdf
+# only 2-3 are needed
+demo-1.svg 

--- a/packages/preview/jurz/0.1.0/LICENSE
+++ b/packages/preview/jurz/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Zuri Klaschka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/jurz/0.1.0/README.md
+++ b/packages/preview/jurz/0.1.0/README.md
@@ -1,0 +1,88 @@
+# jurz – *Randziffern* in Typst
+
+[*Randziffern*](https://de.wikipedia.org/w/index.php?title=Randnummer&oldid=231943223) (also called *Randnummern*) are a way to reference text passages in a document, independent of the page number or the section number. They are used in many German legal texts, for example. This package provides a way to create *Randziffern* in Typst.
+
+## Demo
+
+<table>
+ <tr>
+  <td>
+   <img src="demo-2.svg" alt="left page with Randziffern on the left of the text">
+  </td>
+  <td>
+   <img src="demo-3.svg" alt="right page with Randziffern on the right of the text">
+  </td>
+ </tr>
+</table>
+
+<details>
+ <summary>View source</summary>
+
+```typst
+#show: init-jurz.with(
+  gap: 1em,
+  two-sided: true
+)
+
+#rz #lorem(50)
+
+#lorem(20)
+
+#rz<abc> #lorem(30)
+
+#rz #lorem(40)
+
+#rz #lorem(50)
+
+#lorem(20)
+
+#rz #lorem(24)
+
+Fur further information, look at @abc.
+```
+
+</details>
+
+## Reference
+
+### `init-jurz`
+
+A show rule that initializes the *Randziffern* for the document. This rule should be placed at the beginning of the document. It also allows customizing the behavior of the *Randziffern*.
+
+#### Usage
+
+```typst
+#show: init-jurz.with(
+ // parameters
+ // two-sided: true,
+ // gap: 1em,
+ // supplement: "Rz.",
+ // reset-level: 0,
+)
+```
+
+#### Parameters
+
+- `two-sided` (optional): If `true`, the *Randziffern* are placed on the outer margin of the page. If `false`, they are placed on the left margin. Default is `true`.
+- `gap` (optional): The distance between the *Randziffer* and the text. Default is `1em`.
+- `supplement` (optional): The text that is placed before the *Randziffer* when referencing it. Default is `"Rz."`.
+- `reset-level` (optional): The heading level at which the *Randziffern* are reset. If set to `3`, for example, the numbering of the *Randziffern* restarts after every heading of levels `1`, `2`, or `3`. Default is `0`.
+
+### `rz`
+
+Adds a *Randziffer* to the text. The *Randziffer* is a unique identifier that can be referenced in the text.
+
+You can add references the same way you can with headings. In fact, the *Randziffer* is treated as a heading of level `99` under the hood.
+
+#### Usage
+
+```typst
+#rz #lorem(100)
+#rz<abc> #lorem(100)
+
+See also @abc.
+```
+
+## License
+
+This package is licensed under the MIT License.

--- a/packages/preview/jurz/0.1.0/demo-2.svg
+++ b/packages/preview/jurz/0.1.0/demo-2.svg
@@ -1,0 +1,990 @@
+<svg class="typst-doc" viewBox="0 0 272.1264 385.51239999999996" width="272.1264pt" height="385.51239999999996pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(0 0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 385.5124 L 272.1264 385.5124 L 272.1264 0 Z "/>
+        </g>
+        <g transform="translate(44 22.613825000000006)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 0)">
+                        <g class="typst-group">
+                            <g/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 7.15)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 0)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 206.1264 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(33 42.51975)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-5.650390625 7.09521484375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g256D8ECAB9C962EFCD8FADDE104F1D95" x="0" fill="#000000"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(44 49.759984375)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 64.15021875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 78.540453125)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="13.196766536458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="16.097157161458334" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="21.119129817708334" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="26.645985286458334" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="32.188954036458334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="36.190418880208334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="44.98825963541667" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="49.90281041666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="57.261198046875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="62.825651171875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="68.368619921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="71.269010546875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="76.811979296875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="80.813444140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="89.61128489583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="98.29634348958332" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="103.31831614583332" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="108.81831614583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="114.78023020833332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="119.80220286458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.37055143229165" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="137.39252408854165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="140.29291471354165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="143.27387174479165" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="148.80609830729165" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="154.64447721354165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="159.66644986979165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="172.2347984375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="177.767025" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="183.60540390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="188.6273765625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="193.54192734375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="197.6293296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 92.9306875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.37646484375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="10.91943359375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="13.81982421875" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="19.658203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="25.3623046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="28.83740234375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="33.859375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="37.33447265625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="42.2490234375" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="50.93408203125" fill="#000000"/>
+                <use xlink:href="#gBDEAEBFC2F3FDB731F7FB66BFF129D00" x="57.72528" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.99236984375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="72.84167328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="77.7562240625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="83.718138125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="86.69909515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="99.75835953125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="104.7803321875" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="109.77007828125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="115.30230484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="121.14068375" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="130.4294403125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="135.9938934375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="141.5368621875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="144.4372528125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="149.35180359375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="154.37377625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="163.05883484375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="168.89721375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="177.55755234375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="182.579525" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="188.5414390625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="191.52239609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="200.2074546875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="205.6430015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 107.320921875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="4.705078125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="10.54345703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="23.4297721875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="28.1348503125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="33.6778190625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="37.76522140625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="43.54451828125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="49.08748703125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="53.088951875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.20475921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.76921234375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.31218109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="76.21257171875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="81.1271225" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="89.81218109375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="95.65056" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="99.9366928125" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="106.55494156249999" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="112.71021499999999" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="117.62476578124999" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="121.71216812499999" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="128.89438171875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.369479375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="137.39145203125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="146.076510625" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="150.99106140625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="161.15423203125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="166.93352890625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="171.8480796875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="175.93548203125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="184.620540625" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="189.64251328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="195.14251328125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="201.10442734375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 121.71115625)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="0" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="5.02197265625" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="9.72705078125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="14.43212890625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="19.3466796875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="23.6328125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="27.9189453125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="30.89990234375" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="40.12080625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="45.900103125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="51.443071875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.91816953125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="59.8327203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.118853125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="67.59395078125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="73.688878125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="77.9750109375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="84.633903125" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="89.65587578125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="92.55626640625" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="95.5372234375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="101.06945" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="106.90782890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="112.52599296875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="121.76838125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="126.79035390625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="131.7049046875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="135.18000234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="140.094553125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="144.18195546875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="150.14386953125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="155.9822484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="168.3452421875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="173.25979296875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="180.41282578124998" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="183.39378281249998" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="189.35569687499998" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="195.51097031249998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="201.47288437499998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 136.10139062500002)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="3.47509765625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="9.3134765625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="20.931139374999997" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="23.912096406249997" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="32.597155" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="38.376451875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="43.29100265625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="49.25291671875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.81736984375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="59.731920625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="63.73338546875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="71.58054046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="80.2655990625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="85.28757171875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="88.18796234375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="94.02634125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="105.6440040625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="111.605918125" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="117.148886875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="122.56832046875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="125.5492775" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="132.76801453125" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="138.31098328125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="144.01508484375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="146.996041875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="152.9579559375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="157.87250671875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="166.5575653125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="172.39594421875" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="175.83344421875" fill="#000000"/>
+                <use xlink:href="#gFAB5AB46C3D7E8820D142009AEFE491" x="181.183040625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="194.9437828125" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="200.561946875" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 150.491625)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="8.54541015625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="13.4599609375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="24.89501953125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="27.79541015625" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="30.7763671875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="35.4814453125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.39599609375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="46.62109375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="50.09619140625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="54.18359375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="59.20556640625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="65.16748046875" fill="#000000"/>
+                <use xlink:href="#g6DC016622A31714551059BEE327C8748" x="69.45361328125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="72.85888671875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="77.7734375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.86083984375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="85.8623046875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.52685546875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="96.5078125" fill="#000000"/>
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="105.2197265625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="110.59619140625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="116.13916015625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="119.03955078125" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="124.8779296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="130.58203125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="134.05712890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="139.0791015625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="142.55419921875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="147.46875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="156.15380859375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="161.32080078125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="167.1591796875" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="170.63427734375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 170.931859375)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 185.32209375000002)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 199.712328125)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="12.0634765625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="14.9638671875" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="19.98583984375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="25.5126953125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="31.0556640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="35.05712890625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="42.7216796875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="47.63623046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="53.861328125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="59.42578125" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="64.96875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.869140625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="73.412109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="77.41357421875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="85.078125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="93.76318359375" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="98.78515625" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="104.28515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="110.2470703125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="115.26904296875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="126.7041015625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="131.72607421875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="134.62646484375" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="137.607421875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="143.1396484375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="148.97802734375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="154" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="165.43505859375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="170.96728515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="176.8056640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="181.82763671875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="186.7421875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="190.82958984375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="195.8515625" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="199.32666015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(33 212.912328125)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-5.650390625 7.09521484375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g29521F5593DBC934C33F1D9ECDCE0406" x="0" fill="#000000"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(44 220.1525625)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 234.54279687500002)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 248.93303125)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="13.196766536458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="16.097157161458334" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="21.119129817708334" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="26.645985286458334" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="32.188954036458334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="36.190418880208334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="44.98825963541667" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="49.90281041666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="57.261198046875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="62.825651171875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="68.368619921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="71.269010546875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="76.811979296875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="80.813444140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="89.61128489583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="98.29634348958332" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="103.31831614583332" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="108.81831614583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="114.78023020833332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="119.80220286458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.37055143229165" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="137.39252408854165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="140.29291471354165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="143.27387174479165" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="148.80609830729165" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="154.64447721354165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="159.66644986979165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="172.2347984375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="177.767025" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="183.60540390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="188.6273765625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="193.54192734375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="197.6293296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 263.32326562500003)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.37646484375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="10.91943359375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="13.81982421875" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="19.658203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="25.3623046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="28.83740234375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="33.859375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="37.33447265625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="42.2490234375" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="50.93408203125" fill="#000000"/>
+                <use xlink:href="#gBDEAEBFC2F3FDB731F7FB66BFF129D00" x="57.72528" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.99236984375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="72.84167328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="77.7562240625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="83.718138125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="86.69909515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="99.75835953125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="104.7803321875" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="109.77007828125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="115.30230484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="121.14068375" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="130.4294403125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="135.9938934375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="141.5368621875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="144.4372528125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="149.35180359375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="154.37377625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="163.05883484375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="168.89721375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="177.55755234375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="182.579525" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="188.5414390625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="191.52239609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="200.2074546875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="205.6430015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 277.7135)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="4.705078125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="10.54345703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="21.978515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="26.68359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="32.2265625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="36.31396484375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="42.09326171875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="47.63623046875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="51.6376953125" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.30224609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="64.86669921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="70.40966796875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="73.31005859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="78.224609375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="86.90966796875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="92.748046875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="97.0341796875" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="102.201171875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="108.3564453125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="113.27099609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="117.3583984375" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="120.33935546875" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(33 290.9135)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-5.650390625 7.09521484375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g7109D5BCB43EE139F7DDA5F697B5EBC7" x="0" fill="#000000"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(44 298.153734375)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 312.54396875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 326.93420312499995)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="13.196766536458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="16.097157161458334" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="21.119129817708334" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="26.645985286458334" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="32.188954036458334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="36.190418880208334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="44.98825963541667" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="49.90281041666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="57.261198046875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="62.825651171875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="68.368619921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="71.269010546875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="76.811979296875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="80.813444140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="89.61128489583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="98.29634348958332" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="103.31831614583332" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="108.81831614583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="114.78023020833332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="119.80220286458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.37055143229165" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="137.39252408854165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="140.29291471354165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="143.27387174479165" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="148.80609830729165" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="154.64447721354165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="159.66644986979165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="172.2347984375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="177.767025" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="183.60540390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="188.6273765625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="193.54192734375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="197.6293296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 341.32443749999993)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.37646484375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="10.91943359375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="13.81982421875" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="19.658203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="25.3623046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="28.83740234375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="33.859375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="37.33447265625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="42.2490234375" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="50.93408203125" fill="#000000"/>
+                <use xlink:href="#gBDEAEBFC2F3FDB731F7FB66BFF129D00" x="57.72528" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.99236984375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="72.84167328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="77.7562240625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="83.718138125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="86.69909515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="99.75835953125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="104.7803321875" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="109.77007828125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="115.30230484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="121.14068375" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="130.4294403125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="135.9938934375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="141.5368621875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="144.4372528125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="149.35180359375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="154.37377625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="163.05883484375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="168.89721375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="177.55755234375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="182.579525" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="188.5414390625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="191.52239609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="200.2074546875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="205.6430015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(44 355.74857499999996)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 0)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 206.1264 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(0 7.15)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(100.506559375 7.240234375)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g8610EA03DB4DF9C3714D75A0CBD0FB7D" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <defs id="glyph">
+        <symbol id="g256D8ECAB9C962EFCD8FADDE104F1D95" overflow="visible">
+            <path d="M 4.0390625 1.3427734 Q 4.0390625 1.0151367 4.119629 0.81103516 Q 4.2001953 0.6069336 4.3881836 0.51293945 Q 4.576172 0.4189453 4.729248 0.39208984 Q 4.882324 0.36523438 5.1723633 0.3544922 Q 5.258301 0.30078125 5.258301 0.16113281 Q 5.258301 0.021484375 5.1723633 -0.021484375 Q 3.3676758 0 3.3354492 0 L 1.4716797 -0.021484375 Q 1.3857422 0.032226563 1.3857422 0.16381836 Q 1.3857422 0.29541016 1.4716797 0.3544922 Q 1.7563477 0.36523438 1.9121094 0.39208984 Q 2.067871 0.4189453 2.2558594 0.51293945 Q 2.4438477 0.6069336 2.524414 0.8083496 Q 2.6049805 1.0097656 2.6049805 1.3427734 L 2.6049805 4.7856445 Q 2.6049805 5.1723633 2.5620117 5.274414 Q 2.519043 5.376465 2.3955078 5.376465 Q 1.9013672 5.376465 1.2514648 5.102539 Q 1.0205078 5.269043 1.0097656 5.5751953 Q 1.3266602 5.7094727 2.1645508 6.039795 Q 3.0024414 6.370117 3.3891602 6.5473633 Q 3.727539 6.713867 3.9370117 6.708496 Q 4.125 6.708496 4.125 6.520508 Q 4.0390625 5.89209 4.0390625 5.3120117 L 4.0390625 1.3427734 Z "/>
+        </symbol>
+        <symbol id="gB7C2485A990F0D16073DE98E640F51" overflow="visible">
+            <path d="M 1.6381836 0 Q 1.0688477 0 0.20947266 -0.021484375 Q 0.15576172 0.021484375 0.15576172 0.15307617 Q 0.15576172 0.28466797 0.20947266 0.3383789 Q 0.82714844 0.35986328 0.9963379 0.5209961 Q 1.1655273 0.6821289 1.1655273 1.3427734 L 1.1655273 5.7524414 Q 1.1655273 6.413086 0.9963379 6.571533 Q 0.82714844 6.7299805 0.20947266 6.751465 Q 0.15576172 6.7944336 0.15576172 6.928711 Q 0.15576172 7.0629883 0.20947266 7.116699 Q 1.2192383 7.095215 1.6274414 7.095215 Q 2.067871 7.095215 3.0561523 7.116699 Q 3.099121 7.0629883 3.1018066 6.9313965 Q 3.1044922 6.7998047 3.0561523 6.751465 Q 2.4384766 6.7299805 2.269287 6.571533 Q 2.1000977 6.413086 2.1000977 5.7524414 L 2.1000977 1.1977539 Q 2.1000977 0.7788086 2.2478027 0.60424805 Q 2.3955078 0.4296875 2.7285156 0.4296875 L 3.4213867 0.4296875 Q 4.227051 0.4296875 4.6271973 0.8083496 Q 5.0273438 1.1870117 5.215332 1.8691406 Q 5.4033203 1.9013672 5.5751953 1.8154297 Q 5.4677734 0.859375 5.2905273 -0.021484375 Q 4.2753906 0 3.9799805 0 L 1.6381836 0 Z "/>
+        </symbol>
+        <symbol id="g9ABB161D7FA7D32FC821ED2C0B46F425" overflow="visible">
+            <path d="M 0.45117188 2.2558594 Q 0.45117188 3.3461914 1.0581055 4.060547 Q 1.7133789 4.8286133 2.7822266 4.8286133 Q 3.5717773 4.8286133 4.1169434 4.439209 Q 4.6621094 4.0498047 4.876953 3.5100098 Q 5.091797 2.9702148 5.091797 2.352539 Q 5.091797 1.203125 4.3774414 0.5048828 Q 3.7490234 -0.11279297 2.7607422 -0.107421875 Q 1.659668 -0.107421875 1.0554199 0.6069336 Q 0.45117188 1.3212891 0.45117188 2.2558594 Z M 2.6157227 4.4418945 Q 1.3964844 4.4418945 1.3964844 2.5083008 Q 1.3964844 2.1538086 1.4797363 1.7912598 Q 1.5629883 1.4287109 1.7268066 1.0769043 Q 1.890625 0.72509766 2.199463 0.49951172 Q 2.5083008 0.27392578 2.916504 0.27392578 Q 3.3999023 0.27392578 3.7731934 0.6713867 Q 4.1464844 1.0688477 4.1464844 2.003418 Q 4.1464844 3.1796875 3.7382813 3.810791 Q 3.3300781 4.4418945 2.6157227 4.4418945 Z "/>
+        </symbol>
+        <symbol id="g7B0412412D0F33737832F45BFDAA75C8" overflow="visible">
+            <path d="M 1.9335938 3.9370117 Q 1.9335938 3.8833008 1.9685059 3.8618164 Q 2.003418 3.840332 2.057129 3.9155273 Q 2.2773438 4.291504 2.602295 4.5600586 Q 2.927246 4.8286133 3.2763672 4.8286133 Q 3.5932617 4.8286133 3.7651367 4.659424 Q 3.9370117 4.4902344 3.9370117 4.302246 Q 3.9370117 4.0927734 3.7785645 3.9208984 Q 3.6201172 3.7490234 3.4213867 3.7490234 Q 3.2172852 3.7490234 3.0239258 4.006836 Q 2.916504 4.1464844 2.7392578 4.1464844 Q 2.6049805 4.1464844 2.234375 3.609375 Q 1.9711914 3.211914 1.9711914 2.8735352 L 1.9711914 1.3427734 Q 1.9711914 0.6821289 2.1188965 0.5344238 Q 2.2666016 0.38671875 2.8735352 0.3383789 Q 2.927246 0.28466797 2.927246 0.15307617 Q 2.927246 0.021484375 2.8735352 -0.021484375 Q 2.1054688 0 1.5415039 0 Q 1.0581055 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.82177734 0.37060547 0.9614258 0.5263672 Q 1.1010742 0.6821289 1.1010742 1.3427734 L 1.1010742 3.4858398 Q 1.1010742 3.947754 0.9748535 4.0686035 Q 0.8486328 4.189453 0.38671875 4.232422 Q 0.32226563 4.42041 0.36523438 4.5439453 Q 1.1816406 4.651367 1.7133789 4.86084 Q 1.7993164 4.86084 1.8476563 4.7749023 Q 1.9013672 4.640625 1.9335938 3.9370117 Z "/>
+        </symbol>
+        <symbol id="g6000CEAB22B14B2644F6F5DF3A907DF2" overflow="visible">
+            <path d="M 1.3642578 3.1044922 L 3.3569336 3.1367188 Q 3.5234375 3.1367188 3.5180664 3.2871094 Q 3.5180664 3.9155273 3.2495117 4.178711 Q 2.980957 4.4418945 2.6049805 4.4418945 Q 2.459961 4.4418945 2.3203125 4.404297 Q 2.180664 4.366699 1.9765625 4.2458496 Q 1.7724609 4.125 1.605957 3.8295898 Q 1.4394531 3.5341797 1.3642578 3.1044922 Z M 4.248535 1.0205078 Q 4.4365234 1.0097656 4.479492 0.8486328 Q 3.7436523 -0.107421875 2.6049805 -0.107421875 Q 1.5146484 -0.107421875 0.9238281 0.5961914 Q 0.40820313 1.1923828 0.40820313 2.2236328 Q 0.40820313 3.3891602 1.1064453 4.0981445 Q 1.8046875 4.807129 2.6049805 4.807129 Q 4.463379 4.807129 4.463379 2.8950195 Q 4.463379 2.7070313 4.2592773 2.7070313 L 1.3320313 2.7285156 Q 1.3320313 1.8046875 1.6811523 1.2192383 Q 2.1645508 0.4296875 2.8842773 0.4296875 Q 3.3461914 0.4296875 3.638916 0.5612793 Q 3.9316406 0.6928711 4.248535 1.0205078 Z "/>
+        </symbol>
+        <symbol id="g21713D60D926C2F051E90CCC68C60993" overflow="visible">
+            <path d="M 1.8691406 3.9370117 Q 1.8798828 3.7919922 2.003418 3.9370117 Q 2.7929688 4.8286133 3.6738281 4.8286133 Q 4.0927734 4.8286133 4.3935547 4.600342 Q 4.694336 4.3720703 4.7749023 4.022949 Q 4.801758 3.9155273 4.8930664 4.017578 Q 5.661133 4.8286133 6.708496 4.8286133 Q 7.379883 4.8286133 7.61084 4.3774414 Q 7.841797 3.9262695 7.841797 3.0776367 L 7.841797 1.3427734 Q 7.841797 0.6821289 7.9572754 0.52905273 Q 8.072754 0.37597656 8.54541 0.3383789 Q 8.588379 0.28466797 8.588379 0.15307617 Q 8.588379 0.021484375 8.54541 -0.021484375 Q 7.9277344 0 7.4121094 0 Q 6.8427734 0 6.289551 -0.021484375 Q 6.246582 0.021484375 6.246582 0.15307617 Q 6.246582 0.28466797 6.289551 0.3383789 Q 6.7407227 0.37060547 6.856201 0.5317383 Q 6.9716797 0.6928711 6.9716797 1.3427734 L 6.9716797 3.2763672 Q 6.9716797 3.8027344 6.8078613 4.031006 Q 6.644043 4.2592773 6.3164063 4.2592773 Q 5.5268555 4.2592773 4.86084 3.5288086 Q 4.871582 3.3945313 4.871582 3.088379 L 4.871582 1.3427734 Q 4.871582 0.6821289 4.9816895 0.52905273 Q 5.091797 0.37597656 5.5214844 0.3383789 Q 5.564453 0.28466797 5.564453 0.15844727 Q 5.564453 0.032226563 5.5214844 -0.021484375 Q 4.973633 0 4.4418945 0 Q 3.8725586 0 3.319336 -0.021484375 Q 3.2763672 0.032226563 3.2763672 0.16381836 Q 3.2763672 0.29541016 3.319336 0.3383789 Q 3.78125 0.37060547 3.8913574 0.5263672 Q 4.001465 0.6821289 4.001465 1.3427734 L 4.001465 3.2548828 Q 4.001465 4.2539063 3.2763672 4.2592773 Q 2.75 4.2592773 2.0893555 3.609375 Q 1.9013672 3.4106445 1.9013672 3.147461 L 1.9013672 1.3427734 Q 1.9013672 0.88623047 1.9658203 0.6875 Q 2.0302734 0.48876953 2.1484375 0.4296875 Q 2.2666016 0.37060547 2.583496 0.3383789 Q 2.631836 0.29003906 2.631836 0.15844727 Q 2.631836 0.026855469 2.583496 -0.021484375 Q 1.9228516 0 1.4716797 0 Q 0.9453125 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.7680664 0.37060547 0.90234375 0.5317383 Q 1.0366211 0.6928711 1.0366211 1.3427734 L 1.0366211 3.4858398 Q 1.0366211 3.947754 0.90771484 4.0686035 Q 0.7788086 4.189453 0.31689453 4.232422 Q 0.2524414 4.42041 0.29541016 4.5439453 Q 1.1118164 4.651367 1.6489258 4.86084 Q 1.7348633 4.86084 1.7832031 4.7749023 Q 1.8369141 4.651367 1.8691406 3.9370117 Z "/>
+        </symbol>
+        <symbol id="g8DA966557E0CCF546BA5AA535F299256" overflow="visible">
+            <path d="M 0.98828125 6.590332 Q 0.98828125 6.7890625 1.1762695 6.952881 Q 1.3642578 7.116699 1.5629883 7.116699 Q 1.7724609 7.116699 1.9309082 6.934082 Q 2.0893555 6.751465 2.0893555 6.5473633 Q 2.0893555 6.359375 1.9147949 6.1875 Q 1.7402344 6.015625 1.5200195 6.015625 Q 1.3212891 6.015625 1.1547852 6.198242 Q 0.98828125 6.3808594 0.98828125 6.590332 Z M 1.9926758 1.3427734 Q 1.9926758 0.6821289 2.1242676 0.52905273 Q 2.2558594 0.37597656 2.7822266 0.3383789 Q 2.8359375 0.28466797 2.8359375 0.15307617 Q 2.8359375 0.021484375 2.7822266 -0.021484375 Q 2.057129 0 1.5629883 0 Q 1.0581055 0 0.32763672 -0.021484375 Q 0.28466797 0.021484375 0.28466797 0.15307617 Q 0.28466797 0.28466797 0.32763672 0.3383789 Q 0.8540039 0.38134766 0.98828125 0.5317383 Q 1.1225586 0.6821289 1.1225586 1.3427734 L 1.1225586 3.4858398 Q 1.1225586 3.947754 0.9963379 4.0686035 Q 0.8701172 4.189453 0.40820313 4.232422 Q 0.34375 4.42041 0.38671875 4.5439453 Q 1.4072266 4.6782227 1.890625 4.86084 Q 2.0356445 4.86084 2.0356445 4.7856445 Q 1.9926758 4.0820313 1.9926758 3.5341797 L 1.9926758 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g580AAD674A0E08ED15198255596B26A2" overflow="visible">
+            <path d="M 1.9228516 3.6416016 Q 1.7456055 3.4213867 1.7509766 3.1582031 L 1.7509766 1.1547852 Q 1.7509766 0.8647461 1.7966309 0.7573242 Q 1.8422852 0.64990234 2.0141602 0.49414063 Q 2.2719727 0.2631836 2.7929688 0.2631836 Q 3.2333984 0.2631836 3.5529785 0.44580078 Q 3.8725586 0.62841797 4.036377 0.9399414 Q 4.2001953 1.2514648 4.272705 1.5817871 Q 4.345215 1.9121094 4.345215 2.288086 Q 4.345215 3.1904297 3.9665527 3.75708 Q 3.5878906 4.3237305 3.034668 4.3237305 Q 2.803711 4.3237305 2.4733887 4.119629 Q 2.1430664 3.9155273 1.9228516 3.6416016 Z M 1.7133789 4.0498047 Q 1.7241211 3.8833008 1.8369141 4.001465 Q 2.572754 4.8286133 3.3461914 4.8286133 Q 4.17334 4.8286133 4.7319336 4.1572266 Q 5.2905273 3.4858398 5.2905273 2.583496 Q 5.2905273 1.2944336 4.479492 0.5048828 Q 3.8295898 -0.11279297 2.8574219 -0.107421875 Q 2.3203125 -0.107421875 1.9013672 0.05908203 Q 1.8154297 0.10205078 1.7832031 0.091308594 Q 1.7509766 0.080566406 1.7509766 -0.021484375 L 1.7509766 -1.2084961 Q 1.7509766 -1.8691406 1.8986816 -2.0249023 Q 2.0463867 -2.180664 2.6533203 -2.2128906 Q 2.7070313 -2.2666016 2.7070313 -2.3981934 Q 2.7070313 -2.5297852 2.6533203 -2.572754 Q 1.9282227 -2.5512695 1.3212891 -2.5512695 Q 0.859375 -2.5512695 0.0859375 -2.572754 Q 0.04296875 -2.5297852 0.04296875 -2.3981934 Q 0.04296875 -2.2666016 0.0859375 -2.2128906 Q 0.6015625 -2.1914063 0.74121094 -2.0302734 Q 0.8808594 -1.8691406 0.8808594 -1.2084961 L 0.8808594 3.4858398 Q 0.8808594 3.947754 0.7546387 4.0686035 Q 0.62841797 4.189453 0.1665039 4.232422 Q 0.10205078 4.42041 0.14501953 4.5439453 Q 0.9614258 4.651367 1.4985352 4.86084 Q 1.5844727 4.86084 1.6274414 4.7749023 Q 1.6811523 4.645996 1.7133789 4.0498047 Z "/>
+        </symbol>
+        <symbol id="g5B9E5EB97F9DFC2F689C0AE85A2A0257" overflow="visible">
+            <path d="M 0.5263672 1.5200195 Q 0.5800781 1.5737305 0.6982422 1.5737305 Q 0.81640625 1.5737305 0.8701172 1.5307617 Q 1.0473633 0.7841797 1.2998047 0.51831055 Q 1.5522461 0.2524414 2.0786133 0.2524414 Q 2.4331055 0.2524414 2.7231445 0.45117188 Q 3.0131836 0.64990234 3.0131836 1.0205078 Q 3.0131836 1.3857422 2.7875977 1.605957 Q 2.5620117 1.8261719 1.890625 2.1000977 Q 1.2299805 2.3740234 0.9560547 2.6936035 Q 0.6821289 3.0131836 0.6821289 3.5986328 Q 0.6821289 4.114258 1.144043 4.4714355 Q 1.605957 4.8286133 2.234375 4.8286133 Q 2.4868164 4.8286133 2.75 4.7910156 Q 3.0131836 4.753418 3.3059082 4.6916504 Q 3.5986328 4.629883 3.6738281 4.6191406 Q 3.6523438 4.0336914 3.609375 3.4536133 Q 3.555664 3.3999023 3.432129 3.3999023 Q 3.3085938 3.3999023 3.2548828 3.442871 Q 3.2011719 3.7705078 3.0749512 3.9907227 Q 2.9487305 4.2109375 2.7768555 4.3049316 Q 2.6049805 4.398926 2.4787598 4.4311523 Q 2.352539 4.463379 2.234375 4.463379 Q 1.9389648 4.463379 1.6999512 4.272705 Q 1.4609375 4.0820313 1.4609375 3.7597656 Q 1.4609375 3.3461914 1.7106934 3.1555176 Q 1.9604492 2.9648438 2.5620117 2.7392578 Q 3.8510742 2.2612305 3.8510742 1.2783203 Q 3.8510742 0.89160156 3.668457 0.60424805 Q 3.4858398 0.31689453 3.2011719 0.16918945 Q 2.916504 0.021484375 2.6398926 -0.04296875 Q 2.3632813 -0.107421875 2.1000977 -0.107421875 Q 1.5629883 -0.107421875 1.1010742 0.0107421875 Q 1.0258789 0.032226563 0.8808594 0.032226563 Q 0.7734375 0.032226563 0.6069336 0 Q 0.6015625 0.57470703 0.5263672 1.5200195 Z "/>
+        </symbol>
+        <symbol id="g8B1338AC271281ABE03918097259F338" overflow="visible">
+            <path d="M 2.3847656 -0.107421875 Q 1.6274414 -0.107421875 1.2971191 0.31420898 Q 0.9667969 0.73583984 0.9667969 1.3857422 L 0.9667969 3.496582 Q 0.9667969 4.012207 0.829834 4.178711 Q 0.6928711 4.345215 0.28466797 4.3774414 Q 0.24169922 4.42041 0.24169922 4.552002 Q 0.24169922 4.6835938 0.28466797 4.742676 Q 1.03125 4.7211914 1.4072266 4.7211914 Q 1.6811523 4.7211914 1.7939453 4.742676 Q 1.8798828 4.742676 1.8798828 4.6728516 Q 1.8369141 3.8671875 1.8369141 3.5395508 L 1.8369141 1.5415039 Q 1.8369141 0.89160156 2.1054688 0.64990234 Q 2.3740234 0.40820313 2.7177734 0.40820313 Q 3.211914 0.40820313 3.8188477 0.9345703 Q 3.9960938 1.090332 3.9907227 1.3642578 L 3.9907227 3.4858398 Q 3.9907227 4.012207 3.8591309 4.184082 Q 3.727539 4.355957 3.3085938 4.3774414 Q 3.2548828 4.42041 3.2548828 4.552002 Q 3.2548828 4.6835938 3.3085938 4.742676 Q 4.055176 4.7211914 4.4311523 4.7211914 Q 4.705078 4.7211914 4.817871 4.742676 Q 4.9038086 4.742676 4.9038086 4.6728516 Q 4.86084 3.8671875 4.86084 3.5395508 L 4.86084 1.4287109 Q 4.86084 0.99902344 5.0112305 0.8352051 Q 5.161621 0.6713867 5.666504 0.62841797 Q 5.720215 0.57470703 5.720215 0.4753418 Q 5.720215 0.37597656 5.666504 0.32763672 Q 4.7856445 0.23095703 4.366699 -0.107421875 Q 4.2700195 -0.15039063 4.1572266 -0.107421875 Q 4.060547 0.2685547 4.0390625 0.5371094 Q 4.0283203 0.5908203 3.9719238 0.58813477 Q 3.9155273 0.5854492 3.8725586 0.54785156 Q 3.0561523 -0.107421875 2.3847656 -0.107421875 Z "/>
+        </symbol>
+        <symbol id="gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" overflow="visible">
+            <path d="M 3.7973633 1.3642578 L 3.7973633 3.4536133 Q 3.7973633 3.7060547 3.7624512 3.810791 Q 3.727539 3.9155273 3.609375 4.0498047 Q 3.270996 4.4472656 2.7177734 4.4418945 Q 2.057129 4.4418945 1.6918945 3.894043 Q 1.375 3.442871 1.375 2.4331055 Q 1.375 1.4663086 1.7375488 0.93725586 Q 2.1000977 0.40820313 2.583496 0.40820313 Q 3.0131836 0.40820313 3.6201172 0.9345703 Q 3.7973633 1.090332 3.7973633 1.3642578 Z M 3.6738281 0.55322266 Q 2.868164 -0.107421875 2.2988281 -0.107421875 Q 1.4287109 -0.107421875 0.9291992 0.5397949 Q 0.4296875 1.1870117 0.4296875 2.234375 Q 0.4296875 3.4106445 1.1870117 4.1679688 Q 1.8798828 4.8286133 2.8359375 4.8286133 Q 3.0024414 4.8286133 3.2011719 4.7802734 Q 3.3999023 4.7319336 3.5422363 4.6862793 Q 3.6845703 4.640625 3.6953125 4.640625 Q 3.7919922 4.640625 3.7973633 4.742676 L 3.7973633 6.1499023 Q 3.7973633 6.5043945 3.7785645 6.678955 Q 3.7597656 6.8535156 3.638916 6.9367676 Q 3.5180664 7.0200195 3.4536133 7.0253906 Q 3.3891602 7.0307617 3.088379 7.052246 Q 2.9648438 7.1757813 3.0239258 7.379883 Q 4.001465 7.455078 4.5654297 7.680664 Q 4.710449 7.680664 4.710449 7.567871 Q 4.6674805 7.1274414 4.6621094 6.413086 L 4.6621094 1.4287109 Q 4.6621094 0.99902344 4.8125 0.8352051 Q 4.9628906 0.6713867 5.4677734 0.62841797 Q 5.5214844 0.57470703 5.5214844 0.4753418 Q 5.5214844 0.37597656 5.4677734 0.32763672 Q 4.586914 0.23095703 4.1679688 -0.107421875 Q 4.071289 -0.15039063 3.958496 -0.107421875 Q 3.8618164 0.27929688 3.840332 0.5371094 Q 3.8295898 0.5908203 3.7731934 0.5908203 Q 3.7167969 0.5908203 3.6738281 0.55322266 Z "/>
+        </symbol>
+        <symbol id="gE34A8995945D3EFAE2F41F68D391F085" overflow="visible">
+            <path d="M 1.0473633 1.3427734 L 1.0473633 6.1499023 Q 1.0473633 6.756836 0.93725586 6.8884277 Q 0.82714844 7.0200195 0.3383789 7.052246 Q 0.21484375 7.1757813 0.27392578 7.379883 Q 1.2514648 7.455078 1.8154297 7.680664 Q 1.9604492 7.680664 1.9604492 7.567871 Q 1.9174805 7.1274414 1.9121094 6.413086 L 1.9121094 1.3427734 Q 1.9121094 0.6821289 2.0517578 0.52368164 Q 2.1914063 0.36523438 2.7070313 0.3383789 Q 2.75 0.28466797 2.75 0.15307617 Q 2.75 0.021484375 2.7070313 -0.021484375 Q 1.9819336 0 1.4824219 0 Q 1.0205078 0 0.2524414 -0.021484375 Q 0.19873047 0.021484375 0.19873047 0.15307617 Q 0.19873047 0.28466797 0.2524414 0.3383789 Q 0.7680664 0.35986328 0.90771484 0.5209961 Q 1.0473633 0.6821289 1.0473633 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g4CF119F98FB6E3D69D0CE269123E989F" overflow="visible">
+            <path d="M 0.47265625 4.7211914 L 0.97753906 4.7211914 Q 0.97753906 5.1401367 0.97216797 5.4140625 Q 0.9667969 5.6879883 0.9614258 5.77124 Q 0.9560547 5.854492 0.9506836 5.908203 Q 0.9453125 5.961914 0.9453125 5.9941406 Q 0.9453125 6.074707 1.1870117 6.1445313 Q 1.3803711 6.198242 1.5629883 6.300293 Q 1.7456055 6.3969727 1.8046875 6.4023438 Q 1.890625 6.4023438 1.890625 6.305664 Q 1.8476563 5.8652344 1.8476563 5.145508 L 1.8476563 4.7211914 L 3.1689453 4.7211914 Q 3.2548828 4.7211914 3.2548828 4.651367 L 3.2548828 4.4311523 Q 3.2548828 4.286133 2.9916992 4.291504 L 1.8476563 4.291504 L 1.8476563 1.5092773 Q 1.8476563 0.97216797 1.9255371 0.7331543 Q 2.003418 0.49414063 2.2128906 0.49414063 Q 2.7177734 0.49414063 3.1152344 0.80566406 Q 3.2817383 0.7949219 3.3085938 0.6176758 Q 2.6586914 -0.107421875 1.8261719 -0.107421875 Q 0.97753906 -0.107421875 0.97753906 0.97753906 L 0.97753906 4.291504 L 0.32763672 4.291504 Q 0.27392578 4.291504 0.27392578 4.355957 L 0.27392578 4.5009766 Q 0.27392578 4.7211914 0.47265625 4.7211914 Z "/>
+        </symbol>
+        <symbol id="gC7D7FC064504D98B998DC1A12C11586B" overflow="visible">
+            <path d="M 3.2226563 2.5620117 L 2.352539 2.3310547 Q 1.3051758 2.067871 1.3105469 1.1225586 Q 1.3105469 0.82714844 1.5119629 0.5827637 Q 1.7133789 0.3383789 2.1000977 0.3383789 Q 2.4760742 0.3383789 3.0668945 0.82714844 Q 3.2226563 0.9506836 3.2226563 1.1118164 L 3.2226563 2.5620117 Z M 3.2226563 0.5263672 L 3.2011719 0.5263672 L 2.980957 0.3544922 Q 2.3847656 -0.107421875 1.7832031 -0.107421875 Q 0.39746094 -0.107421875 0.39746094 1.0795898 Q 0.39746094 1.6274414 0.89697266 2.0463867 Q 1.3964844 2.465332 2.2128906 2.6748047 L 3.1582031 2.9057617 Q 3.2226563 2.927246 3.2226563 3.034668 Q 3.2226563 4.463379 2.3310547 4.463379 Q 1.9658203 4.463379 1.7080078 4.3479004 Q 1.4501953 4.232422 1.4501953 4.001465 Q 1.4501953 3.8457031 1.4716797 3.786621 Q 1.5039063 3.722168 1.5092773 3.5878906 Q 1.5092773 3.4643555 1.3588867 3.3381348 Q 1.2084961 3.211914 0.98828125 3.211914 Q 0.6015625 3.211914 0.6069336 3.609375 Q 0.6069336 4.071289 1.173584 4.449951 Q 1.7402344 4.8286133 2.4223633 4.8286133 Q 4.0820313 4.8286133 4.0820313 2.9702148 L 4.0820313 1.3535156 Q 4.0820313 1.1225586 4.0874023 0.9909668 Q 4.0927734 0.859375 4.125 0.7036133 Q 4.1572266 0.54785156 4.2297363 0.48339844 Q 4.302246 0.4189453 4.409668 0.4189453 Q 4.6083984 0.4189453 4.817871 0.5961914 Q 4.973633 0.5102539 5.0058594 0.29541016 Q 4.586914 -0.11279297 3.958496 -0.107421875 Q 3.5825195 -0.107421875 3.4294434 0.056396484 Q 3.2763672 0.22021484 3.2226563 0.5263672 Z "/>
+        </symbol>
+        <symbol id="g67C67974E32647451A0E4FD1D272EE94" overflow="visible">
+            <path d="M 1.144043 1.0473633 Q 1.4716797 1.0473633 1.6704102 0.7492676 Q 1.8691406 0.45117188 1.8691406 -0.04296875 Q 1.8691406 -0.5908203 1.4851074 -0.97753906 Q 1.1010742 -1.3642578 0.56933594 -1.4609375 Q 0.47265625 -1.3642578 0.47265625 -1.1977539 Q 0.8701172 -1.1010742 1.1547852 -0.8083496 Q 1.4394531 -0.515625 1.4394531 -0.31689453 Q 1.4394531 -0.021484375 1.0473633 0.021484375 Q 0.56396484 0.09667969 0.55859375 0.5048828 Q 0.55859375 0.73583984 0.72509766 0.89160156 Q 0.89160156 1.0473633 1.144043 1.0473633 Z "/>
+        </symbol>
+        <symbol id="gB87EDFCDB36CE1A74BA6F566283791D" overflow="visible">
+            <path d="M 4.3774414 0.99902344 Q 3.9907227 0.35986328 3.5637207 0.1262207 Q 3.1367188 -0.107421875 2.583496 -0.107421875 Q 1.5629883 -0.107421875 0.9855957 0.545166 Q 0.40820313 1.1977539 0.40820313 2.288086 Q 0.40820313 3.3999023 1.1010742 4.114258 Q 1.7939453 4.8286133 2.6640625 4.8286133 Q 3.442871 4.8286133 3.894043 4.538574 Q 4.345215 4.248535 4.345215 3.786621 Q 4.345215 3.555664 4.17334 3.4267578 Q 4.001465 3.2978516 3.8081055 3.2978516 Q 3.432129 3.2978516 3.3891602 3.6953125 Q 3.3676758 3.9370117 3.3166504 4.0739746 Q 3.265625 4.2109375 3.0910645 4.337158 Q 2.916504 4.463379 2.6049805 4.463379 Q 2.057129 4.463379 1.7053223 3.9423828 Q 1.3535156 3.4213867 1.3535156 2.5297852 Q 1.3535156 1.5844727 1.7832031 1.0070801 Q 2.2128906 0.4296875 2.8251953 0.4296875 Q 3.5825195 0.4296875 4.1464844 1.1547852 Q 4.3237305 1.1333008 4.3774414 0.99902344 Z "/>
+        </symbol>
+        <symbol id="gD7606749417294B0D6FD3F9982E155E4" overflow="visible">
+            <path d="M 2.0249023 3.9370117 Q 2.803711 4.8286133 3.8295898 4.8286133 Q 4.458008 4.8286133 4.742676 4.4526367 Q 5.038086 4.055176 5.038086 2.980957 L 5.038086 1.3427734 Q 5.038086 0.6928711 5.1643066 0.5397949 Q 5.2905273 0.38671875 5.773926 0.3383789 Q 5.8168945 0.28466797 5.8168945 0.15307617 Q 5.8168945 0.021484375 5.773926 -0.021484375 Q 5.1132813 0 4.6083984 0 Q 4.1464844 0 3.4858398 -0.021484375 Q 3.442871 0.032226563 3.442871 0.16381836 Q 3.442871 0.29541016 3.4858398 0.3383789 Q 3.9370117 0.38134766 4.05249 0.5371094 Q 4.1679688 0.6928711 4.1679688 1.3427734 L 4.1679688 3.0131836 Q 4.1679688 3.5986328 4.0390625 3.8618164 Q 3.8295898 4.2592773 3.4536133 4.2592773 Q 2.7822266 4.2592773 2.1108398 3.609375 Q 1.9228516 3.3999023 1.9228516 3.147461 L 1.9228516 1.3427734 Q 1.9228516 0.6928711 2.03833 0.5397949 Q 2.1538086 0.38671875 2.5942383 0.3383789 Q 2.637207 0.28466797 2.6398926 0.15307617 Q 2.6425781 0.021484375 2.5942383 -0.021484375 Q 1.9335938 0 1.4985352 0 Q 0.9506836 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.80029297 0.38134766 0.9291992 0.5317383 Q 1.0581055 0.6821289 1.0581055 1.3427734 L 1.0581055 3.4858398 Q 1.0581055 3.947754 0.93188477 4.0686035 Q 0.80566406 4.189453 0.3383789 4.232422 Q 0.27392578 4.42041 0.31689453 4.5439453 Q 1.1333008 4.651367 1.6704102 4.86084 Q 1.7563477 4.86084 1.8046875 4.7749023 Q 1.8691406 4.640625 1.890625 3.9370117 Q 1.890625 3.7919922 2.0249023 3.9370117 Z "/>
+        </symbol>
+        <symbol id="gDA8A4BDDF46A0076AFC20015B6D6FA96" overflow="visible">
+            <path d="M 2.980957 2.4545898 L 0.6069336 2.4545898 Q 0.4404297 2.4545898 0.4404297 2.6640625 Q 0.4404297 2.8198242 0.52905273 2.9675293 Q 0.6176758 3.1152344 0.71435547 3.1152344 L 3.1259766 3.1152344 Q 3.2817383 3.1152344 3.2763672 2.8950195 Q 3.2763672 2.7875977 3.177002 2.6210938 Q 3.0776367 2.4545898 2.980957 2.4545898 Z "/>
+        </symbol>
+        <symbol id="g92C9249AEAD95F98902AD6AA7E64704A" overflow="visible">
+            <path d="M 3.5073242 3.0668945 Q 3.5073242 3.7490234 3.2333984 4.119629 Q 2.9594727 4.4902344 2.4438477 4.4902344 Q 1.5629883 4.4902344 1.5629883 3.319336 Q 1.5629883 3.0131836 1.5952148 2.7875977 Q 1.6274414 2.5620117 1.7268066 2.3256836 Q 1.8261719 2.0893555 2.0410156 1.9631348 Q 2.2558594 1.8369141 2.583496 1.8369141 Q 3.5073242 1.8369141 3.5073242 3.0668945 Z M 1.4501953 -0.107421875 Q 1.1118164 -0.515625 1.1118164 -1.144043 Q 1.1118164 -1.6381836 1.5737305 -1.9255371 Q 2.0356445 -2.2128906 2.4331055 -2.2128906 Q 2.9487305 -2.2128906 3.432129 -2.0786133 Q 3.9155273 -1.9443359 4.2512207 -1.659668 Q 4.586914 -1.375 4.586914 -0.99902344 Q 4.586914 -0.7895508 4.4660645 -0.6472168 Q 4.345215 -0.5048828 4.0283203 -0.31689453 Q 3.6899414 -0.12890625 2.696289 -0.13427734 Q 2.6425781 -0.13427734 2.3659668 -0.15039063 Q 2.0893555 -0.1665039 1.890625 -0.1665039 Q 1.6489258 -0.16113281 1.4501953 -0.107421875 Z M 4.882324 4.2592773 Q 4.6728516 4.2592773 4.576172 4.4526367 Q 4.4902344 4.586914 4.355957 4.586914 Q 4.2592773 4.586914 4.119629 4.498291 Q 3.9799805 4.409668 3.9155273 4.3237305 Q 4.3881836 3.840332 4.3881836 3.1796875 Q 4.3881836 2.411621 3.8430176 1.9550781 Q 3.2978516 1.4985352 2.5297852 1.4985352 Q 1.9228516 1.4985352 1.5307617 1.7294922 Q 1.3320313 1.4555664 1.3320313 1.090332 Q 1.3320313 0.7734375 1.5415039 0.6176758 Q 1.7509766 0.46191406 2.0356445 0.46191406 L 2.3632813 0.48339844 Q 2.803711 0.5371094 3.1044922 0.5371094 Q 4.2700195 0.5371094 4.710449 0.1772461 Q 5.1938477 -0.22021484 5.1938477 -0.71435547 Q 5.1938477 -1.2836914 4.7265625 -1.7321777 Q 4.2592773 -2.180664 3.5583496 -2.3981934 Q 2.8574219 -2.6157227 2.1000977 -2.6157227 Q 1.3642578 -2.6157227 0.859375 -2.3203125 Q 0.3544922 -2.0249023 0.3544922 -1.3642578 Q 0.3544922 -0.57470703 1.2514648 -0.032226563 Q 0.74658203 0.22021484 0.74658203 0.81640625 Q 0.74658203 1.1118164 0.8781738 1.4260254 Q 1.0097656 1.7402344 1.2299805 1.9228516 Q 0.66064453 2.4707031 0.66064453 3.1582031 Q 0.66064453 3.894043 1.2219238 4.361328 Q 1.7832031 4.8286133 2.5405273 4.8286133 Q 3.2226563 4.8286133 3.6845703 4.522461 Q 3.8833008 4.7856445 4.213623 4.9333496 Q 4.5439453 5.0810547 4.7856445 5.0810547 Q 5.0058594 5.0810547 5.1481934 4.965576 Q 5.2905273 4.8500977 5.2905273 4.6728516 Q 5.2905273 4.5063477 5.1643066 4.3828125 Q 5.038086 4.2592773 4.882324 4.2592773 Z "/>
+        </symbol>
+        <symbol id="gC57BA794B7588EB72D43E56143860B21" overflow="visible">
+            <path d="M 1.9121094 3.9907227 Q 1.7241211 3.8242188 1.7294922 3.5288086 L 1.7294922 0.7788086 Q 2.1484375 0.2631836 2.519043 0.2631836 Q 3.2763672 0.2631836 3.6738281 0.87280273 Q 4.071289 1.4824219 4.071289 2.465332 Q 4.071289 3.2548828 3.7141113 3.8000488 Q 3.3569336 4.345215 2.8466797 4.345215 Q 2.3095703 4.345215 1.9121094 3.9907227 Z M 1.8369141 4.3344727 Q 2.3847656 4.8286133 3.0668945 4.8286133 Q 3.8242188 4.8286133 4.42041 4.224365 Q 5.0166016 3.6201172 5.0166016 2.6640625 Q 5.0166016 1.434082 4.256592 0.6633301 Q 3.496582 -0.107421875 2.583496 -0.107421875 Q 1.9389648 -0.107421875 1.6166992 0.16113281 Q 1.5253906 0.23632813 1.463623 0.23364258 Q 1.4018555 0.23095703 1.315918 0.13427734 Q 1.2353516 0.04296875 1.0581055 -0.13427734 Q 0.89160156 -0.13427734 0.81640625 0 Q 0.859375 0.20947266 0.859375 0.7788086 L 0.859375 6.1499023 Q 0.859375 6.5043945 0.8432617 6.678955 Q 0.82714844 6.8535156 0.7062988 6.9367676 Q 0.5854492 7.0200195 0.51831055 7.0253906 Q 0.45117188 7.0307617 0.15576172 7.052246 Q 0.032226563 7.1757813 0.0859375 7.379883 Q 1.0634766 7.455078 1.6274414 7.680664 Q 1.7724609 7.680664 1.7724609 7.567871 Q 1.7294922 7.1274414 1.7294922 6.413086 L 1.7294922 4.3881836 Q 1.7294922 4.237793 1.8369141 4.3344727 Z "/>
+        </symbol>
+        <symbol id="gE66BEFED3DE41F88EDBED309C43CEAF8" overflow="visible">
+            <path d="M 3.5395508 4.0498047 Q 3.1796875 4.4526367 2.6748047 4.4526367 Q 2.0356445 4.4526367 1.6838379 3.9155273 Q 1.3320313 3.378418 1.3320313 2.4975586 Q 1.3320313 1.9013672 1.4851074 1.4689941 Q 1.6381836 1.0366211 1.890625 0.81103516 Q 2.1430664 0.5854492 2.4035645 0.4807129 Q 2.6640625 0.37597656 2.927246 0.37597656 Q 3.3730469 0.37597656 3.6523438 0.5209961 Q 3.7543945 0.57470703 3.78125 0.63378906 Q 3.8081055 0.6928711 3.8081055 0.8486328 L 3.8081055 3.378418 Q 3.8081055 3.5878906 3.751709 3.7302246 Q 3.6953125 3.8725586 3.5395508 4.0498047 Z M 3.8081055 -1.2192383 L 3.8081055 0 Q 3.8081055 0.1665039 3.7543945 0.171875 Q 3.7006836 0.1772461 3.5073242 0.05908203 Q 3.211914 -0.11279297 2.6640625 -0.107421875 Q 1.5737305 -0.107421875 0.9802246 0.63916016 Q 0.38671875 1.3857422 0.38671875 2.2773438 Q 0.38671875 3.3676758 1.0500488 4.0981445 Q 1.7133789 4.8286133 2.7177734 4.8286133 Q 3.4643555 4.8286133 3.958496 4.5063477 Q 4.060547 4.4472656 4.114258 4.474121 Q 4.1679688 4.5009766 4.2807617 4.651367 Q 4.4365234 4.86084 4.5117188 4.86084 Q 4.6782227 4.86084 4.6728516 4.586914 L 4.6728516 -1.2192383 Q 4.6728516 -1.8798828 4.807129 -2.0356445 Q 4.9414063 -2.1914063 5.4677734 -2.2128906 Q 5.5214844 -2.2666016 5.5214844 -2.3981934 Q 5.5214844 -2.5297852 5.4677734 -2.572754 Q 4.742676 -2.5512695 4.248535 -2.5512695 Q 3.786621 -2.5512695 3.0131836 -2.572754 Q 2.9702148 -2.5297852 2.9702148 -2.3981934 Q 2.9702148 -2.2666016 3.0131836 -2.2128906 Q 3.5395508 -2.1914063 3.6738281 -2.0356445 Q 3.8081055 -1.8798828 3.8081055 -1.2192383 Z "/>
+        </symbol>
+        <symbol id="g2C727529FF314E30D732EB9FBEF8906D" overflow="visible">
+            <path d="M 3.5771484 4.3774414 Q 3.5234375 4.42041 3.520752 4.552002 Q 3.5180664 4.6835938 3.5771484 4.742676 Q 4.125 4.7211914 4.586914 4.7211914 Q 4.914551 4.7211914 5.3549805 4.742676 Q 5.4086914 4.688965 5.411377 4.5546875 Q 5.4140625 4.42041 5.3549805 4.3774414 Q 4.936035 4.3398438 4.7668457 4.1679688 Q 4.5976563 3.9960938 4.415039 3.5664063 L 2.9487305 0.123535156 Q 2.8413086 -0.12890625 2.6855469 -0.13427734 Q 2.4975586 -0.13427734 2.411621 0.09667969 L 1.0043945 3.5771484 Q 0.82177734 4.0390625 0.6767578 4.184082 Q 0.5317383 4.3291016 0.123535156 4.3774414 Q 0.06982422 4.42041 0.06713867 4.552002 Q 0.064453125 4.6835938 0.123535156 4.742676 Q 0.7841797 4.7211914 1.144043 4.7211914 Q 1.5307617 4.7211914 2.2558594 4.742676 Q 2.3095703 4.688965 2.3095703 4.5546875 Q 2.3095703 4.42041 2.2558594 4.3774414 Q 1.8422852 4.3237305 1.7912598 4.178711 Q 1.7402344 4.0336914 1.9121094 3.6416016 L 2.7070313 1.5200195 Q 2.8413086 1.1816406 2.9111328 1.1682129 Q 2.980957 1.1547852 3.1152344 1.4824219 L 4.001465 3.6416016 Q 4.178711 4.060547 4.0981445 4.202881 Q 4.017578 4.345215 3.5771484 4.3774414 Z "/>
+        </symbol>
+        <symbol id="g2398852476A067707A94262529243E6" overflow="visible">
+            <path d="M 0.62841797 0.47265625 Q 0.62841797 0.71435547 0.7976074 0.88623047 Q 0.9667969 1.0581055 1.2084961 1.0581055 Q 1.4501953 1.0581055 1.6220703 0.88623047 Q 1.7939453 0.71435547 1.7939453 0.47265625 Q 1.7939453 0.23095703 1.6220703 0.061767578 Q 1.4501953 -0.107421875 1.2084961 -0.107421875 Q 0.9667969 -0.107421875 0.7976074 0.061767578 Q 0.62841797 0.23095703 0.62841797 0.47265625 Z "/>
+        </symbol>
+        <symbol id="gBDEAEBFC2F3FDB731F7FB66BFF129D00" overflow="visible">
+            <path d="M 1.890625 5.7524414 L 1.890625 2.927246 Q 1.890625 2.465332 1.9121094 2.1672363 Q 1.9335938 1.8691406 2.067871 1.4851074 Q 2.2021484 1.1010742 2.4545898 0.859375 Q 2.9916992 0.34375 3.7597656 0.3383789 Q 4.296875 0.3383789 4.6835938 0.5102539 Q 5.0703125 0.6821289 5.279785 0.9291992 Q 5.489258 1.1762695 5.6101074 1.5683594 Q 5.730957 1.9604492 5.7578125 2.2827148 Q 5.784668 2.6049805 5.784668 3.0454102 L 5.784668 5.7524414 Q 5.784668 6.0908203 5.7524414 6.2734375 Q 5.720215 6.4560547 5.583252 6.560791 Q 5.446289 6.6655273 5.2905273 6.692383 Q 5.1347656 6.7192383 4.7749023 6.751465 Q 4.7319336 6.7944336 4.7319336 6.928711 Q 4.7319336 7.0629883 4.7749023 7.116699 Q 5.784668 7.095215 6.0478516 7.095215 Q 6.3325195 7.095215 7.17041 7.116699 Q 7.213379 7.0629883 7.213379 6.9313965 Q 7.213379 6.7998047 7.17041 6.751465 Q 6.633301 6.6870117 6.4802246 6.5339355 Q 6.3271484 6.3808594 6.3271484 5.7524414 L 6.3271484 3.2441406 Q 6.3271484 2.465332 6.206299 1.8879395 Q 6.085449 1.3105469 5.7819824 0.8432617 Q 5.4785156 0.37597656 4.9172363 0.13427734 Q 4.355957 -0.107421875 3.5288086 -0.107421875 Q 3.0454102 -0.107421875 2.6398926 0 Q 2.234375 0.107421875 1.831543 0.3786621 Q 1.4287109 0.64990234 1.1923828 1.2058105 Q 0.9560547 1.7617188 0.9560547 2.5620117 L 0.9560547 5.7524414 Q 0.9560547 6.4023438 0.7976074 6.566162 Q 0.63916016 6.7299805 0.107421875 6.751465 Q 0.064453125 6.7944336 0.064453125 6.928711 Q 0.064453125 7.0629883 0.107421875 7.116699 Q 0.9667969 7.095215 1.4179688 7.095215 Q 1.8691406 7.095215 2.9057617 7.116699 Q 2.9487305 7.0629883 2.9487305 6.9313965 Q 2.9487305 6.7998047 2.9057617 6.751465 Q 2.2451172 6.7299805 2.067871 6.571533 Q 1.890625 6.413086 1.890625 5.7524414 Z "/>
+        </symbol>
+        <symbol id="g283FA10DA0826EA1224F4899A26D4FEC" overflow="visible">
+            <path d="M 5.1723633 1.3427734 Q 5.1723633 0.6821289 5.303955 0.52905273 Q 5.435547 0.37597656 5.961914 0.3383789 Q 6.004883 0.28466797 6.004883 0.15307617 Q 6.004883 0.021484375 5.961914 -0.021484375 Q 5.145508 0 4.73999 0 Q 4.3344727 0 3.5664063 -0.021484375 Q 3.5234375 0.021484375 3.520752 0.15307617 Q 3.5180664 0.28466797 3.5664063 0.3383789 Q 4.0498047 0.37060547 4.1760254 0.5263672 Q 4.302246 0.6821289 4.302246 1.3427734 L 4.302246 3.5073242 Q 4.302246 3.9370117 4.213623 4.114258 Q 4.125 4.291504 3.8725586 4.291504 L 1.9013672 4.291504 L 1.9013672 1.3427734 Q 1.9013672 0.6821289 2.032959 0.52905273 Q 2.1645508 0.37597656 2.7177734 0.3383789 Q 2.7714844 0.28466797 2.7714844 0.15307617 Q 2.7714844 0.021484375 2.7177734 -0.021484375 Q 1.9926758 0 1.4716797 0 Q 1.0634766 0 0.31689453 -0.021484375 Q 0.2631836 0.021484375 0.2631836 0.15307617 Q 0.2631836 0.28466797 0.31689453 0.3383789 Q 0.7895508 0.37060547 0.91308594 0.5263672 Q 1.0366211 0.6821289 1.0366211 1.3427734 L 1.0366211 4.291504 L 0.29541016 4.291504 Q 0.24169922 4.291504 0.24169922 4.355957 L 0.24169922 4.5009766 Q 0.24169922 4.7211914 0.49414063 4.7211914 L 1.0366211 4.7211914 L 1.0366211 4.882324 Q 1.0366211 6.289551 1.5952148 6.9501953 Q 2.2236328 7.675293 3.1582031 7.680664 Q 3.9370117 7.680664 4.5251465 7.326172 Q 5.1132813 6.9716797 5.1132813 6.466797 Q 5.1132813 6.289551 4.9709473 6.152588 Q 4.8286133 6.015625 4.640625 6.015625 Q 4.366699 6.015625 4.202881 6.176758 Q 4.0390625 6.3378906 3.958496 6.7299805 Q 3.8510742 7.2993164 3.0239258 7.3046875 Q 2.4868164 7.3046875 2.1940918 6.738037 Q 1.9013672 6.1713867 1.9013672 5.3442383 L 1.9013672 4.7211914 L 4.071289 4.7211914 Q 4.753418 4.7211914 5.102539 4.86084 Q 5.209961 4.86084 5.215332 4.7963867 Q 5.1723633 4.0927734 5.1723633 3.663086 L 5.1723633 1.3427734 Z "/>
+        </symbol>
+        <symbol id="gFAB5AB46C3D7E8820D142009AEFE491" overflow="visible">
+            <path d="M 6.289551 -1.3427734 Q 7.0683594 -1.6489258 7.5705566 -1.7644043 Q 8.072754 -1.8798828 8.6796875 -1.8798828 Q 9.109375 -1.8798828 9.708252 -1.7053223 Q 10.307129 -1.5307617 10.833496 -1.2299805 L 11.021484 -1.4287109 Q 10.495117 -1.9121094 9.713623 -2.199463 Q 8.932129 -2.4868164 8.072754 -2.4868164 Q 6.751465 -2.4868164 5.5322266 -1.9819336 Q 4.4956055 -1.5629883 3.9423828 -1.4018555 Q 3.3891602 -1.2407227 2.8359375 -1.2407227 Q 2.583496 -1.2407227 2.2988281 -1.4663086 Q 2.1269531 -1.6650391 1.9604492 -1.9013672 L 1.5200195 -1.6811523 Q 2.0249023 -0.98828125 2.7929688 -0.4296875 Q 3.0615234 -0.23095703 3.3569336 -0.080566406 Q 2.0786133 0.0859375 1.2434082 1.0285645 Q 0.40820313 1.9711914 0.40820313 3.4106445 Q 0.40820313 5.0595703 1.3212891 6.1499023 Q 2.234375 7.2402344 3.786621 7.2402344 Q 5.317383 7.2402344 6.3217773 6.26001 Q 7.326172 5.279785 7.326172 3.6201172 Q 7.326172 2.2451172 6.644043 1.2783203 Q 5.849121 0.15039063 4.4418945 -0.064453125 Q 3.7919922 -0.24169922 3.1152344 -0.72509766 Q 3.0615234 -0.7626953 3.0078125 -0.80566406 Q 3.1796875 -0.7841797 3.3461914 -0.7788086 Q 4.8500977 -0.7841797 6.289551 -1.3427734 Z M 3.6416016 6.8427734 Q 2.7392578 6.8427734 2.1000977 6.0290527 Q 1.4609375 5.215332 1.4609375 3.5986328 Q 1.4609375 2.0786133 2.2316895 1.1816406 Q 3.0024414 0.28466797 4.071289 0.28466797 Q 5.038086 0.28466797 5.653076 1.1279297 Q 6.2680664 1.9711914 6.2680664 3.4106445 Q 6.2680664 5.0166016 5.5214844 5.9296875 Q 4.7749023 6.8427734 3.6416016 6.8427734 Z M 10.317871 -0.107421875 Q 9.560547 -0.107421875 9.230225 0.31420898 Q 8.899902 0.73583984 8.899902 1.3857422 L 8.899902 3.496582 Q 8.899902 4.012207 8.762939 4.178711 Q 8.625977 4.345215 8.217773 4.3774414 Q 8.1640625 4.42041 8.1640625 4.552002 Q 8.1640625 4.6835938 8.217773 4.742676 Q 8.964355 4.7211914 9.340332 4.7211914 Q 9.614258 4.7211914 9.72168 4.742676 Q 9.807617 4.742676 9.812988 4.6728516 Q 9.77002 3.8671875 9.77002 3.5395508 L 9.77002 1.5415039 Q 9.77002 0.89160156 10.038574 0.64990234 Q 10.307129 0.40820313 10.645508 0.40820313 Q 11.128906 0.40820313 11.746582 0.9345703 Q 11.923828 1.090332 11.923828 1.3642578 L 11.923828 3.4858398 Q 11.923828 4.012207 11.792236 4.184082 Q 11.660645 4.355957 11.241699 4.3774414 Q 11.19873 4.42041 11.19873 4.552002 Q 11.19873 4.6835938 11.241699 4.742676 Q 11.988281 4.7211914 12.364258 4.7211914 Q 12.638184 4.7211914 12.750977 4.742676 Q 12.836914 4.742676 12.836914 4.6728516 Q 12.793945 3.8671875 12.793945 3.5395508 L 12.793945 1.4287109 Q 12.793945 0.99902344 12.94165 0.8352051 Q 13.089355 0.6713867 13.594238 0.62841797 Q 13.637207 0.57470703 13.639893 0.4753418 Q 13.642578 0.37597656 13.594238 0.32763672 Q 12.713379 0.23095703 12.299805 -0.107421875 Q 12.203125 -0.15039063 12.090332 -0.107421875 Q 11.993652 0.2685547 11.966797 0.5371094 Q 11.956055 0.5908203 11.902344 0.58813477 Q 11.848633 0.5854492 11.805664 0.54785156 Q 11 -0.107421875 10.317871 -0.107421875 Z "/>
+        </symbol>
+        <symbol id="g6DC016622A31714551059BEE327C8748" overflow="visible">
+            <path d="M 1.9228516 1.3427734 Q 1.9228516 0.66064453 2.0625 0.51831055 Q 2.2021484 0.37597656 2.8466797 0.3383789 Q 2.9003906 0.28466797 2.9030762 0.15307617 Q 2.9057617 0.021484375 2.8466797 -0.021484375 Q 2.0786133 0 1.4985352 0 Q 1.0581055 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.7680664 0.37060547 0.91308594 0.5317383 Q 1.0581055 0.6928711 1.0581055 1.3427734 L 1.0581055 4.291504 L 0.29541016 4.291504 Q 0.24169922 4.291504 0.24169922 4.355957 L 0.24169922 4.5009766 Q 0.24169922 4.7211914 0.49414063 4.7211914 L 1.0581055 4.7211914 L 1.0581055 5.161621 Q 1.0581055 6.359375 1.6462402 7.0200195 Q 2.234375 7.680664 3.0024414 7.680664 Q 3.663086 7.680664 3.9907227 7.444336 Q 4.345215 7.1811523 4.345215 6.885742 Q 4.345215 6.7192383 4.1921387 6.5769043 Q 4.0390625 6.4345703 3.894043 6.4345703 Q 3.609375 6.4345703 3.4536133 6.7890625 Q 3.3461914 7.0737305 3.1958008 7.189209 Q 3.0454102 7.3046875 2.7929688 7.3046875 Q 1.9228516 7.3046875 1.9228516 5.3442383 L 1.9228516 4.7211914 L 3.1152344 4.7211914 Q 3.2011719 4.7211914 3.2011719 4.651367 L 3.2011719 4.4311523 Q 3.2011719 4.286133 2.9487305 4.291504 L 1.9228516 4.291504 L 1.9228516 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g29521F5593DBC934C33F1D9ECDCE0406" overflow="visible">
+            <path d="M 0.54785156 4.995117 Q 0.54785156 5.602051 1.1762695 6.1552734 Q 1.8046875 6.708496 2.8842773 6.708496 Q 3.894043 6.708496 4.5117188 6.123047 Q 4.984375 5.671875 4.984375 4.9414063 Q 4.984375 4.742676 4.9575195 4.576172 Q 4.930664 4.409668 4.901123 4.2888184 Q 4.871582 4.1679688 4.7614746 4.0095215 Q 4.651367 3.8510742 4.6030273 3.7678223 Q 4.5546875 3.6845703 4.355957 3.4858398 Q 4.1572266 3.2871094 4.0686035 3.206543 Q 3.9799805 3.1259766 3.6791992 2.8493652 Q 3.378418 2.572754 3.2333984 2.4438477 L 2.5888672 1.8476563 Q 2.1323242 1.4287109 2.0786133 0.8701172 L 3.5073242 0.8701172 Q 3.8833008 0.8701172 4.135742 1.1118164 Q 4.3881836 1.3535156 4.5654297 1.9121094 Q 4.817871 1.9121094 5.0595703 1.8046875 Q 4.914551 0.6176758 4.7211914 0 L 0.47265625 0 L 0.4296875 0.3544922 Q 0.45117188 0.5961914 0.7546387 0.9694824 Q 1.0581055 1.3427734 2.0141602 2.2558594 L 2.9487305 3.147461 Q 3.3569336 3.5341797 3.467041 3.9074707 Q 3.5771484 4.2807617 3.5771484 4.9038086 Q 3.5771484 5.505371 3.2871094 5.8759766 Q 2.9863281 6.2626953 2.6264648 6.257324 Q 2.2612305 6.257324 1.9873047 5.9887695 Q 1.7133789 5.720215 1.7133789 5.5 Q 1.7133789 5.3657227 1.7832031 5.215332 Q 1.8369141 5.048828 1.8369141 4.984375 Q 1.8369141 4.7319336 1.6435547 4.5654297 Q 1.4501953 4.398926 1.1977539 4.398926 Q 0.91308594 4.398926 0.73046875 4.586914 Q 0.54785156 4.7749023 0.54785156 4.995117 Z "/>
+        </symbol>
+        <symbol id="g7109D5BCB43EE139F7DDA5F697B5EBC7" overflow="visible">
+            <path d="M 2.7285156 6.246582 Q 2.5512695 6.246582 2.43042 6.2304688 Q 2.3095703 6.2143555 2.1618652 6.1499023 Q 2.0141602 6.085449 1.9147949 5.9350586 Q 1.8154297 5.784668 1.7724609 5.5429688 Q 1.71875 5.2475586 1.5737305 5.0944824 Q 1.4287109 4.9414063 1.090332 4.9414063 Q 0.6713867 4.9414063 0.6713867 5.3442383 Q 0.6713867 5.720215 0.97753906 6.004883 Q 1.2084961 6.2143555 1.3911133 6.340576 Q 1.5737305 6.466797 1.9926758 6.5876465 Q 2.411621 6.708496 2.9379883 6.708496 Q 3.947754 6.708496 4.3344727 6.340576 Q 4.7211914 5.9726563 4.7211914 5.489258 Q 4.7211914 4.9521484 4.2539063 4.42041 Q 4.022949 4.1572266 3.6953125 3.9907227 Q 4.366699 3.947754 4.7507324 3.5019531 Q 5.1347656 3.0561523 5.1347656 2.4438477 Q 5.1347656 1.5844727 4.576172 0.91308594 Q 4.178711 0.4296875 3.574463 0.16113281 Q 2.9702148 -0.107421875 2.3847656 -0.107421875 Q 1.546875 -0.107421875 0.8701172 0.23095703 Q 0.5048828 0.4189453 0.5048828 0.74658203 Q 0.5048828 0.91308594 0.66064453 1.0661621 Q 0.81640625 1.2192383 1.0473633 1.2192383 Q 1.4663086 1.2192383 1.7617188 0.81640625 Q 2.116211 0.3544922 2.5620117 0.3544922 Q 2.980957 0.3544922 3.348877 0.7062988 Q 3.7167969 1.0581055 3.7167969 1.890625 Q 3.7167969 3.3730469 2.3417969 3.378418 Q 2.121582 3.378418 1.8154297 3.2871094 Q 1.7294922 3.383789 1.7294922 3.609375 Q 1.7294922 3.6845703 1.7402344 3.727539 Q 2.5083008 3.899414 2.9648438 4.3720703 Q 3.4213867 4.8447266 3.4213867 5.4677734 Q 3.4213867 6.246582 2.7285156 6.246582 Z "/>
+        </symbol>
+        <symbol id="g8610EA03DB4DF9C3714D75A0CBD0FB7D" overflow="visible">
+            <path d="M 0.6713867 5.145508 Q 0.6713867 5.6933594 1.232666 6.2009277 Q 1.7939453 6.708496 2.6533203 6.708496 Q 3.3999023 6.708496 3.9558105 6.286865 Q 4.5117188 5.8652344 4.5117188 5.038086 Q 4.5117188 4.640625 4.345215 4.2888184 Q 4.178711 3.9370117 3.988037 3.7114258 Q 3.7973633 3.4858398 3.4106445 3.1152344 L 2.2988281 2.0463867 Q 1.4824219 1.2299805 1.4824219 0.71435547 L 3.442871 0.71435547 Q 3.7382813 0.71435547 3.9047852 0.9453125 Q 4.071289 1.1762695 4.2109375 1.7724609 Q 4.42041 1.8154297 4.533203 1.7133789 Q 4.5117188 0.9453125 4.2700195 -0.021484375 Q 3.7651367 0 3.4106445 0 L 1.4824219 0 L 0.56933594 -0.021484375 Q 0.56933594 0.5048828 0.8190918 0.99365234 Q 1.0688477 1.4824219 1.8261719 2.2558594 L 2.6425781 3.0561523 Q 3.5449219 3.9692383 3.5395508 4.995117 Q 3.5395508 5.7094727 3.2495117 6.0183105 Q 2.9594727 6.3271484 2.583496 6.3271484 Q 2.0356445 6.3271484 1.7670898 6.117676 Q 1.4985352 5.908203 1.4985352 5.6557617 Q 1.4985352 5.602051 1.5415039 5.5026855 Q 1.5844727 5.4033203 1.5844727 5.392578 Q 1.6274414 5.2368164 1.6274414 5.161621 Q 1.6274414 4.995117 1.4475098 4.8581543 Q 1.2675781 4.7211914 1.1118164 4.7211914 Q 0.9345703 4.7211914 0.8029785 4.8447266 Q 0.6713867 4.9682617 0.6713867 5.145508 Z "/>
+        </symbol>
+    </defs>
+</svg>

--- a/packages/preview/jurz/0.1.0/demo-3.svg
+++ b/packages/preview/jurz/0.1.0/demo-3.svg
@@ -1,0 +1,939 @@
+<svg class="typst-doc" viewBox="0 0 272.1264 385.51239999999996" width="272.1264pt" height="385.51239999999996pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(0 0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 385.5124 L 272.1264 385.5124 L 272.1264 0 Z "/>
+        </g>
+        <g transform="translate(22 22.613825000000006)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 0)">
+                        <g class="typst-group">
+                            <g/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 7.15)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 0)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 206.1264 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(22 49.759984375)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="4.705078125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="10.54345703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="23.4297721875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="28.1348503125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="33.6778190625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="37.76522140625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="43.54451828125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="49.08748703125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="53.088951875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.20475921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.76921234375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.31218109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="76.21257171875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="81.1271225" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="89.81218109375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="95.65056" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="99.9366928125" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="106.55494156249999" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="112.71021499999999" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="117.62476578124999" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="121.71216812499999" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="128.89438171875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.369479375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="137.39145203125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="146.076510625" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="150.99106140625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="161.15423203125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="166.93352890625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="171.8480796875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="175.93548203125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="184.620540625" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="189.64251328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="195.14251328125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="201.10442734375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 64.15021875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="0" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="5.02197265625" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="9.72705078125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="14.43212890625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="19.3466796875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="23.6328125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="27.9189453125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="30.89990234375" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="40.12080625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="45.900103125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="51.443071875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.91816953125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="59.8327203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.118853125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="67.59395078125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="73.688878125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="77.9750109375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="84.633903125" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="89.65587578125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="92.55626640625" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="95.5372234375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="101.06945" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="106.90782890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="112.52599296875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="121.76838125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="126.79035390625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="131.7049046875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="135.18000234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="140.094553125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="144.18195546875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="150.14386953125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="155.9822484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="168.3452421875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="173.25979296875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="180.41282578124998" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="183.39378281249998" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="189.35569687499998" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="195.51097031249998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="201.47288437499998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 78.540453125)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="3.47509765625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="9.3134765625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="20.74853515625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="23.7294921875" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="32.41455078125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="38.19384765625" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="43.1083984375" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="49.0703125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.634765625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="59.54931640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="63.55078125" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="68.35791015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(239.1264 91.740453125)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.09521484375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g8627CB172E3C4C14F5D9F6D306FBE770" x="0" fill="#000000"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(22 98.9806875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 113.37092187500001)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 127.76115625000001)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="13.196766536458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="16.097157161458334" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="21.119129817708334" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="26.645985286458334" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="32.188954036458334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="36.190418880208334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="44.98825963541667" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="49.90281041666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="57.261198046875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="62.825651171875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="68.368619921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="71.269010546875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="76.811979296875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="80.813444140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="89.61128489583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="98.29634348958332" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="103.31831614583332" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="108.81831614583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="114.78023020833332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="119.80220286458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.37055143229165" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="137.39252408854165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="140.29291471354165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="143.27387174479165" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="148.80609830729165" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="154.64447721354165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="159.66644986979165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="172.2347984375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="177.767025" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="183.60540390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="188.6273765625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="193.54192734375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="197.6293296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 142.15139062500003)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.37646484375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="10.91943359375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="13.81982421875" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="19.658203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="25.3623046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="28.83740234375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="33.859375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="37.33447265625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="42.2490234375" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="50.93408203125" fill="#000000"/>
+                <use xlink:href="#gBDEAEBFC2F3FDB731F7FB66BFF129D00" x="57.72528" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.99236984375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="72.84167328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="77.7562240625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="83.718138125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="86.69909515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="99.75835953125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="104.7803321875" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="109.77007828125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="115.30230484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="121.14068375" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="130.4294403125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="135.9938934375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="141.5368621875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="144.4372528125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="149.35180359375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="154.37377625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="163.05883484375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="168.89721375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="177.55755234375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="182.579525" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="188.5414390625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="191.52239609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="200.2074546875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="205.6430015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 156.541625)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="4.705078125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="10.54345703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="23.4297721875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="28.1348503125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="33.6778190625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="37.76522140625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="43.54451828125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="49.08748703125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="53.088951875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.20475921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.76921234375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.31218109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="76.21257171875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="81.1271225" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="89.81218109375" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="95.65056" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="99.9366928125" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="106.55494156249999" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="112.71021499999999" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="117.62476578124999" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="121.71216812499999" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="128.89438171875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.369479375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="137.39145203125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="146.076510625" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="150.99106140625" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="161.15423203125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="166.93352890625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="171.8480796875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="175.93548203125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="184.620540625" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="189.64251328125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="195.14251328125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="201.10442734375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 170.93185937500004)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="0" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="5.02197265625" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="9.72705078125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="14.43212890625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="19.3466796875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="23.6328125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="27.9189453125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="30.89990234375" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="40.12080625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="45.900103125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="51.443071875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.91816953125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="59.8327203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="64.118853125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="67.59395078125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="73.688878125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="77.9750109375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="84.633903125" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="89.65587578125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="92.55626640625" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="95.5372234375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="101.06945" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="106.90782890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="112.52599296875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="121.76838125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="126.79035390625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="131.7049046875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="135.18000234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="140.094553125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="144.18195546875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="150.14386953125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="155.9822484375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="168.3452421875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="173.25979296875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="180.41282578124998" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="183.39378281249998" fill="#000000"/>
+                <use xlink:href="#g283FA10DA0826EA1224F4899A26D4FEC" x="189.35569687499998" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="195.51097031249998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="201.47288437499998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 185.32209375000002)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="0" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="3.47509765625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="9.3134765625" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="20.931139374999997" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="23.912096406249997" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="32.597155" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="38.376451875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="43.29100265625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="49.25291671875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.81736984375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="59.731920625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="63.73338546875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="71.58054046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="80.2655990625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="85.28757171875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="88.18796234375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="94.02634125" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="105.6440040625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="111.605918125" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="117.148886875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="122.56832046875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="125.5492775" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="132.76801453125" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="138.31098328125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="144.01508484375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="146.996041875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="152.9579559375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="157.87250671875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="166.5575653125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="172.39594421875" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="175.83344421875" fill="#000000"/>
+                <use xlink:href="#gFAB5AB46C3D7E8820D142009AEFE491" x="181.183040625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="194.9437828125" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="200.561946875" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 199.71232812500006)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="8.54541015625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="13.4599609375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="24.89501953125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="27.79541015625" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="30.7763671875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="35.4814453125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.39599609375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="46.62109375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="50.09619140625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="54.18359375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="59.20556640625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="65.16748046875" fill="#000000"/>
+                <use xlink:href="#g6DC016622A31714551059BEE327C8748" x="69.45361328125" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="72.85888671875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="77.7734375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.86083984375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="85.8623046875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.52685546875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="96.5078125" fill="#000000"/>
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="105.2197265625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="110.59619140625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="116.13916015625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="119.03955078125" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="124.8779296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="130.58203125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="134.05712890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="139.0791015625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="142.55419921875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="147.46875" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="156.15380859375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="161.32080078125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="167.1591796875" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="170.63427734375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 220.15256250000004)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 234.54279687500002)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 248.93303125)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="12.0634765625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="14.9638671875" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="19.98583984375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="25.5126953125" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="31.0556640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="35.05712890625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="42.7216796875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="47.63623046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="53.861328125" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="59.42578125" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="64.96875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.869140625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="73.412109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="77.41357421875" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="85.078125" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="93.76318359375" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="98.78515625" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="104.28515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="110.2470703125" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="115.26904296875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="126.7041015625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="131.72607421875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="134.62646484375" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="137.607421875" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="143.1396484375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="148.97802734375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="154" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="165.43505859375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="170.96728515625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="176.8056640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="181.82763671875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="186.7421875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="190.82958984375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="195.8515625" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="199.32666015625" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(239.1264 262.13303125)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.09521484375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g2E3539D098C7287320B8E2FD4F266F8F" x="0" fill="#000000"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(22 269.373265625)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gB7C2485A990F0D16073DE98E640F51" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.80615234375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.34912109375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="15.3505859375" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="20.26513671875" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="31.927202734374998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="34.908159765625" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="40.612261328125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="44.898394140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="50.736773046875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="62.3988390625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="67.9632921875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="73.5062609375" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="76.4066515625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="81.9496203125" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="89.014030078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="93.300162890625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="96.281119921875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="102.733225" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="107.75519765625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.44025625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="121.35480703125" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="124.8299046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="130.223904296875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="134.928982421875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="140.471951171875" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="146.433865234375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="150.719998046875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="155.709744140625" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="160.414822265625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="163.889919921875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="168.804470703125" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="172.279568359375" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="178.117947265625" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="185.18235703124998" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="190.20432968749998" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="195.76878281249998" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="198.74973984374998" fill="#000000"/>
+                <use xlink:href="#gDA8A4BDDF46A0076AFC20015B6D6FA96" x="204.45384140624998" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 283.7635)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="0" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="2.98095703125" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="7.26708984375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="11.97216796875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="14.953125" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="20.9150390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="29.863270442708334" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="34.777821223958334" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="37.678211848958334" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="40.659168880208334" fill="#000000"/>
+                <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="44.134266536458334" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="49.99949010416667" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="54.28562291666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="59.27536901041667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="68.288053515625" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="73.852506640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="82.84370677083332" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="87.75825755208332" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="90.73921458333332" fill="#000000"/>
+                <use xlink:href="#g5B9E5EB97F9DFC2F689C0AE85A2A0257" x="96.57759348958332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="100.86372630208332" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="109.54878489583332" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="115.16694895833332" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="124.17963346354165" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="127.65473111979165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="132.56928190104165" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="141.25434049479165" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="147.03363736979165" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="152.57660611979165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="160.11223984375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="163.093196875" fill="#000000"/>
+                <use xlink:href="#gB87EDFCDB36CE1A74BA6F566283791D" x="169.0551109375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="173.7601890625" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="176.74114609375" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="182.30559921875" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="185.28655625" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="190.851009375" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="196.68938828125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 298.153734375)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="0" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="5.83837890625" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="13.196766536458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="16.097157161458334" fill="#000000"/>
+                <use xlink:href="#gC57BA794B7588EB72D43E56143860B21" x="21.119129817708334" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="26.645985286458334" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="32.188954036458334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="36.190418880208334" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="44.98825963541667" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="49.90281041666667" fill="#000000"/>
+                <use xlink:href="#gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" x="57.261198046875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="62.825651171875" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="68.368619921875" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="71.269010546875" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="76.811979296875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="80.813444140625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="89.61128489583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="98.29634348958332" fill="#000000"/>
+                <use xlink:href="#g92C9249AEAD95F98902AD6AA7E64704A" x="103.31831614583332" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="108.81831614583332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="114.78023020833332" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="119.80220286458332" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="132.37055143229165" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="137.39252408854165" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="140.29291471354165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="143.27387174479165" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="148.80609830729165" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="154.64447721354165" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="159.66644986979165" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="172.2347984375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="177.767025" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="183.60540390625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="188.6273765625" fill="#000000"/>
+                <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="193.54192734375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="197.6293296875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="202.65130234375" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 312.54396875)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g2C727529FF314E30D732EB9FBEF8906D" x="0" fill="#000000"/>
+                <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="5.37646484375" fill="#000000"/>
+                <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="10.91943359375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="13.81982421875" fill="#000000"/>
+                <use xlink:href="#g580AAD674A0E08ED15198255596B26A2" x="19.658203125" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="25.3623046875" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="28.83740234375" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="33.859375" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="37.33447265625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="42.2490234375" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="50.93408203125" fill="#000000"/>
+                <use xlink:href="#gBDEAEBFC2F3FDB731F7FB66BFF129D00" x="56.10107421875" fill="#000000"/>
+                <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="63.3681640625" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="69.59326171875" fill="#000000"/>
+                <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="74.5078125" fill="#000000"/>
+                <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="80.4697265625" fill="#000000"/>
+                <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="83.45068359375" fill="#000000"/>
+                <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="94.8857421875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="99.90771484375" fill="#000000"/>
+                <use xlink:href="#gE66BEFED3DE41F88EDBED309C43CEAF8" x="104.8974609375" fill="#000000"/>
+                <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="110.4296875" fill="#000000"/>
+                <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="116.26806640625" fill="#000000"/>
+                <use xlink:href="#g2398852476A067707A94262529243E6" x="121.0751953125" fill="#000000"/>
+            </g>
+        </g>
+        <g transform="translate(22 325.74396874999996)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.240234375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g11D8B379FEF962E3AE8AB39B50794CD8" x="0" fill="#000000"/>
+                            <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="5.33349609375" fill="#000000"/>
+                            <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="11.171875" fill="#000000"/>
+                            <use xlink:href="#g6DC016622A31714551059BEE327C8748" x="18.00927734375" fill="#000000"/>
+                            <use xlink:href="#g8B1338AC271281ABE03918097259F338" x="21.41455078125" fill="#000000"/>
+                            <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="27.2529296875" fill="#000000"/>
+                            <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="31.34033203125" fill="#000000"/>
+                            <use xlink:href="#gE90EDE5CEA4C1617ABCB9DBF48C9E652" x="34.8154296875" fill="#000000"/>
+                            <use xlink:href="#g6000CEAB22B14B2644F6F5DF3A907DF2" x="40.72900390625" fill="#000000"/>
+                            <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="45.6435546875" fill="#000000"/>
+                            <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="52.48095703125" fill="#000000"/>
+                            <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="55.4619140625" fill="#000000"/>
+                            <use xlink:href="#g6DC016622A31714551059BEE327C8748" x="61.423828125" fill="#000000"/>
+                            <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="64.8291015625" fill="#000000"/>
+                            <use xlink:href="#g7B0412412D0F33737832F45BFDAA75C8" x="70.3720703125" fill="#000000"/>
+                            <use xlink:href="#g21713D60D926C2F051E90CCC68C60993" x="74.45947265625" fill="#000000"/>
+                            <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="83.14453125" fill="#000000"/>
+                            <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="88.16650390625" fill="#000000"/>
+                            <use xlink:href="#g8DA966557E0CCF546BA5AA535F299256" x="91.6416015625" fill="#000000"/>
+                            <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="94.62255859375" fill="#000000"/>
+                            <use xlink:href="#gD7606749417294B0D6FD3F9982E155E4" x="100.16552734375" fill="#000000"/>
+                            <use xlink:href="#g67C67974E32647451A0E4FD1D272EE94" x="106.12744140625" fill="#000000"/>
+                            <use xlink:href="#gE34A8995945D3EFAE2F41F68D391F085" x="111.29443359375" fill="#000000"/>
+                            <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="114.19482421875" fill="#000000"/>
+                            <use xlink:href="#g9ABB161D7FA7D32FC821ED2C0B46F425" x="119.81298828125" fill="#000000"/>
+                            <use xlink:href="#gC5384350C9459EA016613B5F32AFBCA7" x="125.35595703125" fill="#000000"/>
+                            <use xlink:href="#gC7D7FC064504D98B998DC1A12C11586B" x="133.73486328125" fill="#000000"/>
+                            <use xlink:href="#g4CF119F98FB6E3D69D0CE269123E989F" x="138.7568359375" fill="#000000"/>
+                        </g>
+                    </g>
+                    <g transform="translate(144.98193359375 7.240234375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#gE79CB93519F93EB855C3182E0398C9B1" x="0" fill="#000000"/>
+                            <use xlink:href="#g4432869002C8934E6DD2DEAE9F5AFA82" x="6.4560546875" fill="#000000"/>
+                            <use xlink:href="#g2398852476A067707A94262529243E6" x="11.1181640625" fill="#000000"/>
+                            <use xlink:href="#gD231D848F892214029E9504EF6D7DFE" x="16.28515625" fill="#000000"/>
+                        </g>
+                    </g>
+                    <g transform="translate(166.38037109375 7.240234375)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g2398852476A067707A94262529243E6" x="0" fill="#000000"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(22 355.74857499999996)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 0)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 206.1264 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(0 7.15)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(100.506559375 7.240234375)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#gA8AF2E6BB513EDEA9F0D218901DA991E" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <defs id="glyph">
+        <symbol id="gB87EDFCDB36CE1A74BA6F566283791D" overflow="visible">
+            <path d="M 4.3774414 0.99902344 Q 3.9907227 0.35986328 3.5637207 0.1262207 Q 3.1367188 -0.107421875 2.583496 -0.107421875 Q 1.5629883 -0.107421875 0.9855957 0.545166 Q 0.40820313 1.1977539 0.40820313 2.288086 Q 0.40820313 3.3999023 1.1010742 4.114258 Q 1.7939453 4.8286133 2.6640625 4.8286133 Q 3.442871 4.8286133 3.894043 4.538574 Q 4.345215 4.248535 4.345215 3.786621 Q 4.345215 3.555664 4.17334 3.4267578 Q 4.001465 3.2978516 3.8081055 3.2978516 Q 3.432129 3.2978516 3.3891602 3.6953125 Q 3.3676758 3.9370117 3.3166504 4.0739746 Q 3.265625 4.2109375 3.0910645 4.337158 Q 2.916504 4.463379 2.6049805 4.463379 Q 2.057129 4.463379 1.7053223 3.9423828 Q 1.3535156 3.4213867 1.3535156 2.5297852 Q 1.3535156 1.5844727 1.7832031 1.0070801 Q 2.2128906 0.4296875 2.8251953 0.4296875 Q 3.5825195 0.4296875 4.1464844 1.1547852 Q 4.3237305 1.1333008 4.3774414 0.99902344 Z "/>
+        </symbol>
+        <symbol id="g8B1338AC271281ABE03918097259F338" overflow="visible">
+            <path d="M 2.3847656 -0.107421875 Q 1.6274414 -0.107421875 1.2971191 0.31420898 Q 0.9667969 0.73583984 0.9667969 1.3857422 L 0.9667969 3.496582 Q 0.9667969 4.012207 0.829834 4.178711 Q 0.6928711 4.345215 0.28466797 4.3774414 Q 0.24169922 4.42041 0.24169922 4.552002 Q 0.24169922 4.6835938 0.28466797 4.742676 Q 1.03125 4.7211914 1.4072266 4.7211914 Q 1.6811523 4.7211914 1.7939453 4.742676 Q 1.8798828 4.742676 1.8798828 4.6728516 Q 1.8369141 3.8671875 1.8369141 3.5395508 L 1.8369141 1.5415039 Q 1.8369141 0.89160156 2.1054688 0.64990234 Q 2.3740234 0.40820313 2.7177734 0.40820313 Q 3.211914 0.40820313 3.8188477 0.9345703 Q 3.9960938 1.090332 3.9907227 1.3642578 L 3.9907227 3.4858398 Q 3.9907227 4.012207 3.8591309 4.184082 Q 3.727539 4.355957 3.3085938 4.3774414 Q 3.2548828 4.42041 3.2548828 4.552002 Q 3.2548828 4.6835938 3.3085938 4.742676 Q 4.055176 4.7211914 4.4311523 4.7211914 Q 4.705078 4.7211914 4.817871 4.742676 Q 4.9038086 4.742676 4.9038086 4.6728516 Q 4.86084 3.8671875 4.86084 3.5395508 L 4.86084 1.4287109 Q 4.86084 0.99902344 5.0112305 0.8352051 Q 5.161621 0.6713867 5.666504 0.62841797 Q 5.720215 0.57470703 5.720215 0.4753418 Q 5.720215 0.37597656 5.666504 0.32763672 Q 4.7856445 0.23095703 4.366699 -0.107421875 Q 4.2700195 -0.15039063 4.1572266 -0.107421875 Q 4.060547 0.2685547 4.0390625 0.5371094 Q 4.0283203 0.5908203 3.9719238 0.58813477 Q 3.9155273 0.5854492 3.8725586 0.54785156 Q 3.0561523 -0.107421875 2.3847656 -0.107421875 Z "/>
+        </symbol>
+        <symbol id="g21713D60D926C2F051E90CCC68C60993" overflow="visible">
+            <path d="M 1.8691406 3.9370117 Q 1.8798828 3.7919922 2.003418 3.9370117 Q 2.7929688 4.8286133 3.6738281 4.8286133 Q 4.0927734 4.8286133 4.3935547 4.600342 Q 4.694336 4.3720703 4.7749023 4.022949 Q 4.801758 3.9155273 4.8930664 4.017578 Q 5.661133 4.8286133 6.708496 4.8286133 Q 7.379883 4.8286133 7.61084 4.3774414 Q 7.841797 3.9262695 7.841797 3.0776367 L 7.841797 1.3427734 Q 7.841797 0.6821289 7.9572754 0.52905273 Q 8.072754 0.37597656 8.54541 0.3383789 Q 8.588379 0.28466797 8.588379 0.15307617 Q 8.588379 0.021484375 8.54541 -0.021484375 Q 7.9277344 0 7.4121094 0 Q 6.8427734 0 6.289551 -0.021484375 Q 6.246582 0.021484375 6.246582 0.15307617 Q 6.246582 0.28466797 6.289551 0.3383789 Q 6.7407227 0.37060547 6.856201 0.5317383 Q 6.9716797 0.6928711 6.9716797 1.3427734 L 6.9716797 3.2763672 Q 6.9716797 3.8027344 6.8078613 4.031006 Q 6.644043 4.2592773 6.3164063 4.2592773 Q 5.5268555 4.2592773 4.86084 3.5288086 Q 4.871582 3.3945313 4.871582 3.088379 L 4.871582 1.3427734 Q 4.871582 0.6821289 4.9816895 0.52905273 Q 5.091797 0.37597656 5.5214844 0.3383789 Q 5.564453 0.28466797 5.564453 0.15844727 Q 5.564453 0.032226563 5.5214844 -0.021484375 Q 4.973633 0 4.4418945 0 Q 3.8725586 0 3.319336 -0.021484375 Q 3.2763672 0.032226563 3.2763672 0.16381836 Q 3.2763672 0.29541016 3.319336 0.3383789 Q 3.78125 0.37060547 3.8913574 0.5263672 Q 4.001465 0.6821289 4.001465 1.3427734 L 4.001465 3.2548828 Q 4.001465 4.2539063 3.2763672 4.2592773 Q 2.75 4.2592773 2.0893555 3.609375 Q 1.9013672 3.4106445 1.9013672 3.147461 L 1.9013672 1.3427734 Q 1.9013672 0.88623047 1.9658203 0.6875 Q 2.0302734 0.48876953 2.1484375 0.4296875 Q 2.2666016 0.37060547 2.583496 0.3383789 Q 2.631836 0.29003906 2.631836 0.15844727 Q 2.631836 0.026855469 2.583496 -0.021484375 Q 1.9228516 0 1.4716797 0 Q 0.9453125 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.7680664 0.37060547 0.90234375 0.5317383 Q 1.0366211 0.6928711 1.0366211 1.3427734 L 1.0366211 3.4858398 Q 1.0366211 3.947754 0.90771484 4.0686035 Q 0.7788086 4.189453 0.31689453 4.232422 Q 0.2524414 4.42041 0.29541016 4.5439453 Q 1.1118164 4.651367 1.6489258 4.86084 Q 1.7348633 4.86084 1.7832031 4.7749023 Q 1.8369141 4.651367 1.8691406 3.9370117 Z "/>
+        </symbol>
+        <symbol id="g9ABB161D7FA7D32FC821ED2C0B46F425" overflow="visible">
+            <path d="M 0.45117188 2.2558594 Q 0.45117188 3.3461914 1.0581055 4.060547 Q 1.7133789 4.8286133 2.7822266 4.8286133 Q 3.5717773 4.8286133 4.1169434 4.439209 Q 4.6621094 4.0498047 4.876953 3.5100098 Q 5.091797 2.9702148 5.091797 2.352539 Q 5.091797 1.203125 4.3774414 0.5048828 Q 3.7490234 -0.11279297 2.7607422 -0.107421875 Q 1.659668 -0.107421875 1.0554199 0.6069336 Q 0.45117188 1.3212891 0.45117188 2.2558594 Z M 2.6157227 4.4418945 Q 1.3964844 4.4418945 1.3964844 2.5083008 Q 1.3964844 2.1538086 1.4797363 1.7912598 Q 1.5629883 1.4287109 1.7268066 1.0769043 Q 1.890625 0.72509766 2.199463 0.49951172 Q 2.5083008 0.27392578 2.916504 0.27392578 Q 3.3999023 0.27392578 3.7731934 0.6713867 Q 4.1464844 1.0688477 4.1464844 2.003418 Q 4.1464844 3.1796875 3.7382813 3.810791 Q 3.3300781 4.4418945 2.6157227 4.4418945 Z "/>
+        </symbol>
+        <symbol id="g7B0412412D0F33737832F45BFDAA75C8" overflow="visible">
+            <path d="M 1.9335938 3.9370117 Q 1.9335938 3.8833008 1.9685059 3.8618164 Q 2.003418 3.840332 2.057129 3.9155273 Q 2.2773438 4.291504 2.602295 4.5600586 Q 2.927246 4.8286133 3.2763672 4.8286133 Q 3.5932617 4.8286133 3.7651367 4.659424 Q 3.9370117 4.4902344 3.9370117 4.302246 Q 3.9370117 4.0927734 3.7785645 3.9208984 Q 3.6201172 3.7490234 3.4213867 3.7490234 Q 3.2172852 3.7490234 3.0239258 4.006836 Q 2.916504 4.1464844 2.7392578 4.1464844 Q 2.6049805 4.1464844 2.234375 3.609375 Q 1.9711914 3.211914 1.9711914 2.8735352 L 1.9711914 1.3427734 Q 1.9711914 0.6821289 2.1188965 0.5344238 Q 2.2666016 0.38671875 2.8735352 0.3383789 Q 2.927246 0.28466797 2.927246 0.15307617 Q 2.927246 0.021484375 2.8735352 -0.021484375 Q 2.1054688 0 1.5415039 0 Q 1.0581055 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.82177734 0.37060547 0.9614258 0.5263672 Q 1.1010742 0.6821289 1.1010742 1.3427734 L 1.1010742 3.4858398 Q 1.1010742 3.947754 0.9748535 4.0686035 Q 0.8486328 4.189453 0.38671875 4.232422 Q 0.32226563 4.42041 0.36523438 4.5439453 Q 1.1816406 4.651367 1.7133789 4.86084 Q 1.7993164 4.86084 1.8476563 4.7749023 Q 1.9013672 4.640625 1.9335938 3.9370117 Z "/>
+        </symbol>
+        <symbol id="g580AAD674A0E08ED15198255596B26A2" overflow="visible">
+            <path d="M 1.9228516 3.6416016 Q 1.7456055 3.4213867 1.7509766 3.1582031 L 1.7509766 1.1547852 Q 1.7509766 0.8647461 1.7966309 0.7573242 Q 1.8422852 0.64990234 2.0141602 0.49414063 Q 2.2719727 0.2631836 2.7929688 0.2631836 Q 3.2333984 0.2631836 3.5529785 0.44580078 Q 3.8725586 0.62841797 4.036377 0.9399414 Q 4.2001953 1.2514648 4.272705 1.5817871 Q 4.345215 1.9121094 4.345215 2.288086 Q 4.345215 3.1904297 3.9665527 3.75708 Q 3.5878906 4.3237305 3.034668 4.3237305 Q 2.803711 4.3237305 2.4733887 4.119629 Q 2.1430664 3.9155273 1.9228516 3.6416016 Z M 1.7133789 4.0498047 Q 1.7241211 3.8833008 1.8369141 4.001465 Q 2.572754 4.8286133 3.3461914 4.8286133 Q 4.17334 4.8286133 4.7319336 4.1572266 Q 5.2905273 3.4858398 5.2905273 2.583496 Q 5.2905273 1.2944336 4.479492 0.5048828 Q 3.8295898 -0.11279297 2.8574219 -0.107421875 Q 2.3203125 -0.107421875 1.9013672 0.05908203 Q 1.8154297 0.10205078 1.7832031 0.091308594 Q 1.7509766 0.080566406 1.7509766 -0.021484375 L 1.7509766 -1.2084961 Q 1.7509766 -1.8691406 1.8986816 -2.0249023 Q 2.0463867 -2.180664 2.6533203 -2.2128906 Q 2.7070313 -2.2666016 2.7070313 -2.3981934 Q 2.7070313 -2.5297852 2.6533203 -2.572754 Q 1.9282227 -2.5512695 1.3212891 -2.5512695 Q 0.859375 -2.5512695 0.0859375 -2.572754 Q 0.04296875 -2.5297852 0.04296875 -2.3981934 Q 0.04296875 -2.2666016 0.0859375 -2.2128906 Q 0.6015625 -2.1914063 0.74121094 -2.0302734 Q 0.8808594 -1.8691406 0.8808594 -1.2084961 L 0.8808594 3.4858398 Q 0.8808594 3.947754 0.7546387 4.0686035 Q 0.62841797 4.189453 0.1665039 4.232422 Q 0.10205078 4.42041 0.14501953 4.5439453 Q 0.9614258 4.651367 1.4985352 4.86084 Q 1.5844727 4.86084 1.6274414 4.7749023 Q 1.6811523 4.645996 1.7133789 4.0498047 Z "/>
+        </symbol>
+        <symbol id="g6000CEAB22B14B2644F6F5DF3A907DF2" overflow="visible">
+            <path d="M 1.3642578 3.1044922 L 3.3569336 3.1367188 Q 3.5234375 3.1367188 3.5180664 3.2871094 Q 3.5180664 3.9155273 3.2495117 4.178711 Q 2.980957 4.4418945 2.6049805 4.4418945 Q 2.459961 4.4418945 2.3203125 4.404297 Q 2.180664 4.366699 1.9765625 4.2458496 Q 1.7724609 4.125 1.605957 3.8295898 Q 1.4394531 3.5341797 1.3642578 3.1044922 Z M 4.248535 1.0205078 Q 4.4365234 1.0097656 4.479492 0.8486328 Q 3.7436523 -0.107421875 2.6049805 -0.107421875 Q 1.5146484 -0.107421875 0.9238281 0.5961914 Q 0.40820313 1.1923828 0.40820313 2.2236328 Q 0.40820313 3.3891602 1.1064453 4.0981445 Q 1.8046875 4.807129 2.6049805 4.807129 Q 4.463379 4.807129 4.463379 2.8950195 Q 4.463379 2.7070313 4.2592773 2.7070313 L 1.3320313 2.7285156 Q 1.3320313 1.8046875 1.6811523 1.2192383 Q 2.1645508 0.4296875 2.8842773 0.4296875 Q 3.3461914 0.4296875 3.638916 0.5612793 Q 3.9316406 0.6928711 4.248535 1.0205078 Z "/>
+        </symbol>
+        <symbol id="gEDF7A5324D8FFCD7C1E9A7F3CAFF40B6" overflow="visible">
+            <path d="M 3.7973633 1.3642578 L 3.7973633 3.4536133 Q 3.7973633 3.7060547 3.7624512 3.810791 Q 3.727539 3.9155273 3.609375 4.0498047 Q 3.270996 4.4472656 2.7177734 4.4418945 Q 2.057129 4.4418945 1.6918945 3.894043 Q 1.375 3.442871 1.375 2.4331055 Q 1.375 1.4663086 1.7375488 0.93725586 Q 2.1000977 0.40820313 2.583496 0.40820313 Q 3.0131836 0.40820313 3.6201172 0.9345703 Q 3.7973633 1.090332 3.7973633 1.3642578 Z M 3.6738281 0.55322266 Q 2.868164 -0.107421875 2.2988281 -0.107421875 Q 1.4287109 -0.107421875 0.9291992 0.5397949 Q 0.4296875 1.1870117 0.4296875 2.234375 Q 0.4296875 3.4106445 1.1870117 4.1679688 Q 1.8798828 4.8286133 2.8359375 4.8286133 Q 3.0024414 4.8286133 3.2011719 4.7802734 Q 3.3999023 4.7319336 3.5422363 4.6862793 Q 3.6845703 4.640625 3.6953125 4.640625 Q 3.7919922 4.640625 3.7973633 4.742676 L 3.7973633 6.1499023 Q 3.7973633 6.5043945 3.7785645 6.678955 Q 3.7597656 6.8535156 3.638916 6.9367676 Q 3.5180664 7.0200195 3.4536133 7.0253906 Q 3.3891602 7.0307617 3.088379 7.052246 Q 2.9648438 7.1757813 3.0239258 7.379883 Q 4.001465 7.455078 4.5654297 7.680664 Q 4.710449 7.680664 4.710449 7.567871 Q 4.6674805 7.1274414 4.6621094 6.413086 L 4.6621094 1.4287109 Q 4.6621094 0.99902344 4.8125 0.8352051 Q 4.9628906 0.6713867 5.4677734 0.62841797 Q 5.5214844 0.57470703 5.5214844 0.4753418 Q 5.5214844 0.37597656 5.4677734 0.32763672 Q 4.586914 0.23095703 4.1679688 -0.107421875 Q 4.071289 -0.15039063 3.958496 -0.107421875 Q 3.8618164 0.27929688 3.840332 0.5371094 Q 3.8295898 0.5908203 3.7731934 0.5908203 Q 3.7167969 0.5908203 3.6738281 0.55322266 Z "/>
+        </symbol>
+        <symbol id="gE34A8995945D3EFAE2F41F68D391F085" overflow="visible">
+            <path d="M 1.0473633 1.3427734 L 1.0473633 6.1499023 Q 1.0473633 6.756836 0.93725586 6.8884277 Q 0.82714844 7.0200195 0.3383789 7.052246 Q 0.21484375 7.1757813 0.27392578 7.379883 Q 1.2514648 7.455078 1.8154297 7.680664 Q 1.9604492 7.680664 1.9604492 7.567871 Q 1.9174805 7.1274414 1.9121094 6.413086 L 1.9121094 1.3427734 Q 1.9121094 0.6821289 2.0517578 0.52368164 Q 2.1914063 0.36523438 2.7070313 0.3383789 Q 2.75 0.28466797 2.75 0.15307617 Q 2.75 0.021484375 2.7070313 -0.021484375 Q 1.9819336 0 1.4824219 0 Q 1.0205078 0 0.2524414 -0.021484375 Q 0.19873047 0.021484375 0.19873047 0.15307617 Q 0.19873047 0.28466797 0.2524414 0.3383789 Q 0.7680664 0.35986328 0.90771484 0.5209961 Q 1.0473633 0.6821289 1.0473633 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g5B9E5EB97F9DFC2F689C0AE85A2A0257" overflow="visible">
+            <path d="M 0.5263672 1.5200195 Q 0.5800781 1.5737305 0.6982422 1.5737305 Q 0.81640625 1.5737305 0.8701172 1.5307617 Q 1.0473633 0.7841797 1.2998047 0.51831055 Q 1.5522461 0.2524414 2.0786133 0.2524414 Q 2.4331055 0.2524414 2.7231445 0.45117188 Q 3.0131836 0.64990234 3.0131836 1.0205078 Q 3.0131836 1.3857422 2.7875977 1.605957 Q 2.5620117 1.8261719 1.890625 2.1000977 Q 1.2299805 2.3740234 0.9560547 2.6936035 Q 0.6821289 3.0131836 0.6821289 3.5986328 Q 0.6821289 4.114258 1.144043 4.4714355 Q 1.605957 4.8286133 2.234375 4.8286133 Q 2.4868164 4.8286133 2.75 4.7910156 Q 3.0131836 4.753418 3.3059082 4.6916504 Q 3.5986328 4.629883 3.6738281 4.6191406 Q 3.6523438 4.0336914 3.609375 3.4536133 Q 3.555664 3.3999023 3.432129 3.3999023 Q 3.3085938 3.3999023 3.2548828 3.442871 Q 3.2011719 3.7705078 3.0749512 3.9907227 Q 2.9487305 4.2109375 2.7768555 4.3049316 Q 2.6049805 4.398926 2.4787598 4.4311523 Q 2.352539 4.463379 2.234375 4.463379 Q 1.9389648 4.463379 1.6999512 4.272705 Q 1.4609375 4.0820313 1.4609375 3.7597656 Q 1.4609375 3.3461914 1.7106934 3.1555176 Q 1.9604492 2.9648438 2.5620117 2.7392578 Q 3.8510742 2.2612305 3.8510742 1.2783203 Q 3.8510742 0.89160156 3.668457 0.60424805 Q 3.4858398 0.31689453 3.2011719 0.16918945 Q 2.916504 0.021484375 2.6398926 -0.04296875 Q 2.3632813 -0.107421875 2.1000977 -0.107421875 Q 1.5629883 -0.107421875 1.1010742 0.0107421875 Q 1.0258789 0.032226563 0.8808594 0.032226563 Q 0.7734375 0.032226563 0.6069336 0 Q 0.6015625 0.57470703 0.5263672 1.5200195 Z "/>
+        </symbol>
+        <symbol id="g67C67974E32647451A0E4FD1D272EE94" overflow="visible">
+            <path d="M 1.144043 1.0473633 Q 1.4716797 1.0473633 1.6704102 0.7492676 Q 1.8691406 0.45117188 1.8691406 -0.04296875 Q 1.8691406 -0.5908203 1.4851074 -0.97753906 Q 1.1010742 -1.3642578 0.56933594 -1.4609375 Q 0.47265625 -1.3642578 0.47265625 -1.1977539 Q 0.8701172 -1.1010742 1.1547852 -0.8083496 Q 1.4394531 -0.515625 1.4394531 -0.31689453 Q 1.4394531 -0.021484375 1.0473633 0.021484375 Q 0.56396484 0.09667969 0.55859375 0.5048828 Q 0.55859375 0.73583984 0.72509766 0.89160156 Q 0.89160156 1.0473633 1.144043 1.0473633 Z "/>
+        </symbol>
+        <symbol id="g283FA10DA0826EA1224F4899A26D4FEC" overflow="visible">
+            <path d="M 5.1723633 1.3427734 Q 5.1723633 0.6821289 5.303955 0.52905273 Q 5.435547 0.37597656 5.961914 0.3383789 Q 6.004883 0.28466797 6.004883 0.15307617 Q 6.004883 0.021484375 5.961914 -0.021484375 Q 5.145508 0 4.73999 0 Q 4.3344727 0 3.5664063 -0.021484375 Q 3.5234375 0.021484375 3.520752 0.15307617 Q 3.5180664 0.28466797 3.5664063 0.3383789 Q 4.0498047 0.37060547 4.1760254 0.5263672 Q 4.302246 0.6821289 4.302246 1.3427734 L 4.302246 3.5073242 Q 4.302246 3.9370117 4.213623 4.114258 Q 4.125 4.291504 3.8725586 4.291504 L 1.9013672 4.291504 L 1.9013672 1.3427734 Q 1.9013672 0.6821289 2.032959 0.52905273 Q 2.1645508 0.37597656 2.7177734 0.3383789 Q 2.7714844 0.28466797 2.7714844 0.15307617 Q 2.7714844 0.021484375 2.7177734 -0.021484375 Q 1.9926758 0 1.4716797 0 Q 1.0634766 0 0.31689453 -0.021484375 Q 0.2631836 0.021484375 0.2631836 0.15307617 Q 0.2631836 0.28466797 0.31689453 0.3383789 Q 0.7895508 0.37060547 0.91308594 0.5263672 Q 1.0366211 0.6821289 1.0366211 1.3427734 L 1.0366211 4.291504 L 0.29541016 4.291504 Q 0.24169922 4.291504 0.24169922 4.355957 L 0.24169922 4.5009766 Q 0.24169922 4.7211914 0.49414063 4.7211914 L 1.0366211 4.7211914 L 1.0366211 4.882324 Q 1.0366211 6.289551 1.5952148 6.9501953 Q 2.2236328 7.675293 3.1582031 7.680664 Q 3.9370117 7.680664 4.5251465 7.326172 Q 5.1132813 6.9716797 5.1132813 6.466797 Q 5.1132813 6.289551 4.9709473 6.152588 Q 4.8286133 6.015625 4.640625 6.015625 Q 4.366699 6.015625 4.202881 6.176758 Q 4.0390625 6.3378906 3.958496 6.7299805 Q 3.8510742 7.2993164 3.0239258 7.3046875 Q 2.4868164 7.3046875 2.1940918 6.738037 Q 1.9013672 6.1713867 1.9013672 5.3442383 L 1.9013672 4.7211914 L 4.071289 4.7211914 Q 4.753418 4.7211914 5.102539 4.86084 Q 5.209961 4.86084 5.215332 4.7963867 Q 5.1723633 4.0927734 5.1723633 3.663086 L 5.1723633 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g8DA966557E0CCF546BA5AA535F299256" overflow="visible">
+            <path d="M 0.98828125 6.590332 Q 0.98828125 6.7890625 1.1762695 6.952881 Q 1.3642578 7.116699 1.5629883 7.116699 Q 1.7724609 7.116699 1.9309082 6.934082 Q 2.0893555 6.751465 2.0893555 6.5473633 Q 2.0893555 6.359375 1.9147949 6.1875 Q 1.7402344 6.015625 1.5200195 6.015625 Q 1.3212891 6.015625 1.1547852 6.198242 Q 0.98828125 6.3808594 0.98828125 6.590332 Z M 1.9926758 1.3427734 Q 1.9926758 0.6821289 2.1242676 0.52905273 Q 2.2558594 0.37597656 2.7822266 0.3383789 Q 2.8359375 0.28466797 2.8359375 0.15307617 Q 2.8359375 0.021484375 2.7822266 -0.021484375 Q 2.057129 0 1.5629883 0 Q 1.0581055 0 0.32763672 -0.021484375 Q 0.28466797 0.021484375 0.28466797 0.15307617 Q 0.28466797 0.28466797 0.32763672 0.3383789 Q 0.8540039 0.38134766 0.98828125 0.5317383 Q 1.1225586 0.6821289 1.1225586 1.3427734 L 1.1225586 3.4858398 Q 1.1225586 3.947754 0.9963379 4.0686035 Q 0.8701172 4.189453 0.40820313 4.232422 Q 0.34375 4.42041 0.38671875 4.5439453 Q 1.4072266 4.6782227 1.890625 4.86084 Q 2.0356445 4.86084 2.0356445 4.7856445 Q 1.9926758 4.0820313 1.9926758 3.5341797 L 1.9926758 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g4CF119F98FB6E3D69D0CE269123E989F" overflow="visible">
+            <path d="M 0.47265625 4.7211914 L 0.97753906 4.7211914 Q 0.97753906 5.1401367 0.97216797 5.4140625 Q 0.9667969 5.6879883 0.9614258 5.77124 Q 0.9560547 5.854492 0.9506836 5.908203 Q 0.9453125 5.961914 0.9453125 5.9941406 Q 0.9453125 6.074707 1.1870117 6.1445313 Q 1.3803711 6.198242 1.5629883 6.300293 Q 1.7456055 6.3969727 1.8046875 6.4023438 Q 1.890625 6.4023438 1.890625 6.305664 Q 1.8476563 5.8652344 1.8476563 5.145508 L 1.8476563 4.7211914 L 3.1689453 4.7211914 Q 3.2548828 4.7211914 3.2548828 4.651367 L 3.2548828 4.4311523 Q 3.2548828 4.286133 2.9916992 4.291504 L 1.8476563 4.291504 L 1.8476563 1.5092773 Q 1.8476563 0.97216797 1.9255371 0.7331543 Q 2.003418 0.49414063 2.2128906 0.49414063 Q 2.7177734 0.49414063 3.1152344 0.80566406 Q 3.2817383 0.7949219 3.3085938 0.6176758 Q 2.6586914 -0.107421875 1.8261719 -0.107421875 Q 0.97753906 -0.107421875 0.97753906 0.97753906 L 0.97753906 4.291504 L 0.32763672 4.291504 Q 0.27392578 4.291504 0.27392578 4.355957 L 0.27392578 4.5009766 Q 0.27392578 4.7211914 0.47265625 4.7211914 Z "/>
+        </symbol>
+        <symbol id="gC7D7FC064504D98B998DC1A12C11586B" overflow="visible">
+            <path d="M 3.2226563 2.5620117 L 2.352539 2.3310547 Q 1.3051758 2.067871 1.3105469 1.1225586 Q 1.3105469 0.82714844 1.5119629 0.5827637 Q 1.7133789 0.3383789 2.1000977 0.3383789 Q 2.4760742 0.3383789 3.0668945 0.82714844 Q 3.2226563 0.9506836 3.2226563 1.1118164 L 3.2226563 2.5620117 Z M 3.2226563 0.5263672 L 3.2011719 0.5263672 L 2.980957 0.3544922 Q 2.3847656 -0.107421875 1.7832031 -0.107421875 Q 0.39746094 -0.107421875 0.39746094 1.0795898 Q 0.39746094 1.6274414 0.89697266 2.0463867 Q 1.3964844 2.465332 2.2128906 2.6748047 L 3.1582031 2.9057617 Q 3.2226563 2.927246 3.2226563 3.034668 Q 3.2226563 4.463379 2.3310547 4.463379 Q 1.9658203 4.463379 1.7080078 4.3479004 Q 1.4501953 4.232422 1.4501953 4.001465 Q 1.4501953 3.8457031 1.4716797 3.786621 Q 1.5039063 3.722168 1.5092773 3.5878906 Q 1.5092773 3.4643555 1.3588867 3.3381348 Q 1.2084961 3.211914 0.98828125 3.211914 Q 0.6015625 3.211914 0.6069336 3.609375 Q 0.6069336 4.071289 1.173584 4.449951 Q 1.7402344 4.8286133 2.4223633 4.8286133 Q 4.0820313 4.8286133 4.0820313 2.9702148 L 4.0820313 1.3535156 Q 4.0820313 1.1225586 4.0874023 0.9909668 Q 4.0927734 0.859375 4.125 0.7036133 Q 4.1572266 0.54785156 4.2297363 0.48339844 Q 4.302246 0.4189453 4.409668 0.4189453 Q 4.6083984 0.4189453 4.817871 0.5961914 Q 4.973633 0.5102539 5.0058594 0.29541016 Q 4.586914 -0.11279297 3.958496 -0.107421875 Q 3.5825195 -0.107421875 3.4294434 0.056396484 Q 3.2763672 0.22021484 3.2226563 0.5263672 Z "/>
+        </symbol>
+        <symbol id="gD7606749417294B0D6FD3F9982E155E4" overflow="visible">
+            <path d="M 2.0249023 3.9370117 Q 2.803711 4.8286133 3.8295898 4.8286133 Q 4.458008 4.8286133 4.742676 4.4526367 Q 5.038086 4.055176 5.038086 2.980957 L 5.038086 1.3427734 Q 5.038086 0.6928711 5.1643066 0.5397949 Q 5.2905273 0.38671875 5.773926 0.3383789 Q 5.8168945 0.28466797 5.8168945 0.15307617 Q 5.8168945 0.021484375 5.773926 -0.021484375 Q 5.1132813 0 4.6083984 0 Q 4.1464844 0 3.4858398 -0.021484375 Q 3.442871 0.032226563 3.442871 0.16381836 Q 3.442871 0.29541016 3.4858398 0.3383789 Q 3.9370117 0.38134766 4.05249 0.5371094 Q 4.1679688 0.6928711 4.1679688 1.3427734 L 4.1679688 3.0131836 Q 4.1679688 3.5986328 4.0390625 3.8618164 Q 3.8295898 4.2592773 3.4536133 4.2592773 Q 2.7822266 4.2592773 2.1108398 3.609375 Q 1.9228516 3.3999023 1.9228516 3.147461 L 1.9228516 1.3427734 Q 1.9228516 0.6928711 2.03833 0.5397949 Q 2.1538086 0.38671875 2.5942383 0.3383789 Q 2.637207 0.28466797 2.6398926 0.15307617 Q 2.6425781 0.021484375 2.5942383 -0.021484375 Q 1.9335938 0 1.4985352 0 Q 0.9506836 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.80029297 0.38134766 0.9291992 0.5317383 Q 1.0581055 0.6821289 1.0581055 1.3427734 L 1.0581055 3.4858398 Q 1.0581055 3.947754 0.93188477 4.0686035 Q 0.80566406 4.189453 0.3383789 4.232422 Q 0.27392578 4.42041 0.31689453 4.5439453 Q 1.1333008 4.651367 1.6704102 4.86084 Q 1.7563477 4.86084 1.8046875 4.7749023 Q 1.8691406 4.640625 1.890625 3.9370117 Q 1.890625 3.7919922 2.0249023 3.9370117 Z "/>
+        </symbol>
+        <symbol id="g92C9249AEAD95F98902AD6AA7E64704A" overflow="visible">
+            <path d="M 3.5073242 3.0668945 Q 3.5073242 3.7490234 3.2333984 4.119629 Q 2.9594727 4.4902344 2.4438477 4.4902344 Q 1.5629883 4.4902344 1.5629883 3.319336 Q 1.5629883 3.0131836 1.5952148 2.7875977 Q 1.6274414 2.5620117 1.7268066 2.3256836 Q 1.8261719 2.0893555 2.0410156 1.9631348 Q 2.2558594 1.8369141 2.583496 1.8369141 Q 3.5073242 1.8369141 3.5073242 3.0668945 Z M 1.4501953 -0.107421875 Q 1.1118164 -0.515625 1.1118164 -1.144043 Q 1.1118164 -1.6381836 1.5737305 -1.9255371 Q 2.0356445 -2.2128906 2.4331055 -2.2128906 Q 2.9487305 -2.2128906 3.432129 -2.0786133 Q 3.9155273 -1.9443359 4.2512207 -1.659668 Q 4.586914 -1.375 4.586914 -0.99902344 Q 4.586914 -0.7895508 4.4660645 -0.6472168 Q 4.345215 -0.5048828 4.0283203 -0.31689453 Q 3.6899414 -0.12890625 2.696289 -0.13427734 Q 2.6425781 -0.13427734 2.3659668 -0.15039063 Q 2.0893555 -0.1665039 1.890625 -0.1665039 Q 1.6489258 -0.16113281 1.4501953 -0.107421875 Z M 4.882324 4.2592773 Q 4.6728516 4.2592773 4.576172 4.4526367 Q 4.4902344 4.586914 4.355957 4.586914 Q 4.2592773 4.586914 4.119629 4.498291 Q 3.9799805 4.409668 3.9155273 4.3237305 Q 4.3881836 3.840332 4.3881836 3.1796875 Q 4.3881836 2.411621 3.8430176 1.9550781 Q 3.2978516 1.4985352 2.5297852 1.4985352 Q 1.9228516 1.4985352 1.5307617 1.7294922 Q 1.3320313 1.4555664 1.3320313 1.090332 Q 1.3320313 0.7734375 1.5415039 0.6176758 Q 1.7509766 0.46191406 2.0356445 0.46191406 L 2.3632813 0.48339844 Q 2.803711 0.5371094 3.1044922 0.5371094 Q 4.2700195 0.5371094 4.710449 0.1772461 Q 5.1938477 -0.22021484 5.1938477 -0.71435547 Q 5.1938477 -1.2836914 4.7265625 -1.7321777 Q 4.2592773 -2.180664 3.5583496 -2.3981934 Q 2.8574219 -2.6157227 2.1000977 -2.6157227 Q 1.3642578 -2.6157227 0.859375 -2.3203125 Q 0.3544922 -2.0249023 0.3544922 -1.3642578 Q 0.3544922 -0.57470703 1.2514648 -0.032226563 Q 0.74658203 0.22021484 0.74658203 0.81640625 Q 0.74658203 1.1118164 0.8781738 1.4260254 Q 1.0097656 1.7402344 1.2299805 1.9228516 Q 0.66064453 2.4707031 0.66064453 3.1582031 Q 0.66064453 3.894043 1.2219238 4.361328 Q 1.7832031 4.8286133 2.5405273 4.8286133 Q 3.2226563 4.8286133 3.6845703 4.522461 Q 3.8833008 4.7856445 4.213623 4.9333496 Q 4.5439453 5.0810547 4.7856445 5.0810547 Q 5.0058594 5.0810547 5.1481934 4.965576 Q 5.2905273 4.8500977 5.2905273 4.6728516 Q 5.2905273 4.5063477 5.1643066 4.3828125 Q 5.038086 4.2592773 4.882324 4.2592773 Z "/>
+        </symbol>
+        <symbol id="gE66BEFED3DE41F88EDBED309C43CEAF8" overflow="visible">
+            <path d="M 3.5395508 4.0498047 Q 3.1796875 4.4526367 2.6748047 4.4526367 Q 2.0356445 4.4526367 1.6838379 3.9155273 Q 1.3320313 3.378418 1.3320313 2.4975586 Q 1.3320313 1.9013672 1.4851074 1.4689941 Q 1.6381836 1.0366211 1.890625 0.81103516 Q 2.1430664 0.5854492 2.4035645 0.4807129 Q 2.6640625 0.37597656 2.927246 0.37597656 Q 3.3730469 0.37597656 3.6523438 0.5209961 Q 3.7543945 0.57470703 3.78125 0.63378906 Q 3.8081055 0.6928711 3.8081055 0.8486328 L 3.8081055 3.378418 Q 3.8081055 3.5878906 3.751709 3.7302246 Q 3.6953125 3.8725586 3.5395508 4.0498047 Z M 3.8081055 -1.2192383 L 3.8081055 0 Q 3.8081055 0.1665039 3.7543945 0.171875 Q 3.7006836 0.1772461 3.5073242 0.05908203 Q 3.211914 -0.11279297 2.6640625 -0.107421875 Q 1.5737305 -0.107421875 0.9802246 0.63916016 Q 0.38671875 1.3857422 0.38671875 2.2773438 Q 0.38671875 3.3676758 1.0500488 4.0981445 Q 1.7133789 4.8286133 2.7177734 4.8286133 Q 3.4643555 4.8286133 3.958496 4.5063477 Q 4.060547 4.4472656 4.114258 4.474121 Q 4.1679688 4.5009766 4.2807617 4.651367 Q 4.4365234 4.86084 4.5117188 4.86084 Q 4.6782227 4.86084 4.6728516 4.586914 L 4.6728516 -1.2192383 Q 4.6728516 -1.8798828 4.807129 -2.0356445 Q 4.9414063 -2.1914063 5.4677734 -2.2128906 Q 5.5214844 -2.2666016 5.5214844 -2.3981934 Q 5.5214844 -2.5297852 5.4677734 -2.572754 Q 4.742676 -2.5512695 4.248535 -2.5512695 Q 3.786621 -2.5512695 3.0131836 -2.572754 Q 2.9702148 -2.5297852 2.9702148 -2.3981934 Q 2.9702148 -2.2666016 3.0131836 -2.2128906 Q 3.5395508 -2.1914063 3.6738281 -2.0356445 Q 3.8081055 -1.8798828 3.8081055 -1.2192383 Z "/>
+        </symbol>
+        <symbol id="gDA8A4BDDF46A0076AFC20015B6D6FA96" overflow="visible">
+            <path d="M 2.980957 2.4545898 L 0.6069336 2.4545898 Q 0.4404297 2.4545898 0.4404297 2.6640625 Q 0.4404297 2.8198242 0.52905273 2.9675293 Q 0.6176758 3.1152344 0.71435547 3.1152344 L 3.1259766 3.1152344 Q 3.2817383 3.1152344 3.2763672 2.8950195 Q 3.2763672 2.7875977 3.177002 2.6210938 Q 3.0776367 2.4545898 2.980957 2.4545898 Z "/>
+        </symbol>
+        <symbol id="g2398852476A067707A94262529243E6" overflow="visible">
+            <path d="M 0.62841797 0.47265625 Q 0.62841797 0.71435547 0.7976074 0.88623047 Q 0.9667969 1.0581055 1.2084961 1.0581055 Q 1.4501953 1.0581055 1.6220703 0.88623047 Q 1.7939453 0.71435547 1.7939453 0.47265625 Q 1.7939453 0.23095703 1.6220703 0.061767578 Q 1.4501953 -0.107421875 1.2084961 -0.107421875 Q 0.9667969 -0.107421875 0.7976074 0.061767578 Q 0.62841797 0.23095703 0.62841797 0.47265625 Z "/>
+        </symbol>
+        <symbol id="g8627CB172E3C4C14F5D9F6D306FBE770" overflow="visible">
+            <path d="M 2.8735352 5.510742 Q 2.3364258 4.7749023 0.8486328 2.2988281 L 2.8735352 2.2988281 L 2.8735352 5.510742 Z M 5.3120117 2.2988281 Q 5.4785156 2.2988281 5.4785156 2.121582 Q 5.4785156 2.0249023 5.3737793 1.9040527 Q 5.269043 1.7832031 5.161621 1.7832031 L 4.232422 1.7832031 L 4.232422 1.3427734 Q 4.232422 1.0151367 4.2995605 0.81103516 Q 4.366699 0.6069336 4.5251465 0.51293945 Q 4.6835938 0.4189453 4.8286133 0.39208984 Q 4.973633 0.36523438 5.258301 0.3544922 Q 5.3442383 0.30078125 5.3442383 0.16113281 Q 5.3442383 0.021484375 5.258301 -0.021484375 Q 4.9038086 -0.021484375 4.54126 -0.016113281 Q 4.178711 -0.0107421875 3.9692383 -0.0053710938 Q 3.7597656 0 3.5664063 0 L 1.8476563 -0.021484375 Q 1.7617188 0.032226563 1.7617188 0.16381836 Q 1.7617188 0.29541016 1.8476563 0.3544922 Q 2.1323242 0.36523438 2.2773438 0.39208984 Q 2.4223633 0.4189453 2.5808105 0.51293945 Q 2.7392578 0.6069336 2.8063965 0.8083496 Q 2.8735352 1.0097656 2.8735352 1.3427734 L 2.8735352 1.7832031 L 0.9238281 1.7832031 Q 0.63916016 1.7832031 0.55859375 1.8583984 L 0.39746094 2.057129 Q 0.37597656 2.1000977 0.33032227 2.1618652 Q 0.28466797 2.2236328 0.2631836 2.2558594 Q 0.24169922 2.288086 0.24169922 2.3095703 Q 0.24169922 2.3417969 0.31689453 2.4545898 Q 0.5371094 2.7929688 1.0231934 3.526123 Q 1.5092773 4.2592773 1.8208008 4.7373047 Q 2.1323242 5.215332 2.5405273 5.7873535 Q 2.9487305 6.359375 3.2441406 6.708496 L 4.232422 6.708496 L 4.232422 2.2988281 L 5.3120117 2.2988281 Z "/>
+        </symbol>
+        <symbol id="gB7C2485A990F0D16073DE98E640F51" overflow="visible">
+            <path d="M 1.6381836 0 Q 1.0688477 0 0.20947266 -0.021484375 Q 0.15576172 0.021484375 0.15576172 0.15307617 Q 0.15576172 0.28466797 0.20947266 0.3383789 Q 0.82714844 0.35986328 0.9963379 0.5209961 Q 1.1655273 0.6821289 1.1655273 1.3427734 L 1.1655273 5.7524414 Q 1.1655273 6.413086 0.9963379 6.571533 Q 0.82714844 6.7299805 0.20947266 6.751465 Q 0.15576172 6.7944336 0.15576172 6.928711 Q 0.15576172 7.0629883 0.20947266 7.116699 Q 1.2192383 7.095215 1.6274414 7.095215 Q 2.067871 7.095215 3.0561523 7.116699 Q 3.099121 7.0629883 3.1018066 6.9313965 Q 3.1044922 6.7998047 3.0561523 6.751465 Q 2.4384766 6.7299805 2.269287 6.571533 Q 2.1000977 6.413086 2.1000977 5.7524414 L 2.1000977 1.1977539 Q 2.1000977 0.7788086 2.2478027 0.60424805 Q 2.3955078 0.4296875 2.7285156 0.4296875 L 3.4213867 0.4296875 Q 4.227051 0.4296875 4.6271973 0.8083496 Q 5.0273438 1.1870117 5.215332 1.8691406 Q 5.4033203 1.9013672 5.5751953 1.8154297 Q 5.4677734 0.859375 5.2905273 -0.021484375 Q 4.2753906 0 3.9799805 0 L 1.6381836 0 Z "/>
+        </symbol>
+        <symbol id="gC57BA794B7588EB72D43E56143860B21" overflow="visible">
+            <path d="M 1.9121094 3.9907227 Q 1.7241211 3.8242188 1.7294922 3.5288086 L 1.7294922 0.7788086 Q 2.1484375 0.2631836 2.519043 0.2631836 Q 3.2763672 0.2631836 3.6738281 0.87280273 Q 4.071289 1.4824219 4.071289 2.465332 Q 4.071289 3.2548828 3.7141113 3.8000488 Q 3.3569336 4.345215 2.8466797 4.345215 Q 2.3095703 4.345215 1.9121094 3.9907227 Z M 1.8369141 4.3344727 Q 2.3847656 4.8286133 3.0668945 4.8286133 Q 3.8242188 4.8286133 4.42041 4.224365 Q 5.0166016 3.6201172 5.0166016 2.6640625 Q 5.0166016 1.434082 4.256592 0.6633301 Q 3.496582 -0.107421875 2.583496 -0.107421875 Q 1.9389648 -0.107421875 1.6166992 0.16113281 Q 1.5253906 0.23632813 1.463623 0.23364258 Q 1.4018555 0.23095703 1.315918 0.13427734 Q 1.2353516 0.04296875 1.0581055 -0.13427734 Q 0.89160156 -0.13427734 0.81640625 0 Q 0.859375 0.20947266 0.859375 0.7788086 L 0.859375 6.1499023 Q 0.859375 6.5043945 0.8432617 6.678955 Q 0.82714844 6.8535156 0.7062988 6.9367676 Q 0.5854492 7.0200195 0.51831055 7.0253906 Q 0.45117188 7.0307617 0.15576172 7.052246 Q 0.032226563 7.1757813 0.0859375 7.379883 Q 1.0634766 7.455078 1.6274414 7.680664 Q 1.7724609 7.680664 1.7724609 7.567871 Q 1.7294922 7.1274414 1.7294922 6.413086 L 1.7294922 4.3881836 Q 1.7294922 4.237793 1.8369141 4.3344727 Z "/>
+        </symbol>
+        <symbol id="g2C727529FF314E30D732EB9FBEF8906D" overflow="visible">
+            <path d="M 3.5771484 4.3774414 Q 3.5234375 4.42041 3.520752 4.552002 Q 3.5180664 4.6835938 3.5771484 4.742676 Q 4.125 4.7211914 4.586914 4.7211914 Q 4.914551 4.7211914 5.3549805 4.742676 Q 5.4086914 4.688965 5.411377 4.5546875 Q 5.4140625 4.42041 5.3549805 4.3774414 Q 4.936035 4.3398438 4.7668457 4.1679688 Q 4.5976563 3.9960938 4.415039 3.5664063 L 2.9487305 0.123535156 Q 2.8413086 -0.12890625 2.6855469 -0.13427734 Q 2.4975586 -0.13427734 2.411621 0.09667969 L 1.0043945 3.5771484 Q 0.82177734 4.0390625 0.6767578 4.184082 Q 0.5317383 4.3291016 0.123535156 4.3774414 Q 0.06982422 4.42041 0.06713867 4.552002 Q 0.064453125 4.6835938 0.123535156 4.742676 Q 0.7841797 4.7211914 1.144043 4.7211914 Q 1.5307617 4.7211914 2.2558594 4.742676 Q 2.3095703 4.688965 2.3095703 4.5546875 Q 2.3095703 4.42041 2.2558594 4.3774414 Q 1.8422852 4.3237305 1.7912598 4.178711 Q 1.7402344 4.0336914 1.9121094 3.6416016 L 2.7070313 1.5200195 Q 2.8413086 1.1816406 2.9111328 1.1682129 Q 2.980957 1.1547852 3.1152344 1.4824219 L 4.001465 3.6416016 Q 4.178711 4.060547 4.0981445 4.202881 Q 4.017578 4.345215 3.5771484 4.3774414 Z "/>
+        </symbol>
+        <symbol id="gBDEAEBFC2F3FDB731F7FB66BFF129D00" overflow="visible">
+            <path d="M 1.890625 5.7524414 L 1.890625 2.927246 Q 1.890625 2.465332 1.9121094 2.1672363 Q 1.9335938 1.8691406 2.067871 1.4851074 Q 2.2021484 1.1010742 2.4545898 0.859375 Q 2.9916992 0.34375 3.7597656 0.3383789 Q 4.296875 0.3383789 4.6835938 0.5102539 Q 5.0703125 0.6821289 5.279785 0.9291992 Q 5.489258 1.1762695 5.6101074 1.5683594 Q 5.730957 1.9604492 5.7578125 2.2827148 Q 5.784668 2.6049805 5.784668 3.0454102 L 5.784668 5.7524414 Q 5.784668 6.0908203 5.7524414 6.2734375 Q 5.720215 6.4560547 5.583252 6.560791 Q 5.446289 6.6655273 5.2905273 6.692383 Q 5.1347656 6.7192383 4.7749023 6.751465 Q 4.7319336 6.7944336 4.7319336 6.928711 Q 4.7319336 7.0629883 4.7749023 7.116699 Q 5.784668 7.095215 6.0478516 7.095215 Q 6.3325195 7.095215 7.17041 7.116699 Q 7.213379 7.0629883 7.213379 6.9313965 Q 7.213379 6.7998047 7.17041 6.751465 Q 6.633301 6.6870117 6.4802246 6.5339355 Q 6.3271484 6.3808594 6.3271484 5.7524414 L 6.3271484 3.2441406 Q 6.3271484 2.465332 6.206299 1.8879395 Q 6.085449 1.3105469 5.7819824 0.8432617 Q 5.4785156 0.37597656 4.9172363 0.13427734 Q 4.355957 -0.107421875 3.5288086 -0.107421875 Q 3.0454102 -0.107421875 2.6398926 0 Q 2.234375 0.107421875 1.831543 0.3786621 Q 1.4287109 0.64990234 1.1923828 1.2058105 Q 0.9560547 1.7617188 0.9560547 2.5620117 L 0.9560547 5.7524414 Q 0.9560547 6.4023438 0.7976074 6.566162 Q 0.63916016 6.7299805 0.107421875 6.751465 Q 0.064453125 6.7944336 0.064453125 6.928711 Q 0.064453125 7.0629883 0.107421875 7.116699 Q 0.9667969 7.095215 1.4179688 7.095215 Q 1.8691406 7.095215 2.9057617 7.116699 Q 2.9487305 7.0629883 2.9487305 6.9313965 Q 2.9487305 6.7998047 2.9057617 6.751465 Q 2.2451172 6.7299805 2.067871 6.571533 Q 1.890625 6.413086 1.890625 5.7524414 Z "/>
+        </symbol>
+        <symbol id="gFAB5AB46C3D7E8820D142009AEFE491" overflow="visible">
+            <path d="M 6.289551 -1.3427734 Q 7.0683594 -1.6489258 7.5705566 -1.7644043 Q 8.072754 -1.8798828 8.6796875 -1.8798828 Q 9.109375 -1.8798828 9.708252 -1.7053223 Q 10.307129 -1.5307617 10.833496 -1.2299805 L 11.021484 -1.4287109 Q 10.495117 -1.9121094 9.713623 -2.199463 Q 8.932129 -2.4868164 8.072754 -2.4868164 Q 6.751465 -2.4868164 5.5322266 -1.9819336 Q 4.4956055 -1.5629883 3.9423828 -1.4018555 Q 3.3891602 -1.2407227 2.8359375 -1.2407227 Q 2.583496 -1.2407227 2.2988281 -1.4663086 Q 2.1269531 -1.6650391 1.9604492 -1.9013672 L 1.5200195 -1.6811523 Q 2.0249023 -0.98828125 2.7929688 -0.4296875 Q 3.0615234 -0.23095703 3.3569336 -0.080566406 Q 2.0786133 0.0859375 1.2434082 1.0285645 Q 0.40820313 1.9711914 0.40820313 3.4106445 Q 0.40820313 5.0595703 1.3212891 6.1499023 Q 2.234375 7.2402344 3.786621 7.2402344 Q 5.317383 7.2402344 6.3217773 6.26001 Q 7.326172 5.279785 7.326172 3.6201172 Q 7.326172 2.2451172 6.644043 1.2783203 Q 5.849121 0.15039063 4.4418945 -0.064453125 Q 3.7919922 -0.24169922 3.1152344 -0.72509766 Q 3.0615234 -0.7626953 3.0078125 -0.80566406 Q 3.1796875 -0.7841797 3.3461914 -0.7788086 Q 4.8500977 -0.7841797 6.289551 -1.3427734 Z M 3.6416016 6.8427734 Q 2.7392578 6.8427734 2.1000977 6.0290527 Q 1.4609375 5.215332 1.4609375 3.5986328 Q 1.4609375 2.0786133 2.2316895 1.1816406 Q 3.0024414 0.28466797 4.071289 0.28466797 Q 5.038086 0.28466797 5.653076 1.1279297 Q 6.2680664 1.9711914 6.2680664 3.4106445 Q 6.2680664 5.0166016 5.5214844 5.9296875 Q 4.7749023 6.8427734 3.6416016 6.8427734 Z M 10.317871 -0.107421875 Q 9.560547 -0.107421875 9.230225 0.31420898 Q 8.899902 0.73583984 8.899902 1.3857422 L 8.899902 3.496582 Q 8.899902 4.012207 8.762939 4.178711 Q 8.625977 4.345215 8.217773 4.3774414 Q 8.1640625 4.42041 8.1640625 4.552002 Q 8.1640625 4.6835938 8.217773 4.742676 Q 8.964355 4.7211914 9.340332 4.7211914 Q 9.614258 4.7211914 9.72168 4.742676 Q 9.807617 4.742676 9.812988 4.6728516 Q 9.77002 3.8671875 9.77002 3.5395508 L 9.77002 1.5415039 Q 9.77002 0.89160156 10.038574 0.64990234 Q 10.307129 0.40820313 10.645508 0.40820313 Q 11.128906 0.40820313 11.746582 0.9345703 Q 11.923828 1.090332 11.923828 1.3642578 L 11.923828 3.4858398 Q 11.923828 4.012207 11.792236 4.184082 Q 11.660645 4.355957 11.241699 4.3774414 Q 11.19873 4.42041 11.19873 4.552002 Q 11.19873 4.6835938 11.241699 4.742676 Q 11.988281 4.7211914 12.364258 4.7211914 Q 12.638184 4.7211914 12.750977 4.742676 Q 12.836914 4.742676 12.836914 4.6728516 Q 12.793945 3.8671875 12.793945 3.5395508 L 12.793945 1.4287109 Q 12.793945 0.99902344 12.94165 0.8352051 Q 13.089355 0.6713867 13.594238 0.62841797 Q 13.637207 0.57470703 13.639893 0.4753418 Q 13.642578 0.37597656 13.594238 0.32763672 Q 12.713379 0.23095703 12.299805 -0.107421875 Q 12.203125 -0.15039063 12.090332 -0.107421875 Q 11.993652 0.2685547 11.966797 0.5371094 Q 11.956055 0.5908203 11.902344 0.58813477 Q 11.848633 0.5854492 11.805664 0.54785156 Q 11 -0.107421875 10.317871 -0.107421875 Z "/>
+        </symbol>
+        <symbol id="g6DC016622A31714551059BEE327C8748" overflow="visible">
+            <path d="M 1.9228516 1.3427734 Q 1.9228516 0.66064453 2.0625 0.51831055 Q 2.2021484 0.37597656 2.8466797 0.3383789 Q 2.9003906 0.28466797 2.9030762 0.15307617 Q 2.9057617 0.021484375 2.8466797 -0.021484375 Q 2.0786133 0 1.4985352 0 Q 1.0581055 0 0.28466797 -0.021484375 Q 0.24169922 0.021484375 0.24169922 0.15307617 Q 0.24169922 0.28466797 0.28466797 0.3383789 Q 0.7680664 0.37060547 0.91308594 0.5317383 Q 1.0581055 0.6928711 1.0581055 1.3427734 L 1.0581055 4.291504 L 0.29541016 4.291504 Q 0.24169922 4.291504 0.24169922 4.355957 L 0.24169922 4.5009766 Q 0.24169922 4.7211914 0.49414063 4.7211914 L 1.0581055 4.7211914 L 1.0581055 5.161621 Q 1.0581055 6.359375 1.6462402 7.0200195 Q 2.234375 7.680664 3.0024414 7.680664 Q 3.663086 7.680664 3.9907227 7.444336 Q 4.345215 7.1811523 4.345215 6.885742 Q 4.345215 6.7192383 4.1921387 6.5769043 Q 4.0390625 6.4345703 3.894043 6.4345703 Q 3.609375 6.4345703 3.4536133 6.7890625 Q 3.3461914 7.0737305 3.1958008 7.189209 Q 3.0454102 7.3046875 2.7929688 7.3046875 Q 1.9228516 7.3046875 1.9228516 5.3442383 L 1.9228516 4.7211914 L 3.1152344 4.7211914 Q 3.2011719 4.7211914 3.2011719 4.651367 L 3.2011719 4.4311523 Q 3.2011719 4.286133 2.9487305 4.291504 L 1.9228516 4.291504 L 1.9228516 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g2E3539D098C7287320B8E2FD4F266F8F" overflow="visible">
+            <path d="M 3.555664 2.067871 Q 3.555664 2.8574219 3.300537 3.2871094 Q 3.0454102 3.7167969 2.6425781 3.7167969 Q 2.2558594 3.7167969 2.003418 3.6523438 Q 1.7509766 3.5878906 1.090332 3.3461914 L 0.9506836 3.432129 L 1.3857422 6.708496 Q 1.5844727 6.697754 2.067871 6.649414 Q 2.5512695 6.601074 2.8144531 6.601074 Q 3.1904297 6.601074 4.6835938 6.7407227 L 4.9414063 6.601074 L 4.7319336 5.6557617 Q 3.722168 5.5913086 3.4643555 5.5859375 Q 2.4545898 5.5859375 1.8691406 5.6450195 Q 1.8261719 5.392578 1.659668 4.189453 Q 2.229004 4.3344727 2.9594727 4.3344727 Q 3.9155273 4.3344727 4.4821777 3.7946777 Q 5.048828 3.2548828 5.048828 2.411621 Q 5.048828 1.3911133 4.3720703 0.6418457 Q 3.6953125 -0.107421875 2.6264648 -0.107421875 Q 1.5898438 -0.107421875 1.0097656 0.19873047 Q 0.56933594 0.4296875 0.56933594 0.7788086 Q 0.56933594 0.98828125 0.71435547 1.144043 Q 0.859375 1.2998047 1.1333008 1.2998047 Q 1.6811523 1.2998047 1.9604492 0.8701172 Q 2.2773438 0.37597656 2.5620117 0.37597656 Q 3.0239258 0.37597656 3.289795 0.8190918 Q 3.555664 1.262207 3.555664 2.067871 Z "/>
+        </symbol>
+        <symbol id="g11D8B379FEF962E3AE8AB39B50794CD8" overflow="visible">
+            <path d="M 3.1152344 3.555664 L 2.0893555 3.555664 L 2.0893555 1.3427734 Q 2.0893555 0.6821289 2.2612305 0.52368164 Q 2.4331055 0.36523438 3.0454102 0.3383789 Q 3.099121 0.28466797 3.1018066 0.15307617 Q 3.1044922 0.021484375 3.0454102 -0.021484375 Q 2.2773438 0 1.6274414 0 Q 0.9667969 0 0.19873047 -0.021484375 Q 0.15576172 0.021484375 0.15576172 0.15307617 Q 0.15576172 0.28466797 0.19873047 0.3383789 Q 0.81640625 0.35986328 0.9855957 0.5209961 Q 1.1547852 0.6821289 1.1547852 1.3427734 L 1.1547852 5.7524414 Q 1.1547852 6.413086 0.9855957 6.571533 Q 0.81640625 6.7299805 0.19873047 6.751465 Q 0.15576172 6.7944336 0.15576172 6.928711 Q 0.15576172 7.0629883 0.19873047 7.116699 Q 1.0795898 7.095215 1.6166992 7.095215 L 4.4257813 7.095215 Q 4.7158203 7.095215 4.9414063 7.1381836 Q 4.979004 7.1381836 4.984375 7.105957 Q 5.102539 6.472168 5.226074 5.510742 Q 5.0810547 5.4570313 4.882324 5.4570313 Q 4.748047 5.8867188 4.5949707 6.117676 Q 4.4418945 6.348633 4.10083 6.501709 Q 3.7597656 6.654785 3.2011719 6.654785 L 2.7070313 6.654785 Q 2.3310547 6.654785 2.210205 6.5231934 Q 2.0893555 6.3916016 2.0893555 5.951172 L 2.0893555 3.9692383 L 3.1152344 3.9692383 Q 3.786621 3.9692383 3.9396973 4.10083 Q 4.0927734 4.232422 4.114258 4.7211914 Q 4.1572266 4.7749023 4.2888184 4.7749023 Q 4.42041 4.7749023 4.479492 4.7211914 Q 4.458008 4.1518555 4.4526367 3.7705078 Q 4.4526367 3.3515625 4.479492 2.803711 Q 4.4257813 2.75 4.291504 2.75 Q 4.1572266 2.75 4.114258 2.803711 Q 4.0927734 3.099121 4.047119 3.2280273 Q 4.001465 3.3569336 3.7839355 3.4562988 Q 3.5664063 3.555664 3.1152344 3.555664 Z "/>
+        </symbol>
+        <symbol id="gE90EDE5CEA4C1617ABCB9DBF48C9E652" overflow="visible">
+            <path d="M 1.8369141 3.147461 L 1.8369141 1.3427734 Q 1.8369141 0.8754883 1.8933105 0.67944336 Q 1.949707 0.48339844 2.067871 0.4243164 Q 2.1860352 0.36523438 2.4921875 0.3383789 Q 2.5405273 0.29003906 2.543213 0.15844727 Q 2.5458984 0.026855469 2.4921875 -0.021484375 Q 1.8745117 0 1.4072266 0 Q 0.9238281 0 0.19873047 -0.021484375 Q 0.15039063 0.026855469 0.15039063 0.15844727 Q 0.15039063 0.29003906 0.19873047 0.3383789 Q 0.47265625 0.35986328 0.59350586 0.38671875 Q 0.71435547 0.41357422 0.81640625 0.51831055 Q 0.91845703 0.6230469 0.94262695 0.80566406 Q 0.9667969 0.98828125 0.9667969 1.3427734 L 0.9667969 6.1499023 Q 0.9667969 6.5043945 0.9506836 6.678955 Q 0.9345703 6.8535156 0.8137207 6.9367676 Q 0.6928711 7.0200195 0.6257324 7.0253906 Q 0.55859375 7.0307617 0.2631836 7.052246 Q 0.13964844 7.1757813 0.19873047 7.379883 Q 1.1762695 7.455078 1.7402344 7.680664 Q 1.8852539 7.680664 1.8798828 7.567871 Q 1.8369141 7.1274414 1.8369141 6.413086 L 1.8261719 3.9370117 Q 1.8261719 3.8027344 1.9174805 3.9155273 Q 1.9282227 3.9316406 1.9335938 3.9370117 Q 2.7392578 4.8286133 3.8081055 4.8286133 Q 4.4365234 4.8286133 4.7211914 4.4526367 Q 5.0166016 4.065918 5.0166016 2.980957 L 5.0166016 1.3427734 Q 5.0166016 0.6928711 5.1428223 0.5397949 Q 5.269043 0.38671875 5.7524414 0.3383789 Q 5.79541 0.28466797 5.79541 0.15307617 Q 5.79541 0.021484375 5.7524414 -0.021484375 Q 5.0273438 0 4.586914 0 Q 4.0820313 0 3.4643555 -0.021484375 Q 3.4213867 0.032226563 3.4213867 0.16381836 Q 3.4213867 0.29541016 3.4643555 0.3383789 Q 3.9155273 0.38134766 4.031006 0.5371094 Q 4.1464844 0.6928711 4.1464844 1.3427734 L 4.1464844 3.0131836 Q 4.1464844 3.5986328 4.017578 3.8618164 Q 3.8188477 4.2592773 3.432129 4.2592773 Q 2.6855469 4.2592773 2.0249023 3.609375 Q 1.8369141 3.4052734 1.8369141 3.147461 Z "/>
+        </symbol>
+        <symbol id="gC5384350C9459EA016613B5F32AFBCA7" overflow="visible">
+            <path d="M 0.9453125 1.3427734 L 0.9453125 6.1499023 Q 0.9453125 6.5043945 0.9291992 6.678955 Q 0.91308594 6.8535156 0.7922363 6.9367676 Q 0.6713867 7.0200195 0.60424805 7.0253906 Q 0.5371094 7.0307617 0.24169922 7.052246 Q 0.11816406 7.1757813 0.1772461 7.379883 Q 1.1547852 7.455078 1.7133789 7.680664 Q 1.8583984 7.680664 1.8583984 7.567871 Q 1.8154297 7.1274414 1.8154297 6.413086 L 1.8154297 2.578125 Q 2.1699219 2.6264648 2.5620117 2.916504 Q 2.9594727 3.211914 3.442871 3.8188477 Q 3.496582 3.8833008 3.5314941 3.9558105 Q 3.5664063 4.0283203 3.5878906 4.125 Q 3.609375 4.2216797 3.5100098 4.2941895 Q 3.4106445 4.366699 3.1904297 4.3774414 Q 3.147461 4.42041 3.147461 4.552002 Q 3.147461 4.6835938 3.1904297 4.742676 Q 3.6953125 4.7211914 4.2700195 4.7211914 Q 4.7211914 4.7211914 5.226074 4.742676 Q 5.279785 4.688965 5.279785 4.5546875 Q 5.279785 4.42041 5.226074 4.3774414 Q 4.458008 4.302246 4.071289 3.894043 L 3.1044922 2.8950195 Q 3.0615234 2.8520508 3.0561523 2.7822266 Q 3.0561523 2.7285156 3.1367188 2.6264648 L 4.586914 0.80566406 Q 4.7856445 0.55322266 4.989746 0.4699707 Q 5.1938477 0.38671875 5.5322266 0.3383789 Q 5.5859375 0.28466797 5.5859375 0.15307617 Q 5.5859375 0.021484375 5.5322266 -0.021484375 Q 5.091797 0 4.629883 0 Q 4.3881836 0 3.947754 -0.021484375 Q 3.9047852 -0.021484375 3.9047852 0.032226563 Q 3.8833008 0.20947266 3.442871 0.80566406 L 2.6425781 1.8798828 Q 2.465332 2.116211 2.288086 2.239746 Q 2.1430664 2.288086 1.8154297 2.2988281 L 1.8154297 1.3427734 Q 1.8154297 0.6928711 1.920166 0.5344238 Q 2.0249023 0.37597656 2.3847656 0.3383789 Q 2.4384766 0.28466797 2.441162 0.15307617 Q 2.4438477 0.021484375 2.3847656 -0.021484375 Q 1.8798828 0 1.3857422 0 Q 0.9345703 0 0.20947266 -0.021484375 Q 0.15576172 0.021484375 0.15576172 0.15307617 Q 0.15576172 0.28466797 0.20947266 0.3383789 Q 0.6928711 0.37060547 0.8190918 0.5263672 Q 0.9453125 0.6821289 0.9453125 1.3427734 Z "/>
+        </symbol>
+        <symbol id="gE79CB93519F93EB855C3182E0398C9B1" overflow="visible">
+            <path d="M 2.9916992 6.7998047 Q 2.0786133 6.7998047 2.0786133 6.0961914 L 2.0786133 3.5771484 L 2.6049805 3.5771484 Q 3.496582 3.5771484 3.9746094 3.9396973 Q 4.4526367 4.302246 4.4526367 5.258301 Q 4.4526367 6.7998047 2.9916992 6.7998047 Z M 2.0786133 1.3427734 Q 2.0786133 0.6821289 2.2504883 0.52368164 Q 2.4223633 0.36523438 3.034668 0.3383789 Q 3.0776367 0.28466797 3.0776367 0.15307617 Q 3.0776367 0.021484375 3.034668 -0.021484375 Q 2.067871 0 1.6166992 0 Q 1.1762695 0 0.18798828 -0.021484375 Q 0.13427734 0.021484375 0.13427734 0.15307617 Q 0.13427734 0.28466797 0.18798828 0.3383789 Q 0.80566406 0.35986328 0.9748535 0.5209961 Q 1.144043 0.6821289 1.144043 1.3427734 L 1.144043 5.7524414 Q 1.144043 6.413086 0.9748535 6.571533 Q 0.80566406 6.7299805 0.18798828 6.751465 Q 0.13427734 6.7944336 0.13427734 6.928711 Q 0.13427734 7.0629883 0.18798828 7.116699 Q 1.2246094 7.095215 1.605957 7.095215 Q 1.7939453 7.095215 2.2504883 7.1328125 Q 2.7070313 7.17041 2.980957 7.17041 Q 3.6308594 7.17041 4.0820313 7.071045 Q 4.533203 6.9716797 4.882324 6.644043 Q 5.4677734 6.0961914 5.4677734 5.269043 Q 5.4677734 4.5117188 4.989746 4.0336914 Q 4.5117188 3.555664 4.001465 3.3891602 L 5.392578 1.0795898 Q 5.6450195 0.66064453 5.8759766 0.44580078 Q 6.1069336 0.23095703 6.4453125 0.23095703 Q 6.520508 0.0859375 6.4560547 -0.032226563 Q 6.300293 -0.107421875 5.9941406 -0.107421875 Q 5.145508 -0.107421875 4.5439453 0.8701172 L 3.3676758 2.7822266 Q 3.2333984 3.0024414 2.975586 3.1018066 Q 2.7177734 3.2011719 2.0786133 3.2011719 L 2.0786133 1.3427734 Z "/>
+        </symbol>
+        <symbol id="g4432869002C8934E6DD2DEAE9F5AFA82" overflow="visible">
+            <path d="M 0.7788086 4.8286133 Q 1.0742188 4.7211914 1.4287109 4.7211914 L 3.442871 4.7211914 Q 3.5878906 4.7211914 3.7409668 4.7265625 Q 3.894043 4.7319336 4.0041504 4.7373047 Q 4.114258 4.742676 4.125 4.742676 Q 4.2592773 4.742676 4.2592773 4.664795 Q 4.2592773 4.586914 4.060547 4.2592773 Q 2.6533203 1.9389648 1.4179688 0.37597656 L 2.8842773 0.37597656 Q 3.2924805 0.38671875 3.5153809 0.5666504 Q 3.7382813 0.74658203 3.958496 1.2084961 L 4.114258 1.5307617 Q 4.3237305 1.5307617 4.4418945 1.4609375 Q 4.3183594 0.63378906 4.0927734 -0.032226563 L 0.66064453 0 Q 0.40820313 0 0.40820313 0.13427734 Q 0.40820313 0.22021484 0.5048828 0.3544922 Q 2.1538086 2.5673828 3.211914 4.345215 L 1.8046875 4.3129883 Q 1.1870117 4.302246 0.91308594 3.3085938 Q 0.72509766 3.265625 0.54785156 3.3461914 Q 0.7036133 4.17334 0.71435547 4.76416 Q 0.71435547 4.8286133 0.7788086 4.8286133 Z "/>
+        </symbol>
+        <symbol id="gD231D848F892214029E9504EF6D7DFE" overflow="visible">
+            <path d="M 3.1689453 1.3427734 Q 3.1689453 0.6821289 3.3381348 0.52368164 Q 3.5073242 0.36523438 4.125 0.3383789 Q 4.178711 0.28466797 4.178711 0.15307617 Q 4.178711 0.021484375 4.125 -0.021484375 Q 3.0239258 0 2.7822266 0 Q 2.3310547 0 1.2514648 -0.021484375 Q 1.2084961 0.021484375 1.2084961 0.15307617 Q 1.2084961 0.28466797 1.2514648 0.3383789 Q 1.890625 0.35986328 2.1054688 0.5317383 Q 2.3203125 0.7036133 2.3203125 1.3427734 L 2.3203125 4.930664 Q 2.3203125 5.569824 2.1000977 5.564453 Q 1.8046875 5.564453 1.144043 5.2905273 Q 1.0097656 5.376465 0.97753906 5.5859375 Q 2.519043 6.300293 3.1367188 6.6870117 Q 3.2011719 6.6870117 3.2011719 6.633301 Q 3.1689453 6.3808594 3.1689453 5.161621 L 3.1689453 1.3427734 Z "/>
+        </symbol>
+        <symbol id="gA8AF2E6BB513EDEA9F0D218901DA991E" overflow="visible">
+            <path d="M 2.3632813 6.3271484 Q 2.1645508 6.3271484 1.9577637 6.270752 Q 1.7509766 6.2143555 1.5361328 6.010254 Q 1.3212891 5.8061523 1.3212891 5.489258 Q 1.3212891 4.919922 0.89160156 4.914551 Q 0.71435547 4.914551 0.61499023 5.038086 Q 0.515625 5.161621 0.515625 5.2905273 Q 0.515625 5.4570313 0.6203613 5.671875 Q 0.72509766 5.8867188 0.9453125 6.133789 Q 1.1655273 6.3808594 1.6005859 6.5446777 Q 2.0356445 6.708496 2.5942383 6.708496 Q 3.3730469 6.708496 3.7973633 6.2788086 Q 4.1411133 5.9296875 4.1411133 5.4086914 Q 4.1411133 4.9467773 3.8833008 4.600342 Q 3.6254883 4.2539063 2.980957 3.947754 L 2.9916992 3.9262695 Q 3.609375 3.8295898 4.07666 3.4106445 Q 4.5439453 2.9916992 4.5439453 2.1914063 Q 4.5439453 1.144043 3.816162 0.51831055 Q 3.088379 -0.107421875 2.067871 -0.107421875 Q 1.5200195 -0.107421875 1.001709 0.10473633 Q 0.48339844 0.31689453 0.48339844 0.62841797 Q 0.48339844 0.7626953 0.6311035 0.88623047 Q 0.7788086 1.0097656 0.9453125 1.0097656 Q 1.2084961 1.0097656 1.4179688 0.72509766 Q 1.4287109 0.71435547 1.4689941 0.65527344 Q 1.5092773 0.5961914 1.5253906 0.5720215 Q 1.5415039 0.54785156 1.5791016 0.49951172 Q 1.6166992 0.45117188 1.6489258 0.4296875 Q 1.6811523 0.40820313 1.7429199 0.36791992 Q 1.8046875 0.32763672 1.8691406 0.31152344 Q 1.9335938 0.29541016 2.0222168 0.28466797 Q 2.1108398 0.27392578 2.2128906 0.27392578 Q 2.3901367 0.27392578 2.5915527 0.35180664 Q 2.7929688 0.4296875 3.0292969 0.59887695 Q 3.265625 0.7680664 3.4213867 1.144043 Q 3.5771484 1.5200195 3.5771484 2.0356445 Q 3.5771484 3.4536133 2.1323242 3.4536133 Q 1.7939453 3.4536133 1.605957 3.432129 L 1.5522461 3.786621 Q 2.3149414 3.894043 2.7983398 4.380127 Q 3.2817383 4.866211 3.2817383 5.333496 Q 3.2817383 5.833008 3.0185547 6.080078 Q 2.755371 6.3271484 2.3632813 6.3271484 Z "/>
+        </symbol>
+    </defs>
+</svg>

--- a/packages/preview/jurz/0.1.0/demo-images.sh
+++ b/packages/preview/jurz/0.1.0/demo-images.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+typst c demo.typ demo-{n}.svg

--- a/packages/preview/jurz/0.1.0/demo.typ
+++ b/packages/preview/jurz/0.1.0/demo.typ
@@ -1,0 +1,62 @@
+#import "jurz.typ": *
+#import "@preview/chic-hdr:0.4.0": *
+
+#show: chic.with(
+  chic-footer(
+    // left-side: strong(
+    //     link("mailto:admin@chic.hdr", "admin@chic.hdr")
+    // ),
+    center-side: chic-page-number()
+  ),
+  chic-header(
+    // left-side: emph[jurz Demo],
+    // right-side: counter("rz").at(here())
+  ),
+  chic-separator(1pt),
+  // chic-offset(7pt),
+  chic-height(1.5cm)
+)
+#set page(paper: "din-d6", fill: white, margin: (inside: 2em, outside: 4em))
+#set par(justify: true)
+
+
+#v(1fr)
+#align(center)[
+  = jurz Demo
+  
+  Now with auto references like "@abc".
+
+  Zuri Klaschka
+
+  \
+
+  *On the package regsitry under*
+  
+  ```typst
+  #import "@preview/jurz:0.1.0": *
+  ```
+]
+#v(1fr)
+
+#pagebreak(to: "even")
+
+#show: init-jurz.with(
+  gap: 1em,
+  two-sided: true
+)
+
+#rz #lorem(50)
+
+#lorem(20)
+
+#rz<abc> #lorem(30)
+
+#rz #lorem(40)
+
+#rz #lorem(50)
+
+#lorem(20)
+
+#rz #lorem(24)
+
+Fur further information, look at @abc.

--- a/packages/preview/jurz/0.1.0/jurz.typ
+++ b/packages/preview/jurz/0.1.0/jurz.typ
@@ -1,0 +1,45 @@
+#let init-jurz = (
+  two-sided: false, 
+  gap: 1em, 
+  supplement: "Rz.", 
+  reset-level: 0, 
+  body
+) => {
+  // Reset the Rz. in each heading "bigger" (i.e., with a smaller level) than the reset-level
+  show heading: it => {
+    it
+    if (it.level <= reset-level) {
+      counter("rz").update(0)
+    }
+  } 
+
+  // Setup basic settings
+  show heading.where(level: 99): set heading(numbering: (..nums) => {
+    counter("rz").display()
+  }, supplement: supplement, outlined: false)
+
+  // Set up rendering outside the text flow
+  show heading.where(level: 99): it => {
+    counter("rz").step()
+    context {
+      // in one-sided layouts, every page is considered to be an even page
+      let isOddPage = here().page().bit-and(1) > 0 and two-sided;
+
+      let position = if isOddPage { right } else { left }
+      let inner-position = if isOddPage { left } else { right }
+      let dx = gap * if isOddPage { 1 } else { -1 }
+      
+      place(
+        position,
+        dx: dx,
+        place(inner-position, it.body)
+      )
+    }
+  }
+
+  // Display the body
+  body
+}
+
+
+#let rz = heading(level: 99, counter("rz").display())

--- a/packages/preview/jurz/0.1.0/typst.toml
+++ b/packages/preview/jurz/0.1.0/typst.toml
@@ -1,0 +1,15 @@
+[package]
+name = "jurz"
+version = "0.1.0"
+entrypoint = "jurz.typ"
+authors = ["Zuri Klaschka <https://github.com/pklaschka>"]
+license = "MIT"
+description = "Randziffern in Typst"
+categories = ["office", "components", "layout"]
+disciplines = ["law"]
+exclude = [
+	# Demo files
+	"*.svg",
+	"*.sh",
+	"demo.typ",
+]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Initial release of `jurz`, a package to add support for _Randziffern_ to Typst. [*Randziffern*](https://de.wikipedia.org/w/index.php?title=Randnummer&oldid=231943223) (also called *Randnummern*) are a way to reference text passages in a document, independent of the page number or the section number. They are used in many German legal texts, for example.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [ ] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
