### PR TITLE
codedis:0.1.0

### DIFF
--- a/packages/preview/codedis/0.1.0/LICENSE
+++ b/packages/preview/codedis/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Augustin Winther
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/codedis/0.1.0/README.md
+++ b/packages/preview/codedis/0.1.0/README.md
@@ -2,7 +2,7 @@
 
 Used to display code files in Typst. Main feature is that it displays code blocks over multiple pages in a way that implies the code block continues onto the next page. Also a simple and intuitive syntax for displaying code blocks.
 
-Usage:s
+Usage:
 ```typ
 // IMPORT PACKAGE
 #import "@preview/codedis:0.1.0": code

--- a/packages/preview/codedis/0.1.0/README.md
+++ b/packages/preview/codedis/0.1.0/README.md
@@ -2,21 +2,21 @@
 
 Used to display code files in Typst. Main feature is that it displays code blocks over multiple pages in a way that implies the code block continues onto the next page. Also a simple and intuitive syntax for displaying code blocks.
 
-Usage:
+Usage:s
 ```typ
 // IMPORT PACKAGE
 #import "@preview/codedis:0.1.0": code
 
 // READ IN CODE
-#let codeblock_1 = read("some_code.py")
-#let codeblock_2 = read("some_code.cpp")
+#let codeblock-1 = read("some_code.py")
+#let codeblock-2 = read("some_code.cpp")
 
 #set page(numbering: "1")
 #v(80%)
 
 // DEFAULT LANGUAGE IS Python ("py")
-#code(codeblock_1)
-#code(codeblock_2, lang: "cpp")
+#code(codeblock-1)
+#code(codeblock-2, lang: "cpp")
 ```
 
 Renders to:

--- a/packages/preview/codedis/0.1.0/README.md
+++ b/packages/preview/codedis/0.1.0/README.md
@@ -1,0 +1,26 @@
+# CODEDIS - Simple CODE DISplay for Typst
+
+Used to display code files in Typst. Main feature is that it displays code blocks over multiple pages in a way that implies the code block continues onto the next page. Also a simple and intuitive syntax for displaying code blocks.
+
+Usage:
+```typ
+// IMPORT PACKAGE
+#import "@preview/codedis:0.1.0": code
+
+// READ IN CODE
+#let codeblock_1 = read("some_code.py")
+#let codeblock_2 = read("some_code.cpp")
+
+#set page(numbering: "1")
+#v(80%)
+
+// DEFAULT LANGUAGE IS Python ("py")
+#code(codeblock_1)
+#code(codeblock_2, lang: "cpp")
+```
+
+Renders to:
+![image](https://github.com/AugustinWinther/codedis/assets/30674646/76bb13d5-adc8-457f-bd55-53e3fd5c5df7)
+
+
+It is very basic and limited, but it does what I need it too, and hope that it may be of help to others. I'm most likely not going to develop it further than this.

--- a/packages/preview/codedis/0.1.0/lib.typ
+++ b/packages/preview/codedis/0.1.0/lib.typ
@@ -2,8 +2,8 @@
   code, 
   lang: "py",
   stroke: luma(170), // Stroke color
-  fill_1: luma(250), // First line block fill
-  fill_2: luma(240), // Second line block fill
+  fill-1: luma(250), // First line block fill
+  fill-2: luma(240), // Second line block fill
 ) = {
 
   // Change how raw.line looks
@@ -14,7 +14,7 @@
     let end = it.count
 
     // Calculates where to have block strokes given line number
-    let get_stroke(line) = {
+    let get-stroke(line) = {
       if line == start {
         return (top: stroke + 1pt, x: stroke + 1pt)
       } else if line == end {
@@ -25,7 +25,7 @@
     }
 
     // Calculates block radius given line number
-    let get_radius(line) = {
+    let get-radius(line) = {
       if line == start {
         return (top: 1em)
       } else if line == end {
@@ -36,11 +36,11 @@
     }
 
     // Calculates fill given line number
-    let get_fill(line) = {
+    let get-fill(line) = {
       if calc.rem(line, 2) == 0 {
-        return fill_2
+        return fill-2
       } else {
-          return  fill_1
+          return  fill-1
       }
     }
 
@@ -51,9 +51,9 @@
       height: 1.7em,
       width: 100%,
       inset: (x:0.8em, top:0.4em),
-      fill: get_fill(line),
-      radius: get_radius(line),
-      stroke: get_stroke(line),
+      fill: get-fill(line),
+      radius: get-radius(line),
+      stroke: get-stroke(line),
       spacing: 0em,
 
       // Actual line of code with height adjustment for centering it

--- a/packages/preview/codedis/0.1.0/lib.typ
+++ b/packages/preview/codedis/0.1.0/lib.typ
@@ -1,0 +1,69 @@
+#let code(
+  code, 
+  lang: "py",
+  stroke: luma(170), // Stroke color
+  fill_1: luma(250), // First line block fill
+  fill_2: luma(240), // Second line block fill
+) = {
+
+  // Change how raw.line looks
+  show raw.line: it => {
+    
+    // Define line start and end numbers
+    let start = 1
+    let end = it.count
+
+    // Calculates where to have block strokes given line number
+    let get_stroke(line) = {
+      if line == start {
+        return (top: stroke + 1pt, x: stroke + 1pt)
+      } else if line == end {
+          return (bottom: stroke + 1pt, x: stroke + 1pt)
+      } else {
+          return (x: stroke + 1pt)
+      }
+    }
+
+    // Calculates block radius given line number
+    let get_radius(line) = {
+      if line == start {
+        return (top: 1em)
+      } else if line == end {
+          return (bottom: 1em)
+      } else {
+          return (0em)
+      }
+    }
+
+    // Calculates fill given line number
+    let get_fill(line) = {
+      if calc.rem(line, 2) == 0 {
+        return fill_2
+      } else {
+          return  fill_1
+      }
+    }
+
+    // Line block
+    let line = it.number
+    block(
+      breakable: false,
+      height: 1.7em,
+      width: 100%,
+      inset: (x:0.8em, top:0.4em),
+      fill: get_fill(line),
+      radius: get_radius(line),
+      stroke: get_stroke(line),
+      spacing: 0em,
+
+      // Actual line of code with height adjustment for centering it
+      align(left)[#text(size: 9pt)[#it]]            
+    )
+  
+    // Remove spacing between line blocks
+    if line != end {v(-3.2em)} else {v(1em)}
+
+  }
+  
+  raw(code, lang: lang)
+}

--- a/packages/preview/codedis/0.1.0/typst.toml
+++ b/packages/preview/codedis/0.1.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "codedis"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Augustin Winther <https://winther.io>"]
+license = "MIT"
+description = "A simple package for displaying code."
+repository = "https://github.com/AugustinWinther/codedis"
+keywords = ["code", "sourcecode", "source", "raw"]
+categories = ["components"]


### PR DESCRIPTION
I am submitting
- [X] a new package
- [ ] an update for a package

Description: Used to display code files in Typst. Main feature is that it displays code blocks over multiple pages in a way that implies the code block continues onto the next page. Also a simple and intuitive syntax for displaying code blocks.

I have read and followed the submission guidelines and, in particular, I
- [X] selected a name that isn't the most obvious or canonical name for what the package does
- [X] added a `typst.toml` file with all required keys
- [X] added a `README.md` with documentation for my package
- [X] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [X] tested my package locally on my system and it worked
- [X] `exclude`d PDFs or README images, if any, but not the LICENSE
