### PR TITLE
fix typo in zen-zine README example

### DIFF
--- a/packages/preview/zen-zine/0.1.0/README.md
+++ b/packages/preview/zen-zine/0.1.0/README.md
@@ -26,7 +26,7 @@ Here is the template and its preview:
 // the content is wrapped before movement so that
 // padding and alignment are respected.
 #zine(
-  // draw_borders: true,
+  // draw_border: true,
   // zine_page_margin: 5pt,
   contents: my_eight_pages
 )


### PR DESCRIPTION
A simple one-character typo which may confuse some users is removed. I've resolved this issue in the source repository as well, does this warrant a new release of the package? Or since there aren't any code changes its okay?

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: `zen-zine` is a simple package for typsetting 8-page zines onto U.S. Letter paper.

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [x] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
