### PR TITLE
typearea:0.2.0

### DIFF
--- a/packages/preview/typearea/0.2.0/LICENSE
+++ b/packages/preview/typearea/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Adrian Freund
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/typearea/0.2.0/README.md
+++ b/packages/preview/typearea/0.2.0/README.md
@@ -1,0 +1,58 @@
+# typst-typearea
+
+A KOMA-Script inspired package to better configure your typearea and margins.
+
+```typst
+#import "@preview/typearea:0.2.0": typearea
+
+#show: typearea.with(
+  paper: "a4",
+  div: 9,
+  binding-correction: 11mm,
+)
+
+= Hello World
+```
+
+## Reference
+
+`typearea` accepts the following options:
+
+### two-sided
+
+Whether the document is two-sided. Defaults to `true`.
+
+### binding-correction
+
+Binding correction. Defaults to `0pt`. 
+
+Additional margin on the inside of a page when two-sided is true. If two-sided is false it will be on the left or right side, depending on the value of `binding`. A `binding` value of `auto` will currently default to `left`.
+
+Note: Before version 0.2.0 this was called `bcor`.
+
+### div
+
+How many equal parts to split the page into. Controls the margins. Defautls to `9`.
+
+The top and bottom margin will always be one and two parts respectively. In two-sided mode the inside margin will be one part and the outside margin two parts, so the combined margins between the text on the left side and the text on the right side is the same as the margins from the outer edge of the text to the outer edge of the page.
+
+In one-sided mode the left and right margin will take 1.5 parts each.
+
+### header-height / footer-height
+
+The height of the page header/footer.
+
+### header-sep / footer-sep
+
+The distance between the page header/footer and the text area.
+
+### header-include / footer-include
+
+Whether the header/footer should be counted as part of the text area when calculating the margins. Defaults to `false`.
+
+### ..rest
+
+All other arguments are passed on to `page()` as is. You can see which arguments `page()` accepts in the [typst reference for the page function](https://typst.app/docs/reference/layout/page/).
+
+You should prefer this over calling or setting `page()` directly as doing so could break some of `typearea`'s functionality.
+

--- a/packages/preview/typearea/0.2.0/typearea.typ
+++ b/packages/preview/typearea/0.2.0/typearea.typ
@@ -1,0 +1,87 @@
+#let typearea(
+  div: 9,
+  binding-correction: 0mm,
+  two-sided: true,
+  font-size: 11pt,
+  header-include: false,
+  footer-include: false,
+  header-height: 1.25em,
+  header-sep: 1.5em,
+  footer-height: 1.25em,
+  footer-sep: 3.5em,
+  ..rest,
+  body
+) = {
+  if div < 4 {
+    panic("div must be at least 4. Was " + div)
+  }
+  let width = 100% - binding-correction
+  let height = 100%
+  let content-height = height / div * (div - 3)
+  let header-space = header-height + header-sep
+  let footer-space = footer-height + footer-sep
+
+  let overwrite = (:)
+  if "header" in rest.named() {
+    overwrite.insert(
+      "header",
+      block(
+        above: 0pt,
+        below: 0pt,
+        breakable: false,
+        height: header-height,
+        rest.named().at("header"),
+      )
+    )
+  }
+  if "footer" in rest.named() {
+    overwrite.insert(
+      "footer",
+      block(
+        above: 0pt,
+        below: 0pt,
+        breakable: false,
+        height: footer-height,
+        rest.named().at("footer"),
+      )
+    )
+  }
+  let h-div = height / div
+  let w-div = width / div
+
+  let top-margin = h-div + if header-include { header-space } else { 0pt }
+  let bottom-margin = h-div * 2 + if footer-include { footer-space } else { 0pt }
+
+  set page(
+    ..rest,
+    ..overwrite,
+    header-ascent: header-sep,
+    footer-descent: footer-sep,
+    margin: if two-sided {
+      (
+        "top": top-margin,
+        "bottom": bottom-margin,
+        "inside": w-div + binding-correction,
+        "outside": w-div * 2,
+      )
+    // Auto currently defaults to left, as there is no way to check the text language
+    } else if rest.named().at("binding", default: auto) != right {
+      (
+        "top": top-margin,
+        "bottom": bottom-margin,
+        "left": w-div * 1.5 + binding-correction,
+        "right": w-div * 1.5,
+      )
+    } else {
+      (
+        "top": top-margin,
+        "bottom": bottom-margin,
+        "left": w-div * 1.5,
+        "right": w-div * 1.5 + binding-correction,
+      )
+
+    }
+  )
+
+  body
+}

--- a/packages/preview/typearea/0.2.0/typst.toml
+++ b/packages/preview/typearea/0.2.0/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "typearea"
+version = "0.2.0"
+entrypoint = "typearea.typ"
+authors = ["Adrian Freund"]
+license = "MIT"
+repository = "https://github.com/freundTech/typst-typearea"
+description = "A KOMA-Script inspired package to better configure your typearea and margins."


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: typearea is inspired by the LaTeX package of the same name, which is part of KOMA-Script. It allows setting the size of the type area and margins according to typographic practices by specifying a division number and binding correction instead of a fixed margin size.