### PR TITLE
cuti:0.2.1

### DIFF
--- a/packages/preview/cuti/0.2.1/.gitignore
+++ b/packages/preview/cuti/0.2.1/.gitignore
@@ -1,0 +1,2 @@
+lib.pdf
+testing-f

--- a/packages/preview/cuti/0.2.1/LICENSE
+++ b/packages/preview/cuti/0.2.1/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/cuti/0.2.1/README.md
+++ b/packages/preview/cuti/0.2.1/README.md
@@ -1,0 +1,47 @@
+# Cuti
+
+Cuti is a package that simulates fake bold / fake italic. This package is typically used on fonts that do not have a `bold` weight, such as "SimSun".
+
+## Usage
+
+Please refer to the [English Demo & Doc](https://github.com/csimide/cuti/raw/0.2.1/demo-and-doc/demo-and-doc.pdf).
+
+本 Package 提供中文文档： [中文 Demo 与文档](https://github.com/csimide/cuti/raw/0.2.1/demo-and-doc/demo-and-doc-cn.pdf)。
+
+### Getting Started Quickly (For Chinese User)
+
+Please add the following content at the beginning of the document:
+
+```typst
+#import "@preview/cuti:0.2.1": show-cn-fakebold
+#show: show-cn-fakebold
+```
+
+Then, the bolding for SimHei, SimSun, and KaiTi fonts should work correctly.
+
+## Changelog
+
+### `0.2.1`
+
+- feat: The stroke of fake bold will use the same color as the text.
+- fix: Attempted to fix the issue with the spacing of punctuation in fake italic (#2), but there are still problems.
+
+### `0.2.0`
+
+- feat: Added fake italic functionality.
+
+### `0.1.0`
+
+- Basic fake bold functionality.
+
+## License
+
+MIT License
+
+This package refers to the following content:
+
+- [TeX and Chinese Character Processing: Fake Bold and Fake Italic](https://zhuanlan.zhihu.com/p/19686102)
+- Typst issue [#394](https://github.com/typst/typst/issues/394)
+- Typst issue [#2749](https://github.com/typst/typst/issues/2749) (The function `_skew` comes from Enivex's code.)
+
+Thanks to Enter-tainer for the assistance.

--- a/packages/preview/cuti/0.2.1/README.md
+++ b/packages/preview/cuti/0.2.1/README.md
@@ -4,9 +4,9 @@ Cuti is a package that simulates fake bold / fake italic. This package is typica
 
 ## Usage
 
-Please refer to the [English Demo & Doc](https://github.com/csimide/cuti/raw/0.2.1/demo-and-doc/demo-and-doc.pdf).
+Please refer to the [English Demo & Doc](https://github.com/csimide/cuti/raw/0.2.1-fix/demo-and-doc/demo-and-doc.pdf).
 
-本 Package 提供中文文档： [中文 Demo 与文档](https://github.com/csimide/cuti/raw/0.2.1/demo-and-doc/demo-and-doc-cn.pdf)。
+本 Package 提供中文文档： [中文 Demo 与文档](https://github.com/csimide/cuti/raw/0.2.1-fix/demo-and-doc/demo-and-doc-cn.pdf)。
 
 ### Getting Started Quickly (For Chinese User)
 

--- a/packages/preview/cuti/0.2.1/demo-and-doc/demo-and-doc-cn.typ
+++ b/packages/preview/cuti/0.2.1/demo-and-doc/demo-and-doc-cn.typ
@@ -1,0 +1,269 @@
+#import "../lib.typ": *
+#import "./otr/utils.typ": *
+
+#set page(margin: 2cm)
+#set par(justify: true)
+
+#show heading: show-cn-fakebold
+#show raw.where(block: false): set text(font: "Fira Code")
+
+#show heading.where(level: 1): it => {pagebreak(weak: true); it}
+#show heading.where(level: 2): it => {line(length: 100%); it}
+
+= Cuti Demo & 中文文档
+
+== 简介
+
+Cuti 是一个为了方便用户使用伪粗体和伪斜体而设计的包。
+
+== 光速上手
+
+在文档顶端加入
+
+#example(
+  ```typst
+  #import "@preview/cuti:0.2.1": show-cn-fakebold
+  #show: show-cn-fakebold
+  ```,
+  sd: false
+)
+
+宋体、黑体、楷体的加粗就工作了。
+
+#fakebold[请注意: ]如果您使用 Source Han Sans / Source Han Serif 等包含 `bold` 字重的中文字体，不建议您对整个文档使用 `show: show-cn-fakebold` ——对整个文档使用 `show: show-cn-fakebold` 将导致支持中文粗体的字体也会使用“伪粗体”版的粗体。如下所示：
+
+#example(
+  ```typst
+  #set text(font: "Source Han Serif SC")
+  + Regular: 春江潮水连海平，海上明月共潮生。
+  + Bold: #text(weight: "bold")[春江潮水连海平，海上明月共潮生。]
+  #show: show-cn-fakebold
+  + Fakebold: #text(weight: "bold")[春江潮水连海平，海上明月共潮生。]
+  ```
+)
+
+第2行中，使用的是 Source Han Serif SC 的 Bold 字重。但设置 `show: show-cn-fakebold` 后，第3行使用的是伪粗体描边生成 Bold 字重。
+
+
+== Demo
+
+=== Part 1: `font: ("Times New Roman", "SimSun")`
+#block(
+  fill: rgb("dcedc8"),
+  stroke: 0.5pt + luma(180),
+  inset: 10pt,
+  width: 100%,
+)[
+  #set text(font: ("Times New Roman", "SimSun"))
+  #grid(
+    columns: 2,
+    column-gutter: 0.2em,
+    row-gutter: 0.6em,
+    [Regular:], [你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Bold(Font Only):], text(weight: "bold")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Bold(Fake Only):], fakebold[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Bold(Fake+Font):], show-cn-fakebold(text(weight: "bold")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。]),
+    [Italic(Font Only):], text(style: "italic")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Italic(Fake Only):], fakeitalic[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Italic(Fake+Font):], regex-fakeitalic(reg-exp: "[\p{script=Han} ！-･〇-〰—]", text(style: "italic")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。]),
+  )
+]
+
+=== Part 2: `font: "Source Han Serif SC"`
+#block(
+  fill: rgb("dcedc8"),
+  stroke: 0.5pt + luma(180),
+  inset: 10pt,
+  width: 100%,
+)[
+  #set text(font: "Source Han Serif SC")
+  #grid(
+    columns: 2,
+    column-gutter: 0.2em,
+    row-gutter: 0.6em,
+    [Regular:], [前面忘了。同时，逐步发掘「Typst」的奥妙。],
+    [Bold(Font Only):], text(weight: "bold")[前面忘了。同时，逐步发掘「Typst」的奥妙。],
+    [Bold(Fake Only):], fakebold[前面忘了。同时，逐步发掘「Typst」的奥妙。],
+    [Bold(Fake+Font):], show-cn-fakebold(text(weight: "bold")[前面忘了。同时，逐步发掘「Typst」的奥妙。])
+  )
+]
+
+= Fakebold 部分
+
+Cuti 利用 `text` 的 `stroke` 属性生成伪粗体。该工具通常可用于为宋体、黑体、楷体等字体提供“粗体”。Cuti 使用 0.02857em 作为 `stroke` 的参数。在 Microsoft Office 中，使用伪粗体会给字符添加一个 0.02857em 的描边。（实际上，精确值可能是 $1/35$。）
+
+== fakebold
+
+不带其他参数的 `#fakebold[]` 会为字符添加#fakebold[伪粗体]效果。
+
+#example(
+  ```typst
+  - Fakebold: #fakebold[#lorem(5)]
+  - Bold: #text(weight: "bold", lorem(5))
+  - Bold + Fakebold: #fakebold[#text(weight: "bold", lorem(5))]
+  ```
+)
+
+`#fakebold[]` 可以接受与 `#text` 相同的参数。特别地，若指定 `weight` 参数，可以用于指定基于某种字重进行描边。如果不指定 `weight`，基准字重会从上文继承。指定 `stroke` 参数会被忽略。
+
+#example(
+  ```typst
+  - Bold + Fakebold: #fakebold(weight: "bold")[#lorem(5)]
+  - Bold + Fakebold: #set text(weight: "bold"); #fakebold[#lorem(5)]
+  ```
+)
+
+#fakebold[注:] `cuti:0.2.0` 使用的 `base-weight` 参数仍保留以保证兼容性。
+
+如果将文字设置为彩色，伪粗体描边也将变成相应的颜色。
+
+#example(
+  ```typst
+  - Blue + Fakebold: #fakebold(fill: blue)[花生瓜子八宝粥，啤酒饮料矿泉水。#lorem(5)]
+  - Gradient + Fakebold: #set text(fill: gradient.conic(..color.map.rainbow)); #fakebold[花生瓜子八宝粥，啤酒饮料矿泉水。#lorem(5)]
+  ```
+)
+
+== #regex-fakebold
+
+`#regex-fakebold` 设计上是用于多语言、多字体情境的，可以根据参数 `reg-exp` 内的正则表达式只将匹配到的字符应用伪粗体格式。它也可以接受 `#font` 相同的参数。
+
+#example(
+  ```typst
+  + RegExp `[a-o]`: #regex-fakebold(reg-exp: "[a-o]")[#lorem(5)]
+  + RegExp `\p{script=Han}`: #regex-fakebold(reg-exp: "\p{script=Han}")[衬衫的价格是9磅15便士。] 
+  + RegExp `\p{script=Han}`: #set text(weight: "bold"); #regex-fakebold(reg-exp: "\p{script=Han}")[衬衫的价格是9磅15便士。]
+  ```
+)
+
+在上面的例子 \#3 中, `9` 和 `15` 是字体提供的“真”粗体，而其他字符是用 `regular` 字重描边得到的伪粗体。
+
+== show-fakebold
+
+在多语言、多字体的场景中，不同的语言通常使用不同的字体，但是不是所有的字体都自带 `bold` 字重。需要 `strong` 或者 `bold` 效果时，每次都使用  `#fakebold`  `#regex-fakebold` 并不方便。所以，我们提供了用于设置 `show` 规则 `#show-fakebold` 函数。
+
+`show-fakebold` 和 `regex-fakebold` 有着相同的参数。默认情况下 `show-fakebold` 使用 `"."` 作为正则表达式，也就是说，所有字符带加粗或`strong`属性都会被伪粗体加粗。
+
+#example(
+  ```typst
+  #show: show-fakebold
+  - Regular: #lorem(10)
+  - Bold: #text(weight: "bold")[#lorem(10)]
+  ```
+)
+
+正常情况下字体提供的加粗与伪粗体叠加的效果不是我们想要的。一般需要指定正则表达式、指定伪粗体的生效范围。
+
+#example(
+  ```typst
+  #show: show-fakebold.with(reg-exp: "\p{script=Han}")
+  - Regular: 我正在使用 Typst 排版。 
+  - Strong: *我正在使用 Typst 排版。*
+  ```
+)
+
+`show-fakebold` 也接受 `#font` 相同的参数。
+
+== cn-fakebold & show-cn-fakebold
+
+这两个都是为中文排版封装的。
+
+`cn-fakebold` 是 `regex-fakebold` 的封装。`cn-fakebold` 会将中文和常见符号进行伪粗体处理，基准字重为 `regular` 字重。请注意，在混排中英文时，需要另行指定 `weight: "bold"`。
+
+#example(
+  ```typst
+  #set text(font: ("Linux Libertine", "SimSun"))
+  - Regular: 有时，我们点击链接，打开的却是《Never Gonna Give You Up》这首歌。
+  - `cn-fakebold`: #cn-fakebold[《Never Gonna Give You Up》是英国歌手 Rick Astley 演唱的歌曲，于 1987 年发行。] 
+  #set text(weight: "bold")
+  - Bold:《Never Gonna Give You Up》已经成为了一种网络迷因。
+  - Bold + `cn-fakebold`: #cn-fakebold[在 2024 年的今天，《Never Gonna Give You Up》仍有独特的魅力。]
+  ```
+)
+
+`show-cn-fakebold` 是 `show-fakebold` 的封装，默认的正则范围是中文字符与常见标点符号。
+
+#example(
+  ```typst
+  #show: show-cn-fakebold
+  - Regular: 滚滚长江东逝水，浪花淘尽英雄。 #lorem(5)
+  - Bold: #text(weight: "bold")[滚滚长江东逝水，浪花淘尽英雄。 #lorem(5)]
+  - Strong: *滚滚长江东逝水，浪花淘尽英雄。 #lorem(5)*
+  ```
+)
+
+也可以这样使用：
+
+#example(
+  ```typst
+  #show-cn-fakebold[
+    - Regular: 滚滚长江东逝水，浪花淘尽英雄。 #lorem(5)
+    - Strong: *滚滚长江东逝水，浪花淘尽英雄。 #lorem(5)*
+  ]
+  ```
+)
+
+这两个函数也可以接受 `#font` 相同的参数，以指定中文字符加粗的效果。
+
+// ----------------------------------------------------
+
+= Fakeitalic 部分
+
+Cuti 使用的 `skew` 函数来自 typst issue \#2749 (https://github.com/typst/typst/issues/2749) by Enivex.
+
+`skew` 利用 `rotate` 和 `scale` 的组合生成伪斜体。Cuti 使用 $-0.32175$ 作为默认的倾斜角度。在 Microsoft Office 中，使用伪粗体会给字符添加一个 $arctan(1/3)$ 的倾斜效果。请注意，由于不同的英文字体拥有不同的倾斜角度，需要自行寻找一个合适的角度。如果使用 Times New Roman 与中易宋体，则默认的角度是比较合适的。
+
+== fakeitalic
+
+`fakeitalic(` \
+#h(2em) `ang:` #typebox[angle] 默认值 `-0.32175,` \
+#h(2em) #typebox[content] \
+`)`
+
+`#fakeitalic[]` 会为字符添加#fakeitalic[伪斜体]#h(1pt)效果。
+
+#example(
+  ```typst
+  - Regular: #lorem(5)
+  - Italic: #text(style: "italic", lorem(5))
+  - Fakeitalic: #fakeitalic[#lorem(5)]
+  - Fakeitalic + Fakebold: #fakeitalic[#fakebold[#lorem(5)]]
+  ```
+)
+
+可以通过调整 `ang` 参数调整倾斜的角度。
+
+#example(
+  ```typst
+  - -10deg: #fakeitalic(ang: -10deg)[#lorem(5)]
+  - -20deg: #fakeitalic(ang: -20deg)[#lorem(5)]
+  - +20deg: #fakeitalic(ang:  20deg)[#lorem(5)]
+  ```
+)
+
+== #regex-fakeitalic
+
+`regex-fakeitalic(` \
+#h(2em) `reg-exp:` #typebox[str] 默认值: `"[^ ]",` \
+#h(2em) `ang:` #typebox[angle] `,` \
+#h(2em) `spacing:` #typebox[relative] #typebox[none] 默认值: #typebox[none] `,` \
+#h(2em) #typebox[content] \
+`)`
+
+`#regex-fakeitalic` 设计上是用于多语言、多字体情境的，可以根据参数 `reg-exp` 内的正则表达式只将匹配到的字符应用伪斜体格式。它也可以接受 `ang` 参数。
+
+#example(
+  ```typst
+  + RegExp `[a-o]`: #regex-fakeitalic(reg-exp: "[a-o]")[#lorem(5)]
+  + RegExp `\p{script=Han}`: #regex-fakeitalic(reg-exp: "\p{script=Han}")[衬衫的价格是9磅15便士。] 
+  + RegExp `\p{script=Han}`: #set text(style: "italic"); #regex-fakeitalic(reg-exp: "\p{script=Han}", ang: -10deg)[衬衫的价格是9磅15便士。]
+  ```
+)
+
+在上面的例子 \#3 中, `9` 和 `15` 是字体提供的“真”斜体，而其他字符是用 `skew` 变换得到的伪斜体。
+
+== 为什么没有 `show-fakeitalic` 与 `show-cn-fakeitalic`
+
+因为斜体远比我想象中要复杂。斜体与直体、伪斜体与真斜体之间需要留间隔，而我没有找到合适的间隔；不同字体要写不同的角度，很难即开即用。
+
+并且，在 Demo 部分也可以发现：伪粗体的符号间距会出现问题。

--- a/packages/preview/cuti/0.2.1/demo-and-doc/demo-and-doc.typ
+++ b/packages/preview/cuti/0.2.1/demo-and-doc/demo-and-doc.typ
@@ -1,0 +1,203 @@
+#import "../lib.typ": *
+#import "./otr/utils.typ": *
+
+#set page(margin: 2cm)
+#set par(justify: true)
+
+#show raw.where(block: false): set text(font: "Fira Code")
+
+#show heading.where(level: 1): it => {pagebreak(weak: true); it}
+#show heading.where(level: 2): it => {line(length: 100%); it}
+
+= Cuti Demo & Doc
+
+== Introduction
+
+Cuti is a package designed for simulating fake bold / fake italic. 
+
+
+== Demo
+
+=== Part 1: `font: ("Times New Roman", "SimSun")`
+#block(
+  fill: rgb("dcedc8"),
+  stroke: 0.5pt + luma(180),
+  inset: 10pt,
+  width: 100%,
+)[
+  #set text(font: ("Times New Roman", "SimSun"))
+  #grid(
+    columns: 2,
+    column-gutter: 0.2em,
+    row-gutter: 0.6em,
+    [Regular:], [你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Bold(Font Only):], text(weight: "bold")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Bold(Fake Only):], fakebold[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Bold(Fake+Font):], show-cn-fakebold(text(weight: "bold")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。]),
+    [Italic(Font Only):], text(style: "italic")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Italic(Fake Only):], fakeitalic[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。],
+    [Italic(Fake+Font):], regex-fakeitalic(reg-exp: "[\p{script=Han} ！-･〇-〰—]", text(style: "italic")[你说得对，但是《Cuti》是一个用于伪粗体和伪斜体的包。]),
+  )
+]
+
+=== Part 2: `font: "Source Han Serif SC"`
+#block(
+  fill: rgb("dcedc8"),
+  stroke: 0.5pt + luma(180),
+  inset: 10pt,
+  width: 100%,
+)[
+  #set text(font: "Source Han Serif SC")
+  #grid(
+    columns: 2,
+    column-gutter: 0.2em,
+    row-gutter: 0.6em,
+    [Regular:], [前面忘了。同时，逐步发掘「Typst」的奥妙。],
+    [Bold(Font Only):], text(weight: "bold")[前面忘了。同时，逐步发掘「Typst」的奥妙。],
+    [Bold(Fake Only):], fakebold[前面忘了。同时，逐步发掘「Typst」的奥妙。],
+    [Bold(Fake+Font):], show-cn-fakebold(text(weight: "bold")[前面忘了。同时，逐步发掘「Typst」的奥妙。])
+  )
+]
+
+= Fake Bold
+
+Cuti simulates fake bold by utilizing the `stroke` attribute of `text`. This package is typically used on fonts that do not have a `bold` weight, such as "SimSun". This package uses 0.02857em as the parameter for stroke. In Microsoft Office software, enabling fake bold will apply a border of about 0.02857em to characters. This is where the value of 0.02857em is derived from. (In fact, the exact value may be $1/35$.)
+
+== fakebold
+
+`#fakebold[]` with no parmerter will apply the #fakebold[fakebold] effect to characters.
+
+#example(
+  ```typst
+  - Fakebold: #fakebold[#lorem(5)]
+  - Bold: #text(weight: "bold", lorem(5))
+  - Bold + Fakebold: #fakebold[#text(weight: "bold", lorem(5))]
+  ```
+)
+
+`#fakebold[]` can accept the same parameters as `#text`. In particular, if the `weight` parameter is specified, it can be used to outline based on a certain font weight. If `weight` is not specified, the baseline font weight will be inherited from the context. Specifying the `stroke` parameter will be ignored.
+
+#example(
+  ```typst
+  - Bold + Fakebold: #fakebold(weight: "bold")[#lorem(5)]
+  - Bold + Fakebold: #set text(weight: "bold"); #fakebold[#lorem(5)]
+  ```
+)
+
+*Note:* The `base-weight` parameter used by `cuti:0.2.0` is still retained to ensure compatibility.
+
+== #regex-fakebold
+
+The `#regex-fakebold` is designed to be used in multilingual and multi-font scenarios. It allows the use of a RegExp string as the `reg-exp` parameter to match characters that will have the fake bold effect applied. It can also accept the same parameters as `#text`.
+
+#example(
+  ```typst
+  + RegExp `[a-o]`: #regex-fakebold(reg-exp: "[a-o]")[#lorem(5)]
+  + RegExp `\p{script=Han}`: #regex-fakebold(reg-exp: "\p{script=Han}")[衬衫的价格是9磅15便士。] 
+  + RegExp `\p{script=Han}`: #set text(weight: "bold"); #regex-fakebold(reg-exp: "\p{script=Han}")[衬衫的价格是9磅15便士。]
+  ```
+)
+
+In Example \#3, `9` and `15` are the real bold characters from the font file, while the other characters are simulated as "fake bold" based on the `regular` weight.
+
+If the `fill` parameter of `#text` is set to a specific color or gradient, , the fake bold outline will also change to the corresponding color.
+
+#example(
+  ```typst
+  - Blue + Fakebold: #fakebold(fill: blue)[花生瓜子八宝粥，啤酒饮料矿泉水。#lorem(5)]
+  - Gradient + Fakebold: #set text(fill: gradient.conic(..color.map.rainbow)); #fakebold[花生瓜子八宝粥，啤酒饮料矿泉水。#lorem(5)]
+  ```
+)
+
+== show-fakebold
+
+In multilingual and multi-font scenarios, different languages often utilize their own fonts, but not all fonts contain the `bold` weight. It can be inconvenient to use `#fakebold` or `#regex-fakebold` each time we require `strong` or `bold` effects. Therefore, the `#show-fakebold` function is introduced for `show` rule.
+
+The `show-fakebold` function shares the same parameters as `regex-fakebold`. By default, `show-fakebold` will apply the RegExp `"."`, which means all characters with the `strong` or `weight: "bold"` property will be fakebolded if the corresponding show rule has been set.
+
+#example(
+  ```typst
+  #show: show-fakebold
+  - Regular: #lorem(10)
+  - Bold: #text(weight: "bold")[#lorem(10)]
+  ```
+)
+
+Typically, the combination of bold + fakebold is not the desired effect. It is usually necessary to specify the RegExp to indicate which characters should utilize the fakebold effect.
+
+#example(
+  ```typst
+  #show: show-fakebold.with(reg-exp: "\p{script=Han}")
+  - Regular: 我正在使用 Typst 排版。 
+  - Strong: *我正在使用 Typst 排版。*
+  ```
+)
+
+It can also accept the same parameters as `#text`.
+
+== cn-fakebold & show-cn-fakebold
+
+`cn-fakebold(`#typebox[content]`)`
+
+`show-cn-fakebold(`#typebox[content]`)`
+
+`cn-fakebold` and `show-cn-fakebold` are encapsulations of the above `regex-fakebold` and `show-fakebold`, pre-configured for use with Chinese text. Please refer to the Chinese documentation for detailed usage instructions.
+
+= Fake Italic
+
+The `skew` function used in cuti is from typst issue #2749 (https://github.com/typst/typst/issues/2749) by Enivex.
+
+Cuti simulates fake italic by utilizing `rotate` and `scale`. This package uses $-0.32175$ as the default angle. In Microsoft Office software, enabling fake italic will apply a $arctan(1/3)$ skew effect to characters. Please note that due to different English fonts having varying skew angles, you may need to find a suitable angle on your own. If using Times New Roman alongside SimSun, the default angle is relatively appropriate.
+
+== fakeitalic
+
+`fakeitalic(` \
+#h(2em) `ang:` #typebox[angle] default: `-0.32175,` \
+#h(2em) #typebox[content] \
+`)`
+
+`#fakeitalic[]` will apply the #fakeitalic[fakeitalic]#h(1pt) effect to characters.
+
+#example(
+  ```typst
+  - Regular: #lorem(5)
+  - Italic: #text(style: "italic", lorem(5))
+  - Fakeitalic: #fakeitalic[#lorem(5)]
+  - Fakeitalic + Fakebold: #fakeitalic[#fakebold[#lorem(5)]]
+  ```
+)
+
+The angle of skew can be adjusted through the `ang` parameter.
+
+#example(
+  ```typst
+  - -10deg: #fakeitalic(ang: -10deg)[#lorem(5)]
+  - -20deg: #fakeitalic(ang: -20deg)[#lorem(5)]
+  - +20deg: #fakeitalic(ang:  20deg)[#lorem(5)]
+  ```
+)
+
+== #regex-fakeitalic
+
+`regex-fakeitalic(` \
+#h(2em) `reg-exp:` #typebox[str] default: `"[^ ]",` \
+#h(2em) `ang:` #typebox[angle] `,` \
+#h(2em) `spacing:` #typebox[relative] #typebox[none] default: #typebox[none] `,` \
+#h(2em) #typebox[content] \
+`)`
+
+The `#regex-fakeitalic` is designed to be used in multilingual and multi-font scenarios. It allows the use of a RegExp string as the `reg-exp` parameter to match characters that will have the fake bold effect applied. It also accepts the `ang` parameter.
+
+#example(
+  ```typst
+  + RegExp `[a-o]`: #regex-fakeitalic(reg-exp: "[a-o]")[#lorem(5)]
+  + RegExp `\p{script=Han}`: #regex-fakeitalic(reg-exp: "\p{script=Han}")[衬衫的价格是9磅15便士。] 
+  + RegExp `\p{script=Han}`: #set text(style: "italic"); #regex-fakeitalic(reg-exp: "\p{script=Han}", ang: -10deg)[衬衫的价格是9磅15便士。]
+  ```
+)
+
+In Example \#3, `9` and `15` are the real italic characters from the font file, while the other characters are simulated as "fake italic".
+
+== Issues at hand
+
+The current implementation of faux italics disrupts spacing, particularly the spacing between symbols and characters. This is especially evident in the demo.

--- a/packages/preview/cuti/0.2.1/demo-and-doc/otr/utils.typ
+++ b/packages/preview/cuti/0.2.1/demo-and-doc/otr/utils.typ
@@ -1,0 +1,53 @@
+#import "@preview/sourcerer:0.2.1": code
+
+#let example(source, sd: true) = {
+  block(
+    //breakable: false,
+    {
+      {
+        code(
+          radius: 0pt,
+          inset: 10pt,
+          line-offset: 10pt,
+          text-style: (font: ("Fira Code", "Source Han Sans SC")),
+          stroke: 0.5pt+luma(180),
+          source
+        )
+      }
+      if sd {
+        v(-1.2em)
+        block(
+          fill: rgb("dcedc8"),
+          stroke: 0.5pt + luma(180),
+          inset: 10pt,
+          width: 100%,
+          eval("#import \"../../lib.typ\": * \n" + source.text, mode: "markup")
+        )
+      }
+    }
+  )
+}
+
+#let typebox(fill: "default", s) = {
+  set text(size: 10pt)
+
+  let fillcolor = if fill == "default" {
+    (
+      "int": rgb("#e7d9ff"),
+      "str": rgb("#d1ffe2"),
+      "bool": rgb("#ffedc1"),
+      "none": rgb("#ffcbc4"),
+      "content": rgb("#a6ebe6"),
+      "angle": rgb("#e7d9ff"),
+      "relative": rgb("#e7d9ff"),
+    ).at(s.text, default: luma(220))
+  } else {fill}
+
+  box(
+    inset: 3pt,
+    fill: fillcolor,
+    radius: 3pt,
+    baseline: 3pt,
+    raw(s.text)
+  )
+}

--- a/packages/preview/cuti/0.2.1/lib.typ
+++ b/packages/preview/cuti/0.2.1/lib.typ
@@ -54,7 +54,7 @@
 
 #let regex-fakeitalic(reg-exp: ".", ang: -0.32175, spacing: none, s) = {
   show regex(reg-exp): it => {
-    box(place(_skew(-12deg, it)), baseline: -0.7em) + hide(it)
+    box(place(_skew(ang, it)), baseline: -0.7em) + hide(it)
   }
   s
   if spacing != none {h(spacing)}

--- a/packages/preview/cuti/0.2.1/lib.typ
+++ b/packages/preview/cuti/0.2.1/lib.typ
@@ -1,0 +1,63 @@
+#let fakebold(base-weight: none, s, ..params) = {
+  set text(weight: base-weight) if base-weight != none
+  set text(..params) if params != ()
+  context {
+    set text(stroke: 0.02857em + text.fill)
+    s
+  }
+}
+
+#let regex-fakebold(reg-exp: ".", base-weight: none, s, ..params) = {
+  show regex(reg-exp): it => {
+    fakebold(base-weight: base-weight, it, ..params)
+  }
+  s
+}
+
+#let show-fakebold(reg-exp: ".", base-weight: none, s, ..params) = {
+  show text.where(weight: "bold").or(strong): it => {
+    regex-fakebold(reg-exp: reg-exp, base-weight: base-weight, it, ..params)
+  }
+  s
+}
+
+#let cn-fakebold(s, ..params) = {
+  regex-fakebold(reg-exp: "[\p{script=Han}！-･〇-〰—]", base-weight: "regular", s, ..params)
+}
+
+#let show-cn-fakebold(s, ..params) = {
+  show-fakebold(reg-exp: "[\p{script=Han}！-･〇-〰—]", base-weight: "regular", s, ..params)
+}
+
+
+// https://github.com/typst/typst/issues/2749
+#let _skew(angle, vscale: 1, body) = {
+  let (a, b, c, d)= (1, vscale*calc.tan(angle), 0, vscale)
+  let E = (a + d)/2
+  let F = (a - d)/2
+  let G = (b + c)/2
+  let H = (c - b)/2
+  let Q = calc.sqrt(E*E + H*H)
+  let R = calc.sqrt(F*F + G*G)
+  let sx = Q + R
+  let sy = Q - R
+  let a1 = calc.atan2(F,G)
+  let a2 = calc.atan2(E,H)
+  let theta = (a2 - a1) /2
+  let phi = (a2 + a1)/2
+  
+  set rotate(origin: bottom+center)
+  set scale(origin: bottom+center)
+  
+  rotate(phi, scale(x: sx * 100%, y: sy * 100%, rotate(theta, body)))
+}
+
+#let regex-fakeitalic(reg-exp: ".", ang: -0.32175, spacing: none, s) = {
+  show regex(reg-exp): it => {
+    box(place(_skew(-12deg, it)), baseline: -0.7em) + hide(it)
+  }
+  s
+  if spacing != none {h(spacing)}
+}
+
+#let fakeitalic(ang: -0.32175, s) = regex-fakeitalic(reg-exp: "[^ ]", ang: ang, s)

--- a/packages/preview/cuti/0.2.1/typst.toml
+++ b/packages/preview/cuti/0.2.1/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cuti"
+version = "0.2.1"
+entrypoint = "lib.typ"
+authors = ["csimide", "Enivex"]
+license = "MIT"
+description = "Easily simulate (fake) bold and italic characters."
+compiler = "0.11.0"
+repository = "https://github.com/csimide/cuti"
+exclude = ["demo-and-doc"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Description: 
- feat: The stroke of fake bold will use the same color as the text (`fill`).
- fix: Partially fixed the issue of incorrect spacing between punctuation marks in `regex-fakeitalic`.

P.S. Due to the excessive size of the demo and documentation PDF files, I did not submit the compiled PDF files to the `packages` repository.