### PR TITLE
acrotastic:0.1.0

### DIFF
--- a/packages/preview/acrotastic/0.1.0/LICENSE
+++ b/packages/preview/acrotastic/0.1.0/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2024 Julian Herzog
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/acrotastic/0.1.0/README.md
+++ b/packages/preview/acrotastic/0.1.0/README.md
@@ -92,3 +92,7 @@ Moreover you have to be careful when using states.
 ## Contributing
 
 If you notice any bug or want to contribute a new feature, please open an issue or a pull request on the fork [Julian702/typst-packages](https://github.com/Julian702/typst-packages?tab=readme-ov-file)
+
+## Acknowledgement
+
+Thanks to @Grisely who developed the [acrostiche package](https://typst.app/universe/package/acrostiche/) which was the basis for acrotastic.

--- a/packages/preview/acrotastic/0.1.0/README.md
+++ b/packages/preview/acrotastic/0.1.0/README.md
@@ -1,0 +1,94 @@
+# Acrotastic (0.1.0)
+
+Manages all your acronyms for you.
+
+Acrotastics main features are clickable abbreviations that auto-expand on the first occurence, manual short and long forms, implicit or manual plural form support, and customizable index printing.
+
+## Quick Start
+
+```
+#import "@preview/acrotastic:0.1.0": *
+
+#init-acronyms((
+  "WTP": ("Wonderful Typst Package","Wonderful Typst Packages"),
+))
+
+Acrotastic is a #acr("WTP")! This #acr("WTP") enables easy acronym manipulation.
+```
+
+## Usage
+
+### Define acronyms
+
+First, define the acronyms in a dictionary, with the keys being the acronyms and the values being arrays of their definitions. If there is only a singular version of the definition, the array contains only one value. If there are both singular and plural versions, define the definition as an array where the first item is the singular definition and the second item is the plural.
+Then, initialize Acrotastic by passing the dictionay you just defined to the `#init-acronyms(...)` function.
+
+Here is a example of the `acronyms.typ` file:
+
+```
+#import "@preview/acrotastic:0.1.0": *
+
+#init-acronyms((
+  "NN": ("Neural Network"),
+  "OS": ("Operating System",),
+  "BIOS": ("Basic Input/Output System", "Basic Input/Output Systems"),
+))
+```
+
+### Call Acrotastic functions
+
+There is a large number of different functions to fit every use case. You will find an overview of all functions and their descriptions in the table below.
+
+| Function               | Description                                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#acr(...)`            | On the first occurrence the long version of the abbreviation and the abbreviation itself are displayed in brackets. The next time only the abbreviation is displayed. |
+| `#acrpl(...)`          | Same as `#acr(...)` but the plural will be diplayed. If no plural is defined, an 's' is added to the singular form.                                                   |
+| `#acrf(...)`           | The acronym will be displayed as if it is the first time. This means that it is again shown in the long form and the abbreviation in brackets.                        |
+| `#acrfpl(...)`         | Same as `#acrf(...)` but the plural will be displayed. If no plural is defined, an 's' is added to the singular form.                                                 |
+| `#acrs(...)`           | Always displays the short form of the acronym.                                                                                                                        |
+| `#acrspl(...)`         | Same as `#acrs(...)` but adds an 's' to the acronym for the plural form.                                                                                              |
+| `#acrl(...)`           | Always displays the long form of the acronym.                                                                                                                         |
+| `#acrlpl(...)`         | Same as `#acrl(...)` but the plural will be displayed. If no plural is defined, an 's' is added to the singular form.                                                 |
+| `#reset-acronym(...)`  | Resets a specific acronym. The acronym will be expanded on the next use.                                                                                              |
+| `reset-all-acronyms()` | Resets all acronyms. The acronyms will be expanded on their next use.                                                                                                 |
+
+You can alternatively use `#acr(...)`, `#acrf(...)`, `#acrs(...)` and `#acrl(...)` with `plural: true` to display the plural form.
+
+```
+#acr("BIOS", plural: true)
+```
+
+To deactivate the link to the abbreviations directory (for whatever reason), you can set `link: false`.
+
+```
+#acr("BIOS", link: false)
+```
+
+### Print Abbreviations directory
+
+You can also print an index of all acronyms used in the document with the `#print-index()` function. There are some parameters for customization.
+
+| parameter    | values               | default                 | description                                                                                                   |
+| ------------ | -------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| title        | string               | "List of Abbreviations" | Heading of the acronym index                                                                                  |
+| level        | number               | 1                       | Level of the heading                                                                                          |
+| sorted       | "up", "down", "keep" | "up"                    | "Up" sorts alphabetically, "Down" sorts reversed alphabetically and "keep" uses the order from initialization |
+| delimiter    | string               | ":"                     | String to place after the acronym in the list                                                                 |
+| acr-col-size | percentage           | 20%                     | Size of the acronym column in percent                                                                         |
+
+## Possible Errors
+
+| Error                                                                                                      | Solution                                                                                                                     |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Acronym is not a key in the acronyms dictionary.                                                           | Make sure that the acronym is defined in the dictionary passed to `#init-acronyms(dict)`                                     |
+| No definitions found for acronym. Make sure it is defined in the dictionary passed to #init-acronyms(dict) | The acronym is in the dictionary, but has no correct definition.                                                             |
+| Definitions should be arrays of one or two strings. Definition of acronym is:                              | The acronym has a definition, but the definition doesn't have the right type. Make sure it's an array of one or two strings. |
+
+Moreover you have to be careful when using states.
+
+- For every acronym "ABC" that you define, the state named "acronym-state-ABC" is initialized and used. To avoid errors, do not try to use this state manually for other purposes. Similarly, the state named "acronyms" is reserved to Acrotastic. Please avoid using it.
+- The functions above are leveraging the state `display` function and only works if the return value is actually printed in the document. For more information on states, see the [Typst documentation on states](https://typst.app/docs/reference/introspection/state/).
+
+## Contributing
+
+If you notice any bug or want to contribute a new feature, please open an issue or a pull request on the fork [Julian702/typst-packages](https://github.com/Julian702/typst-packages?tab=readme-ov-file)

--- a/packages/preview/acrotastic/0.1.0/acrotastic.typ
+++ b/packages/preview/acrotastic/0.1.0/acrotastic.typ
@@ -20,7 +20,7 @@
 }
 
 // Check if an acronym exists
-#let isValid(acr) = {
+#let is-valid(acr) = {
   acros.display(acronyms => {
     if acr not in acronyms {
       panic(acr + " is not a key in the acronyms dictionary.")
@@ -32,7 +32,7 @@
 
 // Display acronym as clickable link
 #let display-link(acr, text) = {
-  if isValid(acr) {link(label(acr), text)}
+  if is-valid(acr) {link(label(acr), text)}
 }
 
 // Display acronym
@@ -50,7 +50,7 @@
 // Display acronym in long form.
 #let acrl(acr, plural: false, link: true) = {
   acros.display(acronyms => {
-    if isValid(acr) {
+    if is-valid(acr) {
       let defs = acronyms.at(acr)
       if type(defs) == "string" {
         if plural {

--- a/packages/preview/acrotastic/0.1.0/acrotastic.typ
+++ b/packages/preview/acrotastic/0.1.0/acrotastic.typ
@@ -1,0 +1,130 @@
+// Acronym package for Typst
+// Author: Julian
+
+#let prefix = "acronym-state-"
+#let acros = state("acronyms", none)
+#let init-acronyms(acronyms) = {
+  acros.update(acronyms)
+}
+
+// Reset a specific acronym. It will be expanded on next use.
+#let reset-acronym(acr) = { 
+    state(prefix + acr, false).update(false)
+}
+
+// Reset all acronyms. They will all be expanded on the next use.
+#let reset-all-acronyms() = { 
+  state("acronyms",none).display(acronyms =>
+    for acr in acronyms.keys() {reset-acronym(acr)}
+  )
+}
+
+// Check if an acronym exists
+#let isValid(acr) = {
+  acros.display(acronyms => {
+    if acr not in acronyms {
+      panic(acr + " is not a key in the acronyms dictionary.")
+      return false
+    }
+  })
+  return true
+}
+
+// Display acronym as clickable link
+#let display-link(acr, text) = {
+  if isValid(acr) {link(label(acr), text)}
+}
+
+// Display acronym
+#let display(acr, text, link: true) = {
+  if link {display-link(acr, text)} else {text}
+}
+
+// Display acronym in short form.
+#let acrs(acr, plural: false, link: true) = {
+  if plural {display(acr, acr + "s", link: link)} else {display(acr, acr, link: link)}
+}
+// Display acronym in short plural form
+#let acrspl(acr, link: true) = {acrs(acr, plural: true, link: link)}
+
+// Display acronym in long form.
+#let acrl(acr, plural: false, link: true) = {
+  acros.display(acronyms => {
+    if isValid(acr) {
+      let defs = acronyms.at(acr)
+      if type(defs) == "string" {
+        if plural {
+          display(acr, defs + "s", link: link)
+        } else {
+          display(acr, defs, link: link)
+        }
+      } else if type(defs) == "array" {
+        if defs.len() == 0 {
+          panic("No definitions found for acronym " + acr + ". Make sure it is defined in the dictionary passed to #init-acronyms(dict)")
+        }
+        if plural {
+          if defs.len() == 1 {
+            display(acr, defs.at(0) + "s", link: link)
+          } else if defs.len() == 2 {
+            display(acr, defs.at(1), link: link)
+          } else {
+            panic("Definitions should be arrays of one or two strings. Definition of " + acr + " is: " + type(defs))
+          }
+        } else {  
+          display(acr, defs.at(0), link: link)
+        }
+      } else {
+        panic("Definitions should be arrays of one or two strings. Definition of " + acr + " is: " + type(defs))
+      }
+    }
+  })
+}
+// Display acronym in long plural form.
+#let acrlpl(acr, link: true) = {acrl(acr, plural: true, link: link)}
+
+// Display acronym for the first time. 
+#let acrf(acr, plural: false, link: true) = {
+  if plural {
+    display(acr, [#acrlpl(acr) (#acr\s)], link: link)
+  } else {
+    display(acr, [#acrl(acr) (#acr)], link: link)
+  }
+  state(prefix + acr, false).update(true)
+}
+// Display acronym in plural form for the first time.
+#let acrfpl(acr, link: true) = {acrf(acr, plural: true, link: link)}
+
+// Display acronym. Expands it if used for the first time.
+#let acr(acr, plural: false, link: true) = {
+  state(prefix + acr, false).display(seen => {
+    if seen {
+      if plural {acrspl(acr, link: link)} else {acrs(acr, link: link)}
+    } else {
+      if plural {acrfpl(acr, link: link)} else {acrf(acr, link: link)}
+    }
+  })
+}
+// Display acronym in the plural form. Expands it if used for the first time. 
+#let acrpl(acronym, link: true) = {acr(acronym, plural: true, link: link)}
+
+// Print an index of all the acronyms and their definitions.
+#let print-index(title: "List of Abbreviations", sorted: "up", delimiter: ":", acr-col-size: 20%, level: 1) = {
+  assert(sorted in ("keep","up","down"), message:"Sorted must be a string either \"keep\", \"up\" or \"down\"")
+  if title != "" {heading(level: level, outlined: outlined)[#title]}
+  acros.display(acronyms=>{
+    let acr-list = acronyms.keys()
+    if sorted == "up" {
+      acr-list = acr-list.sorted()
+    } else if sorted == "down" {
+      acr-list = acr-list.sorted().rev()
+    }
+    for acr in acr-list{
+      table(
+        columns: (acr-col-size,100%-acr-col-size),
+        stroke:none,
+        inset: 0pt,
+        [*#acr#label(acr)#delimiter*], [#acrl(acr, link: false)]
+      )
+    }
+  })
+}

--- a/packages/preview/acrotastic/0.1.0/typst.toml
+++ b/packages/preview/acrotastic/0.1.0/typst.toml
@@ -7,4 +7,4 @@ license="MIT"
 description="Manage acronyms and their definitions in Typst."
 repository="https://github.com/Julian702/typst-packages"
 keywords=["acronym", "acronyms", "acro", "abbreviation", "abbreviations", "abbrev"]
-categroies=["model", "paper", "thesis"]
+categories=["model", "paper", "thesis"]

--- a/packages/preview/acrotastic/0.1.0/typst.toml
+++ b/packages/preview/acrotastic/0.1.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name="acrotastic"
+version="0.1.0"
+entrypoint="acrotastic.typ"
+authors=["@Julian702"]
+license="MIT"
+description="Manage acronyms and their definitions in Typst."
+repository="https://github.com/Julian702/typst-packages"
+keywords=["acronym", "acronyms", "acro", "abbreviation", "abbreviations", "abbrev"]
+categroies=["model", "paper", "thesis"]

--- a/packages/preview/acrotastic/0.1.0/typst.toml
+++ b/packages/preview/acrotastic/0.1.0/typst.toml
@@ -7,4 +7,4 @@ license="MIT"
 description="Manage acronyms and their definitions in Typst."
 repository="https://github.com/Julian702/typst-packages"
 keywords=["acronym", "acronyms", "acro", "abbreviation", "abbreviations", "abbrev"]
-categories=["model", "paper", "thesis"]
+categories=["model"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Acrotastics main features are clickable abbreviations that auto-expand on the first occurence, manual short and long forms, implicit or manual plural form support, and customizable index printing.

Acrotastic has several advantages over existing packages for managing acronyms:

- Acronyms are clickable and linked to the list of abbreviations
- More functions to manually display the short, long, plural or a second first form
- More customization options for the list of abbreviations
- Cleaner code

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [x] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
