### PR TITLE
fontawesome:0.2.1

### DIFF
--- a/packages/preview/fontawesome/0.2.1/LICENSE
+++ b/packages/preview/fontawesome/0.2.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 duskmoon314 (Campbell He)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/fontawesome/0.2.1/README.md
+++ b/packages/preview/fontawesome/0.2.1/README.md
@@ -1,0 +1,125 @@
+# typst-fontawesome
+
+A Typst library for Font Awesome icons through the desktop fonts.
+
+p.s. The library is based on the Font Awesome 6 desktop fonts (v6.5.2)
+
+## Usage
+
+### Install the fonts
+
+You can download the fonts from the official website: https://fontawesome.com/download
+
+Or you can use the helper script to download the fonts and metadata:
+
+`python helper.py -dd -v {version}`
+
+Here `-dd` means to download and extract the zip file. You can use `-d` to only download the zip file.
+
+After downloading the zip file, you can install the fonts depending on your OS.
+
+#### Typst web app
+
+You can simply upload the `otf` files to the web app and use them with this package.
+
+#### Mac
+
+You can double click the `otf` files to install them.
+
+#### Windows
+
+You can right-click the `otf` files and select `Install`.
+
+### Import the library
+
+#### Using the typst packages
+
+You can install the library using the typst packages:
+
+`#import "@preview/fontawesome:0.2.1": *`
+
+#### Manually install
+
+Copy all files start with `lib` to your project and import the library:
+
+`#import "lib.typ": *`
+
+There are three files:
+
+- `lib.typ`: The main entrypoint of the library.
+- `lib-impl.typ`: The implementation of `fa-icon`.
+- `lib-gen.typ`: The generated icons.
+
+I recommend renaming these files to avoid conflicts with other libraries.
+
+### Use the icons
+
+You can use the `fa-icon` function to create an icon with its name:
+
+`#fa-icon("chess-queen")`
+
+Or you can use the `fa-` prefix to create an icon with its name:
+
+`#fa-chess-queen()` (This is equivalent to `#fa-icon().with("chess-queen")`)
+
+You can also set `solid` to `true` to use the solid version of the icon:
+
+`#fa-icon("chess-queen", solid: true)`
+
+If the icon only has a solid version, you can omit the `solid` parameter because the library automatically sets `solid` to `true` for these icons. For instance, the generated function for these icons would be like `#fa-icon().with("arrow-trend-up", solid: true)`.
+
+However, some icons (e.g. 0, 1, 2...) have a regular version that isn't mentioned in the metadata. In this case, you need to set `solid` to `false` to use the regular version.
+
+Notice that `fa-icon` currently doesn't automatically set `solid` to `true` for icons that only have a solid version. Thus, you may not get the expected glyph if you don't set `solid` to `true` for these icons. I haven't decided whether to change this behavior yet.
+
+#### Full list of icons
+
+You can find all icons on the [official website](https://fontawesome.com/search?o=r&m=free)
+
+#### Different sets
+
+By default, the library uses two sets: `Free` and `Brands`.
+That is, three font files are used:
+
+- Font Awesome 6 Free (Also named as _Font Awesome 6 Free Regular_)
+- Font Awesome 6 Free Solid
+- Font Awesome 6 Brands
+
+Due to some limitations of typst 0.11.0, the regular and solid versions are treated as different fonts.
+In this library, `solid` is used to switch between the regular and solid versions.
+
+To use `Pro` or other sets, you can pass the `font` parameter to the inner `text` function: \
+`fa-icon("github", font: "Font Awesome 6 Pro Solid")`
+
+But you need to install the fonts first and take care of `solid` yourself.
+
+#### Customization
+
+The `fa-icon` function passes args to `text`, so you can customize the icon by passing parameters to it:
+
+`#fa-icon("chess-queen", fill: blue)`
+
+## Example
+
+See the [`example.typ`](https://typst.app/project/rQwGUWt5p33vrsb_uNPR9F) file for a complete example.
+
+## Contribution
+
+Feel free to open an issue or a pull request if you find any problems or have any suggestions.
+
+### Python helper
+
+The `helper.py` script is used to download fonts and generate typst code. I aim only to use standard python libraries, so running it on any platform with python installed should be easy.
+
+### Repo structure
+
+- `helper.py`: The helper script to download fonts and generate typst code.
+- `lib.typ`: The main entrypoint of the library.
+- `lib-impl.typ`: The implementation of `fa-icon`.
+- `lib-gen.typ`: The generated functions of icons.
+- `example.typ`: An example file to show how to use the library.
+- `gallery.typ`: The generated gallery of icons. It is used in the example file.
+
+## License
+
+This library is licensed under the MIT license. Feel free to use it in your project.

--- a/packages/preview/fontawesome/0.2.1/lib-gen.typ
+++ b/packages/preview/fontawesome/0.2.1/lib-gen.typ
@@ -1,0 +1,4960 @@
+#import "lib-impl.typ": fa-icon
+
+// Generated icon list of Font Aewsome 6.5.2
+
+#let fa-icon-map = (
+  "0": "\u{30}",
+  "1": "\u{31}",
+  "2": "\u{32}",
+  "3": "\u{33}",
+  "4": "\u{34}",
+  "5": "\u{35}",
+  "6": "\u{36}",
+  "7": "\u{37}",
+  "8": "\u{38}",
+  "9": "\u{39}",
+  "42-group": "\u{e080}",
+  "innosoft": "\u{e080}",
+  "500px": "\u{f26e}",
+  "a": "\u{41}",
+  "accessible-icon": "\u{f368}",
+  "accusoft": "\u{f369}",
+  "address-book": "\u{f2b9}",
+  "contact-book": "\u{f2b9}",
+  "address-card": "\u{f2bb}",
+  "contact-card": "\u{f2bb}",
+  "vcard": "\u{f2bb}",
+  "adn": "\u{f170}",
+  "adversal": "\u{f36a}",
+  "affiliatetheme": "\u{f36b}",
+  "airbnb": "\u{f834}",
+  "algolia": "\u{f36c}",
+  "align-center": "\u{f037}",
+  "align-justify": "\u{f039}",
+  "align-left": "\u{f036}",
+  "align-right": "\u{f038}",
+  "alipay": "\u{f642}",
+  "amazon": "\u{f270}",
+  "amazon-pay": "\u{f42c}",
+  "amilia": "\u{f36d}",
+  "anchor": "\u{f13d}",
+  "anchor-circle-check": "\u{e4aa}",
+  "anchor-circle-exclamation": "\u{e4ab}",
+  "anchor-circle-xmark": "\u{e4ac}",
+  "anchor-lock": "\u{e4ad}",
+  "android": "\u{f17b}",
+  "angellist": "\u{f209}",
+  "angle-down": "\u{f107}",
+  "angle-left": "\u{f104}",
+  "angle-right": "\u{f105}",
+  "angle-up": "\u{f106}",
+  "angles-down": "\u{f103}",
+  "angle-double-down": "\u{f103}",
+  "angles-left": "\u{f100}",
+  "angle-double-left": "\u{f100}",
+  "angles-right": "\u{f101}",
+  "angle-double-right": "\u{f101}",
+  "angles-up": "\u{f102}",
+  "angle-double-up": "\u{f102}",
+  "angrycreative": "\u{f36e}",
+  "angular": "\u{f420}",
+  "ankh": "\u{f644}",
+  "app-store": "\u{f36f}",
+  "app-store-ios": "\u{f370}",
+  "apper": "\u{f371}",
+  "apple": "\u{f179}",
+  "apple-pay": "\u{f415}",
+  "apple-whole": "\u{f5d1}",
+  "apple-alt": "\u{f5d1}",
+  "archway": "\u{f557}",
+  "arrow-down": "\u{f063}",
+  "arrow-down-1-9": "\u{f162}",
+  "sort-numeric-asc": "\u{f162}",
+  "sort-numeric-down": "\u{f162}",
+  "arrow-down-9-1": "\u{f886}",
+  "sort-numeric-desc": "\u{f886}",
+  "sort-numeric-down-alt": "\u{f886}",
+  "arrow-down-a-z": "\u{f15d}",
+  "sort-alpha-asc": "\u{f15d}",
+  "sort-alpha-down": "\u{f15d}",
+  "arrow-down-long": "\u{f175}",
+  "long-arrow-down": "\u{f175}",
+  "arrow-down-short-wide": "\u{f884}",
+  "sort-amount-desc": "\u{f884}",
+  "sort-amount-down-alt": "\u{f884}",
+  "arrow-down-up-across-line": "\u{e4af}",
+  "arrow-down-up-lock": "\u{e4b0}",
+  "arrow-down-wide-short": "\u{f160}",
+  "sort-amount-asc": "\u{f160}",
+  "sort-amount-down": "\u{f160}",
+  "arrow-down-z-a": "\u{f881}",
+  "sort-alpha-desc": "\u{f881}",
+  "sort-alpha-down-alt": "\u{f881}",
+  "arrow-left": "\u{f060}",
+  "arrow-left-long": "\u{f177}",
+  "long-arrow-left": "\u{f177}",
+  "arrow-pointer": "\u{f245}",
+  "mouse-pointer": "\u{f245}",
+  "arrow-right": "\u{f061}",
+  "arrow-right-arrow-left": "\u{f0ec}",
+  "exchange": "\u{f0ec}",
+  "arrow-right-from-bracket": "\u{f08b}",
+  "sign-out": "\u{f08b}",
+  "arrow-right-long": "\u{f178}",
+  "long-arrow-right": "\u{f178}",
+  "arrow-right-to-bracket": "\u{f090}",
+  "sign-in": "\u{f090}",
+  "arrow-right-to-city": "\u{e4b3}",
+  "arrow-rotate-left": "\u{f0e2}",
+  "arrow-left-rotate": "\u{f0e2}",
+  "arrow-rotate-back": "\u{f0e2}",
+  "arrow-rotate-backward": "\u{f0e2}",
+  "undo": "\u{f0e2}",
+  "arrow-rotate-right": "\u{f01e}",
+  "arrow-right-rotate": "\u{f01e}",
+  "arrow-rotate-forward": "\u{f01e}",
+  "redo": "\u{f01e}",
+  "arrow-trend-down": "\u{e097}",
+  "arrow-trend-up": "\u{e098}",
+  "arrow-turn-down": "\u{f149}",
+  "level-down": "\u{f149}",
+  "arrow-turn-up": "\u{f148}",
+  "level-up": "\u{f148}",
+  "arrow-up": "\u{f062}",
+  "arrow-up-1-9": "\u{f163}",
+  "sort-numeric-up": "\u{f163}",
+  "arrow-up-9-1": "\u{f887}",
+  "sort-numeric-up-alt": "\u{f887}",
+  "arrow-up-a-z": "\u{f15e}",
+  "sort-alpha-up": "\u{f15e}",
+  "arrow-up-from-bracket": "\u{e09a}",
+  "arrow-up-from-ground-water": "\u{e4b5}",
+  "arrow-up-from-water-pump": "\u{e4b6}",
+  "arrow-up-long": "\u{f176}",
+  "long-arrow-up": "\u{f176}",
+  "arrow-up-right-dots": "\u{e4b7}",
+  "arrow-up-right-from-square": "\u{f08e}",
+  "external-link": "\u{f08e}",
+  "arrow-up-short-wide": "\u{f885}",
+  "sort-amount-up-alt": "\u{f885}",
+  "arrow-up-wide-short": "\u{f161}",
+  "sort-amount-up": "\u{f161}",
+  "arrow-up-z-a": "\u{f882}",
+  "sort-alpha-up-alt": "\u{f882}",
+  "arrows-down-to-line": "\u{e4b8}",
+  "arrows-down-to-people": "\u{e4b9}",
+  "arrows-left-right": "\u{f07e}",
+  "arrows-h": "\u{f07e}",
+  "arrows-left-right-to-line": "\u{e4ba}",
+  "arrows-rotate": "\u{f021}",
+  "refresh": "\u{f021}",
+  "sync": "\u{f021}",
+  "arrows-spin": "\u{e4bb}",
+  "arrows-split-up-and-left": "\u{e4bc}",
+  "arrows-to-circle": "\u{e4bd}",
+  "arrows-to-dot": "\u{e4be}",
+  "arrows-to-eye": "\u{e4bf}",
+  "arrows-turn-right": "\u{e4c0}",
+  "arrows-turn-to-dots": "\u{e4c1}",
+  "arrows-up-down": "\u{f07d}",
+  "arrows-v": "\u{f07d}",
+  "arrows-up-down-left-right": "\u{f047}",
+  "arrows": "\u{f047}",
+  "arrows-up-to-line": "\u{e4c2}",
+  "artstation": "\u{f77a}",
+  "asterisk": "\u{2a}",
+  "asymmetrik": "\u{f372}",
+  "at": "\u{40}",
+  "atlassian": "\u{f77b}",
+  "atom": "\u{f5d2}",
+  "audible": "\u{f373}",
+  "audio-description": "\u{f29e}",
+  "austral-sign": "\u{e0a9}",
+  "autoprefixer": "\u{f41c}",
+  "avianex": "\u{f374}",
+  "aviato": "\u{f421}",
+  "award": "\u{f559}",
+  "aws": "\u{f375}",
+  "b": "\u{42}",
+  "baby": "\u{f77c}",
+  "baby-carriage": "\u{f77d}",
+  "carriage-baby": "\u{f77d}",
+  "backward": "\u{f04a}",
+  "backward-fast": "\u{f049}",
+  "fast-backward": "\u{f049}",
+  "backward-step": "\u{f048}",
+  "step-backward": "\u{f048}",
+  "bacon": "\u{f7e5}",
+  "bacteria": "\u{e059}",
+  "bacterium": "\u{e05a}",
+  "bag-shopping": "\u{f290}",
+  "shopping-bag": "\u{f290}",
+  "bahai": "\u{f666}",
+  "haykal": "\u{f666}",
+  "baht-sign": "\u{e0ac}",
+  "ban": "\u{f05e}",
+  "cancel": "\u{f05e}",
+  "ban-smoking": "\u{f54d}",
+  "smoking-ban": "\u{f54d}",
+  "bandage": "\u{f462}",
+  "band-aid": "\u{f462}",
+  "bandcamp": "\u{f2d5}",
+  "bangladeshi-taka-sign": "\u{e2e6}",
+  "barcode": "\u{f02a}",
+  "bars": "\u{f0c9}",
+  "navicon": "\u{f0c9}",
+  "bars-progress": "\u{f828}",
+  "tasks-alt": "\u{f828}",
+  "bars-staggered": "\u{f550}",
+  "reorder": "\u{f550}",
+  "stream": "\u{f550}",
+  "baseball": "\u{f433}",
+  "baseball-ball": "\u{f433}",
+  "baseball-bat-ball": "\u{f432}",
+  "basket-shopping": "\u{f291}",
+  "shopping-basket": "\u{f291}",
+  "basketball": "\u{f434}",
+  "basketball-ball": "\u{f434}",
+  "bath": "\u{f2cd}",
+  "bathtub": "\u{f2cd}",
+  "battery-empty": "\u{f244}",
+  "battery-0": "\u{f244}",
+  "battery-full": "\u{f240}",
+  "battery": "\u{f240}",
+  "battery-5": "\u{f240}",
+  "battery-half": "\u{f242}",
+  "battery-3": "\u{f242}",
+  "battery-quarter": "\u{f243}",
+  "battery-2": "\u{f243}",
+  "battery-three-quarters": "\u{f241}",
+  "battery-4": "\u{f241}",
+  "battle-net": "\u{f835}",
+  "bed": "\u{f236}",
+  "bed-pulse": "\u{f487}",
+  "procedures": "\u{f487}",
+  "beer-mug-empty": "\u{f0fc}",
+  "beer": "\u{f0fc}",
+  "behance": "\u{f1b4}",
+  "bell": "\u{f0f3}",
+  "bell-concierge": "\u{f562}",
+  "concierge-bell": "\u{f562}",
+  "bell-slash": "\u{f1f6}",
+  "bezier-curve": "\u{f55b}",
+  "bicycle": "\u{f206}",
+  "bilibili": "\u{e3d9}",
+  "bimobject": "\u{f378}",
+  "binoculars": "\u{f1e5}",
+  "biohazard": "\u{f780}",
+  "bitbucket": "\u{f171}",
+  "bitcoin": "\u{f379}",
+  "bitcoin-sign": "\u{e0b4}",
+  "bity": "\u{f37a}",
+  "black-tie": "\u{f27e}",
+  "blackberry": "\u{f37b}",
+  "blender": "\u{f517}",
+  "blender-phone": "\u{f6b6}",
+  "blog": "\u{f781}",
+  "blogger": "\u{f37c}",
+  "blogger-b": "\u{f37d}",
+  "bluesky": "\u{e671}",
+  "bluetooth": "\u{f293}",
+  "bluetooth-b": "\u{f294}",
+  "bold": "\u{f032}",
+  "bolt": "\u{f0e7}",
+  "zap": "\u{f0e7}",
+  "bolt-lightning": "\u{e0b7}",
+  "bomb": "\u{f1e2}",
+  "bone": "\u{f5d7}",
+  "bong": "\u{f55c}",
+  "book": "\u{f02d}",
+  "book-atlas": "\u{f558}",
+  "atlas": "\u{f558}",
+  "book-bible": "\u{f647}",
+  "bible": "\u{f647}",
+  "book-bookmark": "\u{e0bb}",
+  "book-journal-whills": "\u{f66a}",
+  "journal-whills": "\u{f66a}",
+  "book-medical": "\u{f7e6}",
+  "book-open": "\u{f518}",
+  "book-open-reader": "\u{f5da}",
+  "book-reader": "\u{f5da}",
+  "book-quran": "\u{f687}",
+  "quran": "\u{f687}",
+  "book-skull": "\u{f6b7}",
+  "book-dead": "\u{f6b7}",
+  "book-tanakh": "\u{f827}",
+  "tanakh": "\u{f827}",
+  "bookmark": "\u{f02e}",
+  "bootstrap": "\u{f836}",
+  "border-all": "\u{f84c}",
+  "border-none": "\u{f850}",
+  "border-top-left": "\u{f853}",
+  "border-style": "\u{f853}",
+  "bore-hole": "\u{e4c3}",
+  "bots": "\u{e340}",
+  "bottle-droplet": "\u{e4c4}",
+  "bottle-water": "\u{e4c5}",
+  "bowl-food": "\u{e4c6}",
+  "bowl-rice": "\u{e2eb}",
+  "bowling-ball": "\u{f436}",
+  "box": "\u{f466}",
+  "box-archive": "\u{f187}",
+  "archive": "\u{f187}",
+  "box-open": "\u{f49e}",
+  "box-tissue": "\u{e05b}",
+  "boxes-packing": "\u{e4c7}",
+  "boxes-stacked": "\u{f468}",
+  "boxes": "\u{f468}",
+  "boxes-alt": "\u{f468}",
+  "braille": "\u{f2a1}",
+  "brain": "\u{f5dc}",
+  "brave": "\u{e63c}",
+  "brave-reverse": "\u{e63d}",
+  "brazilian-real-sign": "\u{e46c}",
+  "bread-slice": "\u{f7ec}",
+  "bridge": "\u{e4c8}",
+  "bridge-circle-check": "\u{e4c9}",
+  "bridge-circle-exclamation": "\u{e4ca}",
+  "bridge-circle-xmark": "\u{e4cb}",
+  "bridge-lock": "\u{e4cc}",
+  "bridge-water": "\u{e4ce}",
+  "briefcase": "\u{f0b1}",
+  "briefcase-medical": "\u{f469}",
+  "broom": "\u{f51a}",
+  "broom-ball": "\u{f458}",
+  "quidditch": "\u{f458}",
+  "quidditch-broom-ball": "\u{f458}",
+  "brush": "\u{f55d}",
+  "btc": "\u{f15a}",
+  "bucket": "\u{e4cf}",
+  "buffer": "\u{f837}",
+  "bug": "\u{f188}",
+  "bug-slash": "\u{e490}",
+  "bugs": "\u{e4d0}",
+  "building": "\u{f1ad}",
+  "building-circle-arrow-right": "\u{e4d1}",
+  "building-circle-check": "\u{e4d2}",
+  "building-circle-exclamation": "\u{e4d3}",
+  "building-circle-xmark": "\u{e4d4}",
+  "building-columns": "\u{f19c}",
+  "bank": "\u{f19c}",
+  "institution": "\u{f19c}",
+  "museum": "\u{f19c}",
+  "university": "\u{f19c}",
+  "building-flag": "\u{e4d5}",
+  "building-lock": "\u{e4d6}",
+  "building-ngo": "\u{e4d7}",
+  "building-shield": "\u{e4d8}",
+  "building-un": "\u{e4d9}",
+  "building-user": "\u{e4da}",
+  "building-wheat": "\u{e4db}",
+  "bullhorn": "\u{f0a1}",
+  "bullseye": "\u{f140}",
+  "burger": "\u{f805}",
+  "hamburger": "\u{f805}",
+  "buromobelexperte": "\u{f37f}",
+  "burst": "\u{e4dc}",
+  "bus": "\u{f207}",
+  "bus-simple": "\u{f55e}",
+  "bus-alt": "\u{f55e}",
+  "business-time": "\u{f64a}",
+  "briefcase-clock": "\u{f64a}",
+  "buy-n-large": "\u{f8a6}",
+  "buysellads": "\u{f20d}",
+  "c": "\u{43}",
+  "cable-car": "\u{f7da}",
+  "tram": "\u{f7da}",
+  "cake-candles": "\u{f1fd}",
+  "birthday-cake": "\u{f1fd}",
+  "cake": "\u{f1fd}",
+  "calculator": "\u{f1ec}",
+  "calendar": "\u{f133}",
+  "calendar-check": "\u{f274}",
+  "calendar-day": "\u{f783}",
+  "calendar-days": "\u{f073}",
+  "calendar-alt": "\u{f073}",
+  "calendar-minus": "\u{f272}",
+  "calendar-plus": "\u{f271}",
+  "calendar-week": "\u{f784}",
+  "calendar-xmark": "\u{f273}",
+  "calendar-times": "\u{f273}",
+  "camera": "\u{f030}",
+  "camera-alt": "\u{f030}",
+  "camera-retro": "\u{f083}",
+  "camera-rotate": "\u{e0d8}",
+  "campground": "\u{f6bb}",
+  "canadian-maple-leaf": "\u{f785}",
+  "candy-cane": "\u{f786}",
+  "cannabis": "\u{f55f}",
+  "capsules": "\u{f46b}",
+  "car": "\u{f1b9}",
+  "automobile": "\u{f1b9}",
+  "car-battery": "\u{f5df}",
+  "battery-car": "\u{f5df}",
+  "car-burst": "\u{f5e1}",
+  "car-crash": "\u{f5e1}",
+  "car-on": "\u{e4dd}",
+  "car-rear": "\u{f5de}",
+  "car-alt": "\u{f5de}",
+  "car-side": "\u{f5e4}",
+  "car-tunnel": "\u{e4de}",
+  "caravan": "\u{f8ff}",
+  "caret-down": "\u{f0d7}",
+  "caret-left": "\u{f0d9}",
+  "caret-right": "\u{f0da}",
+  "caret-up": "\u{f0d8}",
+  "carrot": "\u{f787}",
+  "cart-arrow-down": "\u{f218}",
+  "cart-flatbed": "\u{f474}",
+  "dolly-flatbed": "\u{f474}",
+  "cart-flatbed-suitcase": "\u{f59d}",
+  "luggage-cart": "\u{f59d}",
+  "cart-plus": "\u{f217}",
+  "cart-shopping": "\u{f07a}",
+  "shopping-cart": "\u{f07a}",
+  "cash-register": "\u{f788}",
+  "cat": "\u{f6be}",
+  "cc-amazon-pay": "\u{f42d}",
+  "cc-amex": "\u{f1f3}",
+  "cc-apple-pay": "\u{f416}",
+  "cc-diners-club": "\u{f24c}",
+  "cc-discover": "\u{f1f2}",
+  "cc-jcb": "\u{f24b}",
+  "cc-mastercard": "\u{f1f1}",
+  "cc-paypal": "\u{f1f4}",
+  "cc-stripe": "\u{f1f5}",
+  "cc-visa": "\u{f1f0}",
+  "cedi-sign": "\u{e0df}",
+  "cent-sign": "\u{e3f5}",
+  "centercode": "\u{f380}",
+  "centos": "\u{f789}",
+  "certificate": "\u{f0a3}",
+  "chair": "\u{f6c0}",
+  "chalkboard": "\u{f51b}",
+  "blackboard": "\u{f51b}",
+  "chalkboard-user": "\u{f51c}",
+  "chalkboard-teacher": "\u{f51c}",
+  "champagne-glasses": "\u{f79f}",
+  "glass-cheers": "\u{f79f}",
+  "charging-station": "\u{f5e7}",
+  "chart-area": "\u{f1fe}",
+  "area-chart": "\u{f1fe}",
+  "chart-bar": "\u{f080}",
+  "bar-chart": "\u{f080}",
+  "chart-column": "\u{e0e3}",
+  "chart-gantt": "\u{e0e4}",
+  "chart-line": "\u{f201}",
+  "line-chart": "\u{f201}",
+  "chart-pie": "\u{f200}",
+  "pie-chart": "\u{f200}",
+  "chart-simple": "\u{e473}",
+  "check": "\u{f00c}",
+  "check-double": "\u{f560}",
+  "check-to-slot": "\u{f772}",
+  "vote-yea": "\u{f772}",
+  "cheese": "\u{f7ef}",
+  "chess": "\u{f439}",
+  "chess-bishop": "\u{f43a}",
+  "chess-board": "\u{f43c}",
+  "chess-king": "\u{f43f}",
+  "chess-knight": "\u{f441}",
+  "chess-pawn": "\u{f443}",
+  "chess-queen": "\u{f445}",
+  "chess-rook": "\u{f447}",
+  "chevron-down": "\u{f078}",
+  "chevron-left": "\u{f053}",
+  "chevron-right": "\u{f054}",
+  "chevron-up": "\u{f077}",
+  "child": "\u{f1ae}",
+  "child-combatant": "\u{e4e0}",
+  "child-rifle": "\u{e4e0}",
+  "child-dress": "\u{e59c}",
+  "child-reaching": "\u{e59d}",
+  "children": "\u{e4e1}",
+  "chrome": "\u{f268}",
+  "chromecast": "\u{f838}",
+  "church": "\u{f51d}",
+  "circle": "\u{f111}",
+  "circle-arrow-down": "\u{f0ab}",
+  "arrow-circle-down": "\u{f0ab}",
+  "circle-arrow-left": "\u{f0a8}",
+  "arrow-circle-left": "\u{f0a8}",
+  "circle-arrow-right": "\u{f0a9}",
+  "arrow-circle-right": "\u{f0a9}",
+  "circle-arrow-up": "\u{f0aa}",
+  "arrow-circle-up": "\u{f0aa}",
+  "circle-check": "\u{f058}",
+  "check-circle": "\u{f058}",
+  "circle-chevron-down": "\u{f13a}",
+  "chevron-circle-down": "\u{f13a}",
+  "circle-chevron-left": "\u{f137}",
+  "chevron-circle-left": "\u{f137}",
+  "circle-chevron-right": "\u{f138}",
+  "chevron-circle-right": "\u{f138}",
+  "circle-chevron-up": "\u{f139}",
+  "chevron-circle-up": "\u{f139}",
+  "circle-dollar-to-slot": "\u{f4b9}",
+  "donate": "\u{f4b9}",
+  "circle-dot": "\u{f192}",
+  "dot-circle": "\u{f192}",
+  "circle-down": "\u{f358}",
+  "arrow-alt-circle-down": "\u{f358}",
+  "circle-exclamation": "\u{f06a}",
+  "exclamation-circle": "\u{f06a}",
+  "circle-h": "\u{f47e}",
+  "hospital-symbol": "\u{f47e}",
+  "circle-half-stroke": "\u{f042}",
+  "adjust": "\u{f042}",
+  "circle-info": "\u{f05a}",
+  "info-circle": "\u{f05a}",
+  "circle-left": "\u{f359}",
+  "arrow-alt-circle-left": "\u{f359}",
+  "circle-minus": "\u{f056}",
+  "minus-circle": "\u{f056}",
+  "circle-nodes": "\u{e4e2}",
+  "circle-notch": "\u{f1ce}",
+  "circle-pause": "\u{f28b}",
+  "pause-circle": "\u{f28b}",
+  "circle-play": "\u{f144}",
+  "play-circle": "\u{f144}",
+  "circle-plus": "\u{f055}",
+  "plus-circle": "\u{f055}",
+  "circle-question": "\u{f059}",
+  "question-circle": "\u{f059}",
+  "circle-radiation": "\u{f7ba}",
+  "radiation-alt": "\u{f7ba}",
+  "circle-right": "\u{f35a}",
+  "arrow-alt-circle-right": "\u{f35a}",
+  "circle-stop": "\u{f28d}",
+  "stop-circle": "\u{f28d}",
+  "circle-up": "\u{f35b}",
+  "arrow-alt-circle-up": "\u{f35b}",
+  "circle-user": "\u{f2bd}",
+  "user-circle": "\u{f2bd}",
+  "circle-xmark": "\u{f057}",
+  "times-circle": "\u{f057}",
+  "xmark-circle": "\u{f057}",
+  "city": "\u{f64f}",
+  "clapperboard": "\u{e131}",
+  "clipboard": "\u{f328}",
+  "clipboard-check": "\u{f46c}",
+  "clipboard-list": "\u{f46d}",
+  "clipboard-question": "\u{e4e3}",
+  "clipboard-user": "\u{f7f3}",
+  "clock": "\u{f017}",
+  "clock-four": "\u{f017}",
+  "clock-rotate-left": "\u{f1da}",
+  "history": "\u{f1da}",
+  "clone": "\u{f24d}",
+  "closed-captioning": "\u{f20a}",
+  "cloud": "\u{f0c2}",
+  "cloud-arrow-down": "\u{f0ed}",
+  "cloud-download": "\u{f0ed}",
+  "cloud-download-alt": "\u{f0ed}",
+  "cloud-arrow-up": "\u{f0ee}",
+  "cloud-upload": "\u{f0ee}",
+  "cloud-upload-alt": "\u{f0ee}",
+  "cloud-bolt": "\u{f76c}",
+  "thunderstorm": "\u{f76c}",
+  "cloud-meatball": "\u{f73b}",
+  "cloud-moon": "\u{f6c3}",
+  "cloud-moon-rain": "\u{f73c}",
+  "cloud-rain": "\u{f73d}",
+  "cloud-showers-heavy": "\u{f740}",
+  "cloud-showers-water": "\u{e4e4}",
+  "cloud-sun": "\u{f6c4}",
+  "cloud-sun-rain": "\u{f743}",
+  "cloudflare": "\u{e07d}",
+  "cloudscale": "\u{f383}",
+  "cloudsmith": "\u{f384}",
+  "cloudversify": "\u{f385}",
+  "clover": "\u{e139}",
+  "cmplid": "\u{e360}",
+  "code": "\u{f121}",
+  "code-branch": "\u{f126}",
+  "code-commit": "\u{f386}",
+  "code-compare": "\u{e13a}",
+  "code-fork": "\u{e13b}",
+  "code-merge": "\u{f387}",
+  "code-pull-request": "\u{e13c}",
+  "codepen": "\u{f1cb}",
+  "codiepie": "\u{f284}",
+  "coins": "\u{f51e}",
+  "colon-sign": "\u{e140}",
+  "comment": "\u{f075}",
+  "comment-dollar": "\u{f651}",
+  "comment-dots": "\u{f4ad}",
+  "commenting": "\u{f4ad}",
+  "comment-medical": "\u{f7f5}",
+  "comment-slash": "\u{f4b3}",
+  "comment-sms": "\u{f7cd}",
+  "sms": "\u{f7cd}",
+  "comments": "\u{f086}",
+  "comments-dollar": "\u{f653}",
+  "compact-disc": "\u{f51f}",
+  "compass": "\u{f14e}",
+  "compass-drafting": "\u{f568}",
+  "drafting-compass": "\u{f568}",
+  "compress": "\u{f066}",
+  "computer": "\u{e4e5}",
+  "computer-mouse": "\u{f8cc}",
+  "mouse": "\u{f8cc}",
+  "confluence": "\u{f78d}",
+  "connectdevelop": "\u{f20e}",
+  "contao": "\u{f26d}",
+  "cookie": "\u{f563}",
+  "cookie-bite": "\u{f564}",
+  "copy": "\u{f0c5}",
+  "copyright": "\u{f1f9}",
+  "cotton-bureau": "\u{f89e}",
+  "couch": "\u{f4b8}",
+  "cow": "\u{f6c8}",
+  "cpanel": "\u{f388}",
+  "creative-commons": "\u{f25e}",
+  "creative-commons-by": "\u{f4e7}",
+  "creative-commons-nc": "\u{f4e8}",
+  "creative-commons-nc-eu": "\u{f4e9}",
+  "creative-commons-nc-jp": "\u{f4ea}",
+  "creative-commons-nd": "\u{f4eb}",
+  "creative-commons-pd": "\u{f4ec}",
+  "creative-commons-pd-alt": "\u{f4ed}",
+  "creative-commons-remix": "\u{f4ee}",
+  "creative-commons-sa": "\u{f4ef}",
+  "creative-commons-sampling": "\u{f4f0}",
+  "creative-commons-sampling-plus": "\u{f4f1}",
+  "creative-commons-share": "\u{f4f2}",
+  "creative-commons-zero": "\u{f4f3}",
+  "credit-card": "\u{f09d}",
+  "credit-card-alt": "\u{f09d}",
+  "critical-role": "\u{f6c9}",
+  "crop": "\u{f125}",
+  "crop-simple": "\u{f565}",
+  "crop-alt": "\u{f565}",
+  "cross": "\u{f654}",
+  "crosshairs": "\u{f05b}",
+  "crow": "\u{f520}",
+  "crown": "\u{f521}",
+  "crutch": "\u{f7f7}",
+  "cruzeiro-sign": "\u{e152}",
+  "css3": "\u{f13c}",
+  "css3-alt": "\u{f38b}",
+  "cube": "\u{f1b2}",
+  "cubes": "\u{f1b3}",
+  "cubes-stacked": "\u{e4e6}",
+  "cuttlefish": "\u{f38c}",
+  "d": "\u{44}",
+  "d-and-d": "\u{f38d}",
+  "d-and-d-beyond": "\u{f6ca}",
+  "dailymotion": "\u{e052}",
+  "dashcube": "\u{f210}",
+  "database": "\u{f1c0}",
+  "debian": "\u{e60b}",
+  "deezer": "\u{e077}",
+  "delete-left": "\u{f55a}",
+  "backspace": "\u{f55a}",
+  "delicious": "\u{f1a5}",
+  "democrat": "\u{f747}",
+  "deploydog": "\u{f38e}",
+  "deskpro": "\u{f38f}",
+  "desktop": "\u{f390}",
+  "desktop-alt": "\u{f390}",
+  "dev": "\u{f6cc}",
+  "deviantart": "\u{f1bd}",
+  "dharmachakra": "\u{f655}",
+  "dhl": "\u{f790}",
+  "diagram-next": "\u{e476}",
+  "diagram-predecessor": "\u{e477}",
+  "diagram-project": "\u{f542}",
+  "project-diagram": "\u{f542}",
+  "diagram-successor": "\u{e47a}",
+  "diamond": "\u{f219}",
+  "diamond-turn-right": "\u{f5eb}",
+  "directions": "\u{f5eb}",
+  "diaspora": "\u{f791}",
+  "dice": "\u{f522}",
+  "dice-d20": "\u{f6cf}",
+  "dice-d6": "\u{f6d1}",
+  "dice-five": "\u{f523}",
+  "dice-four": "\u{f524}",
+  "dice-one": "\u{f525}",
+  "dice-six": "\u{f526}",
+  "dice-three": "\u{f527}",
+  "dice-two": "\u{f528}",
+  "digg": "\u{f1a6}",
+  "digital-ocean": "\u{f391}",
+  "discord": "\u{f392}",
+  "discourse": "\u{f393}",
+  "disease": "\u{f7fa}",
+  "display": "\u{e163}",
+  "divide": "\u{f529}",
+  "dna": "\u{f471}",
+  "dochub": "\u{f394}",
+  "docker": "\u{f395}",
+  "dog": "\u{f6d3}",
+  "dollar-sign": "\u{24}",
+  "dollar": "\u{24}",
+  "usd": "\u{24}",
+  "dolly": "\u{f472}",
+  "dolly-box": "\u{f472}",
+  "dong-sign": "\u{e169}",
+  "door-closed": "\u{f52a}",
+  "door-open": "\u{f52b}",
+  "dove": "\u{f4ba}",
+  "down-left-and-up-right-to-center": "\u{f422}",
+  "compress-alt": "\u{f422}",
+  "down-long": "\u{f309}",
+  "long-arrow-alt-down": "\u{f309}",
+  "download": "\u{f019}",
+  "draft2digital": "\u{f396}",
+  "dragon": "\u{f6d5}",
+  "draw-polygon": "\u{f5ee}",
+  "dribbble": "\u{f17d}",
+  "dropbox": "\u{f16b}",
+  "droplet": "\u{f043}",
+  "tint": "\u{f043}",
+  "droplet-slash": "\u{f5c7}",
+  "tint-slash": "\u{f5c7}",
+  "drum": "\u{f569}",
+  "drum-steelpan": "\u{f56a}",
+  "drumstick-bite": "\u{f6d7}",
+  "drupal": "\u{f1a9}",
+  "dumbbell": "\u{f44b}",
+  "dumpster": "\u{f793}",
+  "dumpster-fire": "\u{f794}",
+  "dungeon": "\u{f6d9}",
+  "dyalog": "\u{f399}",
+  "e": "\u{45}",
+  "ear-deaf": "\u{f2a4}",
+  "deaf": "\u{f2a4}",
+  "deafness": "\u{f2a4}",
+  "hard-of-hearing": "\u{f2a4}",
+  "ear-listen": "\u{f2a2}",
+  "assistive-listening-systems": "\u{f2a2}",
+  "earlybirds": "\u{f39a}",
+  "earth-africa": "\u{f57c}",
+  "globe-africa": "\u{f57c}",
+  "earth-americas": "\u{f57d}",
+  "earth": "\u{f57d}",
+  "earth-america": "\u{f57d}",
+  "globe-americas": "\u{f57d}",
+  "earth-asia": "\u{f57e}",
+  "globe-asia": "\u{f57e}",
+  "earth-europe": "\u{f7a2}",
+  "globe-europe": "\u{f7a2}",
+  "earth-oceania": "\u{e47b}",
+  "globe-oceania": "\u{e47b}",
+  "ebay": "\u{f4f4}",
+  "edge": "\u{f282}",
+  "edge-legacy": "\u{e078}",
+  "egg": "\u{f7fb}",
+  "eject": "\u{f052}",
+  "elementor": "\u{f430}",
+  "elevator": "\u{e16d}",
+  "ellipsis": "\u{f141}",
+  "ellipsis-h": "\u{f141}",
+  "ellipsis-vertical": "\u{f142}",
+  "ellipsis-v": "\u{f142}",
+  "ello": "\u{f5f1}",
+  "ember": "\u{f423}",
+  "empire": "\u{f1d1}",
+  "envelope": "\u{f0e0}",
+  "envelope-circle-check": "\u{e4e8}",
+  "envelope-open": "\u{f2b6}",
+  "envelope-open-text": "\u{f658}",
+  "envelopes-bulk": "\u{f674}",
+  "mail-bulk": "\u{f674}",
+  "envira": "\u{f299}",
+  "equals": "\u{3d}",
+  "eraser": "\u{f12d}",
+  "erlang": "\u{f39d}",
+  "ethereum": "\u{f42e}",
+  "ethernet": "\u{f796}",
+  "etsy": "\u{f2d7}",
+  "euro-sign": "\u{f153}",
+  "eur": "\u{f153}",
+  "euro": "\u{f153}",
+  "evernote": "\u{f839}",
+  "exclamation": "\u{21}",
+  "expand": "\u{f065}",
+  "expeditedssl": "\u{f23e}",
+  "explosion": "\u{e4e9}",
+  "eye": "\u{f06e}",
+  "eye-dropper": "\u{f1fb}",
+  "eye-dropper-empty": "\u{f1fb}",
+  "eyedropper": "\u{f1fb}",
+  "eye-low-vision": "\u{f2a8}",
+  "low-vision": "\u{f2a8}",
+  "eye-slash": "\u{f070}",
+  "f": "\u{46}",
+  "face-angry": "\u{f556}",
+  "angry": "\u{f556}",
+  "face-dizzy": "\u{f567}",
+  "dizzy": "\u{f567}",
+  "face-flushed": "\u{f579}",
+  "flushed": "\u{f579}",
+  "face-frown": "\u{f119}",
+  "frown": "\u{f119}",
+  "face-frown-open": "\u{f57a}",
+  "frown-open": "\u{f57a}",
+  "face-grimace": "\u{f57f}",
+  "grimace": "\u{f57f}",
+  "face-grin": "\u{f580}",
+  "grin": "\u{f580}",
+  "face-grin-beam": "\u{f582}",
+  "grin-beam": "\u{f582}",
+  "face-grin-beam-sweat": "\u{f583}",
+  "grin-beam-sweat": "\u{f583}",
+  "face-grin-hearts": "\u{f584}",
+  "grin-hearts": "\u{f584}",
+  "face-grin-squint": "\u{f585}",
+  "grin-squint": "\u{f585}",
+  "face-grin-squint-tears": "\u{f586}",
+  "grin-squint-tears": "\u{f586}",
+  "face-grin-stars": "\u{f587}",
+  "grin-stars": "\u{f587}",
+  "face-grin-tears": "\u{f588}",
+  "grin-tears": "\u{f588}",
+  "face-grin-tongue": "\u{f589}",
+  "grin-tongue": "\u{f589}",
+  "face-grin-tongue-squint": "\u{f58a}",
+  "grin-tongue-squint": "\u{f58a}",
+  "face-grin-tongue-wink": "\u{f58b}",
+  "grin-tongue-wink": "\u{f58b}",
+  "face-grin-wide": "\u{f581}",
+  "grin-alt": "\u{f581}",
+  "face-grin-wink": "\u{f58c}",
+  "grin-wink": "\u{f58c}",
+  "face-kiss": "\u{f596}",
+  "kiss": "\u{f596}",
+  "face-kiss-beam": "\u{f597}",
+  "kiss-beam": "\u{f597}",
+  "face-kiss-wink-heart": "\u{f598}",
+  "kiss-wink-heart": "\u{f598}",
+  "face-laugh": "\u{f599}",
+  "laugh": "\u{f599}",
+  "face-laugh-beam": "\u{f59a}",
+  "laugh-beam": "\u{f59a}",
+  "face-laugh-squint": "\u{f59b}",
+  "laugh-squint": "\u{f59b}",
+  "face-laugh-wink": "\u{f59c}",
+  "laugh-wink": "\u{f59c}",
+  "face-meh": "\u{f11a}",
+  "meh": "\u{f11a}",
+  "face-meh-blank": "\u{f5a4}",
+  "meh-blank": "\u{f5a4}",
+  "face-rolling-eyes": "\u{f5a5}",
+  "meh-rolling-eyes": "\u{f5a5}",
+  "face-sad-cry": "\u{f5b3}",
+  "sad-cry": "\u{f5b3}",
+  "face-sad-tear": "\u{f5b4}",
+  "sad-tear": "\u{f5b4}",
+  "face-smile": "\u{f118}",
+  "smile": "\u{f118}",
+  "face-smile-beam": "\u{f5b8}",
+  "smile-beam": "\u{f5b8}",
+  "face-smile-wink": "\u{f4da}",
+  "smile-wink": "\u{f4da}",
+  "face-surprise": "\u{f5c2}",
+  "surprise": "\u{f5c2}",
+  "face-tired": "\u{f5c8}",
+  "tired": "\u{f5c8}",
+  "facebook": "\u{f09a}",
+  "facebook-f": "\u{f39e}",
+  "facebook-messenger": "\u{f39f}",
+  "fan": "\u{f863}",
+  "fantasy-flight-games": "\u{f6dc}",
+  "faucet": "\u{e005}",
+  "faucet-drip": "\u{e006}",
+  "fax": "\u{f1ac}",
+  "feather": "\u{f52d}",
+  "feather-pointed": "\u{f56b}",
+  "feather-alt": "\u{f56b}",
+  "fedex": "\u{f797}",
+  "fedora": "\u{f798}",
+  "ferry": "\u{e4ea}",
+  "figma": "\u{f799}",
+  "file": "\u{f15b}",
+  "file-arrow-down": "\u{f56d}",
+  "file-download": "\u{f56d}",
+  "file-arrow-up": "\u{f574}",
+  "file-upload": "\u{f574}",
+  "file-audio": "\u{f1c7}",
+  "file-circle-check": "\u{e5a0}",
+  "file-circle-exclamation": "\u{e4eb}",
+  "file-circle-minus": "\u{e4ed}",
+  "file-circle-plus": "\u{e494}",
+  "file-circle-question": "\u{e4ef}",
+  "file-circle-xmark": "\u{e5a1}",
+  "file-code": "\u{f1c9}",
+  "file-contract": "\u{f56c}",
+  "file-csv": "\u{f6dd}",
+  "file-excel": "\u{f1c3}",
+  "file-export": "\u{f56e}",
+  "arrow-right-from-file": "\u{f56e}",
+  "file-image": "\u{f1c5}",
+  "file-import": "\u{f56f}",
+  "arrow-right-to-file": "\u{f56f}",
+  "file-invoice": "\u{f570}",
+  "file-invoice-dollar": "\u{f571}",
+  "file-lines": "\u{f15c}",
+  "file-alt": "\u{f15c}",
+  "file-text": "\u{f15c}",
+  "file-medical": "\u{f477}",
+  "file-pdf": "\u{f1c1}",
+  "file-pen": "\u{f31c}",
+  "file-edit": "\u{f31c}",
+  "file-powerpoint": "\u{f1c4}",
+  "file-prescription": "\u{f572}",
+  "file-shield": "\u{e4f0}",
+  "file-signature": "\u{f573}",
+  "file-video": "\u{f1c8}",
+  "file-waveform": "\u{f478}",
+  "file-medical-alt": "\u{f478}",
+  "file-word": "\u{f1c2}",
+  "file-zipper": "\u{f1c6}",
+  "file-archive": "\u{f1c6}",
+  "fill": "\u{f575}",
+  "fill-drip": "\u{f576}",
+  "film": "\u{f008}",
+  "filter": "\u{f0b0}",
+  "filter-circle-dollar": "\u{f662}",
+  "funnel-dollar": "\u{f662}",
+  "filter-circle-xmark": "\u{e17b}",
+  "fingerprint": "\u{f577}",
+  "fire": "\u{f06d}",
+  "fire-burner": "\u{e4f1}",
+  "fire-extinguisher": "\u{f134}",
+  "fire-flame-curved": "\u{f7e4}",
+  "fire-alt": "\u{f7e4}",
+  "fire-flame-simple": "\u{f46a}",
+  "burn": "\u{f46a}",
+  "firefox": "\u{f269}",
+  "firefox-browser": "\u{e007}",
+  "first-order": "\u{f2b0}",
+  "first-order-alt": "\u{f50a}",
+  "firstdraft": "\u{f3a1}",
+  "fish": "\u{f578}",
+  "fish-fins": "\u{e4f2}",
+  "flag": "\u{f024}",
+  "flag-checkered": "\u{f11e}",
+  "flag-usa": "\u{f74d}",
+  "flask": "\u{f0c3}",
+  "flask-vial": "\u{e4f3}",
+  "flickr": "\u{f16e}",
+  "flipboard": "\u{f44d}",
+  "floppy-disk": "\u{f0c7}",
+  "save": "\u{f0c7}",
+  "florin-sign": "\u{e184}",
+  "fly": "\u{f417}",
+  "folder": "\u{f07b}",
+  "folder-blank": "\u{f07b}",
+  "folder-closed": "\u{e185}",
+  "folder-minus": "\u{f65d}",
+  "folder-open": "\u{f07c}",
+  "folder-plus": "\u{f65e}",
+  "folder-tree": "\u{f802}",
+  "font": "\u{f031}",
+  "font-awesome": "\u{f2b4}",
+  "font-awesome-flag": "\u{f2b4}",
+  "font-awesome-logo-full": "\u{f2b4}",
+  "fonticons": "\u{f280}",
+  "fonticons-fi": "\u{f3a2}",
+  "football": "\u{f44e}",
+  "football-ball": "\u{f44e}",
+  "fort-awesome": "\u{f286}",
+  "fort-awesome-alt": "\u{f3a3}",
+  "forumbee": "\u{f211}",
+  "forward": "\u{f04e}",
+  "forward-fast": "\u{f050}",
+  "fast-forward": "\u{f050}",
+  "forward-step": "\u{f051}",
+  "step-forward": "\u{f051}",
+  "foursquare": "\u{f180}",
+  "franc-sign": "\u{e18f}",
+  "free-code-camp": "\u{f2c5}",
+  "freebsd": "\u{f3a4}",
+  "frog": "\u{f52e}",
+  "fulcrum": "\u{f50b}",
+  "futbol": "\u{f1e3}",
+  "futbol-ball": "\u{f1e3}",
+  "soccer-ball": "\u{f1e3}",
+  "g": "\u{47}",
+  "galactic-republic": "\u{f50c}",
+  "galactic-senate": "\u{f50d}",
+  "gamepad": "\u{f11b}",
+  "gas-pump": "\u{f52f}",
+  "gauge": "\u{f624}",
+  "dashboard": "\u{f624}",
+  "gauge-med": "\u{f624}",
+  "tachometer-alt-average": "\u{f624}",
+  "gauge-high": "\u{f625}",
+  "tachometer-alt": "\u{f625}",
+  "tachometer-alt-fast": "\u{f625}",
+  "gauge-simple": "\u{f629}",
+  "gauge-simple-med": "\u{f629}",
+  "tachometer-average": "\u{f629}",
+  "gauge-simple-high": "\u{f62a}",
+  "tachometer": "\u{f62a}",
+  "tachometer-fast": "\u{f62a}",
+  "gavel": "\u{f0e3}",
+  "legal": "\u{f0e3}",
+  "gear": "\u{f013}",
+  "cog": "\u{f013}",
+  "gears": "\u{f085}",
+  "cogs": "\u{f085}",
+  "gem": "\u{f3a5}",
+  "genderless": "\u{f22d}",
+  "get-pocket": "\u{f265}",
+  "gg": "\u{f260}",
+  "gg-circle": "\u{f261}",
+  "ghost": "\u{f6e2}",
+  "gift": "\u{f06b}",
+  "gifts": "\u{f79c}",
+  "git": "\u{f1d3}",
+  "git-alt": "\u{f841}",
+  "github": "\u{f09b}",
+  "github-alt": "\u{f113}",
+  "gitkraken": "\u{f3a6}",
+  "gitlab": "\u{f296}",
+  "gitter": "\u{f426}",
+  "glass-water": "\u{e4f4}",
+  "glass-water-droplet": "\u{e4f5}",
+  "glasses": "\u{f530}",
+  "glide": "\u{f2a5}",
+  "glide-g": "\u{f2a6}",
+  "globe": "\u{f0ac}",
+  "gofore": "\u{f3a7}",
+  "golang": "\u{e40f}",
+  "golf-ball-tee": "\u{f450}",
+  "golf-ball": "\u{f450}",
+  "goodreads": "\u{f3a8}",
+  "goodreads-g": "\u{f3a9}",
+  "google": "\u{f1a0}",
+  "google-drive": "\u{f3aa}",
+  "google-pay": "\u{e079}",
+  "google-play": "\u{f3ab}",
+  "google-plus": "\u{f2b3}",
+  "google-plus-g": "\u{f0d5}",
+  "google-scholar": "\u{e63b}",
+  "google-wallet": "\u{f1ee}",
+  "gopuram": "\u{f664}",
+  "graduation-cap": "\u{f19d}",
+  "mortar-board": "\u{f19d}",
+  "gratipay": "\u{f184}",
+  "grav": "\u{f2d6}",
+  "greater-than": "\u{3e}",
+  "greater-than-equal": "\u{f532}",
+  "grip": "\u{f58d}",
+  "grip-horizontal": "\u{f58d}",
+  "grip-lines": "\u{f7a4}",
+  "grip-lines-vertical": "\u{f7a5}",
+  "grip-vertical": "\u{f58e}",
+  "gripfire": "\u{f3ac}",
+  "group-arrows-rotate": "\u{e4f6}",
+  "grunt": "\u{f3ad}",
+  "guarani-sign": "\u{e19a}",
+  "guilded": "\u{e07e}",
+  "guitar": "\u{f7a6}",
+  "gulp": "\u{f3ae}",
+  "gun": "\u{e19b}",
+  "h": "\u{48}",
+  "hacker-news": "\u{f1d4}",
+  "hackerrank": "\u{f5f7}",
+  "hammer": "\u{f6e3}",
+  "hamsa": "\u{f665}",
+  "hand": "\u{f256}",
+  "hand-paper": "\u{f256}",
+  "hand-back-fist": "\u{f255}",
+  "hand-rock": "\u{f255}",
+  "hand-dots": "\u{f461}",
+  "allergies": "\u{f461}",
+  "hand-fist": "\u{f6de}",
+  "fist-raised": "\u{f6de}",
+  "hand-holding": "\u{f4bd}",
+  "hand-holding-dollar": "\u{f4c0}",
+  "hand-holding-usd": "\u{f4c0}",
+  "hand-holding-droplet": "\u{f4c1}",
+  "hand-holding-water": "\u{f4c1}",
+  "hand-holding-hand": "\u{e4f7}",
+  "hand-holding-heart": "\u{f4be}",
+  "hand-holding-medical": "\u{e05c}",
+  "hand-lizard": "\u{f258}",
+  "hand-middle-finger": "\u{f806}",
+  "hand-peace": "\u{f25b}",
+  "hand-point-down": "\u{f0a7}",
+  "hand-point-left": "\u{f0a5}",
+  "hand-point-right": "\u{f0a4}",
+  "hand-point-up": "\u{f0a6}",
+  "hand-pointer": "\u{f25a}",
+  "hand-scissors": "\u{f257}",
+  "hand-sparkles": "\u{e05d}",
+  "hand-spock": "\u{f259}",
+  "handcuffs": "\u{e4f8}",
+  "hands": "\u{f2a7}",
+  "sign-language": "\u{f2a7}",
+  "signing": "\u{f2a7}",
+  "hands-asl-interpreting": "\u{f2a3}",
+  "american-sign-language-interpreting": "\u{f2a3}",
+  "asl-interpreting": "\u{f2a3}",
+  "hands-american-sign-language-interpreting": "\u{f2a3}",
+  "hands-bound": "\u{e4f9}",
+  "hands-bubbles": "\u{e05e}",
+  "hands-wash": "\u{e05e}",
+  "hands-clapping": "\u{e1a8}",
+  "hands-holding": "\u{f4c2}",
+  "hands-holding-child": "\u{e4fa}",
+  "hands-holding-circle": "\u{e4fb}",
+  "hands-praying": "\u{f684}",
+  "praying-hands": "\u{f684}",
+  "handshake": "\u{f2b5}",
+  "handshake-angle": "\u{f4c4}",
+  "hands-helping": "\u{f4c4}",
+  "handshake-simple": "\u{f4c6}",
+  "handshake-alt": "\u{f4c6}",
+  "handshake-simple-slash": "\u{e05f}",
+  "handshake-alt-slash": "\u{e05f}",
+  "handshake-slash": "\u{e060}",
+  "hanukiah": "\u{f6e6}",
+  "hard-drive": "\u{f0a0}",
+  "hdd": "\u{f0a0}",
+  "hashnode": "\u{e499}",
+  "hashtag": "\u{23}",
+  "hat-cowboy": "\u{f8c0}",
+  "hat-cowboy-side": "\u{f8c1}",
+  "hat-wizard": "\u{f6e8}",
+  "head-side-cough": "\u{e061}",
+  "head-side-cough-slash": "\u{e062}",
+  "head-side-mask": "\u{e063}",
+  "head-side-virus": "\u{e064}",
+  "heading": "\u{f1dc}",
+  "header": "\u{f1dc}",
+  "headphones": "\u{f025}",
+  "headphones-simple": "\u{f58f}",
+  "headphones-alt": "\u{f58f}",
+  "headset": "\u{f590}",
+  "heart": "\u{f004}",
+  "heart-circle-bolt": "\u{e4fc}",
+  "heart-circle-check": "\u{e4fd}",
+  "heart-circle-exclamation": "\u{e4fe}",
+  "heart-circle-minus": "\u{e4ff}",
+  "heart-circle-plus": "\u{e500}",
+  "heart-circle-xmark": "\u{e501}",
+  "heart-crack": "\u{f7a9}",
+  "heart-broken": "\u{f7a9}",
+  "heart-pulse": "\u{f21e}",
+  "heartbeat": "\u{f21e}",
+  "helicopter": "\u{f533}",
+  "helicopter-symbol": "\u{e502}",
+  "helmet-safety": "\u{f807}",
+  "hard-hat": "\u{f807}",
+  "hat-hard": "\u{f807}",
+  "helmet-un": "\u{e503}",
+  "highlighter": "\u{f591}",
+  "hill-avalanche": "\u{e507}",
+  "hill-rockslide": "\u{e508}",
+  "hippo": "\u{f6ed}",
+  "hips": "\u{f452}",
+  "hire-a-helper": "\u{f3b0}",
+  "hive": "\u{e07f}",
+  "hockey-puck": "\u{f453}",
+  "holly-berry": "\u{f7aa}",
+  "hooli": "\u{f427}",
+  "hornbill": "\u{f592}",
+  "horse": "\u{f6f0}",
+  "horse-head": "\u{f7ab}",
+  "hospital": "\u{f0f8}",
+  "hospital-alt": "\u{f0f8}",
+  "hospital-wide": "\u{f0f8}",
+  "hospital-user": "\u{f80d}",
+  "hot-tub-person": "\u{f593}",
+  "hot-tub": "\u{f593}",
+  "hotdog": "\u{f80f}",
+  "hotel": "\u{f594}",
+  "hotjar": "\u{f3b1}",
+  "hourglass": "\u{f254}",
+  "hourglass-empty": "\u{f254}",
+  "hourglass-end": "\u{f253}",
+  "hourglass-3": "\u{f253}",
+  "hourglass-half": "\u{f252}",
+  "hourglass-2": "\u{f252}",
+  "hourglass-start": "\u{f251}",
+  "hourglass-1": "\u{f251}",
+  "house": "\u{f015}",
+  "home": "\u{f015}",
+  "home-alt": "\u{f015}",
+  "home-lg-alt": "\u{f015}",
+  "house-chimney": "\u{e3af}",
+  "home-lg": "\u{e3af}",
+  "house-chimney-crack": "\u{f6f1}",
+  "house-damage": "\u{f6f1}",
+  "house-chimney-medical": "\u{f7f2}",
+  "clinic-medical": "\u{f7f2}",
+  "house-chimney-user": "\u{e065}",
+  "house-chimney-window": "\u{e00d}",
+  "house-circle-check": "\u{e509}",
+  "house-circle-exclamation": "\u{e50a}",
+  "house-circle-xmark": "\u{e50b}",
+  "house-crack": "\u{e3b1}",
+  "house-fire": "\u{e50c}",
+  "house-flag": "\u{e50d}",
+  "house-flood-water": "\u{e50e}",
+  "house-flood-water-circle-arrow-right": "\u{e50f}",
+  "house-laptop": "\u{e066}",
+  "laptop-house": "\u{e066}",
+  "house-lock": "\u{e510}",
+  "house-medical": "\u{e3b2}",
+  "house-medical-circle-check": "\u{e511}",
+  "house-medical-circle-exclamation": "\u{e512}",
+  "house-medical-circle-xmark": "\u{e513}",
+  "house-medical-flag": "\u{e514}",
+  "house-signal": "\u{e012}",
+  "house-tsunami": "\u{e515}",
+  "house-user": "\u{e1b0}",
+  "home-user": "\u{e1b0}",
+  "houzz": "\u{f27c}",
+  "hryvnia-sign": "\u{f6f2}",
+  "hryvnia": "\u{f6f2}",
+  "html5": "\u{f13b}",
+  "hubspot": "\u{f3b2}",
+  "hurricane": "\u{f751}",
+  "i": "\u{49}",
+  "i-cursor": "\u{f246}",
+  "ice-cream": "\u{f810}",
+  "icicles": "\u{f7ad}",
+  "icons": "\u{f86d}",
+  "heart-music-camera-bolt": "\u{f86d}",
+  "id-badge": "\u{f2c1}",
+  "id-card": "\u{f2c2}",
+  "drivers-license": "\u{f2c2}",
+  "id-card-clip": "\u{f47f}",
+  "id-card-alt": "\u{f47f}",
+  "ideal": "\u{e013}",
+  "igloo": "\u{f7ae}",
+  "image": "\u{f03e}",
+  "image-portrait": "\u{f3e0}",
+  "portrait": "\u{f3e0}",
+  "images": "\u{f302}",
+  "imdb": "\u{f2d8}",
+  "inbox": "\u{f01c}",
+  "indent": "\u{f03c}",
+  "indian-rupee-sign": "\u{e1bc}",
+  "indian-rupee": "\u{e1bc}",
+  "inr": "\u{e1bc}",
+  "industry": "\u{f275}",
+  "infinity": "\u{f534}",
+  "info": "\u{f129}",
+  "instagram": "\u{f16d}",
+  "instalod": "\u{e081}",
+  "intercom": "\u{f7af}",
+  "internet-explorer": "\u{f26b}",
+  "invision": "\u{f7b0}",
+  "ioxhost": "\u{f208}",
+  "italic": "\u{f033}",
+  "itch-io": "\u{f83a}",
+  "itunes": "\u{f3b4}",
+  "itunes-note": "\u{f3b5}",
+  "j": "\u{4a}",
+  "jar": "\u{e516}",
+  "jar-wheat": "\u{e517}",
+  "java": "\u{f4e4}",
+  "jedi": "\u{f669}",
+  "jedi-order": "\u{f50e}",
+  "jenkins": "\u{f3b6}",
+  "jet-fighter": "\u{f0fb}",
+  "fighter-jet": "\u{f0fb}",
+  "jet-fighter-up": "\u{e518}",
+  "jira": "\u{f7b1}",
+  "joget": "\u{f3b7}",
+  "joint": "\u{f595}",
+  "joomla": "\u{f1aa}",
+  "js": "\u{f3b8}",
+  "jsfiddle": "\u{f1cc}",
+  "jug-detergent": "\u{e519}",
+  "jxl": "\u{e67b}",
+  "k": "\u{4b}",
+  "kaaba": "\u{f66b}",
+  "kaggle": "\u{f5fa}",
+  "key": "\u{f084}",
+  "keybase": "\u{f4f5}",
+  "keyboard": "\u{f11c}",
+  "keycdn": "\u{f3ba}",
+  "khanda": "\u{f66d}",
+  "kickstarter": "\u{f3bb}",
+  "square-kickstarter": "\u{f3bb}",
+  "kickstarter-k": "\u{f3bc}",
+  "kip-sign": "\u{e1c4}",
+  "kit-medical": "\u{f479}",
+  "first-aid": "\u{f479}",
+  "kitchen-set": "\u{e51a}",
+  "kiwi-bird": "\u{f535}",
+  "korvue": "\u{f42f}",
+  "l": "\u{4c}",
+  "land-mine-on": "\u{e51b}",
+  "landmark": "\u{f66f}",
+  "landmark-dome": "\u{f752}",
+  "landmark-alt": "\u{f752}",
+  "landmark-flag": "\u{e51c}",
+  "language": "\u{f1ab}",
+  "laptop": "\u{f109}",
+  "laptop-code": "\u{f5fc}",
+  "laptop-file": "\u{e51d}",
+  "laptop-medical": "\u{f812}",
+  "laravel": "\u{f3bd}",
+  "lari-sign": "\u{e1c8}",
+  "lastfm": "\u{f202}",
+  "layer-group": "\u{f5fd}",
+  "leaf": "\u{f06c}",
+  "leanpub": "\u{f212}",
+  "left-long": "\u{f30a}",
+  "long-arrow-alt-left": "\u{f30a}",
+  "left-right": "\u{f337}",
+  "arrows-alt-h": "\u{f337}",
+  "lemon": "\u{f094}",
+  "less": "\u{f41d}",
+  "less-than": "\u{3c}",
+  "less-than-equal": "\u{f537}",
+  "letterboxd": "\u{e62d}",
+  "life-ring": "\u{f1cd}",
+  "lightbulb": "\u{f0eb}",
+  "line": "\u{f3c0}",
+  "lines-leaning": "\u{e51e}",
+  "link": "\u{f0c1}",
+  "chain": "\u{f0c1}",
+  "link-slash": "\u{f127}",
+  "chain-broken": "\u{f127}",
+  "chain-slash": "\u{f127}",
+  "unlink": "\u{f127}",
+  "linkedin": "\u{f08c}",
+  "linkedin-in": "\u{f0e1}",
+  "linode": "\u{f2b8}",
+  "linux": "\u{f17c}",
+  "lira-sign": "\u{f195}",
+  "list": "\u{f03a}",
+  "list-squares": "\u{f03a}",
+  "list-check": "\u{f0ae}",
+  "tasks": "\u{f0ae}",
+  "list-ol": "\u{f0cb}",
+  "list-1-2": "\u{f0cb}",
+  "list-numeric": "\u{f0cb}",
+  "list-ul": "\u{f0ca}",
+  "list-dots": "\u{f0ca}",
+  "litecoin-sign": "\u{e1d3}",
+  "location-arrow": "\u{f124}",
+  "location-crosshairs": "\u{f601}",
+  "location": "\u{f601}",
+  "location-dot": "\u{f3c5}",
+  "map-marker-alt": "\u{f3c5}",
+  "location-pin": "\u{f041}",
+  "map-marker": "\u{f041}",
+  "location-pin-lock": "\u{e51f}",
+  "lock": "\u{f023}",
+  "lock-open": "\u{f3c1}",
+  "locust": "\u{e520}",
+  "lungs": "\u{f604}",
+  "lungs-virus": "\u{e067}",
+  "lyft": "\u{f3c3}",
+  "m": "\u{4d}",
+  "magento": "\u{f3c4}",
+  "magnet": "\u{f076}",
+  "magnifying-glass": "\u{f002}",
+  "search": "\u{f002}",
+  "magnifying-glass-arrow-right": "\u{e521}",
+  "magnifying-glass-chart": "\u{e522}",
+  "magnifying-glass-dollar": "\u{f688}",
+  "search-dollar": "\u{f688}",
+  "magnifying-glass-location": "\u{f689}",
+  "search-location": "\u{f689}",
+  "magnifying-glass-minus": "\u{f010}",
+  "search-minus": "\u{f010}",
+  "magnifying-glass-plus": "\u{f00e}",
+  "search-plus": "\u{f00e}",
+  "mailchimp": "\u{f59e}",
+  "manat-sign": "\u{e1d5}",
+  "mandalorian": "\u{f50f}",
+  "map": "\u{f279}",
+  "map-location": "\u{f59f}",
+  "map-marked": "\u{f59f}",
+  "map-location-dot": "\u{f5a0}",
+  "map-marked-alt": "\u{f5a0}",
+  "map-pin": "\u{f276}",
+  "markdown": "\u{f60f}",
+  "marker": "\u{f5a1}",
+  "mars": "\u{f222}",
+  "mars-and-venus": "\u{f224}",
+  "mars-and-venus-burst": "\u{e523}",
+  "mars-double": "\u{f227}",
+  "mars-stroke": "\u{f229}",
+  "mars-stroke-right": "\u{f22b}",
+  "mars-stroke-h": "\u{f22b}",
+  "mars-stroke-up": "\u{f22a}",
+  "mars-stroke-v": "\u{f22a}",
+  "martini-glass": "\u{f57b}",
+  "glass-martini-alt": "\u{f57b}",
+  "martini-glass-citrus": "\u{f561}",
+  "cocktail": "\u{f561}",
+  "martini-glass-empty": "\u{f000}",
+  "glass-martini": "\u{f000}",
+  "mask": "\u{f6fa}",
+  "mask-face": "\u{e1d7}",
+  "mask-ventilator": "\u{e524}",
+  "masks-theater": "\u{f630}",
+  "theater-masks": "\u{f630}",
+  "mastodon": "\u{f4f6}",
+  "mattress-pillow": "\u{e525}",
+  "maxcdn": "\u{f136}",
+  "maximize": "\u{f31e}",
+  "expand-arrows-alt": "\u{f31e}",
+  "mdb": "\u{f8ca}",
+  "medal": "\u{f5a2}",
+  "medapps": "\u{f3c6}",
+  "medium": "\u{f23a}",
+  "medium-m": "\u{f23a}",
+  "medrt": "\u{f3c8}",
+  "meetup": "\u{f2e0}",
+  "megaport": "\u{f5a3}",
+  "memory": "\u{f538}",
+  "mendeley": "\u{f7b3}",
+  "menorah": "\u{f676}",
+  "mercury": "\u{f223}",
+  "message": "\u{f27a}",
+  "comment-alt": "\u{f27a}",
+  "meta": "\u{e49b}",
+  "meteor": "\u{f753}",
+  "microblog": "\u{e01a}",
+  "microchip": "\u{f2db}",
+  "microphone": "\u{f130}",
+  "microphone-lines": "\u{f3c9}",
+  "microphone-alt": "\u{f3c9}",
+  "microphone-lines-slash": "\u{f539}",
+  "microphone-alt-slash": "\u{f539}",
+  "microphone-slash": "\u{f131}",
+  "microscope": "\u{f610}",
+  "microsoft": "\u{f3ca}",
+  "mill-sign": "\u{e1ed}",
+  "minimize": "\u{f78c}",
+  "compress-arrows-alt": "\u{f78c}",
+  "mintbit": "\u{e62f}",
+  "minus": "\u{f068}",
+  "subtract": "\u{f068}",
+  "mitten": "\u{f7b5}",
+  "mix": "\u{f3cb}",
+  "mixcloud": "\u{f289}",
+  "mixer": "\u{e056}",
+  "mizuni": "\u{f3cc}",
+  "mobile": "\u{f3ce}",
+  "mobile-android": "\u{f3ce}",
+  "mobile-phone": "\u{f3ce}",
+  "mobile-button": "\u{f10b}",
+  "mobile-retro": "\u{e527}",
+  "mobile-screen": "\u{f3cf}",
+  "mobile-android-alt": "\u{f3cf}",
+  "mobile-screen-button": "\u{f3cd}",
+  "mobile-alt": "\u{f3cd}",
+  "modx": "\u{f285}",
+  "monero": "\u{f3d0}",
+  "money-bill": "\u{f0d6}",
+  "money-bill-1": "\u{f3d1}",
+  "money-bill-alt": "\u{f3d1}",
+  "money-bill-1-wave": "\u{f53b}",
+  "money-bill-wave-alt": "\u{f53b}",
+  "money-bill-transfer": "\u{e528}",
+  "money-bill-trend-up": "\u{e529}",
+  "money-bill-wave": "\u{f53a}",
+  "money-bill-wheat": "\u{e52a}",
+  "money-bills": "\u{e1f3}",
+  "money-check": "\u{f53c}",
+  "money-check-dollar": "\u{f53d}",
+  "money-check-alt": "\u{f53d}",
+  "monument": "\u{f5a6}",
+  "moon": "\u{f186}",
+  "mortar-pestle": "\u{f5a7}",
+  "mosque": "\u{f678}",
+  "mosquito": "\u{e52b}",
+  "mosquito-net": "\u{e52c}",
+  "motorcycle": "\u{f21c}",
+  "mound": "\u{e52d}",
+  "mountain": "\u{f6fc}",
+  "mountain-city": "\u{e52e}",
+  "mountain-sun": "\u{e52f}",
+  "mug-hot": "\u{f7b6}",
+  "mug-saucer": "\u{f0f4}",
+  "coffee": "\u{f0f4}",
+  "music": "\u{f001}",
+  "n": "\u{4e}",
+  "naira-sign": "\u{e1f6}",
+  "napster": "\u{f3d2}",
+  "neos": "\u{f612}",
+  "network-wired": "\u{f6ff}",
+  "neuter": "\u{f22c}",
+  "newspaper": "\u{f1ea}",
+  "nfc-directional": "\u{e530}",
+  "nfc-symbol": "\u{e531}",
+  "nimblr": "\u{f5a8}",
+  "node": "\u{f419}",
+  "node-js": "\u{f3d3}",
+  "not-equal": "\u{f53e}",
+  "notdef": "\u{e1fe}",
+  "note-sticky": "\u{f249}",
+  "sticky-note": "\u{f249}",
+  "notes-medical": "\u{f481}",
+  "npm": "\u{f3d4}",
+  "ns8": "\u{f3d5}",
+  "nutritionix": "\u{f3d6}",
+  "o": "\u{4f}",
+  "object-group": "\u{f247}",
+  "object-ungroup": "\u{f248}",
+  "octopus-deploy": "\u{e082}",
+  "odnoklassniki": "\u{f263}",
+  "odysee": "\u{e5c6}",
+  "oil-can": "\u{f613}",
+  "oil-well": "\u{e532}",
+  "old-republic": "\u{f510}",
+  "om": "\u{f679}",
+  "opencart": "\u{f23d}",
+  "openid": "\u{f19b}",
+  "opensuse": "\u{e62b}",
+  "opera": "\u{f26a}",
+  "optin-monster": "\u{f23c}",
+  "orcid": "\u{f8d2}",
+  "osi": "\u{f41a}",
+  "otter": "\u{f700}",
+  "outdent": "\u{f03b}",
+  "dedent": "\u{f03b}",
+  "p": "\u{50}",
+  "padlet": "\u{e4a0}",
+  "page4": "\u{f3d7}",
+  "pagelines": "\u{f18c}",
+  "pager": "\u{f815}",
+  "paint-roller": "\u{f5aa}",
+  "paintbrush": "\u{f1fc}",
+  "paint-brush": "\u{f1fc}",
+  "palette": "\u{f53f}",
+  "palfed": "\u{f3d8}",
+  "pallet": "\u{f482}",
+  "panorama": "\u{e209}",
+  "paper-plane": "\u{f1d8}",
+  "paperclip": "\u{f0c6}",
+  "parachute-box": "\u{f4cd}",
+  "paragraph": "\u{f1dd}",
+  "passport": "\u{f5ab}",
+  "paste": "\u{f0ea}",
+  "file-clipboard": "\u{f0ea}",
+  "patreon": "\u{f3d9}",
+  "pause": "\u{f04c}",
+  "paw": "\u{f1b0}",
+  "paypal": "\u{f1ed}",
+  "peace": "\u{f67c}",
+  "pen": "\u{f304}",
+  "pen-clip": "\u{f305}",
+  "pen-alt": "\u{f305}",
+  "pen-fancy": "\u{f5ac}",
+  "pen-nib": "\u{f5ad}",
+  "pen-ruler": "\u{f5ae}",
+  "pencil-ruler": "\u{f5ae}",
+  "pen-to-square": "\u{f044}",
+  "edit": "\u{f044}",
+  "pencil": "\u{f303}",
+  "pencil-alt": "\u{f303}",
+  "people-arrows": "\u{e068}",
+  "people-arrows-left-right": "\u{e068}",
+  "people-carry-box": "\u{f4ce}",
+  "people-carry": "\u{f4ce}",
+  "people-group": "\u{e533}",
+  "people-line": "\u{e534}",
+  "people-pulling": "\u{e535}",
+  "people-robbery": "\u{e536}",
+  "people-roof": "\u{e537}",
+  "pepper-hot": "\u{f816}",
+  "perbyte": "\u{e083}",
+  "percent": "\u{25}",
+  "percentage": "\u{25}",
+  "periscope": "\u{f3da}",
+  "person": "\u{f183}",
+  "male": "\u{f183}",
+  "person-arrow-down-to-line": "\u{e538}",
+  "person-arrow-up-from-line": "\u{e539}",
+  "person-biking": "\u{f84a}",
+  "biking": "\u{f84a}",
+  "person-booth": "\u{f756}",
+  "person-breastfeeding": "\u{e53a}",
+  "person-burst": "\u{e53b}",
+  "person-cane": "\u{e53c}",
+  "person-chalkboard": "\u{e53d}",
+  "person-circle-check": "\u{e53e}",
+  "person-circle-exclamation": "\u{e53f}",
+  "person-circle-minus": "\u{e540}",
+  "person-circle-plus": "\u{e541}",
+  "person-circle-question": "\u{e542}",
+  "person-circle-xmark": "\u{e543}",
+  "person-digging": "\u{f85e}",
+  "digging": "\u{f85e}",
+  "person-dots-from-line": "\u{f470}",
+  "diagnoses": "\u{f470}",
+  "person-dress": "\u{f182}",
+  "female": "\u{f182}",
+  "person-dress-burst": "\u{e544}",
+  "person-drowning": "\u{e545}",
+  "person-falling": "\u{e546}",
+  "person-falling-burst": "\u{e547}",
+  "person-half-dress": "\u{e548}",
+  "person-harassing": "\u{e549}",
+  "person-hiking": "\u{f6ec}",
+  "hiking": "\u{f6ec}",
+  "person-military-pointing": "\u{e54a}",
+  "person-military-rifle": "\u{e54b}",
+  "person-military-to-person": "\u{e54c}",
+  "person-praying": "\u{f683}",
+  "pray": "\u{f683}",
+  "person-pregnant": "\u{e31e}",
+  "person-rays": "\u{e54d}",
+  "person-rifle": "\u{e54e}",
+  "person-running": "\u{f70c}",
+  "running": "\u{f70c}",
+  "person-shelter": "\u{e54f}",
+  "person-skating": "\u{f7c5}",
+  "skating": "\u{f7c5}",
+  "person-skiing": "\u{f7c9}",
+  "skiing": "\u{f7c9}",
+  "person-skiing-nordic": "\u{f7ca}",
+  "skiing-nordic": "\u{f7ca}",
+  "person-snowboarding": "\u{f7ce}",
+  "snowboarding": "\u{f7ce}",
+  "person-swimming": "\u{f5c4}",
+  "swimmer": "\u{f5c4}",
+  "person-through-window": "\u{e5a9}",
+  "person-walking": "\u{f554}",
+  "walking": "\u{f554}",
+  "person-walking-arrow-loop-left": "\u{e551}",
+  "person-walking-arrow-right": "\u{e552}",
+  "person-walking-dashed-line-arrow-right": "\u{e553}",
+  "person-walking-luggage": "\u{e554}",
+  "person-walking-with-cane": "\u{f29d}",
+  "blind": "\u{f29d}",
+  "peseta-sign": "\u{e221}",
+  "peso-sign": "\u{e222}",
+  "phabricator": "\u{f3db}",
+  "phoenix-framework": "\u{f3dc}",
+  "phoenix-squadron": "\u{f511}",
+  "phone": "\u{f095}",
+  "phone-flip": "\u{f879}",
+  "phone-alt": "\u{f879}",
+  "phone-slash": "\u{f3dd}",
+  "phone-volume": "\u{f2a0}",
+  "volume-control-phone": "\u{f2a0}",
+  "photo-film": "\u{f87c}",
+  "photo-video": "\u{f87c}",
+  "php": "\u{f457}",
+  "pied-piper": "\u{f2ae}",
+  "pied-piper-alt": "\u{f1a8}",
+  "pied-piper-hat": "\u{f4e5}",
+  "pied-piper-pp": "\u{f1a7}",
+  "piggy-bank": "\u{f4d3}",
+  "pills": "\u{f484}",
+  "pinterest": "\u{f0d2}",
+  "pinterest-p": "\u{f231}",
+  "pix": "\u{e43a}",
+  "pixiv": "\u{e640}",
+  "pizza-slice": "\u{f818}",
+  "place-of-worship": "\u{f67f}",
+  "plane": "\u{f072}",
+  "plane-arrival": "\u{f5af}",
+  "plane-circle-check": "\u{e555}",
+  "plane-circle-exclamation": "\u{e556}",
+  "plane-circle-xmark": "\u{e557}",
+  "plane-departure": "\u{f5b0}",
+  "plane-lock": "\u{e558}",
+  "plane-slash": "\u{e069}",
+  "plane-up": "\u{e22d}",
+  "plant-wilt": "\u{e5aa}",
+  "plate-wheat": "\u{e55a}",
+  "play": "\u{f04b}",
+  "playstation": "\u{f3df}",
+  "plug": "\u{f1e6}",
+  "plug-circle-bolt": "\u{e55b}",
+  "plug-circle-check": "\u{e55c}",
+  "plug-circle-exclamation": "\u{e55d}",
+  "plug-circle-minus": "\u{e55e}",
+  "plug-circle-plus": "\u{e55f}",
+  "plug-circle-xmark": "\u{e560}",
+  "plus": "\u{2b}",
+  "add": "\u{2b}",
+  "plus-minus": "\u{e43c}",
+  "podcast": "\u{f2ce}",
+  "poo": "\u{f2fe}",
+  "poo-storm": "\u{f75a}",
+  "poo-bolt": "\u{f75a}",
+  "poop": "\u{f619}",
+  "power-off": "\u{f011}",
+  "prescription": "\u{f5b1}",
+  "prescription-bottle": "\u{f485}",
+  "prescription-bottle-medical": "\u{f486}",
+  "prescription-bottle-alt": "\u{f486}",
+  "print": "\u{f02f}",
+  "product-hunt": "\u{f288}",
+  "pump-medical": "\u{e06a}",
+  "pump-soap": "\u{e06b}",
+  "pushed": "\u{f3e1}",
+  "puzzle-piece": "\u{f12e}",
+  "python": "\u{f3e2}",
+  "q": "\u{51}",
+  "qq": "\u{f1d6}",
+  "qrcode": "\u{f029}",
+  "question": "\u{3f}",
+  "quinscape": "\u{f459}",
+  "quora": "\u{f2c4}",
+  "quote-left": "\u{f10d}",
+  "quote-left-alt": "\u{f10d}",
+  "quote-right": "\u{f10e}",
+  "quote-right-alt": "\u{f10e}",
+  "r": "\u{52}",
+  "r-project": "\u{f4f7}",
+  "radiation": "\u{f7b9}",
+  "radio": "\u{f8d7}",
+  "rainbow": "\u{f75b}",
+  "ranking-star": "\u{e561}",
+  "raspberry-pi": "\u{f7bb}",
+  "ravelry": "\u{f2d9}",
+  "react": "\u{f41b}",
+  "reacteurope": "\u{f75d}",
+  "readme": "\u{f4d5}",
+  "rebel": "\u{f1d0}",
+  "receipt": "\u{f543}",
+  "record-vinyl": "\u{f8d9}",
+  "rectangle-ad": "\u{f641}",
+  "ad": "\u{f641}",
+  "rectangle-list": "\u{f022}",
+  "list-alt": "\u{f022}",
+  "rectangle-xmark": "\u{f410}",
+  "rectangle-times": "\u{f410}",
+  "times-rectangle": "\u{f410}",
+  "window-close": "\u{f410}",
+  "recycle": "\u{f1b8}",
+  "red-river": "\u{f3e3}",
+  "reddit": "\u{f1a1}",
+  "reddit-alien": "\u{f281}",
+  "redhat": "\u{f7bc}",
+  "registered": "\u{f25d}",
+  "renren": "\u{f18b}",
+  "repeat": "\u{f363}",
+  "reply": "\u{f3e5}",
+  "mail-reply": "\u{f3e5}",
+  "reply-all": "\u{f122}",
+  "mail-reply-all": "\u{f122}",
+  "replyd": "\u{f3e6}",
+  "republican": "\u{f75e}",
+  "researchgate": "\u{f4f8}",
+  "resolving": "\u{f3e7}",
+  "restroom": "\u{f7bd}",
+  "retweet": "\u{f079}",
+  "rev": "\u{f5b2}",
+  "ribbon": "\u{f4d6}",
+  "right-from-bracket": "\u{f2f5}",
+  "sign-out-alt": "\u{f2f5}",
+  "right-left": "\u{f362}",
+  "exchange-alt": "\u{f362}",
+  "right-long": "\u{f30b}",
+  "long-arrow-alt-right": "\u{f30b}",
+  "right-to-bracket": "\u{f2f6}",
+  "sign-in-alt": "\u{f2f6}",
+  "ring": "\u{f70b}",
+  "road": "\u{f018}",
+  "road-barrier": "\u{e562}",
+  "road-bridge": "\u{e563}",
+  "road-circle-check": "\u{e564}",
+  "road-circle-exclamation": "\u{e565}",
+  "road-circle-xmark": "\u{e566}",
+  "road-lock": "\u{e567}",
+  "road-spikes": "\u{e568}",
+  "robot": "\u{f544}",
+  "rocket": "\u{f135}",
+  "rocketchat": "\u{f3e8}",
+  "rockrms": "\u{f3e9}",
+  "rotate": "\u{f2f1}",
+  "sync-alt": "\u{f2f1}",
+  "rotate-left": "\u{f2ea}",
+  "rotate-back": "\u{f2ea}",
+  "rotate-backward": "\u{f2ea}",
+  "undo-alt": "\u{f2ea}",
+  "rotate-right": "\u{f2f9}",
+  "redo-alt": "\u{f2f9}",
+  "rotate-forward": "\u{f2f9}",
+  "route": "\u{f4d7}",
+  "rss": "\u{f09e}",
+  "feed": "\u{f09e}",
+  "ruble-sign": "\u{f158}",
+  "rouble": "\u{f158}",
+  "rub": "\u{f158}",
+  "ruble": "\u{f158}",
+  "rug": "\u{e569}",
+  "ruler": "\u{f545}",
+  "ruler-combined": "\u{f546}",
+  "ruler-horizontal": "\u{f547}",
+  "ruler-vertical": "\u{f548}",
+  "rupee-sign": "\u{f156}",
+  "rupee": "\u{f156}",
+  "rupiah-sign": "\u{e23d}",
+  "rust": "\u{e07a}",
+  "s": "\u{53}",
+  "sack-dollar": "\u{f81d}",
+  "sack-xmark": "\u{e56a}",
+  "safari": "\u{f267}",
+  "sailboat": "\u{e445}",
+  "salesforce": "\u{f83b}",
+  "sass": "\u{f41e}",
+  "satellite": "\u{f7bf}",
+  "satellite-dish": "\u{f7c0}",
+  "scale-balanced": "\u{f24e}",
+  "balance-scale": "\u{f24e}",
+  "scale-unbalanced": "\u{f515}",
+  "balance-scale-left": "\u{f515}",
+  "scale-unbalanced-flip": "\u{f516}",
+  "balance-scale-right": "\u{f516}",
+  "schlix": "\u{f3ea}",
+  "school": "\u{f549}",
+  "school-circle-check": "\u{e56b}",
+  "school-circle-exclamation": "\u{e56c}",
+  "school-circle-xmark": "\u{e56d}",
+  "school-flag": "\u{e56e}",
+  "school-lock": "\u{e56f}",
+  "scissors": "\u{f0c4}",
+  "cut": "\u{f0c4}",
+  "screenpal": "\u{e570}",
+  "screwdriver": "\u{f54a}",
+  "screwdriver-wrench": "\u{f7d9}",
+  "tools": "\u{f7d9}",
+  "scribd": "\u{f28a}",
+  "scroll": "\u{f70e}",
+  "scroll-torah": "\u{f6a0}",
+  "torah": "\u{f6a0}",
+  "sd-card": "\u{f7c2}",
+  "searchengin": "\u{f3eb}",
+  "section": "\u{e447}",
+  "seedling": "\u{f4d8}",
+  "sprout": "\u{f4d8}",
+  "sellcast": "\u{f2da}",
+  "sellsy": "\u{f213}",
+  "server": "\u{f233}",
+  "servicestack": "\u{f3ec}",
+  "shapes": "\u{f61f}",
+  "triangle-circle-square": "\u{f61f}",
+  "share": "\u{f064}",
+  "mail-forward": "\u{f064}",
+  "share-from-square": "\u{f14d}",
+  "share-square": "\u{f14d}",
+  "share-nodes": "\u{f1e0}",
+  "share-alt": "\u{f1e0}",
+  "sheet-plastic": "\u{e571}",
+  "shekel-sign": "\u{f20b}",
+  "ils": "\u{f20b}",
+  "shekel": "\u{f20b}",
+  "sheqel": "\u{f20b}",
+  "sheqel-sign": "\u{f20b}",
+  "shield": "\u{f132}",
+  "shield-blank": "\u{f132}",
+  "shield-cat": "\u{e572}",
+  "shield-dog": "\u{e573}",
+  "shield-halved": "\u{f3ed}",
+  "shield-alt": "\u{f3ed}",
+  "shield-heart": "\u{e574}",
+  "shield-virus": "\u{e06c}",
+  "ship": "\u{f21a}",
+  "shirt": "\u{f553}",
+  "t-shirt": "\u{f553}",
+  "tshirt": "\u{f553}",
+  "shirtsinbulk": "\u{f214}",
+  "shoe-prints": "\u{f54b}",
+  "shoelace": "\u{e60c}",
+  "shop": "\u{f54f}",
+  "store-alt": "\u{f54f}",
+  "shop-lock": "\u{e4a5}",
+  "shop-slash": "\u{e070}",
+  "store-alt-slash": "\u{e070}",
+  "shopify": "\u{e057}",
+  "shopware": "\u{f5b5}",
+  "shower": "\u{f2cc}",
+  "shrimp": "\u{e448}",
+  "shuffle": "\u{f074}",
+  "random": "\u{f074}",
+  "shuttle-space": "\u{f197}",
+  "space-shuttle": "\u{f197}",
+  "sign-hanging": "\u{f4d9}",
+  "sign": "\u{f4d9}",
+  "signal": "\u{f012}",
+  "signal-5": "\u{f012}",
+  "signal-perfect": "\u{f012}",
+  "signal-messenger": "\u{e663}",
+  "signature": "\u{f5b7}",
+  "signs-post": "\u{f277}",
+  "map-signs": "\u{f277}",
+  "sim-card": "\u{f7c4}",
+  "simplybuilt": "\u{f215}",
+  "sink": "\u{e06d}",
+  "sistrix": "\u{f3ee}",
+  "sitemap": "\u{f0e8}",
+  "sith": "\u{f512}",
+  "sitrox": "\u{e44a}",
+  "sketch": "\u{f7c6}",
+  "skull": "\u{f54c}",
+  "skull-crossbones": "\u{f714}",
+  "skyatlas": "\u{f216}",
+  "skype": "\u{f17e}",
+  "slack": "\u{f198}",
+  "slack-hash": "\u{f198}",
+  "slash": "\u{f715}",
+  "sleigh": "\u{f7cc}",
+  "sliders": "\u{f1de}",
+  "sliders-h": "\u{f1de}",
+  "slideshare": "\u{f1e7}",
+  "smog": "\u{f75f}",
+  "smoking": "\u{f48d}",
+  "snapchat": "\u{f2ab}",
+  "snapchat-ghost": "\u{f2ab}",
+  "snowflake": "\u{f2dc}",
+  "snowman": "\u{f7d0}",
+  "snowplow": "\u{f7d2}",
+  "soap": "\u{e06e}",
+  "socks": "\u{f696}",
+  "solar-panel": "\u{f5ba}",
+  "sort": "\u{f0dc}",
+  "unsorted": "\u{f0dc}",
+  "sort-down": "\u{f0dd}",
+  "sort-desc": "\u{f0dd}",
+  "sort-up": "\u{f0de}",
+  "sort-asc": "\u{f0de}",
+  "soundcloud": "\u{f1be}",
+  "sourcetree": "\u{f7d3}",
+  "spa": "\u{f5bb}",
+  "space-awesome": "\u{e5ac}",
+  "spaghetti-monster-flying": "\u{f67b}",
+  "pastafarianism": "\u{f67b}",
+  "speakap": "\u{f3f3}",
+  "speaker-deck": "\u{f83c}",
+  "spell-check": "\u{f891}",
+  "spider": "\u{f717}",
+  "spinner": "\u{f110}",
+  "splotch": "\u{f5bc}",
+  "spoon": "\u{f2e5}",
+  "utensil-spoon": "\u{f2e5}",
+  "spotify": "\u{f1bc}",
+  "spray-can": "\u{f5bd}",
+  "spray-can-sparkles": "\u{f5d0}",
+  "air-freshener": "\u{f5d0}",
+  "square": "\u{f0c8}",
+  "square-arrow-up-right": "\u{f14c}",
+  "external-link-square": "\u{f14c}",
+  "square-behance": "\u{f1b5}",
+  "behance-square": "\u{f1b5}",
+  "square-caret-down": "\u{f150}",
+  "caret-square-down": "\u{f150}",
+  "square-caret-left": "\u{f191}",
+  "caret-square-left": "\u{f191}",
+  "square-caret-right": "\u{f152}",
+  "caret-square-right": "\u{f152}",
+  "square-caret-up": "\u{f151}",
+  "caret-square-up": "\u{f151}",
+  "square-check": "\u{f14a}",
+  "check-square": "\u{f14a}",
+  "square-dribbble": "\u{f397}",
+  "dribbble-square": "\u{f397}",
+  "square-envelope": "\u{f199}",
+  "envelope-square": "\u{f199}",
+  "square-facebook": "\u{f082}",
+  "facebook-square": "\u{f082}",
+  "square-font-awesome": "\u{e5ad}",
+  "square-font-awesome-stroke": "\u{f35c}",
+  "font-awesome-alt": "\u{f35c}",
+  "square-full": "\u{f45c}",
+  "square-git": "\u{f1d2}",
+  "git-square": "\u{f1d2}",
+  "square-github": "\u{f092}",
+  "github-square": "\u{f092}",
+  "square-gitlab": "\u{e5ae}",
+  "gitlab-square": "\u{e5ae}",
+  "square-google-plus": "\u{f0d4}",
+  "google-plus-square": "\u{f0d4}",
+  "square-h": "\u{f0fd}",
+  "h-square": "\u{f0fd}",
+  "square-hacker-news": "\u{f3af}",
+  "hacker-news-square": "\u{f3af}",
+  "square-instagram": "\u{e055}",
+  "instagram-square": "\u{e055}",
+  "square-js": "\u{f3b9}",
+  "js-square": "\u{f3b9}",
+  "square-lastfm": "\u{f203}",
+  "lastfm-square": "\u{f203}",
+  "square-letterboxd": "\u{e62e}",
+  "square-minus": "\u{f146}",
+  "minus-square": "\u{f146}",
+  "square-nfi": "\u{e576}",
+  "square-odnoklassniki": "\u{f264}",
+  "odnoklassniki-square": "\u{f264}",
+  "square-parking": "\u{f540}",
+  "parking": "\u{f540}",
+  "square-pen": "\u{f14b}",
+  "pen-square": "\u{f14b}",
+  "pencil-square": "\u{f14b}",
+  "square-person-confined": "\u{e577}",
+  "square-phone": "\u{f098}",
+  "phone-square": "\u{f098}",
+  "square-phone-flip": "\u{f87b}",
+  "phone-square-alt": "\u{f87b}",
+  "square-pied-piper": "\u{e01e}",
+  "pied-piper-square": "\u{e01e}",
+  "square-pinterest": "\u{f0d3}",
+  "pinterest-square": "\u{f0d3}",
+  "square-plus": "\u{f0fe}",
+  "plus-square": "\u{f0fe}",
+  "square-poll-horizontal": "\u{f682}",
+  "poll-h": "\u{f682}",
+  "square-poll-vertical": "\u{f681}",
+  "poll": "\u{f681}",
+  "square-reddit": "\u{f1a2}",
+  "reddit-square": "\u{f1a2}",
+  "square-root-variable": "\u{f698}",
+  "square-root-alt": "\u{f698}",
+  "square-rss": "\u{f143}",
+  "rss-square": "\u{f143}",
+  "square-share-nodes": "\u{f1e1}",
+  "share-alt-square": "\u{f1e1}",
+  "square-snapchat": "\u{f2ad}",
+  "snapchat-square": "\u{f2ad}",
+  "square-steam": "\u{f1b7}",
+  "steam-square": "\u{f1b7}",
+  "square-threads": "\u{e619}",
+  "square-tumblr": "\u{f174}",
+  "tumblr-square": "\u{f174}",
+  "square-twitter": "\u{f081}",
+  "twitter-square": "\u{f081}",
+  "square-up-right": "\u{f360}",
+  "external-link-square-alt": "\u{f360}",
+  "square-upwork": "\u{e67c}",
+  "square-viadeo": "\u{f2aa}",
+  "viadeo-square": "\u{f2aa}",
+  "square-vimeo": "\u{f194}",
+  "vimeo-square": "\u{f194}",
+  "square-virus": "\u{e578}",
+  "square-web-awesome": "\u{e683}",
+  "square-web-awesome-stroke": "\u{e684}",
+  "square-whatsapp": "\u{f40c}",
+  "whatsapp-square": "\u{f40c}",
+  "square-x-twitter": "\u{e61a}",
+  "square-xing": "\u{f169}",
+  "xing-square": "\u{f169}",
+  "square-xmark": "\u{f2d3}",
+  "times-square": "\u{f2d3}",
+  "xmark-square": "\u{f2d3}",
+  "square-youtube": "\u{f431}",
+  "youtube-square": "\u{f431}",
+  "squarespace": "\u{f5be}",
+  "stack-exchange": "\u{f18d}",
+  "stack-overflow": "\u{f16c}",
+  "stackpath": "\u{f842}",
+  "staff-snake": "\u{e579}",
+  "rod-asclepius": "\u{e579}",
+  "rod-snake": "\u{e579}",
+  "staff-aesculapius": "\u{e579}",
+  "stairs": "\u{e289}",
+  "stamp": "\u{f5bf}",
+  "stapler": "\u{e5af}",
+  "star": "\u{f005}",
+  "star-and-crescent": "\u{f699}",
+  "star-half": "\u{f089}",
+  "star-half-stroke": "\u{f5c0}",
+  "star-half-alt": "\u{f5c0}",
+  "star-of-david": "\u{f69a}",
+  "star-of-life": "\u{f621}",
+  "staylinked": "\u{f3f5}",
+  "steam": "\u{f1b6}",
+  "steam-symbol": "\u{f3f6}",
+  "sterling-sign": "\u{f154}",
+  "gbp": "\u{f154}",
+  "pound-sign": "\u{f154}",
+  "stethoscope": "\u{f0f1}",
+  "sticker-mule": "\u{f3f7}",
+  "stop": "\u{f04d}",
+  "stopwatch": "\u{f2f2}",
+  "stopwatch-20": "\u{e06f}",
+  "store": "\u{f54e}",
+  "store-slash": "\u{e071}",
+  "strava": "\u{f428}",
+  "street-view": "\u{f21d}",
+  "strikethrough": "\u{f0cc}",
+  "stripe": "\u{f429}",
+  "stripe-s": "\u{f42a}",
+  "stroopwafel": "\u{f551}",
+  "stubber": "\u{e5c7}",
+  "studiovinari": "\u{f3f8}",
+  "stumbleupon": "\u{f1a4}",
+  "stumbleupon-circle": "\u{f1a3}",
+  "subscript": "\u{f12c}",
+  "suitcase": "\u{f0f2}",
+  "suitcase-medical": "\u{f0fa}",
+  "medkit": "\u{f0fa}",
+  "suitcase-rolling": "\u{f5c1}",
+  "sun": "\u{f185}",
+  "sun-plant-wilt": "\u{e57a}",
+  "superpowers": "\u{f2dd}",
+  "superscript": "\u{f12b}",
+  "supple": "\u{f3f9}",
+  "suse": "\u{f7d6}",
+  "swatchbook": "\u{f5c3}",
+  "swift": "\u{f8e1}",
+  "symfony": "\u{f83d}",
+  "synagogue": "\u{f69b}",
+  "syringe": "\u{f48e}",
+  "t": "\u{54}",
+  "table": "\u{f0ce}",
+  "table-cells": "\u{f00a}",
+  "th": "\u{f00a}",
+  "table-cells-column-lock": "\u{e678}",
+  "table-cells-large": "\u{f009}",
+  "th-large": "\u{f009}",
+  "table-cells-row-lock": "\u{e67a}",
+  "table-columns": "\u{f0db}",
+  "columns": "\u{f0db}",
+  "table-list": "\u{f00b}",
+  "th-list": "\u{f00b}",
+  "table-tennis-paddle-ball": "\u{f45d}",
+  "ping-pong-paddle-ball": "\u{f45d}",
+  "table-tennis": "\u{f45d}",
+  "tablet": "\u{f3fb}",
+  "tablet-android": "\u{f3fb}",
+  "tablet-button": "\u{f10a}",
+  "tablet-screen-button": "\u{f3fa}",
+  "tablet-alt": "\u{f3fa}",
+  "tablets": "\u{f490}",
+  "tachograph-digital": "\u{f566}",
+  "digital-tachograph": "\u{f566}",
+  "tag": "\u{f02b}",
+  "tags": "\u{f02c}",
+  "tape": "\u{f4db}",
+  "tarp": "\u{e57b}",
+  "tarp-droplet": "\u{e57c}",
+  "taxi": "\u{f1ba}",
+  "cab": "\u{f1ba}",
+  "teamspeak": "\u{f4f9}",
+  "teeth": "\u{f62e}",
+  "teeth-open": "\u{f62f}",
+  "telegram": "\u{f2c6}",
+  "telegram-plane": "\u{f2c6}",
+  "temperature-arrow-down": "\u{e03f}",
+  "temperature-down": "\u{e03f}",
+  "temperature-arrow-up": "\u{e040}",
+  "temperature-up": "\u{e040}",
+  "temperature-empty": "\u{f2cb}",
+  "temperature-0": "\u{f2cb}",
+  "thermometer-0": "\u{f2cb}",
+  "thermometer-empty": "\u{f2cb}",
+  "temperature-full": "\u{f2c7}",
+  "temperature-4": "\u{f2c7}",
+  "thermometer-4": "\u{f2c7}",
+  "thermometer-full": "\u{f2c7}",
+  "temperature-half": "\u{f2c9}",
+  "temperature-2": "\u{f2c9}",
+  "thermometer-2": "\u{f2c9}",
+  "thermometer-half": "\u{f2c9}",
+  "temperature-high": "\u{f769}",
+  "temperature-low": "\u{f76b}",
+  "temperature-quarter": "\u{f2ca}",
+  "temperature-1": "\u{f2ca}",
+  "thermometer-1": "\u{f2ca}",
+  "thermometer-quarter": "\u{f2ca}",
+  "temperature-three-quarters": "\u{f2c8}",
+  "temperature-3": "\u{f2c8}",
+  "thermometer-3": "\u{f2c8}",
+  "thermometer-three-quarters": "\u{f2c8}",
+  "tencent-weibo": "\u{f1d5}",
+  "tenge-sign": "\u{f7d7}",
+  "tenge": "\u{f7d7}",
+  "tent": "\u{e57d}",
+  "tent-arrow-down-to-line": "\u{e57e}",
+  "tent-arrow-left-right": "\u{e57f}",
+  "tent-arrow-turn-left": "\u{e580}",
+  "tent-arrows-down": "\u{e581}",
+  "tents": "\u{e582}",
+  "terminal": "\u{f120}",
+  "text-height": "\u{f034}",
+  "text-slash": "\u{f87d}",
+  "remove-format": "\u{f87d}",
+  "text-width": "\u{f035}",
+  "the-red-yeti": "\u{f69d}",
+  "themeco": "\u{f5c6}",
+  "themeisle": "\u{f2b2}",
+  "thermometer": "\u{f491}",
+  "think-peaks": "\u{f731}",
+  "threads": "\u{e618}",
+  "thumbs-down": "\u{f165}",
+  "thumbs-up": "\u{f164}",
+  "thumbtack": "\u{f08d}",
+  "thumb-tack": "\u{f08d}",
+  "ticket": "\u{f145}",
+  "ticket-simple": "\u{f3ff}",
+  "ticket-alt": "\u{f3ff}",
+  "tiktok": "\u{e07b}",
+  "timeline": "\u{e29c}",
+  "toggle-off": "\u{f204}",
+  "toggle-on": "\u{f205}",
+  "toilet": "\u{f7d8}",
+  "toilet-paper": "\u{f71e}",
+  "toilet-paper-slash": "\u{e072}",
+  "toilet-portable": "\u{e583}",
+  "toilets-portable": "\u{e584}",
+  "toolbox": "\u{f552}",
+  "tooth": "\u{f5c9}",
+  "torii-gate": "\u{f6a1}",
+  "tornado": "\u{f76f}",
+  "tower-broadcast": "\u{f519}",
+  "broadcast-tower": "\u{f519}",
+  "tower-cell": "\u{e585}",
+  "tower-observation": "\u{e586}",
+  "tractor": "\u{f722}",
+  "trade-federation": "\u{f513}",
+  "trademark": "\u{f25c}",
+  "traffic-light": "\u{f637}",
+  "trailer": "\u{e041}",
+  "train": "\u{f238}",
+  "train-subway": "\u{f239}",
+  "subway": "\u{f239}",
+  "train-tram": "\u{e5b4}",
+  "transgender": "\u{f225}",
+  "transgender-alt": "\u{f225}",
+  "trash": "\u{f1f8}",
+  "trash-arrow-up": "\u{f829}",
+  "trash-restore": "\u{f829}",
+  "trash-can": "\u{f2ed}",
+  "trash-alt": "\u{f2ed}",
+  "trash-can-arrow-up": "\u{f82a}",
+  "trash-restore-alt": "\u{f82a}",
+  "tree": "\u{f1bb}",
+  "tree-city": "\u{e587}",
+  "trello": "\u{f181}",
+  "triangle-exclamation": "\u{f071}",
+  "exclamation-triangle": "\u{f071}",
+  "warning": "\u{f071}",
+  "trophy": "\u{f091}",
+  "trowel": "\u{e589}",
+  "trowel-bricks": "\u{e58a}",
+  "truck": "\u{f0d1}",
+  "truck-arrow-right": "\u{e58b}",
+  "truck-droplet": "\u{e58c}",
+  "truck-fast": "\u{f48b}",
+  "shipping-fast": "\u{f48b}",
+  "truck-field": "\u{e58d}",
+  "truck-field-un": "\u{e58e}",
+  "truck-front": "\u{e2b7}",
+  "truck-medical": "\u{f0f9}",
+  "ambulance": "\u{f0f9}",
+  "truck-monster": "\u{f63b}",
+  "truck-moving": "\u{f4df}",
+  "truck-pickup": "\u{f63c}",
+  "truck-plane": "\u{e58f}",
+  "truck-ramp-box": "\u{f4de}",
+  "truck-loading": "\u{f4de}",
+  "tty": "\u{f1e4}",
+  "teletype": "\u{f1e4}",
+  "tumblr": "\u{f173}",
+  "turkish-lira-sign": "\u{e2bb}",
+  "try": "\u{e2bb}",
+  "turkish-lira": "\u{e2bb}",
+  "turn-down": "\u{f3be}",
+  "level-down-alt": "\u{f3be}",
+  "turn-up": "\u{f3bf}",
+  "level-up-alt": "\u{f3bf}",
+  "tv": "\u{f26c}",
+  "television": "\u{f26c}",
+  "tv-alt": "\u{f26c}",
+  "twitch": "\u{f1e8}",
+  "twitter": "\u{f099}",
+  "typo3": "\u{f42b}",
+  "u": "\u{55}",
+  "uber": "\u{f402}",
+  "ubuntu": "\u{f7df}",
+  "uikit": "\u{f403}",
+  "umbraco": "\u{f8e8}",
+  "umbrella": "\u{f0e9}",
+  "umbrella-beach": "\u{f5ca}",
+  "uncharted": "\u{e084}",
+  "underline": "\u{f0cd}",
+  "uniregistry": "\u{f404}",
+  "unity": "\u{e049}",
+  "universal-access": "\u{f29a}",
+  "unlock": "\u{f09c}",
+  "unlock-keyhole": "\u{f13e}",
+  "unlock-alt": "\u{f13e}",
+  "unsplash": "\u{e07c}",
+  "untappd": "\u{f405}",
+  "up-down": "\u{f338}",
+  "arrows-alt-v": "\u{f338}",
+  "up-down-left-right": "\u{f0b2}",
+  "arrows-alt": "\u{f0b2}",
+  "up-long": "\u{f30c}",
+  "long-arrow-alt-up": "\u{f30c}",
+  "up-right-and-down-left-from-center": "\u{f424}",
+  "expand-alt": "\u{f424}",
+  "up-right-from-square": "\u{f35d}",
+  "external-link-alt": "\u{f35d}",
+  "upload": "\u{f093}",
+  "ups": "\u{f7e0}",
+  "upwork": "\u{e641}",
+  "usb": "\u{f287}",
+  "user": "\u{f007}",
+  "user-astronaut": "\u{f4fb}",
+  "user-check": "\u{f4fc}",
+  "user-clock": "\u{f4fd}",
+  "user-doctor": "\u{f0f0}",
+  "user-md": "\u{f0f0}",
+  "user-gear": "\u{f4fe}",
+  "user-cog": "\u{f4fe}",
+  "user-graduate": "\u{f501}",
+  "user-group": "\u{f500}",
+  "user-friends": "\u{f500}",
+  "user-injured": "\u{f728}",
+  "user-large": "\u{f406}",
+  "user-alt": "\u{f406}",
+  "user-large-slash": "\u{f4fa}",
+  "user-alt-slash": "\u{f4fa}",
+  "user-lock": "\u{f502}",
+  "user-minus": "\u{f503}",
+  "user-ninja": "\u{f504}",
+  "user-nurse": "\u{f82f}",
+  "user-pen": "\u{f4ff}",
+  "user-edit": "\u{f4ff}",
+  "user-plus": "\u{f234}",
+  "user-secret": "\u{f21b}",
+  "user-shield": "\u{f505}",
+  "user-slash": "\u{f506}",
+  "user-tag": "\u{f507}",
+  "user-tie": "\u{f508}",
+  "user-xmark": "\u{f235}",
+  "user-times": "\u{f235}",
+  "users": "\u{f0c0}",
+  "users-between-lines": "\u{e591}",
+  "users-gear": "\u{f509}",
+  "users-cog": "\u{f509}",
+  "users-line": "\u{e592}",
+  "users-rays": "\u{e593}",
+  "users-rectangle": "\u{e594}",
+  "users-slash": "\u{e073}",
+  "users-viewfinder": "\u{e595}",
+  "usps": "\u{f7e1}",
+  "ussunnah": "\u{f407}",
+  "utensils": "\u{f2e7}",
+  "cutlery": "\u{f2e7}",
+  "v": "\u{56}",
+  "vaadin": "\u{f408}",
+  "van-shuttle": "\u{f5b6}",
+  "shuttle-van": "\u{f5b6}",
+  "vault": "\u{e2c5}",
+  "vector-square": "\u{f5cb}",
+  "venus": "\u{f221}",
+  "venus-double": "\u{f226}",
+  "venus-mars": "\u{f228}",
+  "vest": "\u{e085}",
+  "vest-patches": "\u{e086}",
+  "viacoin": "\u{f237}",
+  "viadeo": "\u{f2a9}",
+  "vial": "\u{f492}",
+  "vial-circle-check": "\u{e596}",
+  "vial-virus": "\u{e597}",
+  "vials": "\u{f493}",
+  "viber": "\u{f409}",
+  "video": "\u{f03d}",
+  "video-camera": "\u{f03d}",
+  "video-slash": "\u{f4e2}",
+  "vihara": "\u{f6a7}",
+  "vimeo": "\u{f40a}",
+  "vimeo-v": "\u{f27d}",
+  "vine": "\u{f1ca}",
+  "virus": "\u{e074}",
+  "virus-covid": "\u{e4a8}",
+  "virus-covid-slash": "\u{e4a9}",
+  "virus-slash": "\u{e075}",
+  "viruses": "\u{e076}",
+  "vk": "\u{f189}",
+  "vnv": "\u{f40b}",
+  "voicemail": "\u{f897}",
+  "volcano": "\u{f770}",
+  "volleyball": "\u{f45f}",
+  "volleyball-ball": "\u{f45f}",
+  "volume-high": "\u{f028}",
+  "volume-up": "\u{f028}",
+  "volume-low": "\u{f027}",
+  "volume-down": "\u{f027}",
+  "volume-off": "\u{f026}",
+  "volume-xmark": "\u{f6a9}",
+  "volume-mute": "\u{f6a9}",
+  "volume-times": "\u{f6a9}",
+  "vr-cardboard": "\u{f729}",
+  "vuejs": "\u{f41f}",
+  "w": "\u{57}",
+  "walkie-talkie": "\u{f8ef}",
+  "wallet": "\u{f555}",
+  "wand-magic": "\u{f0d0}",
+  "magic": "\u{f0d0}",
+  "wand-magic-sparkles": "\u{e2ca}",
+  "magic-wand-sparkles": "\u{e2ca}",
+  "wand-sparkles": "\u{f72b}",
+  "warehouse": "\u{f494}",
+  "watchman-monitoring": "\u{e087}",
+  "water": "\u{f773}",
+  "water-ladder": "\u{f5c5}",
+  "ladder-water": "\u{f5c5}",
+  "swimming-pool": "\u{f5c5}",
+  "wave-square": "\u{f83e}",
+  "waze": "\u{f83f}",
+  "web-awesome": "\u{e682}",
+  "webflow": "\u{e65c}",
+  "weebly": "\u{f5cc}",
+  "weibo": "\u{f18a}",
+  "weight-hanging": "\u{f5cd}",
+  "weight-scale": "\u{f496}",
+  "weight": "\u{f496}",
+  "weixin": "\u{f1d7}",
+  "whatsapp": "\u{f232}",
+  "wheat-awn": "\u{e2cd}",
+  "wheat-alt": "\u{e2cd}",
+  "wheat-awn-circle-exclamation": "\u{e598}",
+  "wheelchair": "\u{f193}",
+  "wheelchair-move": "\u{e2ce}",
+  "wheelchair-alt": "\u{e2ce}",
+  "whiskey-glass": "\u{f7a0}",
+  "glass-whiskey": "\u{f7a0}",
+  "whmcs": "\u{f40d}",
+  "wifi": "\u{f1eb}",
+  "wifi-3": "\u{f1eb}",
+  "wifi-strong": "\u{f1eb}",
+  "wikipedia-w": "\u{f266}",
+  "wind": "\u{f72e}",
+  "window-maximize": "\u{f2d0}",
+  "window-minimize": "\u{f2d1}",
+  "window-restore": "\u{f2d2}",
+  "windows": "\u{f17a}",
+  "wine-bottle": "\u{f72f}",
+  "wine-glass": "\u{f4e3}",
+  "wine-glass-empty": "\u{f5ce}",
+  "wine-glass-alt": "\u{f5ce}",
+  "wirsindhandwerk": "\u{e2d0}",
+  "wsh": "\u{e2d0}",
+  "wix": "\u{f5cf}",
+  "wizards-of-the-coast": "\u{f730}",
+  "wodu": "\u{e088}",
+  "wolf-pack-battalion": "\u{f514}",
+  "won-sign": "\u{f159}",
+  "krw": "\u{f159}",
+  "won": "\u{f159}",
+  "wordpress": "\u{f19a}",
+  "wordpress-simple": "\u{f411}",
+  "worm": "\u{e599}",
+  "wpbeginner": "\u{f297}",
+  "wpexplorer": "\u{f2de}",
+  "wpforms": "\u{f298}",
+  "wpressr": "\u{f3e4}",
+  "rendact": "\u{f3e4}",
+  "wrench": "\u{f0ad}",
+  "x": "\u{58}",
+  "x-ray": "\u{f497}",
+  "x-twitter": "\u{e61b}",
+  "xbox": "\u{f412}",
+  "xing": "\u{f168}",
+  "xmark": "\u{f00d}",
+  "close": "\u{f00d}",
+  "multiply": "\u{f00d}",
+  "remove": "\u{f00d}",
+  "times": "\u{f00d}",
+  "xmarks-lines": "\u{e59a}",
+  "y": "\u{59}",
+  "y-combinator": "\u{f23b}",
+  "yahoo": "\u{f19e}",
+  "yammer": "\u{f840}",
+  "yandex": "\u{f413}",
+  "yandex-international": "\u{f414}",
+  "yarn": "\u{f7e3}",
+  "yelp": "\u{f1e9}",
+  "yen-sign": "\u{f157}",
+  "cny": "\u{f157}",
+  "jpy": "\u{f157}",
+  "rmb": "\u{f157}",
+  "yen": "\u{f157}",
+  "yin-yang": "\u{f6ad}",
+  "yoast": "\u{f2b1}",
+  "youtube": "\u{f167}",
+  "z": "\u{5a}",
+  "zhihu": "\u{f63f}",
+)
+#let fa-0 = fa-icon.with("\u{30}", solid: true)
+#let fa-1 = fa-icon.with("\u{31}", solid: true)
+#let fa-2 = fa-icon.with("\u{32}", solid: true)
+#let fa-3 = fa-icon.with("\u{33}", solid: true)
+#let fa-4 = fa-icon.with("\u{34}", solid: true)
+#let fa-5 = fa-icon.with("\u{35}", solid: true)
+#let fa-6 = fa-icon.with("\u{36}", solid: true)
+#let fa-7 = fa-icon.with("\u{37}", solid: true)
+#let fa-8 = fa-icon.with("\u{38}", solid: true)
+#let fa-9 = fa-icon.with("\u{39}", solid: true)
+#let fa-42-group = fa-icon.with("\u{e080}")
+#let fa-innosoft = fa-icon.with("\u{e080}")
+#let fa-500px = fa-icon.with("\u{f26e}")
+#let fa-a = fa-icon.with("\u{41}", solid: true)
+#let fa-accessible-icon = fa-icon.with("\u{f368}")
+#let fa-accusoft = fa-icon.with("\u{f369}")
+#let fa-address-book = fa-icon.with("\u{f2b9}")
+#let fa-contact-book = fa-icon.with("\u{f2b9}")
+#let fa-address-card = fa-icon.with("\u{f2bb}")
+#let fa-contact-card = fa-icon.with("\u{f2bb}")
+#let fa-vcard = fa-icon.with("\u{f2bb}")
+#let fa-adn = fa-icon.with("\u{f170}")
+#let fa-adversal = fa-icon.with("\u{f36a}")
+#let fa-affiliatetheme = fa-icon.with("\u{f36b}")
+#let fa-airbnb = fa-icon.with("\u{f834}")
+#let fa-algolia = fa-icon.with("\u{f36c}")
+#let fa-align-center = fa-icon.with("\u{f037}", solid: true)
+#let fa-align-justify = fa-icon.with("\u{f039}", solid: true)
+#let fa-align-left = fa-icon.with("\u{f036}", solid: true)
+#let fa-align-right = fa-icon.with("\u{f038}", solid: true)
+#let fa-alipay = fa-icon.with("\u{f642}")
+#let fa-amazon = fa-icon.with("\u{f270}")
+#let fa-amazon-pay = fa-icon.with("\u{f42c}")
+#let fa-amilia = fa-icon.with("\u{f36d}")
+#let fa-anchor = fa-icon.with("\u{f13d}", solid: true)
+#let fa-anchor-circle-check = fa-icon.with("\u{e4aa}", solid: true)
+#let fa-anchor-circle-exclamation = fa-icon.with("\u{e4ab}", solid: true)
+#let fa-anchor-circle-xmark = fa-icon.with("\u{e4ac}", solid: true)
+#let fa-anchor-lock = fa-icon.with("\u{e4ad}", solid: true)
+#let fa-android = fa-icon.with("\u{f17b}")
+#let fa-angellist = fa-icon.with("\u{f209}")
+#let fa-angle-down = fa-icon.with("\u{f107}", solid: true)
+#let fa-angle-left = fa-icon.with("\u{f104}", solid: true)
+#let fa-angle-right = fa-icon.with("\u{f105}", solid: true)
+#let fa-angle-up = fa-icon.with("\u{f106}", solid: true)
+#let fa-angles-down = fa-icon.with("\u{f103}", solid: true)
+#let fa-angle-double-down = fa-icon.with("\u{f103}")
+#let fa-angles-left = fa-icon.with("\u{f100}", solid: true)
+#let fa-angle-double-left = fa-icon.with("\u{f100}")
+#let fa-angles-right = fa-icon.with("\u{f101}", solid: true)
+#let fa-angle-double-right = fa-icon.with("\u{f101}")
+#let fa-angles-up = fa-icon.with("\u{f102}", solid: true)
+#let fa-angle-double-up = fa-icon.with("\u{f102}")
+#let fa-angrycreative = fa-icon.with("\u{f36e}")
+#let fa-angular = fa-icon.with("\u{f420}")
+#let fa-ankh = fa-icon.with("\u{f644}", solid: true)
+#let fa-app-store = fa-icon.with("\u{f36f}")
+#let fa-app-store-ios = fa-icon.with("\u{f370}")
+#let fa-apper = fa-icon.with("\u{f371}")
+#let fa-apple = fa-icon.with("\u{f179}")
+#let fa-apple-pay = fa-icon.with("\u{f415}")
+#let fa-apple-whole = fa-icon.with("\u{f5d1}", solid: true)
+#let fa-apple-alt = fa-icon.with("\u{f5d1}")
+#let fa-archway = fa-icon.with("\u{f557}", solid: true)
+#let fa-arrow-down = fa-icon.with("\u{f063}", solid: true)
+#let fa-arrow-down-1-9 = fa-icon.with("\u{f162}", solid: true)
+#let fa-sort-numeric-asc = fa-icon.with("\u{f162}")
+#let fa-sort-numeric-down = fa-icon.with("\u{f162}")
+#let fa-arrow-down-9-1 = fa-icon.with("\u{f886}", solid: true)
+#let fa-sort-numeric-desc = fa-icon.with("\u{f886}")
+#let fa-sort-numeric-down-alt = fa-icon.with("\u{f886}")
+#let fa-arrow-down-a-z = fa-icon.with("\u{f15d}", solid: true)
+#let fa-sort-alpha-asc = fa-icon.with("\u{f15d}")
+#let fa-sort-alpha-down = fa-icon.with("\u{f15d}")
+#let fa-arrow-down-long = fa-icon.with("\u{f175}", solid: true)
+#let fa-long-arrow-down = fa-icon.with("\u{f175}")
+#let fa-arrow-down-short-wide = fa-icon.with("\u{f884}", solid: true)
+#let fa-sort-amount-desc = fa-icon.with("\u{f884}")
+#let fa-sort-amount-down-alt = fa-icon.with("\u{f884}")
+#let fa-arrow-down-up-across-line = fa-icon.with("\u{e4af}", solid: true)
+#let fa-arrow-down-up-lock = fa-icon.with("\u{e4b0}", solid: true)
+#let fa-arrow-down-wide-short = fa-icon.with("\u{f160}", solid: true)
+#let fa-sort-amount-asc = fa-icon.with("\u{f160}")
+#let fa-sort-amount-down = fa-icon.with("\u{f160}")
+#let fa-arrow-down-z-a = fa-icon.with("\u{f881}", solid: true)
+#let fa-sort-alpha-desc = fa-icon.with("\u{f881}")
+#let fa-sort-alpha-down-alt = fa-icon.with("\u{f881}")
+#let fa-arrow-left = fa-icon.with("\u{f060}", solid: true)
+#let fa-arrow-left-long = fa-icon.with("\u{f177}", solid: true)
+#let fa-long-arrow-left = fa-icon.with("\u{f177}")
+#let fa-arrow-pointer = fa-icon.with("\u{f245}", solid: true)
+#let fa-mouse-pointer = fa-icon.with("\u{f245}")
+#let fa-arrow-right = fa-icon.with("\u{f061}", solid: true)
+#let fa-arrow-right-arrow-left = fa-icon.with("\u{f0ec}", solid: true)
+#let fa-exchange = fa-icon.with("\u{f0ec}")
+#let fa-arrow-right-from-bracket = fa-icon.with("\u{f08b}", solid: true)
+#let fa-sign-out = fa-icon.with("\u{f08b}")
+#let fa-arrow-right-long = fa-icon.with("\u{f178}", solid: true)
+#let fa-long-arrow-right = fa-icon.with("\u{f178}")
+#let fa-arrow-right-to-bracket = fa-icon.with("\u{f090}", solid: true)
+#let fa-sign-in = fa-icon.with("\u{f090}")
+#let fa-arrow-right-to-city = fa-icon.with("\u{e4b3}", solid: true)
+#let fa-arrow-rotate-left = fa-icon.with("\u{f0e2}", solid: true)
+#let fa-arrow-left-rotate = fa-icon.with("\u{f0e2}")
+#let fa-arrow-rotate-back = fa-icon.with("\u{f0e2}")
+#let fa-arrow-rotate-backward = fa-icon.with("\u{f0e2}")
+#let fa-undo = fa-icon.with("\u{f0e2}")
+#let fa-arrow-rotate-right = fa-icon.with("\u{f01e}", solid: true)
+#let fa-arrow-right-rotate = fa-icon.with("\u{f01e}")
+#let fa-arrow-rotate-forward = fa-icon.with("\u{f01e}")
+#let fa-redo = fa-icon.with("\u{f01e}")
+#let fa-arrow-trend-down = fa-icon.with("\u{e097}", solid: true)
+#let fa-arrow-trend-up = fa-icon.with("\u{e098}", solid: true)
+#let fa-arrow-turn-down = fa-icon.with("\u{f149}", solid: true)
+#let fa-level-down = fa-icon.with("\u{f149}")
+#let fa-arrow-turn-up = fa-icon.with("\u{f148}", solid: true)
+#let fa-level-up = fa-icon.with("\u{f148}")
+#let fa-arrow-up = fa-icon.with("\u{f062}", solid: true)
+#let fa-arrow-up-1-9 = fa-icon.with("\u{f163}", solid: true)
+#let fa-sort-numeric-up = fa-icon.with("\u{f163}")
+#let fa-arrow-up-9-1 = fa-icon.with("\u{f887}", solid: true)
+#let fa-sort-numeric-up-alt = fa-icon.with("\u{f887}")
+#let fa-arrow-up-a-z = fa-icon.with("\u{f15e}", solid: true)
+#let fa-sort-alpha-up = fa-icon.with("\u{f15e}")
+#let fa-arrow-up-from-bracket = fa-icon.with("\u{e09a}", solid: true)
+#let fa-arrow-up-from-ground-water = fa-icon.with("\u{e4b5}", solid: true)
+#let fa-arrow-up-from-water-pump = fa-icon.with("\u{e4b6}", solid: true)
+#let fa-arrow-up-long = fa-icon.with("\u{f176}", solid: true)
+#let fa-long-arrow-up = fa-icon.with("\u{f176}")
+#let fa-arrow-up-right-dots = fa-icon.with("\u{e4b7}", solid: true)
+#let fa-arrow-up-right-from-square = fa-icon.with("\u{f08e}", solid: true)
+#let fa-external-link = fa-icon.with("\u{f08e}")
+#let fa-arrow-up-short-wide = fa-icon.with("\u{f885}", solid: true)
+#let fa-sort-amount-up-alt = fa-icon.with("\u{f885}")
+#let fa-arrow-up-wide-short = fa-icon.with("\u{f161}", solid: true)
+#let fa-sort-amount-up = fa-icon.with("\u{f161}")
+#let fa-arrow-up-z-a = fa-icon.with("\u{f882}", solid: true)
+#let fa-sort-alpha-up-alt = fa-icon.with("\u{f882}")
+#let fa-arrows-down-to-line = fa-icon.with("\u{e4b8}", solid: true)
+#let fa-arrows-down-to-people = fa-icon.with("\u{e4b9}", solid: true)
+#let fa-arrows-left-right = fa-icon.with("\u{f07e}", solid: true)
+#let fa-arrows-h = fa-icon.with("\u{f07e}")
+#let fa-arrows-left-right-to-line = fa-icon.with("\u{e4ba}", solid: true)
+#let fa-arrows-rotate = fa-icon.with("\u{f021}", solid: true)
+#let fa-refresh = fa-icon.with("\u{f021}")
+#let fa-sync = fa-icon.with("\u{f021}")
+#let fa-arrows-spin = fa-icon.with("\u{e4bb}", solid: true)
+#let fa-arrows-split-up-and-left = fa-icon.with("\u{e4bc}", solid: true)
+#let fa-arrows-to-circle = fa-icon.with("\u{e4bd}", solid: true)
+#let fa-arrows-to-dot = fa-icon.with("\u{e4be}", solid: true)
+#let fa-arrows-to-eye = fa-icon.with("\u{e4bf}", solid: true)
+#let fa-arrows-turn-right = fa-icon.with("\u{e4c0}", solid: true)
+#let fa-arrows-turn-to-dots = fa-icon.with("\u{e4c1}", solid: true)
+#let fa-arrows-up-down = fa-icon.with("\u{f07d}", solid: true)
+#let fa-arrows-v = fa-icon.with("\u{f07d}")
+#let fa-arrows-up-down-left-right = fa-icon.with("\u{f047}", solid: true)
+#let fa-arrows = fa-icon.with("\u{f047}")
+#let fa-arrows-up-to-line = fa-icon.with("\u{e4c2}", solid: true)
+#let fa-artstation = fa-icon.with("\u{f77a}")
+#let fa-asterisk = fa-icon.with("\u{2a}", solid: true)
+#let fa-asymmetrik = fa-icon.with("\u{f372}")
+#let fa-at = fa-icon.with("\u{40}", solid: true)
+#let fa-atlassian = fa-icon.with("\u{f77b}")
+#let fa-atom = fa-icon.with("\u{f5d2}", solid: true)
+#let fa-audible = fa-icon.with("\u{f373}")
+#let fa-audio-description = fa-icon.with("\u{f29e}", solid: true)
+#let fa-austral-sign = fa-icon.with("\u{e0a9}", solid: true)
+#let fa-autoprefixer = fa-icon.with("\u{f41c}")
+#let fa-avianex = fa-icon.with("\u{f374}")
+#let fa-aviato = fa-icon.with("\u{f421}")
+#let fa-award = fa-icon.with("\u{f559}", solid: true)
+#let fa-aws = fa-icon.with("\u{f375}")
+#let fa-b = fa-icon.with("\u{42}", solid: true)
+#let fa-baby = fa-icon.with("\u{f77c}", solid: true)
+#let fa-baby-carriage = fa-icon.with("\u{f77d}", solid: true)
+#let fa-carriage-baby = fa-icon.with("\u{f77d}")
+#let fa-backward = fa-icon.with("\u{f04a}", solid: true)
+#let fa-backward-fast = fa-icon.with("\u{f049}", solid: true)
+#let fa-fast-backward = fa-icon.with("\u{f049}")
+#let fa-backward-step = fa-icon.with("\u{f048}", solid: true)
+#let fa-step-backward = fa-icon.with("\u{f048}")
+#let fa-bacon = fa-icon.with("\u{f7e5}", solid: true)
+#let fa-bacteria = fa-icon.with("\u{e059}", solid: true)
+#let fa-bacterium = fa-icon.with("\u{e05a}", solid: true)
+#let fa-bag-shopping = fa-icon.with("\u{f290}", solid: true)
+#let fa-shopping-bag = fa-icon.with("\u{f290}")
+#let fa-bahai = fa-icon.with("\u{f666}", solid: true)
+#let fa-haykal = fa-icon.with("\u{f666}")
+#let fa-baht-sign = fa-icon.with("\u{e0ac}", solid: true)
+#let fa-ban = fa-icon.with("\u{f05e}", solid: true)
+#let fa-cancel = fa-icon.with("\u{f05e}")
+#let fa-ban-smoking = fa-icon.with("\u{f54d}", solid: true)
+#let fa-smoking-ban = fa-icon.with("\u{f54d}")
+#let fa-bandage = fa-icon.with("\u{f462}", solid: true)
+#let fa-band-aid = fa-icon.with("\u{f462}")
+#let fa-bandcamp = fa-icon.with("\u{f2d5}")
+#let fa-bangladeshi-taka-sign = fa-icon.with("\u{e2e6}", solid: true)
+#let fa-barcode = fa-icon.with("\u{f02a}", solid: true)
+#let fa-bars = fa-icon.with("\u{f0c9}", solid: true)
+#let fa-navicon = fa-icon.with("\u{f0c9}")
+#let fa-bars-progress = fa-icon.with("\u{f828}", solid: true)
+#let fa-tasks-alt = fa-icon.with("\u{f828}")
+#let fa-bars-staggered = fa-icon.with("\u{f550}", solid: true)
+#let fa-reorder = fa-icon.with("\u{f550}")
+#let fa-stream = fa-icon.with("\u{f550}")
+#let fa-baseball = fa-icon.with("\u{f433}", solid: true)
+#let fa-baseball-ball = fa-icon.with("\u{f433}")
+#let fa-baseball-bat-ball = fa-icon.with("\u{f432}", solid: true)
+#let fa-basket-shopping = fa-icon.with("\u{f291}", solid: true)
+#let fa-shopping-basket = fa-icon.with("\u{f291}")
+#let fa-basketball = fa-icon.with("\u{f434}", solid: true)
+#let fa-basketball-ball = fa-icon.with("\u{f434}")
+#let fa-bath = fa-icon.with("\u{f2cd}", solid: true)
+#let fa-bathtub = fa-icon.with("\u{f2cd}")
+#let fa-battery-empty = fa-icon.with("\u{f244}", solid: true)
+#let fa-battery-0 = fa-icon.with("\u{f244}")
+#let fa-battery-full = fa-icon.with("\u{f240}", solid: true)
+#let fa-battery = fa-icon.with("\u{f240}")
+#let fa-battery-5 = fa-icon.with("\u{f240}")
+#let fa-battery-half = fa-icon.with("\u{f242}", solid: true)
+#let fa-battery-3 = fa-icon.with("\u{f242}")
+#let fa-battery-quarter = fa-icon.with("\u{f243}", solid: true)
+#let fa-battery-2 = fa-icon.with("\u{f243}")
+#let fa-battery-three-quarters = fa-icon.with("\u{f241}", solid: true)
+#let fa-battery-4 = fa-icon.with("\u{f241}")
+#let fa-battle-net = fa-icon.with("\u{f835}")
+#let fa-bed = fa-icon.with("\u{f236}", solid: true)
+#let fa-bed-pulse = fa-icon.with("\u{f487}", solid: true)
+#let fa-procedures = fa-icon.with("\u{f487}")
+#let fa-beer-mug-empty = fa-icon.with("\u{f0fc}", solid: true)
+#let fa-beer = fa-icon.with("\u{f0fc}")
+#let fa-behance = fa-icon.with("\u{f1b4}")
+#let fa-bell = fa-icon.with("\u{f0f3}")
+#let fa-bell-concierge = fa-icon.with("\u{f562}", solid: true)
+#let fa-concierge-bell = fa-icon.with("\u{f562}")
+#let fa-bell-slash = fa-icon.with("\u{f1f6}")
+#let fa-bezier-curve = fa-icon.with("\u{f55b}", solid: true)
+#let fa-bicycle = fa-icon.with("\u{f206}", solid: true)
+#let fa-bilibili = fa-icon.with("\u{e3d9}")
+#let fa-bimobject = fa-icon.with("\u{f378}")
+#let fa-binoculars = fa-icon.with("\u{f1e5}", solid: true)
+#let fa-biohazard = fa-icon.with("\u{f780}", solid: true)
+#let fa-bitbucket = fa-icon.with("\u{f171}")
+#let fa-bitcoin = fa-icon.with("\u{f379}")
+#let fa-bitcoin-sign = fa-icon.with("\u{e0b4}", solid: true)
+#let fa-bity = fa-icon.with("\u{f37a}")
+#let fa-black-tie = fa-icon.with("\u{f27e}")
+#let fa-blackberry = fa-icon.with("\u{f37b}")
+#let fa-blender = fa-icon.with("\u{f517}", solid: true)
+#let fa-blender-phone = fa-icon.with("\u{f6b6}", solid: true)
+#let fa-blog = fa-icon.with("\u{f781}", solid: true)
+#let fa-blogger = fa-icon.with("\u{f37c}")
+#let fa-blogger-b = fa-icon.with("\u{f37d}")
+#let fa-bluesky = fa-icon.with("\u{e671}")
+#let fa-bluetooth = fa-icon.with("\u{f293}")
+#let fa-bluetooth-b = fa-icon.with("\u{f294}")
+#let fa-bold = fa-icon.with("\u{f032}", solid: true)
+#let fa-bolt = fa-icon.with("\u{f0e7}", solid: true)
+#let fa-zap = fa-icon.with("\u{f0e7}")
+#let fa-bolt-lightning = fa-icon.with("\u{e0b7}", solid: true)
+#let fa-bomb = fa-icon.with("\u{f1e2}", solid: true)
+#let fa-bone = fa-icon.with("\u{f5d7}", solid: true)
+#let fa-bong = fa-icon.with("\u{f55c}", solid: true)
+#let fa-book = fa-icon.with("\u{f02d}", solid: true)
+#let fa-book-atlas = fa-icon.with("\u{f558}", solid: true)
+#let fa-atlas = fa-icon.with("\u{f558}")
+#let fa-book-bible = fa-icon.with("\u{f647}", solid: true)
+#let fa-bible = fa-icon.with("\u{f647}")
+#let fa-book-bookmark = fa-icon.with("\u{e0bb}", solid: true)
+#let fa-book-journal-whills = fa-icon.with("\u{f66a}", solid: true)
+#let fa-journal-whills = fa-icon.with("\u{f66a}")
+#let fa-book-medical = fa-icon.with("\u{f7e6}", solid: true)
+#let fa-book-open = fa-icon.with("\u{f518}", solid: true)
+#let fa-book-open-reader = fa-icon.with("\u{f5da}", solid: true)
+#let fa-book-reader = fa-icon.with("\u{f5da}")
+#let fa-book-quran = fa-icon.with("\u{f687}", solid: true)
+#let fa-quran = fa-icon.with("\u{f687}")
+#let fa-book-skull = fa-icon.with("\u{f6b7}", solid: true)
+#let fa-book-dead = fa-icon.with("\u{f6b7}")
+#let fa-book-tanakh = fa-icon.with("\u{f827}", solid: true)
+#let fa-tanakh = fa-icon.with("\u{f827}")
+#let fa-bookmark = fa-icon.with("\u{f02e}")
+#let fa-bootstrap = fa-icon.with("\u{f836}")
+#let fa-border-all = fa-icon.with("\u{f84c}", solid: true)
+#let fa-border-none = fa-icon.with("\u{f850}", solid: true)
+#let fa-border-top-left = fa-icon.with("\u{f853}", solid: true)
+#let fa-border-style = fa-icon.with("\u{f853}")
+#let fa-bore-hole = fa-icon.with("\u{e4c3}", solid: true)
+#let fa-bots = fa-icon.with("\u{e340}")
+#let fa-bottle-droplet = fa-icon.with("\u{e4c4}", solid: true)
+#let fa-bottle-water = fa-icon.with("\u{e4c5}", solid: true)
+#let fa-bowl-food = fa-icon.with("\u{e4c6}", solid: true)
+#let fa-bowl-rice = fa-icon.with("\u{e2eb}", solid: true)
+#let fa-bowling-ball = fa-icon.with("\u{f436}", solid: true)
+#let fa-box = fa-icon.with("\u{f466}", solid: true)
+#let fa-box-archive = fa-icon.with("\u{f187}", solid: true)
+#let fa-archive = fa-icon.with("\u{f187}")
+#let fa-box-open = fa-icon.with("\u{f49e}", solid: true)
+#let fa-box-tissue = fa-icon.with("\u{e05b}", solid: true)
+#let fa-boxes-packing = fa-icon.with("\u{e4c7}", solid: true)
+#let fa-boxes-stacked = fa-icon.with("\u{f468}", solid: true)
+#let fa-boxes = fa-icon.with("\u{f468}")
+#let fa-boxes-alt = fa-icon.with("\u{f468}")
+#let fa-braille = fa-icon.with("\u{f2a1}", solid: true)
+#let fa-brain = fa-icon.with("\u{f5dc}", solid: true)
+#let fa-brave = fa-icon.with("\u{e63c}")
+#let fa-brave-reverse = fa-icon.with("\u{e63d}")
+#let fa-brazilian-real-sign = fa-icon.with("\u{e46c}", solid: true)
+#let fa-bread-slice = fa-icon.with("\u{f7ec}", solid: true)
+#let fa-bridge = fa-icon.with("\u{e4c8}", solid: true)
+#let fa-bridge-circle-check = fa-icon.with("\u{e4c9}", solid: true)
+#let fa-bridge-circle-exclamation = fa-icon.with("\u{e4ca}", solid: true)
+#let fa-bridge-circle-xmark = fa-icon.with("\u{e4cb}", solid: true)
+#let fa-bridge-lock = fa-icon.with("\u{e4cc}", solid: true)
+#let fa-bridge-water = fa-icon.with("\u{e4ce}", solid: true)
+#let fa-briefcase = fa-icon.with("\u{f0b1}", solid: true)
+#let fa-briefcase-medical = fa-icon.with("\u{f469}", solid: true)
+#let fa-broom = fa-icon.with("\u{f51a}", solid: true)
+#let fa-broom-ball = fa-icon.with("\u{f458}", solid: true)
+#let fa-quidditch = fa-icon.with("\u{f458}")
+#let fa-quidditch-broom-ball = fa-icon.with("\u{f458}")
+#let fa-brush = fa-icon.with("\u{f55d}", solid: true)
+#let fa-btc = fa-icon.with("\u{f15a}")
+#let fa-bucket = fa-icon.with("\u{e4cf}", solid: true)
+#let fa-buffer = fa-icon.with("\u{f837}")
+#let fa-bug = fa-icon.with("\u{f188}", solid: true)
+#let fa-bug-slash = fa-icon.with("\u{e490}", solid: true)
+#let fa-bugs = fa-icon.with("\u{e4d0}", solid: true)
+#let fa-building = fa-icon.with("\u{f1ad}")
+#let fa-building-circle-arrow-right = fa-icon.with("\u{e4d1}", solid: true)
+#let fa-building-circle-check = fa-icon.with("\u{e4d2}", solid: true)
+#let fa-building-circle-exclamation = fa-icon.with("\u{e4d3}", solid: true)
+#let fa-building-circle-xmark = fa-icon.with("\u{e4d4}", solid: true)
+#let fa-building-columns = fa-icon.with("\u{f19c}", solid: true)
+#let fa-bank = fa-icon.with("\u{f19c}")
+#let fa-institution = fa-icon.with("\u{f19c}")
+#let fa-museum = fa-icon.with("\u{f19c}")
+#let fa-university = fa-icon.with("\u{f19c}")
+#let fa-building-flag = fa-icon.with("\u{e4d5}", solid: true)
+#let fa-building-lock = fa-icon.with("\u{e4d6}", solid: true)
+#let fa-building-ngo = fa-icon.with("\u{e4d7}", solid: true)
+#let fa-building-shield = fa-icon.with("\u{e4d8}", solid: true)
+#let fa-building-un = fa-icon.with("\u{e4d9}", solid: true)
+#let fa-building-user = fa-icon.with("\u{e4da}", solid: true)
+#let fa-building-wheat = fa-icon.with("\u{e4db}", solid: true)
+#let fa-bullhorn = fa-icon.with("\u{f0a1}", solid: true)
+#let fa-bullseye = fa-icon.with("\u{f140}", solid: true)
+#let fa-burger = fa-icon.with("\u{f805}", solid: true)
+#let fa-hamburger = fa-icon.with("\u{f805}")
+#let fa-buromobelexperte = fa-icon.with("\u{f37f}")
+#let fa-burst = fa-icon.with("\u{e4dc}", solid: true)
+#let fa-bus = fa-icon.with("\u{f207}", solid: true)
+#let fa-bus-simple = fa-icon.with("\u{f55e}", solid: true)
+#let fa-bus-alt = fa-icon.with("\u{f55e}")
+#let fa-business-time = fa-icon.with("\u{f64a}", solid: true)
+#let fa-briefcase-clock = fa-icon.with("\u{f64a}")
+#let fa-buy-n-large = fa-icon.with("\u{f8a6}")
+#let fa-buysellads = fa-icon.with("\u{f20d}")
+#let fa-c = fa-icon.with("\u{43}", solid: true)
+#let fa-cable-car = fa-icon.with("\u{f7da}", solid: true)
+#let fa-tram = fa-icon.with("\u{f7da}")
+#let fa-cake-candles = fa-icon.with("\u{f1fd}", solid: true)
+#let fa-birthday-cake = fa-icon.with("\u{f1fd}")
+#let fa-cake = fa-icon.with("\u{f1fd}")
+#let fa-calculator = fa-icon.with("\u{f1ec}", solid: true)
+#let fa-calendar = fa-icon.with("\u{f133}")
+#let fa-calendar-check = fa-icon.with("\u{f274}")
+#let fa-calendar-day = fa-icon.with("\u{f783}", solid: true)
+#let fa-calendar-days = fa-icon.with("\u{f073}")
+#let fa-calendar-alt = fa-icon.with("\u{f073}")
+#let fa-calendar-minus = fa-icon.with("\u{f272}")
+#let fa-calendar-plus = fa-icon.with("\u{f271}")
+#let fa-calendar-week = fa-icon.with("\u{f784}", solid: true)
+#let fa-calendar-xmark = fa-icon.with("\u{f273}")
+#let fa-calendar-times = fa-icon.with("\u{f273}")
+#let fa-camera = fa-icon.with("\u{f030}", solid: true)
+#let fa-camera-alt = fa-icon.with("\u{f030}")
+#let fa-camera-retro = fa-icon.with("\u{f083}", solid: true)
+#let fa-camera-rotate = fa-icon.with("\u{e0d8}", solid: true)
+#let fa-campground = fa-icon.with("\u{f6bb}", solid: true)
+#let fa-canadian-maple-leaf = fa-icon.with("\u{f785}")
+#let fa-candy-cane = fa-icon.with("\u{f786}", solid: true)
+#let fa-cannabis = fa-icon.with("\u{f55f}", solid: true)
+#let fa-capsules = fa-icon.with("\u{f46b}", solid: true)
+#let fa-car = fa-icon.with("\u{f1b9}", solid: true)
+#let fa-automobile = fa-icon.with("\u{f1b9}")
+#let fa-car-battery = fa-icon.with("\u{f5df}", solid: true)
+#let fa-battery-car = fa-icon.with("\u{f5df}")
+#let fa-car-burst = fa-icon.with("\u{f5e1}", solid: true)
+#let fa-car-crash = fa-icon.with("\u{f5e1}")
+#let fa-car-on = fa-icon.with("\u{e4dd}", solid: true)
+#let fa-car-rear = fa-icon.with("\u{f5de}", solid: true)
+#let fa-car-alt = fa-icon.with("\u{f5de}")
+#let fa-car-side = fa-icon.with("\u{f5e4}", solid: true)
+#let fa-car-tunnel = fa-icon.with("\u{e4de}", solid: true)
+#let fa-caravan = fa-icon.with("\u{f8ff}", solid: true)
+#let fa-caret-down = fa-icon.with("\u{f0d7}", solid: true)
+#let fa-caret-left = fa-icon.with("\u{f0d9}", solid: true)
+#let fa-caret-right = fa-icon.with("\u{f0da}", solid: true)
+#let fa-caret-up = fa-icon.with("\u{f0d8}", solid: true)
+#let fa-carrot = fa-icon.with("\u{f787}", solid: true)
+#let fa-cart-arrow-down = fa-icon.with("\u{f218}", solid: true)
+#let fa-cart-flatbed = fa-icon.with("\u{f474}", solid: true)
+#let fa-dolly-flatbed = fa-icon.with("\u{f474}")
+#let fa-cart-flatbed-suitcase = fa-icon.with("\u{f59d}", solid: true)
+#let fa-luggage-cart = fa-icon.with("\u{f59d}")
+#let fa-cart-plus = fa-icon.with("\u{f217}", solid: true)
+#let fa-cart-shopping = fa-icon.with("\u{f07a}", solid: true)
+#let fa-shopping-cart = fa-icon.with("\u{f07a}")
+#let fa-cash-register = fa-icon.with("\u{f788}", solid: true)
+#let fa-cat = fa-icon.with("\u{f6be}", solid: true)
+#let fa-cc-amazon-pay = fa-icon.with("\u{f42d}")
+#let fa-cc-amex = fa-icon.with("\u{f1f3}")
+#let fa-cc-apple-pay = fa-icon.with("\u{f416}")
+#let fa-cc-diners-club = fa-icon.with("\u{f24c}")
+#let fa-cc-discover = fa-icon.with("\u{f1f2}")
+#let fa-cc-jcb = fa-icon.with("\u{f24b}")
+#let fa-cc-mastercard = fa-icon.with("\u{f1f1}")
+#let fa-cc-paypal = fa-icon.with("\u{f1f4}")
+#let fa-cc-stripe = fa-icon.with("\u{f1f5}")
+#let fa-cc-visa = fa-icon.with("\u{f1f0}")
+#let fa-cedi-sign = fa-icon.with("\u{e0df}", solid: true)
+#let fa-cent-sign = fa-icon.with("\u{e3f5}", solid: true)
+#let fa-centercode = fa-icon.with("\u{f380}")
+#let fa-centos = fa-icon.with("\u{f789}")
+#let fa-certificate = fa-icon.with("\u{f0a3}", solid: true)
+#let fa-chair = fa-icon.with("\u{f6c0}", solid: true)
+#let fa-chalkboard = fa-icon.with("\u{f51b}", solid: true)
+#let fa-blackboard = fa-icon.with("\u{f51b}")
+#let fa-chalkboard-user = fa-icon.with("\u{f51c}", solid: true)
+#let fa-chalkboard-teacher = fa-icon.with("\u{f51c}")
+#let fa-champagne-glasses = fa-icon.with("\u{f79f}", solid: true)
+#let fa-glass-cheers = fa-icon.with("\u{f79f}")
+#let fa-charging-station = fa-icon.with("\u{f5e7}", solid: true)
+#let fa-chart-area = fa-icon.with("\u{f1fe}", solid: true)
+#let fa-area-chart = fa-icon.with("\u{f1fe}")
+#let fa-chart-bar = fa-icon.with("\u{f080}")
+#let fa-bar-chart = fa-icon.with("\u{f080}")
+#let fa-chart-column = fa-icon.with("\u{e0e3}", solid: true)
+#let fa-chart-gantt = fa-icon.with("\u{e0e4}", solid: true)
+#let fa-chart-line = fa-icon.with("\u{f201}", solid: true)
+#let fa-line-chart = fa-icon.with("\u{f201}")
+#let fa-chart-pie = fa-icon.with("\u{f200}", solid: true)
+#let fa-pie-chart = fa-icon.with("\u{f200}")
+#let fa-chart-simple = fa-icon.with("\u{e473}", solid: true)
+#let fa-check = fa-icon.with("\u{f00c}", solid: true)
+#let fa-check-double = fa-icon.with("\u{f560}", solid: true)
+#let fa-check-to-slot = fa-icon.with("\u{f772}", solid: true)
+#let fa-vote-yea = fa-icon.with("\u{f772}")
+#let fa-cheese = fa-icon.with("\u{f7ef}", solid: true)
+#let fa-chess = fa-icon.with("\u{f439}", solid: true)
+#let fa-chess-bishop = fa-icon.with("\u{f43a}")
+#let fa-chess-board = fa-icon.with("\u{f43c}", solid: true)
+#let fa-chess-king = fa-icon.with("\u{f43f}")
+#let fa-chess-knight = fa-icon.with("\u{f441}")
+#let fa-chess-pawn = fa-icon.with("\u{f443}")
+#let fa-chess-queen = fa-icon.with("\u{f445}")
+#let fa-chess-rook = fa-icon.with("\u{f447}")
+#let fa-chevron-down = fa-icon.with("\u{f078}", solid: true)
+#let fa-chevron-left = fa-icon.with("\u{f053}", solid: true)
+#let fa-chevron-right = fa-icon.with("\u{f054}", solid: true)
+#let fa-chevron-up = fa-icon.with("\u{f077}", solid: true)
+#let fa-child = fa-icon.with("\u{f1ae}", solid: true)
+#let fa-child-combatant = fa-icon.with("\u{e4e0}", solid: true)
+#let fa-child-rifle = fa-icon.with("\u{e4e0}")
+#let fa-child-dress = fa-icon.with("\u{e59c}", solid: true)
+#let fa-child-reaching = fa-icon.with("\u{e59d}", solid: true)
+#let fa-children = fa-icon.with("\u{e4e1}", solid: true)
+#let fa-chrome = fa-icon.with("\u{f268}")
+#let fa-chromecast = fa-icon.with("\u{f838}")
+#let fa-church = fa-icon.with("\u{f51d}", solid: true)
+#let fa-circle = fa-icon.with("\u{f111}")
+#let fa-circle-arrow-down = fa-icon.with("\u{f0ab}", solid: true)
+#let fa-arrow-circle-down = fa-icon.with("\u{f0ab}")
+#let fa-circle-arrow-left = fa-icon.with("\u{f0a8}", solid: true)
+#let fa-arrow-circle-left = fa-icon.with("\u{f0a8}")
+#let fa-circle-arrow-right = fa-icon.with("\u{f0a9}", solid: true)
+#let fa-arrow-circle-right = fa-icon.with("\u{f0a9}")
+#let fa-circle-arrow-up = fa-icon.with("\u{f0aa}", solid: true)
+#let fa-arrow-circle-up = fa-icon.with("\u{f0aa}")
+#let fa-circle-check = fa-icon.with("\u{f058}")
+#let fa-check-circle = fa-icon.with("\u{f058}")
+#let fa-circle-chevron-down = fa-icon.with("\u{f13a}", solid: true)
+#let fa-chevron-circle-down = fa-icon.with("\u{f13a}")
+#let fa-circle-chevron-left = fa-icon.with("\u{f137}", solid: true)
+#let fa-chevron-circle-left = fa-icon.with("\u{f137}")
+#let fa-circle-chevron-right = fa-icon.with("\u{f138}", solid: true)
+#let fa-chevron-circle-right = fa-icon.with("\u{f138}")
+#let fa-circle-chevron-up = fa-icon.with("\u{f139}", solid: true)
+#let fa-chevron-circle-up = fa-icon.with("\u{f139}")
+#let fa-circle-dollar-to-slot = fa-icon.with("\u{f4b9}", solid: true)
+#let fa-donate = fa-icon.with("\u{f4b9}")
+#let fa-circle-dot = fa-icon.with("\u{f192}")
+#let fa-dot-circle = fa-icon.with("\u{f192}")
+#let fa-circle-down = fa-icon.with("\u{f358}")
+#let fa-arrow-alt-circle-down = fa-icon.with("\u{f358}")
+#let fa-circle-exclamation = fa-icon.with("\u{f06a}", solid: true)
+#let fa-exclamation-circle = fa-icon.with("\u{f06a}")
+#let fa-circle-h = fa-icon.with("\u{f47e}", solid: true)
+#let fa-hospital-symbol = fa-icon.with("\u{f47e}")
+#let fa-circle-half-stroke = fa-icon.with("\u{f042}", solid: true)
+#let fa-adjust = fa-icon.with("\u{f042}")
+#let fa-circle-info = fa-icon.with("\u{f05a}", solid: true)
+#let fa-info-circle = fa-icon.with("\u{f05a}")
+#let fa-circle-left = fa-icon.with("\u{f359}")
+#let fa-arrow-alt-circle-left = fa-icon.with("\u{f359}")
+#let fa-circle-minus = fa-icon.with("\u{f056}", solid: true)
+#let fa-minus-circle = fa-icon.with("\u{f056}")
+#let fa-circle-nodes = fa-icon.with("\u{e4e2}", solid: true)
+#let fa-circle-notch = fa-icon.with("\u{f1ce}", solid: true)
+#let fa-circle-pause = fa-icon.with("\u{f28b}")
+#let fa-pause-circle = fa-icon.with("\u{f28b}")
+#let fa-circle-play = fa-icon.with("\u{f144}")
+#let fa-play-circle = fa-icon.with("\u{f144}")
+#let fa-circle-plus = fa-icon.with("\u{f055}", solid: true)
+#let fa-plus-circle = fa-icon.with("\u{f055}")
+#let fa-circle-question = fa-icon.with("\u{f059}")
+#let fa-question-circle = fa-icon.with("\u{f059}")
+#let fa-circle-radiation = fa-icon.with("\u{f7ba}", solid: true)
+#let fa-radiation-alt = fa-icon.with("\u{f7ba}")
+#let fa-circle-right = fa-icon.with("\u{f35a}")
+#let fa-arrow-alt-circle-right = fa-icon.with("\u{f35a}")
+#let fa-circle-stop = fa-icon.with("\u{f28d}")
+#let fa-stop-circle = fa-icon.with("\u{f28d}")
+#let fa-circle-up = fa-icon.with("\u{f35b}")
+#let fa-arrow-alt-circle-up = fa-icon.with("\u{f35b}")
+#let fa-circle-user = fa-icon.with("\u{f2bd}")
+#let fa-user-circle = fa-icon.with("\u{f2bd}")
+#let fa-circle-xmark = fa-icon.with("\u{f057}")
+#let fa-times-circle = fa-icon.with("\u{f057}")
+#let fa-xmark-circle = fa-icon.with("\u{f057}")
+#let fa-city = fa-icon.with("\u{f64f}", solid: true)
+#let fa-clapperboard = fa-icon.with("\u{e131}", solid: true)
+#let fa-clipboard = fa-icon.with("\u{f328}")
+#let fa-clipboard-check = fa-icon.with("\u{f46c}", solid: true)
+#let fa-clipboard-list = fa-icon.with("\u{f46d}", solid: true)
+#let fa-clipboard-question = fa-icon.with("\u{e4e3}", solid: true)
+#let fa-clipboard-user = fa-icon.with("\u{f7f3}", solid: true)
+#let fa-clock = fa-icon.with("\u{f017}")
+#let fa-clock-four = fa-icon.with("\u{f017}")
+#let fa-clock-rotate-left = fa-icon.with("\u{f1da}", solid: true)
+#let fa-history = fa-icon.with("\u{f1da}")
+#let fa-clone = fa-icon.with("\u{f24d}")
+#let fa-closed-captioning = fa-icon.with("\u{f20a}")
+#let fa-cloud = fa-icon.with("\u{f0c2}", solid: true)
+#let fa-cloud-arrow-down = fa-icon.with("\u{f0ed}", solid: true)
+#let fa-cloud-download = fa-icon.with("\u{f0ed}")
+#let fa-cloud-download-alt = fa-icon.with("\u{f0ed}")
+#let fa-cloud-arrow-up = fa-icon.with("\u{f0ee}", solid: true)
+#let fa-cloud-upload = fa-icon.with("\u{f0ee}")
+#let fa-cloud-upload-alt = fa-icon.with("\u{f0ee}")
+#let fa-cloud-bolt = fa-icon.with("\u{f76c}", solid: true)
+#let fa-thunderstorm = fa-icon.with("\u{f76c}")
+#let fa-cloud-meatball = fa-icon.with("\u{f73b}", solid: true)
+#let fa-cloud-moon = fa-icon.with("\u{f6c3}", solid: true)
+#let fa-cloud-moon-rain = fa-icon.with("\u{f73c}", solid: true)
+#let fa-cloud-rain = fa-icon.with("\u{f73d}", solid: true)
+#let fa-cloud-showers-heavy = fa-icon.with("\u{f740}", solid: true)
+#let fa-cloud-showers-water = fa-icon.with("\u{e4e4}", solid: true)
+#let fa-cloud-sun = fa-icon.with("\u{f6c4}", solid: true)
+#let fa-cloud-sun-rain = fa-icon.with("\u{f743}", solid: true)
+#let fa-cloudflare = fa-icon.with("\u{e07d}")
+#let fa-cloudscale = fa-icon.with("\u{f383}")
+#let fa-cloudsmith = fa-icon.with("\u{f384}")
+#let fa-cloudversify = fa-icon.with("\u{f385}")
+#let fa-clover = fa-icon.with("\u{e139}", solid: true)
+#let fa-cmplid = fa-icon.with("\u{e360}")
+#let fa-code = fa-icon.with("\u{f121}", solid: true)
+#let fa-code-branch = fa-icon.with("\u{f126}", solid: true)
+#let fa-code-commit = fa-icon.with("\u{f386}", solid: true)
+#let fa-code-compare = fa-icon.with("\u{e13a}", solid: true)
+#let fa-code-fork = fa-icon.with("\u{e13b}", solid: true)
+#let fa-code-merge = fa-icon.with("\u{f387}", solid: true)
+#let fa-code-pull-request = fa-icon.with("\u{e13c}", solid: true)
+#let fa-codepen = fa-icon.with("\u{f1cb}")
+#let fa-codiepie = fa-icon.with("\u{f284}")
+#let fa-coins = fa-icon.with("\u{f51e}", solid: true)
+#let fa-colon-sign = fa-icon.with("\u{e140}", solid: true)
+#let fa-comment = fa-icon.with("\u{f075}")
+#let fa-comment-dollar = fa-icon.with("\u{f651}", solid: true)
+#let fa-comment-dots = fa-icon.with("\u{f4ad}")
+#let fa-commenting = fa-icon.with("\u{f4ad}")
+#let fa-comment-medical = fa-icon.with("\u{f7f5}", solid: true)
+#let fa-comment-slash = fa-icon.with("\u{f4b3}", solid: true)
+#let fa-comment-sms = fa-icon.with("\u{f7cd}", solid: true)
+#let fa-sms = fa-icon.with("\u{f7cd}")
+#let fa-comments = fa-icon.with("\u{f086}")
+#let fa-comments-dollar = fa-icon.with("\u{f653}", solid: true)
+#let fa-compact-disc = fa-icon.with("\u{f51f}", solid: true)
+#let fa-compass = fa-icon.with("\u{f14e}")
+#let fa-compass-drafting = fa-icon.with("\u{f568}", solid: true)
+#let fa-drafting-compass = fa-icon.with("\u{f568}")
+#let fa-compress = fa-icon.with("\u{f066}", solid: true)
+#let fa-computer = fa-icon.with("\u{e4e5}", solid: true)
+#let fa-computer-mouse = fa-icon.with("\u{f8cc}", solid: true)
+#let fa-mouse = fa-icon.with("\u{f8cc}")
+#let fa-confluence = fa-icon.with("\u{f78d}")
+#let fa-connectdevelop = fa-icon.with("\u{f20e}")
+#let fa-contao = fa-icon.with("\u{f26d}")
+#let fa-cookie = fa-icon.with("\u{f563}", solid: true)
+#let fa-cookie-bite = fa-icon.with("\u{f564}", solid: true)
+#let fa-copy = fa-icon.with("\u{f0c5}")
+#let fa-copyright = fa-icon.with("\u{f1f9}")
+#let fa-cotton-bureau = fa-icon.with("\u{f89e}")
+#let fa-couch = fa-icon.with("\u{f4b8}", solid: true)
+#let fa-cow = fa-icon.with("\u{f6c8}", solid: true)
+#let fa-cpanel = fa-icon.with("\u{f388}")
+#let fa-creative-commons = fa-icon.with("\u{f25e}")
+#let fa-creative-commons-by = fa-icon.with("\u{f4e7}")
+#let fa-creative-commons-nc = fa-icon.with("\u{f4e8}")
+#let fa-creative-commons-nc-eu = fa-icon.with("\u{f4e9}")
+#let fa-creative-commons-nc-jp = fa-icon.with("\u{f4ea}")
+#let fa-creative-commons-nd = fa-icon.with("\u{f4eb}")
+#let fa-creative-commons-pd = fa-icon.with("\u{f4ec}")
+#let fa-creative-commons-pd-alt = fa-icon.with("\u{f4ed}")
+#let fa-creative-commons-remix = fa-icon.with("\u{f4ee}")
+#let fa-creative-commons-sa = fa-icon.with("\u{f4ef}")
+#let fa-creative-commons-sampling = fa-icon.with("\u{f4f0}")
+#let fa-creative-commons-sampling-plus = fa-icon.with("\u{f4f1}")
+#let fa-creative-commons-share = fa-icon.with("\u{f4f2}")
+#let fa-creative-commons-zero = fa-icon.with("\u{f4f3}")
+#let fa-credit-card = fa-icon.with("\u{f09d}")
+#let fa-credit-card-alt = fa-icon.with("\u{f09d}")
+#let fa-critical-role = fa-icon.with("\u{f6c9}")
+#let fa-crop = fa-icon.with("\u{f125}", solid: true)
+#let fa-crop-simple = fa-icon.with("\u{f565}", solid: true)
+#let fa-crop-alt = fa-icon.with("\u{f565}")
+#let fa-cross = fa-icon.with("\u{f654}", solid: true)
+#let fa-crosshairs = fa-icon.with("\u{f05b}", solid: true)
+#let fa-crow = fa-icon.with("\u{f520}", solid: true)
+#let fa-crown = fa-icon.with("\u{f521}", solid: true)
+#let fa-crutch = fa-icon.with("\u{f7f7}", solid: true)
+#let fa-cruzeiro-sign = fa-icon.with("\u{e152}", solid: true)
+#let fa-css3 = fa-icon.with("\u{f13c}")
+#let fa-css3-alt = fa-icon.with("\u{f38b}")
+#let fa-cube = fa-icon.with("\u{f1b2}", solid: true)
+#let fa-cubes = fa-icon.with("\u{f1b3}", solid: true)
+#let fa-cubes-stacked = fa-icon.with("\u{e4e6}", solid: true)
+#let fa-cuttlefish = fa-icon.with("\u{f38c}")
+#let fa-d = fa-icon.with("\u{44}", solid: true)
+#let fa-d-and-d = fa-icon.with("\u{f38d}")
+#let fa-d-and-d-beyond = fa-icon.with("\u{f6ca}")
+#let fa-dailymotion = fa-icon.with("\u{e052}")
+#let fa-dashcube = fa-icon.with("\u{f210}")
+#let fa-database = fa-icon.with("\u{f1c0}", solid: true)
+#let fa-debian = fa-icon.with("\u{e60b}")
+#let fa-deezer = fa-icon.with("\u{e077}")
+#let fa-delete-left = fa-icon.with("\u{f55a}", solid: true)
+#let fa-backspace = fa-icon.with("\u{f55a}")
+#let fa-delicious = fa-icon.with("\u{f1a5}")
+#let fa-democrat = fa-icon.with("\u{f747}", solid: true)
+#let fa-deploydog = fa-icon.with("\u{f38e}")
+#let fa-deskpro = fa-icon.with("\u{f38f}")
+#let fa-desktop = fa-icon.with("\u{f390}", solid: true)
+#let fa-desktop-alt = fa-icon.with("\u{f390}")
+#let fa-dev = fa-icon.with("\u{f6cc}")
+#let fa-deviantart = fa-icon.with("\u{f1bd}")
+#let fa-dharmachakra = fa-icon.with("\u{f655}", solid: true)
+#let fa-dhl = fa-icon.with("\u{f790}")
+#let fa-diagram-next = fa-icon.with("\u{e476}", solid: true)
+#let fa-diagram-predecessor = fa-icon.with("\u{e477}", solid: true)
+#let fa-diagram-project = fa-icon.with("\u{f542}", solid: true)
+#let fa-project-diagram = fa-icon.with("\u{f542}")
+#let fa-diagram-successor = fa-icon.with("\u{e47a}", solid: true)
+#let fa-diamond = fa-icon.with("\u{f219}", solid: true)
+#let fa-diamond-turn-right = fa-icon.with("\u{f5eb}", solid: true)
+#let fa-directions = fa-icon.with("\u{f5eb}")
+#let fa-diaspora = fa-icon.with("\u{f791}")
+#let fa-dice = fa-icon.with("\u{f522}", solid: true)
+#let fa-dice-d20 = fa-icon.with("\u{f6cf}", solid: true)
+#let fa-dice-d6 = fa-icon.with("\u{f6d1}", solid: true)
+#let fa-dice-five = fa-icon.with("\u{f523}", solid: true)
+#let fa-dice-four = fa-icon.with("\u{f524}", solid: true)
+#let fa-dice-one = fa-icon.with("\u{f525}", solid: true)
+#let fa-dice-six = fa-icon.with("\u{f526}", solid: true)
+#let fa-dice-three = fa-icon.with("\u{f527}", solid: true)
+#let fa-dice-two = fa-icon.with("\u{f528}", solid: true)
+#let fa-digg = fa-icon.with("\u{f1a6}")
+#let fa-digital-ocean = fa-icon.with("\u{f391}")
+#let fa-discord = fa-icon.with("\u{f392}")
+#let fa-discourse = fa-icon.with("\u{f393}")
+#let fa-disease = fa-icon.with("\u{f7fa}", solid: true)
+#let fa-display = fa-icon.with("\u{e163}", solid: true)
+#let fa-divide = fa-icon.with("\u{f529}", solid: true)
+#let fa-dna = fa-icon.with("\u{f471}", solid: true)
+#let fa-dochub = fa-icon.with("\u{f394}")
+#let fa-docker = fa-icon.with("\u{f395}")
+#let fa-dog = fa-icon.with("\u{f6d3}", solid: true)
+#let fa-dollar-sign = fa-icon.with("\u{24}", solid: true)
+#let fa-dollar = fa-icon.with("\u{24}")
+#let fa-usd = fa-icon.with("\u{24}")
+#let fa-dolly = fa-icon.with("\u{f472}", solid: true)
+#let fa-dolly-box = fa-icon.with("\u{f472}")
+#let fa-dong-sign = fa-icon.with("\u{e169}", solid: true)
+#let fa-door-closed = fa-icon.with("\u{f52a}", solid: true)
+#let fa-door-open = fa-icon.with("\u{f52b}", solid: true)
+#let fa-dove = fa-icon.with("\u{f4ba}", solid: true)
+#let fa-down-left-and-up-right-to-center = fa-icon.with("\u{f422}", solid: true)
+#let fa-compress-alt = fa-icon.with("\u{f422}")
+#let fa-down-long = fa-icon.with("\u{f309}", solid: true)
+#let fa-long-arrow-alt-down = fa-icon.with("\u{f309}")
+#let fa-download = fa-icon.with("\u{f019}", solid: true)
+#let fa-draft2digital = fa-icon.with("\u{f396}")
+#let fa-dragon = fa-icon.with("\u{f6d5}", solid: true)
+#let fa-draw-polygon = fa-icon.with("\u{f5ee}", solid: true)
+#let fa-dribbble = fa-icon.with("\u{f17d}")
+#let fa-dropbox = fa-icon.with("\u{f16b}")
+#let fa-droplet = fa-icon.with("\u{f043}", solid: true)
+#let fa-tint = fa-icon.with("\u{f043}")
+#let fa-droplet-slash = fa-icon.with("\u{f5c7}", solid: true)
+#let fa-tint-slash = fa-icon.with("\u{f5c7}")
+#let fa-drum = fa-icon.with("\u{f569}", solid: true)
+#let fa-drum-steelpan = fa-icon.with("\u{f56a}", solid: true)
+#let fa-drumstick-bite = fa-icon.with("\u{f6d7}", solid: true)
+#let fa-drupal = fa-icon.with("\u{f1a9}")
+#let fa-dumbbell = fa-icon.with("\u{f44b}", solid: true)
+#let fa-dumpster = fa-icon.with("\u{f793}", solid: true)
+#let fa-dumpster-fire = fa-icon.with("\u{f794}", solid: true)
+#let fa-dungeon = fa-icon.with("\u{f6d9}", solid: true)
+#let fa-dyalog = fa-icon.with("\u{f399}")
+#let fa-e = fa-icon.with("\u{45}", solid: true)
+#let fa-ear-deaf = fa-icon.with("\u{f2a4}", solid: true)
+#let fa-deaf = fa-icon.with("\u{f2a4}")
+#let fa-deafness = fa-icon.with("\u{f2a4}")
+#let fa-hard-of-hearing = fa-icon.with("\u{f2a4}")
+#let fa-ear-listen = fa-icon.with("\u{f2a2}", solid: true)
+#let fa-assistive-listening-systems = fa-icon.with("\u{f2a2}")
+#let fa-earlybirds = fa-icon.with("\u{f39a}")
+#let fa-earth-africa = fa-icon.with("\u{f57c}", solid: true)
+#let fa-globe-africa = fa-icon.with("\u{f57c}")
+#let fa-earth-americas = fa-icon.with("\u{f57d}", solid: true)
+#let fa-earth = fa-icon.with("\u{f57d}")
+#let fa-earth-america = fa-icon.with("\u{f57d}")
+#let fa-globe-americas = fa-icon.with("\u{f57d}")
+#let fa-earth-asia = fa-icon.with("\u{f57e}", solid: true)
+#let fa-globe-asia = fa-icon.with("\u{f57e}")
+#let fa-earth-europe = fa-icon.with("\u{f7a2}", solid: true)
+#let fa-globe-europe = fa-icon.with("\u{f7a2}")
+#let fa-earth-oceania = fa-icon.with("\u{e47b}", solid: true)
+#let fa-globe-oceania = fa-icon.with("\u{e47b}")
+#let fa-ebay = fa-icon.with("\u{f4f4}")
+#let fa-edge = fa-icon.with("\u{f282}")
+#let fa-edge-legacy = fa-icon.with("\u{e078}")
+#let fa-egg = fa-icon.with("\u{f7fb}", solid: true)
+#let fa-eject = fa-icon.with("\u{f052}", solid: true)
+#let fa-elementor = fa-icon.with("\u{f430}")
+#let fa-elevator = fa-icon.with("\u{e16d}", solid: true)
+#let fa-ellipsis = fa-icon.with("\u{f141}", solid: true)
+#let fa-ellipsis-h = fa-icon.with("\u{f141}")
+#let fa-ellipsis-vertical = fa-icon.with("\u{f142}", solid: true)
+#let fa-ellipsis-v = fa-icon.with("\u{f142}")
+#let fa-ello = fa-icon.with("\u{f5f1}")
+#let fa-ember = fa-icon.with("\u{f423}")
+#let fa-empire = fa-icon.with("\u{f1d1}")
+#let fa-envelope = fa-icon.with("\u{f0e0}")
+#let fa-envelope-circle-check = fa-icon.with("\u{e4e8}", solid: true)
+#let fa-envelope-open = fa-icon.with("\u{f2b6}")
+#let fa-envelope-open-text = fa-icon.with("\u{f658}", solid: true)
+#let fa-envelopes-bulk = fa-icon.with("\u{f674}", solid: true)
+#let fa-mail-bulk = fa-icon.with("\u{f674}")
+#let fa-envira = fa-icon.with("\u{f299}")
+#let fa-equals = fa-icon.with("\u{3d}", solid: true)
+#let fa-eraser = fa-icon.with("\u{f12d}", solid: true)
+#let fa-erlang = fa-icon.with("\u{f39d}")
+#let fa-ethereum = fa-icon.with("\u{f42e}")
+#let fa-ethernet = fa-icon.with("\u{f796}", solid: true)
+#let fa-etsy = fa-icon.with("\u{f2d7}")
+#let fa-euro-sign = fa-icon.with("\u{f153}", solid: true)
+#let fa-eur = fa-icon.with("\u{f153}")
+#let fa-euro = fa-icon.with("\u{f153}")
+#let fa-evernote = fa-icon.with("\u{f839}")
+#let fa-exclamation = fa-icon.with("\u{21}", solid: true)
+#let fa-expand = fa-icon.with("\u{f065}", solid: true)
+#let fa-expeditedssl = fa-icon.with("\u{f23e}")
+#let fa-explosion = fa-icon.with("\u{e4e9}", solid: true)
+#let fa-eye = fa-icon.with("\u{f06e}")
+#let fa-eye-dropper = fa-icon.with("\u{f1fb}", solid: true)
+#let fa-eye-dropper-empty = fa-icon.with("\u{f1fb}")
+#let fa-eyedropper = fa-icon.with("\u{f1fb}")
+#let fa-eye-low-vision = fa-icon.with("\u{f2a8}", solid: true)
+#let fa-low-vision = fa-icon.with("\u{f2a8}")
+#let fa-eye-slash = fa-icon.with("\u{f070}")
+#let fa-f = fa-icon.with("\u{46}", solid: true)
+#let fa-face-angry = fa-icon.with("\u{f556}")
+#let fa-angry = fa-icon.with("\u{f556}")
+#let fa-face-dizzy = fa-icon.with("\u{f567}")
+#let fa-dizzy = fa-icon.with("\u{f567}")
+#let fa-face-flushed = fa-icon.with("\u{f579}")
+#let fa-flushed = fa-icon.with("\u{f579}")
+#let fa-face-frown = fa-icon.with("\u{f119}")
+#let fa-frown = fa-icon.with("\u{f119}")
+#let fa-face-frown-open = fa-icon.with("\u{f57a}")
+#let fa-frown-open = fa-icon.with("\u{f57a}")
+#let fa-face-grimace = fa-icon.with("\u{f57f}")
+#let fa-grimace = fa-icon.with("\u{f57f}")
+#let fa-face-grin = fa-icon.with("\u{f580}")
+#let fa-grin = fa-icon.with("\u{f580}")
+#let fa-face-grin-beam = fa-icon.with("\u{f582}")
+#let fa-grin-beam = fa-icon.with("\u{f582}")
+#let fa-face-grin-beam-sweat = fa-icon.with("\u{f583}")
+#let fa-grin-beam-sweat = fa-icon.with("\u{f583}")
+#let fa-face-grin-hearts = fa-icon.with("\u{f584}")
+#let fa-grin-hearts = fa-icon.with("\u{f584}")
+#let fa-face-grin-squint = fa-icon.with("\u{f585}")
+#let fa-grin-squint = fa-icon.with("\u{f585}")
+#let fa-face-grin-squint-tears = fa-icon.with("\u{f586}")
+#let fa-grin-squint-tears = fa-icon.with("\u{f586}")
+#let fa-face-grin-stars = fa-icon.with("\u{f587}")
+#let fa-grin-stars = fa-icon.with("\u{f587}")
+#let fa-face-grin-tears = fa-icon.with("\u{f588}")
+#let fa-grin-tears = fa-icon.with("\u{f588}")
+#let fa-face-grin-tongue = fa-icon.with("\u{f589}")
+#let fa-grin-tongue = fa-icon.with("\u{f589}")
+#let fa-face-grin-tongue-squint = fa-icon.with("\u{f58a}")
+#let fa-grin-tongue-squint = fa-icon.with("\u{f58a}")
+#let fa-face-grin-tongue-wink = fa-icon.with("\u{f58b}")
+#let fa-grin-tongue-wink = fa-icon.with("\u{f58b}")
+#let fa-face-grin-wide = fa-icon.with("\u{f581}")
+#let fa-grin-alt = fa-icon.with("\u{f581}")
+#let fa-face-grin-wink = fa-icon.with("\u{f58c}")
+#let fa-grin-wink = fa-icon.with("\u{f58c}")
+#let fa-face-kiss = fa-icon.with("\u{f596}")
+#let fa-kiss = fa-icon.with("\u{f596}")
+#let fa-face-kiss-beam = fa-icon.with("\u{f597}")
+#let fa-kiss-beam = fa-icon.with("\u{f597}")
+#let fa-face-kiss-wink-heart = fa-icon.with("\u{f598}")
+#let fa-kiss-wink-heart = fa-icon.with("\u{f598}")
+#let fa-face-laugh = fa-icon.with("\u{f599}")
+#let fa-laugh = fa-icon.with("\u{f599}")
+#let fa-face-laugh-beam = fa-icon.with("\u{f59a}")
+#let fa-laugh-beam = fa-icon.with("\u{f59a}")
+#let fa-face-laugh-squint = fa-icon.with("\u{f59b}")
+#let fa-laugh-squint = fa-icon.with("\u{f59b}")
+#let fa-face-laugh-wink = fa-icon.with("\u{f59c}")
+#let fa-laugh-wink = fa-icon.with("\u{f59c}")
+#let fa-face-meh = fa-icon.with("\u{f11a}")
+#let fa-meh = fa-icon.with("\u{f11a}")
+#let fa-face-meh-blank = fa-icon.with("\u{f5a4}")
+#let fa-meh-blank = fa-icon.with("\u{f5a4}")
+#let fa-face-rolling-eyes = fa-icon.with("\u{f5a5}")
+#let fa-meh-rolling-eyes = fa-icon.with("\u{f5a5}")
+#let fa-face-sad-cry = fa-icon.with("\u{f5b3}")
+#let fa-sad-cry = fa-icon.with("\u{f5b3}")
+#let fa-face-sad-tear = fa-icon.with("\u{f5b4}")
+#let fa-sad-tear = fa-icon.with("\u{f5b4}")
+#let fa-face-smile = fa-icon.with("\u{f118}")
+#let fa-smile = fa-icon.with("\u{f118}")
+#let fa-face-smile-beam = fa-icon.with("\u{f5b8}")
+#let fa-smile-beam = fa-icon.with("\u{f5b8}")
+#let fa-face-smile-wink = fa-icon.with("\u{f4da}")
+#let fa-smile-wink = fa-icon.with("\u{f4da}")
+#let fa-face-surprise = fa-icon.with("\u{f5c2}")
+#let fa-surprise = fa-icon.with("\u{f5c2}")
+#let fa-face-tired = fa-icon.with("\u{f5c8}")
+#let fa-tired = fa-icon.with("\u{f5c8}")
+#let fa-facebook = fa-icon.with("\u{f09a}")
+#let fa-facebook-f = fa-icon.with("\u{f39e}")
+#let fa-facebook-messenger = fa-icon.with("\u{f39f}")
+#let fa-fan = fa-icon.with("\u{f863}", solid: true)
+#let fa-fantasy-flight-games = fa-icon.with("\u{f6dc}")
+#let fa-faucet = fa-icon.with("\u{e005}", solid: true)
+#let fa-faucet-drip = fa-icon.with("\u{e006}", solid: true)
+#let fa-fax = fa-icon.with("\u{f1ac}", solid: true)
+#let fa-feather = fa-icon.with("\u{f52d}", solid: true)
+#let fa-feather-pointed = fa-icon.with("\u{f56b}", solid: true)
+#let fa-feather-alt = fa-icon.with("\u{f56b}")
+#let fa-fedex = fa-icon.with("\u{f797}")
+#let fa-fedora = fa-icon.with("\u{f798}")
+#let fa-ferry = fa-icon.with("\u{e4ea}", solid: true)
+#let fa-figma = fa-icon.with("\u{f799}")
+#let fa-file = fa-icon.with("\u{f15b}")
+#let fa-file-arrow-down = fa-icon.with("\u{f56d}", solid: true)
+#let fa-file-download = fa-icon.with("\u{f56d}")
+#let fa-file-arrow-up = fa-icon.with("\u{f574}", solid: true)
+#let fa-file-upload = fa-icon.with("\u{f574}")
+#let fa-file-audio = fa-icon.with("\u{f1c7}")
+#let fa-file-circle-check = fa-icon.with("\u{e5a0}", solid: true)
+#let fa-file-circle-exclamation = fa-icon.with("\u{e4eb}", solid: true)
+#let fa-file-circle-minus = fa-icon.with("\u{e4ed}", solid: true)
+#let fa-file-circle-plus = fa-icon.with("\u{e494}", solid: true)
+#let fa-file-circle-question = fa-icon.with("\u{e4ef}", solid: true)
+#let fa-file-circle-xmark = fa-icon.with("\u{e5a1}", solid: true)
+#let fa-file-code = fa-icon.with("\u{f1c9}")
+#let fa-file-contract = fa-icon.with("\u{f56c}", solid: true)
+#let fa-file-csv = fa-icon.with("\u{f6dd}", solid: true)
+#let fa-file-excel = fa-icon.with("\u{f1c3}")
+#let fa-file-export = fa-icon.with("\u{f56e}", solid: true)
+#let fa-arrow-right-from-file = fa-icon.with("\u{f56e}")
+#let fa-file-image = fa-icon.with("\u{f1c5}")
+#let fa-file-import = fa-icon.with("\u{f56f}", solid: true)
+#let fa-arrow-right-to-file = fa-icon.with("\u{f56f}")
+#let fa-file-invoice = fa-icon.with("\u{f570}", solid: true)
+#let fa-file-invoice-dollar = fa-icon.with("\u{f571}", solid: true)
+#let fa-file-lines = fa-icon.with("\u{f15c}")
+#let fa-file-alt = fa-icon.with("\u{f15c}")
+#let fa-file-text = fa-icon.with("\u{f15c}")
+#let fa-file-medical = fa-icon.with("\u{f477}", solid: true)
+#let fa-file-pdf = fa-icon.with("\u{f1c1}")
+#let fa-file-pen = fa-icon.with("\u{f31c}", solid: true)
+#let fa-file-edit = fa-icon.with("\u{f31c}")
+#let fa-file-powerpoint = fa-icon.with("\u{f1c4}")
+#let fa-file-prescription = fa-icon.with("\u{f572}", solid: true)
+#let fa-file-shield = fa-icon.with("\u{e4f0}", solid: true)
+#let fa-file-signature = fa-icon.with("\u{f573}", solid: true)
+#let fa-file-video = fa-icon.with("\u{f1c8}")
+#let fa-file-waveform = fa-icon.with("\u{f478}", solid: true)
+#let fa-file-medical-alt = fa-icon.with("\u{f478}")
+#let fa-file-word = fa-icon.with("\u{f1c2}")
+#let fa-file-zipper = fa-icon.with("\u{f1c6}")
+#let fa-file-archive = fa-icon.with("\u{f1c6}")
+#let fa-fill = fa-icon.with("\u{f575}", solid: true)
+#let fa-fill-drip = fa-icon.with("\u{f576}", solid: true)
+#let fa-film = fa-icon.with("\u{f008}", solid: true)
+#let fa-filter = fa-icon.with("\u{f0b0}", solid: true)
+#let fa-filter-circle-dollar = fa-icon.with("\u{f662}", solid: true)
+#let fa-funnel-dollar = fa-icon.with("\u{f662}")
+#let fa-filter-circle-xmark = fa-icon.with("\u{e17b}", solid: true)
+#let fa-fingerprint = fa-icon.with("\u{f577}", solid: true)
+#let fa-fire = fa-icon.with("\u{f06d}", solid: true)
+#let fa-fire-burner = fa-icon.with("\u{e4f1}", solid: true)
+#let fa-fire-extinguisher = fa-icon.with("\u{f134}", solid: true)
+#let fa-fire-flame-curved = fa-icon.with("\u{f7e4}", solid: true)
+#let fa-fire-alt = fa-icon.with("\u{f7e4}")
+#let fa-fire-flame-simple = fa-icon.with("\u{f46a}", solid: true)
+#let fa-burn = fa-icon.with("\u{f46a}")
+#let fa-firefox = fa-icon.with("\u{f269}")
+#let fa-firefox-browser = fa-icon.with("\u{e007}")
+#let fa-first-order = fa-icon.with("\u{f2b0}")
+#let fa-first-order-alt = fa-icon.with("\u{f50a}")
+#let fa-firstdraft = fa-icon.with("\u{f3a1}")
+#let fa-fish = fa-icon.with("\u{f578}", solid: true)
+#let fa-fish-fins = fa-icon.with("\u{e4f2}", solid: true)
+#let fa-flag = fa-icon.with("\u{f024}")
+#let fa-flag-checkered = fa-icon.with("\u{f11e}", solid: true)
+#let fa-flag-usa = fa-icon.with("\u{f74d}", solid: true)
+#let fa-flask = fa-icon.with("\u{f0c3}", solid: true)
+#let fa-flask-vial = fa-icon.with("\u{e4f3}", solid: true)
+#let fa-flickr = fa-icon.with("\u{f16e}")
+#let fa-flipboard = fa-icon.with("\u{f44d}")
+#let fa-floppy-disk = fa-icon.with("\u{f0c7}")
+#let fa-save = fa-icon.with("\u{f0c7}")
+#let fa-florin-sign = fa-icon.with("\u{e184}", solid: true)
+#let fa-fly = fa-icon.with("\u{f417}")
+#let fa-folder = fa-icon.with("\u{f07b}")
+#let fa-folder-blank = fa-icon.with("\u{f07b}")
+#let fa-folder-closed = fa-icon.with("\u{e185}")
+#let fa-folder-minus = fa-icon.with("\u{f65d}", solid: true)
+#let fa-folder-open = fa-icon.with("\u{f07c}")
+#let fa-folder-plus = fa-icon.with("\u{f65e}", solid: true)
+#let fa-folder-tree = fa-icon.with("\u{f802}", solid: true)
+#let fa-font = fa-icon.with("\u{f031}", solid: true)
+#let fa-font-awesome = fa-icon.with("\u{f2b4}")
+#let fa-font-awesome-flag = fa-icon.with("\u{f2b4}")
+#let fa-font-awesome-logo-full = fa-icon.with("\u{f2b4}")
+#let fa-fonticons = fa-icon.with("\u{f280}")
+#let fa-fonticons-fi = fa-icon.with("\u{f3a2}")
+#let fa-football = fa-icon.with("\u{f44e}", solid: true)
+#let fa-football-ball = fa-icon.with("\u{f44e}")
+#let fa-fort-awesome = fa-icon.with("\u{f286}")
+#let fa-fort-awesome-alt = fa-icon.with("\u{f3a3}")
+#let fa-forumbee = fa-icon.with("\u{f211}")
+#let fa-forward = fa-icon.with("\u{f04e}", solid: true)
+#let fa-forward-fast = fa-icon.with("\u{f050}", solid: true)
+#let fa-fast-forward = fa-icon.with("\u{f050}")
+#let fa-forward-step = fa-icon.with("\u{f051}", solid: true)
+#let fa-step-forward = fa-icon.with("\u{f051}")
+#let fa-foursquare = fa-icon.with("\u{f180}")
+#let fa-franc-sign = fa-icon.with("\u{e18f}", solid: true)
+#let fa-free-code-camp = fa-icon.with("\u{f2c5}")
+#let fa-freebsd = fa-icon.with("\u{f3a4}")
+#let fa-frog = fa-icon.with("\u{f52e}", solid: true)
+#let fa-fulcrum = fa-icon.with("\u{f50b}")
+#let fa-futbol = fa-icon.with("\u{f1e3}")
+#let fa-futbol-ball = fa-icon.with("\u{f1e3}")
+#let fa-soccer-ball = fa-icon.with("\u{f1e3}")
+#let fa-g = fa-icon.with("\u{47}", solid: true)
+#let fa-galactic-republic = fa-icon.with("\u{f50c}")
+#let fa-galactic-senate = fa-icon.with("\u{f50d}")
+#let fa-gamepad = fa-icon.with("\u{f11b}", solid: true)
+#let fa-gas-pump = fa-icon.with("\u{f52f}", solid: true)
+#let fa-gauge = fa-icon.with("\u{f624}", solid: true)
+#let fa-dashboard = fa-icon.with("\u{f624}")
+#let fa-gauge-med = fa-icon.with("\u{f624}")
+#let fa-tachometer-alt-average = fa-icon.with("\u{f624}")
+#let fa-gauge-high = fa-icon.with("\u{f625}", solid: true)
+#let fa-tachometer-alt = fa-icon.with("\u{f625}")
+#let fa-tachometer-alt-fast = fa-icon.with("\u{f625}")
+#let fa-gauge-simple = fa-icon.with("\u{f629}", solid: true)
+#let fa-gauge-simple-med = fa-icon.with("\u{f629}")
+#let fa-tachometer-average = fa-icon.with("\u{f629}")
+#let fa-gauge-simple-high = fa-icon.with("\u{f62a}", solid: true)
+#let fa-tachometer = fa-icon.with("\u{f62a}")
+#let fa-tachometer-fast = fa-icon.with("\u{f62a}")
+#let fa-gavel = fa-icon.with("\u{f0e3}", solid: true)
+#let fa-legal = fa-icon.with("\u{f0e3}")
+#let fa-gear = fa-icon.with("\u{f013}", solid: true)
+#let fa-cog = fa-icon.with("\u{f013}")
+#let fa-gears = fa-icon.with("\u{f085}", solid: true)
+#let fa-cogs = fa-icon.with("\u{f085}")
+#let fa-gem = fa-icon.with("\u{f3a5}")
+#let fa-genderless = fa-icon.with("\u{f22d}", solid: true)
+#let fa-get-pocket = fa-icon.with("\u{f265}")
+#let fa-gg = fa-icon.with("\u{f260}")
+#let fa-gg-circle = fa-icon.with("\u{f261}")
+#let fa-ghost = fa-icon.with("\u{f6e2}", solid: true)
+#let fa-gift = fa-icon.with("\u{f06b}", solid: true)
+#let fa-gifts = fa-icon.with("\u{f79c}", solid: true)
+#let fa-git = fa-icon.with("\u{f1d3}")
+#let fa-git-alt = fa-icon.with("\u{f841}")
+#let fa-github = fa-icon.with("\u{f09b}")
+#let fa-github-alt = fa-icon.with("\u{f113}")
+#let fa-gitkraken = fa-icon.with("\u{f3a6}")
+#let fa-gitlab = fa-icon.with("\u{f296}")
+#let fa-gitter = fa-icon.with("\u{f426}")
+#let fa-glass-water = fa-icon.with("\u{e4f4}", solid: true)
+#let fa-glass-water-droplet = fa-icon.with("\u{e4f5}", solid: true)
+#let fa-glasses = fa-icon.with("\u{f530}", solid: true)
+#let fa-glide = fa-icon.with("\u{f2a5}")
+#let fa-glide-g = fa-icon.with("\u{f2a6}")
+#let fa-globe = fa-icon.with("\u{f0ac}", solid: true)
+#let fa-gofore = fa-icon.with("\u{f3a7}")
+#let fa-golang = fa-icon.with("\u{e40f}")
+#let fa-golf-ball-tee = fa-icon.with("\u{f450}", solid: true)
+#let fa-golf-ball = fa-icon.with("\u{f450}")
+#let fa-goodreads = fa-icon.with("\u{f3a8}")
+#let fa-goodreads-g = fa-icon.with("\u{f3a9}")
+#let fa-google = fa-icon.with("\u{f1a0}")
+#let fa-google-drive = fa-icon.with("\u{f3aa}")
+#let fa-google-pay = fa-icon.with("\u{e079}")
+#let fa-google-play = fa-icon.with("\u{f3ab}")
+#let fa-google-plus = fa-icon.with("\u{f2b3}")
+#let fa-google-plus-g = fa-icon.with("\u{f0d5}")
+#let fa-google-scholar = fa-icon.with("\u{e63b}")
+#let fa-google-wallet = fa-icon.with("\u{f1ee}")
+#let fa-gopuram = fa-icon.with("\u{f664}", solid: true)
+#let fa-graduation-cap = fa-icon.with("\u{f19d}", solid: true)
+#let fa-mortar-board = fa-icon.with("\u{f19d}")
+#let fa-gratipay = fa-icon.with("\u{f184}")
+#let fa-grav = fa-icon.with("\u{f2d6}")
+#let fa-greater-than = fa-icon.with("\u{3e}", solid: true)
+#let fa-greater-than-equal = fa-icon.with("\u{f532}", solid: true)
+#let fa-grip = fa-icon.with("\u{f58d}", solid: true)
+#let fa-grip-horizontal = fa-icon.with("\u{f58d}")
+#let fa-grip-lines = fa-icon.with("\u{f7a4}", solid: true)
+#let fa-grip-lines-vertical = fa-icon.with("\u{f7a5}", solid: true)
+#let fa-grip-vertical = fa-icon.with("\u{f58e}", solid: true)
+#let fa-gripfire = fa-icon.with("\u{f3ac}")
+#let fa-group-arrows-rotate = fa-icon.with("\u{e4f6}", solid: true)
+#let fa-grunt = fa-icon.with("\u{f3ad}")
+#let fa-guarani-sign = fa-icon.with("\u{e19a}", solid: true)
+#let fa-guilded = fa-icon.with("\u{e07e}")
+#let fa-guitar = fa-icon.with("\u{f7a6}", solid: true)
+#let fa-gulp = fa-icon.with("\u{f3ae}")
+#let fa-gun = fa-icon.with("\u{e19b}", solid: true)
+#let fa-h = fa-icon.with("\u{48}", solid: true)
+#let fa-hacker-news = fa-icon.with("\u{f1d4}")
+#let fa-hackerrank = fa-icon.with("\u{f5f7}")
+#let fa-hammer = fa-icon.with("\u{f6e3}", solid: true)
+#let fa-hamsa = fa-icon.with("\u{f665}", solid: true)
+#let fa-hand = fa-icon.with("\u{f256}")
+#let fa-hand-paper = fa-icon.with("\u{f256}")
+#let fa-hand-back-fist = fa-icon.with("\u{f255}")
+#let fa-hand-rock = fa-icon.with("\u{f255}")
+#let fa-hand-dots = fa-icon.with("\u{f461}", solid: true)
+#let fa-allergies = fa-icon.with("\u{f461}")
+#let fa-hand-fist = fa-icon.with("\u{f6de}", solid: true)
+#let fa-fist-raised = fa-icon.with("\u{f6de}")
+#let fa-hand-holding = fa-icon.with("\u{f4bd}", solid: true)
+#let fa-hand-holding-dollar = fa-icon.with("\u{f4c0}", solid: true)
+#let fa-hand-holding-usd = fa-icon.with("\u{f4c0}")
+#let fa-hand-holding-droplet = fa-icon.with("\u{f4c1}", solid: true)
+#let fa-hand-holding-water = fa-icon.with("\u{f4c1}")
+#let fa-hand-holding-hand = fa-icon.with("\u{e4f7}", solid: true)
+#let fa-hand-holding-heart = fa-icon.with("\u{f4be}", solid: true)
+#let fa-hand-holding-medical = fa-icon.with("\u{e05c}", solid: true)
+#let fa-hand-lizard = fa-icon.with("\u{f258}")
+#let fa-hand-middle-finger = fa-icon.with("\u{f806}", solid: true)
+#let fa-hand-peace = fa-icon.with("\u{f25b}")
+#let fa-hand-point-down = fa-icon.with("\u{f0a7}")
+#let fa-hand-point-left = fa-icon.with("\u{f0a5}")
+#let fa-hand-point-right = fa-icon.with("\u{f0a4}")
+#let fa-hand-point-up = fa-icon.with("\u{f0a6}")
+#let fa-hand-pointer = fa-icon.with("\u{f25a}")
+#let fa-hand-scissors = fa-icon.with("\u{f257}")
+#let fa-hand-sparkles = fa-icon.with("\u{e05d}", solid: true)
+#let fa-hand-spock = fa-icon.with("\u{f259}")
+#let fa-handcuffs = fa-icon.with("\u{e4f8}", solid: true)
+#let fa-hands = fa-icon.with("\u{f2a7}", solid: true)
+#let fa-sign-language = fa-icon.with("\u{f2a7}")
+#let fa-signing = fa-icon.with("\u{f2a7}")
+#let fa-hands-asl-interpreting = fa-icon.with("\u{f2a3}", solid: true)
+#let fa-american-sign-language-interpreting = fa-icon.with("\u{f2a3}")
+#let fa-asl-interpreting = fa-icon.with("\u{f2a3}")
+#let fa-hands-american-sign-language-interpreting = fa-icon.with("\u{f2a3}")
+#let fa-hands-bound = fa-icon.with("\u{e4f9}", solid: true)
+#let fa-hands-bubbles = fa-icon.with("\u{e05e}", solid: true)
+#let fa-hands-wash = fa-icon.with("\u{e05e}")
+#let fa-hands-clapping = fa-icon.with("\u{e1a8}", solid: true)
+#let fa-hands-holding = fa-icon.with("\u{f4c2}", solid: true)
+#let fa-hands-holding-child = fa-icon.with("\u{e4fa}", solid: true)
+#let fa-hands-holding-circle = fa-icon.with("\u{e4fb}", solid: true)
+#let fa-hands-praying = fa-icon.with("\u{f684}", solid: true)
+#let fa-praying-hands = fa-icon.with("\u{f684}")
+#let fa-handshake = fa-icon.with("\u{f2b5}")
+#let fa-handshake-angle = fa-icon.with("\u{f4c4}", solid: true)
+#let fa-hands-helping = fa-icon.with("\u{f4c4}")
+#let fa-handshake-simple = fa-icon.with("\u{f4c6}", solid: true)
+#let fa-handshake-alt = fa-icon.with("\u{f4c6}")
+#let fa-handshake-simple-slash = fa-icon.with("\u{e05f}", solid: true)
+#let fa-handshake-alt-slash = fa-icon.with("\u{e05f}")
+#let fa-handshake-slash = fa-icon.with("\u{e060}", solid: true)
+#let fa-hanukiah = fa-icon.with("\u{f6e6}", solid: true)
+#let fa-hard-drive = fa-icon.with("\u{f0a0}")
+#let fa-hdd = fa-icon.with("\u{f0a0}")
+#let fa-hashnode = fa-icon.with("\u{e499}")
+#let fa-hashtag = fa-icon.with("\u{23}", solid: true)
+#let fa-hat-cowboy = fa-icon.with("\u{f8c0}", solid: true)
+#let fa-hat-cowboy-side = fa-icon.with("\u{f8c1}", solid: true)
+#let fa-hat-wizard = fa-icon.with("\u{f6e8}", solid: true)
+#let fa-head-side-cough = fa-icon.with("\u{e061}", solid: true)
+#let fa-head-side-cough-slash = fa-icon.with("\u{e062}", solid: true)
+#let fa-head-side-mask = fa-icon.with("\u{e063}", solid: true)
+#let fa-head-side-virus = fa-icon.with("\u{e064}", solid: true)
+#let fa-heading = fa-icon.with("\u{f1dc}", solid: true)
+#let fa-header = fa-icon.with("\u{f1dc}")
+#let fa-headphones = fa-icon.with("\u{f025}", solid: true)
+#let fa-headphones-simple = fa-icon.with("\u{f58f}", solid: true)
+#let fa-headphones-alt = fa-icon.with("\u{f58f}")
+#let fa-headset = fa-icon.with("\u{f590}", solid: true)
+#let fa-heart = fa-icon.with("\u{f004}")
+#let fa-heart-circle-bolt = fa-icon.with("\u{e4fc}", solid: true)
+#let fa-heart-circle-check = fa-icon.with("\u{e4fd}", solid: true)
+#let fa-heart-circle-exclamation = fa-icon.with("\u{e4fe}", solid: true)
+#let fa-heart-circle-minus = fa-icon.with("\u{e4ff}", solid: true)
+#let fa-heart-circle-plus = fa-icon.with("\u{e500}", solid: true)
+#let fa-heart-circle-xmark = fa-icon.with("\u{e501}", solid: true)
+#let fa-heart-crack = fa-icon.with("\u{f7a9}", solid: true)
+#let fa-heart-broken = fa-icon.with("\u{f7a9}")
+#let fa-heart-pulse = fa-icon.with("\u{f21e}", solid: true)
+#let fa-heartbeat = fa-icon.with("\u{f21e}")
+#let fa-helicopter = fa-icon.with("\u{f533}", solid: true)
+#let fa-helicopter-symbol = fa-icon.with("\u{e502}", solid: true)
+#let fa-helmet-safety = fa-icon.with("\u{f807}", solid: true)
+#let fa-hard-hat = fa-icon.with("\u{f807}")
+#let fa-hat-hard = fa-icon.with("\u{f807}")
+#let fa-helmet-un = fa-icon.with("\u{e503}", solid: true)
+#let fa-highlighter = fa-icon.with("\u{f591}", solid: true)
+#let fa-hill-avalanche = fa-icon.with("\u{e507}", solid: true)
+#let fa-hill-rockslide = fa-icon.with("\u{e508}", solid: true)
+#let fa-hippo = fa-icon.with("\u{f6ed}", solid: true)
+#let fa-hips = fa-icon.with("\u{f452}")
+#let fa-hire-a-helper = fa-icon.with("\u{f3b0}")
+#let fa-hive = fa-icon.with("\u{e07f}")
+#let fa-hockey-puck = fa-icon.with("\u{f453}", solid: true)
+#let fa-holly-berry = fa-icon.with("\u{f7aa}", solid: true)
+#let fa-hooli = fa-icon.with("\u{f427}")
+#let fa-hornbill = fa-icon.with("\u{f592}")
+#let fa-horse = fa-icon.with("\u{f6f0}", solid: true)
+#let fa-horse-head = fa-icon.with("\u{f7ab}", solid: true)
+#let fa-hospital = fa-icon.with("\u{f0f8}")
+#let fa-hospital-alt = fa-icon.with("\u{f0f8}")
+#let fa-hospital-wide = fa-icon.with("\u{f0f8}")
+#let fa-hospital-user = fa-icon.with("\u{f80d}", solid: true)
+#let fa-hot-tub-person = fa-icon.with("\u{f593}", solid: true)
+#let fa-hot-tub = fa-icon.with("\u{f593}")
+#let fa-hotdog = fa-icon.with("\u{f80f}", solid: true)
+#let fa-hotel = fa-icon.with("\u{f594}", solid: true)
+#let fa-hotjar = fa-icon.with("\u{f3b1}")
+#let fa-hourglass = fa-icon.with("\u{f254}")
+#let fa-hourglass-empty = fa-icon.with("\u{f254}")
+#let fa-hourglass-end = fa-icon.with("\u{f253}", solid: true)
+#let fa-hourglass-3 = fa-icon.with("\u{f253}")
+#let fa-hourglass-half = fa-icon.with("\u{f252}")
+#let fa-hourglass-2 = fa-icon.with("\u{f252}")
+#let fa-hourglass-start = fa-icon.with("\u{f251}", solid: true)
+#let fa-hourglass-1 = fa-icon.with("\u{f251}")
+#let fa-house = fa-icon.with("\u{f015}", solid: true)
+#let fa-home = fa-icon.with("\u{f015}")
+#let fa-home-alt = fa-icon.with("\u{f015}")
+#let fa-home-lg-alt = fa-icon.with("\u{f015}")
+#let fa-house-chimney = fa-icon.with("\u{e3af}", solid: true)
+#let fa-home-lg = fa-icon.with("\u{e3af}")
+#let fa-house-chimney-crack = fa-icon.with("\u{f6f1}", solid: true)
+#let fa-house-damage = fa-icon.with("\u{f6f1}")
+#let fa-house-chimney-medical = fa-icon.with("\u{f7f2}", solid: true)
+#let fa-clinic-medical = fa-icon.with("\u{f7f2}")
+#let fa-house-chimney-user = fa-icon.with("\u{e065}", solid: true)
+#let fa-house-chimney-window = fa-icon.with("\u{e00d}", solid: true)
+#let fa-house-circle-check = fa-icon.with("\u{e509}", solid: true)
+#let fa-house-circle-exclamation = fa-icon.with("\u{e50a}", solid: true)
+#let fa-house-circle-xmark = fa-icon.with("\u{e50b}", solid: true)
+#let fa-house-crack = fa-icon.with("\u{e3b1}", solid: true)
+#let fa-house-fire = fa-icon.with("\u{e50c}", solid: true)
+#let fa-house-flag = fa-icon.with("\u{e50d}", solid: true)
+#let fa-house-flood-water = fa-icon.with("\u{e50e}", solid: true)
+#let fa-house-flood-water-circle-arrow-right = fa-icon.with("\u{e50f}", solid: true)
+#let fa-house-laptop = fa-icon.with("\u{e066}", solid: true)
+#let fa-laptop-house = fa-icon.with("\u{e066}")
+#let fa-house-lock = fa-icon.with("\u{e510}", solid: true)
+#let fa-house-medical = fa-icon.with("\u{e3b2}", solid: true)
+#let fa-house-medical-circle-check = fa-icon.with("\u{e511}", solid: true)
+#let fa-house-medical-circle-exclamation = fa-icon.with("\u{e512}", solid: true)
+#let fa-house-medical-circle-xmark = fa-icon.with("\u{e513}", solid: true)
+#let fa-house-medical-flag = fa-icon.with("\u{e514}", solid: true)
+#let fa-house-signal = fa-icon.with("\u{e012}", solid: true)
+#let fa-house-tsunami = fa-icon.with("\u{e515}", solid: true)
+#let fa-house-user = fa-icon.with("\u{e1b0}", solid: true)
+#let fa-home-user = fa-icon.with("\u{e1b0}")
+#let fa-houzz = fa-icon.with("\u{f27c}")
+#let fa-hryvnia-sign = fa-icon.with("\u{f6f2}", solid: true)
+#let fa-hryvnia = fa-icon.with("\u{f6f2}")
+#let fa-html5 = fa-icon.with("\u{f13b}")
+#let fa-hubspot = fa-icon.with("\u{f3b2}")
+#let fa-hurricane = fa-icon.with("\u{f751}", solid: true)
+#let fa-i = fa-icon.with("\u{49}", solid: true)
+#let fa-i-cursor = fa-icon.with("\u{f246}", solid: true)
+#let fa-ice-cream = fa-icon.with("\u{f810}", solid: true)
+#let fa-icicles = fa-icon.with("\u{f7ad}", solid: true)
+#let fa-icons = fa-icon.with("\u{f86d}", solid: true)
+#let fa-heart-music-camera-bolt = fa-icon.with("\u{f86d}")
+#let fa-id-badge = fa-icon.with("\u{f2c1}")
+#let fa-id-card = fa-icon.with("\u{f2c2}")
+#let fa-drivers-license = fa-icon.with("\u{f2c2}")
+#let fa-id-card-clip = fa-icon.with("\u{f47f}", solid: true)
+#let fa-id-card-alt = fa-icon.with("\u{f47f}")
+#let fa-ideal = fa-icon.with("\u{e013}")
+#let fa-igloo = fa-icon.with("\u{f7ae}", solid: true)
+#let fa-image = fa-icon.with("\u{f03e}")
+#let fa-image-portrait = fa-icon.with("\u{f3e0}", solid: true)
+#let fa-portrait = fa-icon.with("\u{f3e0}")
+#let fa-images = fa-icon.with("\u{f302}")
+#let fa-imdb = fa-icon.with("\u{f2d8}")
+#let fa-inbox = fa-icon.with("\u{f01c}", solid: true)
+#let fa-indent = fa-icon.with("\u{f03c}", solid: true)
+#let fa-indian-rupee-sign = fa-icon.with("\u{e1bc}", solid: true)
+#let fa-indian-rupee = fa-icon.with("\u{e1bc}")
+#let fa-inr = fa-icon.with("\u{e1bc}")
+#let fa-industry = fa-icon.with("\u{f275}", solid: true)
+#let fa-infinity = fa-icon.with("\u{f534}", solid: true)
+#let fa-info = fa-icon.with("\u{f129}", solid: true)
+#let fa-instagram = fa-icon.with("\u{f16d}")
+#let fa-instalod = fa-icon.with("\u{e081}")
+#let fa-intercom = fa-icon.with("\u{f7af}")
+#let fa-internet-explorer = fa-icon.with("\u{f26b}")
+#let fa-invision = fa-icon.with("\u{f7b0}")
+#let fa-ioxhost = fa-icon.with("\u{f208}")
+#let fa-italic = fa-icon.with("\u{f033}", solid: true)
+#let fa-itch-io = fa-icon.with("\u{f83a}")
+#let fa-itunes = fa-icon.with("\u{f3b4}")
+#let fa-itunes-note = fa-icon.with("\u{f3b5}")
+#let fa-j = fa-icon.with("\u{4a}", solid: true)
+#let fa-jar = fa-icon.with("\u{e516}", solid: true)
+#let fa-jar-wheat = fa-icon.with("\u{e517}", solid: true)
+#let fa-java = fa-icon.with("\u{f4e4}")
+#let fa-jedi = fa-icon.with("\u{f669}", solid: true)
+#let fa-jedi-order = fa-icon.with("\u{f50e}")
+#let fa-jenkins = fa-icon.with("\u{f3b6}")
+#let fa-jet-fighter = fa-icon.with("\u{f0fb}", solid: true)
+#let fa-fighter-jet = fa-icon.with("\u{f0fb}")
+#let fa-jet-fighter-up = fa-icon.with("\u{e518}", solid: true)
+#let fa-jira = fa-icon.with("\u{f7b1}")
+#let fa-joget = fa-icon.with("\u{f3b7}")
+#let fa-joint = fa-icon.with("\u{f595}", solid: true)
+#let fa-joomla = fa-icon.with("\u{f1aa}")
+#let fa-js = fa-icon.with("\u{f3b8}")
+#let fa-jsfiddle = fa-icon.with("\u{f1cc}")
+#let fa-jug-detergent = fa-icon.with("\u{e519}", solid: true)
+#let fa-jxl = fa-icon.with("\u{e67b}")
+#let fa-k = fa-icon.with("\u{4b}", solid: true)
+#let fa-kaaba = fa-icon.with("\u{f66b}", solid: true)
+#let fa-kaggle = fa-icon.with("\u{f5fa}")
+#let fa-key = fa-icon.with("\u{f084}", solid: true)
+#let fa-keybase = fa-icon.with("\u{f4f5}")
+#let fa-keyboard = fa-icon.with("\u{f11c}")
+#let fa-keycdn = fa-icon.with("\u{f3ba}")
+#let fa-khanda = fa-icon.with("\u{f66d}", solid: true)
+#let fa-kickstarter = fa-icon.with("\u{f3bb}")
+#let fa-square-kickstarter = fa-icon.with("\u{f3bb}")
+#let fa-kickstarter-k = fa-icon.with("\u{f3bc}")
+#let fa-kip-sign = fa-icon.with("\u{e1c4}", solid: true)
+#let fa-kit-medical = fa-icon.with("\u{f479}", solid: true)
+#let fa-first-aid = fa-icon.with("\u{f479}")
+#let fa-kitchen-set = fa-icon.with("\u{e51a}", solid: true)
+#let fa-kiwi-bird = fa-icon.with("\u{f535}", solid: true)
+#let fa-korvue = fa-icon.with("\u{f42f}")
+#let fa-l = fa-icon.with("\u{4c}", solid: true)
+#let fa-land-mine-on = fa-icon.with("\u{e51b}", solid: true)
+#let fa-landmark = fa-icon.with("\u{f66f}", solid: true)
+#let fa-landmark-dome = fa-icon.with("\u{f752}", solid: true)
+#let fa-landmark-alt = fa-icon.with("\u{f752}")
+#let fa-landmark-flag = fa-icon.with("\u{e51c}", solid: true)
+#let fa-language = fa-icon.with("\u{f1ab}", solid: true)
+#let fa-laptop = fa-icon.with("\u{f109}", solid: true)
+#let fa-laptop-code = fa-icon.with("\u{f5fc}", solid: true)
+#let fa-laptop-file = fa-icon.with("\u{e51d}", solid: true)
+#let fa-laptop-medical = fa-icon.with("\u{f812}", solid: true)
+#let fa-laravel = fa-icon.with("\u{f3bd}")
+#let fa-lari-sign = fa-icon.with("\u{e1c8}", solid: true)
+#let fa-lastfm = fa-icon.with("\u{f202}")
+#let fa-layer-group = fa-icon.with("\u{f5fd}", solid: true)
+#let fa-leaf = fa-icon.with("\u{f06c}", solid: true)
+#let fa-leanpub = fa-icon.with("\u{f212}")
+#let fa-left-long = fa-icon.with("\u{f30a}", solid: true)
+#let fa-long-arrow-alt-left = fa-icon.with("\u{f30a}")
+#let fa-left-right = fa-icon.with("\u{f337}", solid: true)
+#let fa-arrows-alt-h = fa-icon.with("\u{f337}")
+#let fa-lemon = fa-icon.with("\u{f094}")
+#let fa-less = fa-icon.with("\u{f41d}")
+#let fa-less-than = fa-icon.with("\u{3c}", solid: true)
+#let fa-less-than-equal = fa-icon.with("\u{f537}", solid: true)
+#let fa-letterboxd = fa-icon.with("\u{e62d}")
+#let fa-life-ring = fa-icon.with("\u{f1cd}")
+#let fa-lightbulb = fa-icon.with("\u{f0eb}")
+#let fa-line = fa-icon.with("\u{f3c0}")
+#let fa-lines-leaning = fa-icon.with("\u{e51e}", solid: true)
+#let fa-link = fa-icon.with("\u{f0c1}", solid: true)
+#let fa-chain = fa-icon.with("\u{f0c1}")
+#let fa-link-slash = fa-icon.with("\u{f127}", solid: true)
+#let fa-chain-broken = fa-icon.with("\u{f127}")
+#let fa-chain-slash = fa-icon.with("\u{f127}")
+#let fa-unlink = fa-icon.with("\u{f127}")
+#let fa-linkedin = fa-icon.with("\u{f08c}")
+#let fa-linkedin-in = fa-icon.with("\u{f0e1}")
+#let fa-linode = fa-icon.with("\u{f2b8}")
+#let fa-linux = fa-icon.with("\u{f17c}")
+#let fa-lira-sign = fa-icon.with("\u{f195}", solid: true)
+#let fa-list = fa-icon.with("\u{f03a}", solid: true)
+#let fa-list-squares = fa-icon.with("\u{f03a}")
+#let fa-list-check = fa-icon.with("\u{f0ae}", solid: true)
+#let fa-tasks = fa-icon.with("\u{f0ae}")
+#let fa-list-ol = fa-icon.with("\u{f0cb}", solid: true)
+#let fa-list-1-2 = fa-icon.with("\u{f0cb}")
+#let fa-list-numeric = fa-icon.with("\u{f0cb}")
+#let fa-list-ul = fa-icon.with("\u{f0ca}", solid: true)
+#let fa-list-dots = fa-icon.with("\u{f0ca}")
+#let fa-litecoin-sign = fa-icon.with("\u{e1d3}", solid: true)
+#let fa-location-arrow = fa-icon.with("\u{f124}", solid: true)
+#let fa-location-crosshairs = fa-icon.with("\u{f601}", solid: true)
+#let fa-location = fa-icon.with("\u{f601}")
+#let fa-location-dot = fa-icon.with("\u{f3c5}", solid: true)
+#let fa-map-marker-alt = fa-icon.with("\u{f3c5}")
+#let fa-location-pin = fa-icon.with("\u{f041}", solid: true)
+#let fa-map-marker = fa-icon.with("\u{f041}")
+#let fa-location-pin-lock = fa-icon.with("\u{e51f}", solid: true)
+#let fa-lock = fa-icon.with("\u{f023}", solid: true)
+#let fa-lock-open = fa-icon.with("\u{f3c1}", solid: true)
+#let fa-locust = fa-icon.with("\u{e520}", solid: true)
+#let fa-lungs = fa-icon.with("\u{f604}", solid: true)
+#let fa-lungs-virus = fa-icon.with("\u{e067}", solid: true)
+#let fa-lyft = fa-icon.with("\u{f3c3}")
+#let fa-m = fa-icon.with("\u{4d}", solid: true)
+#let fa-magento = fa-icon.with("\u{f3c4}")
+#let fa-magnet = fa-icon.with("\u{f076}", solid: true)
+#let fa-magnifying-glass = fa-icon.with("\u{f002}", solid: true)
+#let fa-search = fa-icon.with("\u{f002}")
+#let fa-magnifying-glass-arrow-right = fa-icon.with("\u{e521}", solid: true)
+#let fa-magnifying-glass-chart = fa-icon.with("\u{e522}", solid: true)
+#let fa-magnifying-glass-dollar = fa-icon.with("\u{f688}", solid: true)
+#let fa-search-dollar = fa-icon.with("\u{f688}")
+#let fa-magnifying-glass-location = fa-icon.with("\u{f689}", solid: true)
+#let fa-search-location = fa-icon.with("\u{f689}")
+#let fa-magnifying-glass-minus = fa-icon.with("\u{f010}", solid: true)
+#let fa-search-minus = fa-icon.with("\u{f010}")
+#let fa-magnifying-glass-plus = fa-icon.with("\u{f00e}", solid: true)
+#let fa-search-plus = fa-icon.with("\u{f00e}")
+#let fa-mailchimp = fa-icon.with("\u{f59e}")
+#let fa-manat-sign = fa-icon.with("\u{e1d5}", solid: true)
+#let fa-mandalorian = fa-icon.with("\u{f50f}")
+#let fa-map = fa-icon.with("\u{f279}")
+#let fa-map-location = fa-icon.with("\u{f59f}", solid: true)
+#let fa-map-marked = fa-icon.with("\u{f59f}")
+#let fa-map-location-dot = fa-icon.with("\u{f5a0}", solid: true)
+#let fa-map-marked-alt = fa-icon.with("\u{f5a0}")
+#let fa-map-pin = fa-icon.with("\u{f276}", solid: true)
+#let fa-markdown = fa-icon.with("\u{f60f}")
+#let fa-marker = fa-icon.with("\u{f5a1}", solid: true)
+#let fa-mars = fa-icon.with("\u{f222}", solid: true)
+#let fa-mars-and-venus = fa-icon.with("\u{f224}", solid: true)
+#let fa-mars-and-venus-burst = fa-icon.with("\u{e523}", solid: true)
+#let fa-mars-double = fa-icon.with("\u{f227}", solid: true)
+#let fa-mars-stroke = fa-icon.with("\u{f229}", solid: true)
+#let fa-mars-stroke-right = fa-icon.with("\u{f22b}", solid: true)
+#let fa-mars-stroke-h = fa-icon.with("\u{f22b}")
+#let fa-mars-stroke-up = fa-icon.with("\u{f22a}", solid: true)
+#let fa-mars-stroke-v = fa-icon.with("\u{f22a}")
+#let fa-martini-glass = fa-icon.with("\u{f57b}", solid: true)
+#let fa-glass-martini-alt = fa-icon.with("\u{f57b}")
+#let fa-martini-glass-citrus = fa-icon.with("\u{f561}", solid: true)
+#let fa-cocktail = fa-icon.with("\u{f561}")
+#let fa-martini-glass-empty = fa-icon.with("\u{f000}", solid: true)
+#let fa-glass-martini = fa-icon.with("\u{f000}")
+#let fa-mask = fa-icon.with("\u{f6fa}", solid: true)
+#let fa-mask-face = fa-icon.with("\u{e1d7}", solid: true)
+#let fa-mask-ventilator = fa-icon.with("\u{e524}", solid: true)
+#let fa-masks-theater = fa-icon.with("\u{f630}", solid: true)
+#let fa-theater-masks = fa-icon.with("\u{f630}")
+#let fa-mastodon = fa-icon.with("\u{f4f6}")
+#let fa-mattress-pillow = fa-icon.with("\u{e525}", solid: true)
+#let fa-maxcdn = fa-icon.with("\u{f136}")
+#let fa-maximize = fa-icon.with("\u{f31e}", solid: true)
+#let fa-expand-arrows-alt = fa-icon.with("\u{f31e}")
+#let fa-mdb = fa-icon.with("\u{f8ca}")
+#let fa-medal = fa-icon.with("\u{f5a2}", solid: true)
+#let fa-medapps = fa-icon.with("\u{f3c6}")
+#let fa-medium = fa-icon.with("\u{f23a}")
+#let fa-medium-m = fa-icon.with("\u{f23a}")
+#let fa-medrt = fa-icon.with("\u{f3c8}")
+#let fa-meetup = fa-icon.with("\u{f2e0}")
+#let fa-megaport = fa-icon.with("\u{f5a3}")
+#let fa-memory = fa-icon.with("\u{f538}", solid: true)
+#let fa-mendeley = fa-icon.with("\u{f7b3}")
+#let fa-menorah = fa-icon.with("\u{f676}", solid: true)
+#let fa-mercury = fa-icon.with("\u{f223}", solid: true)
+#let fa-message = fa-icon.with("\u{f27a}")
+#let fa-comment-alt = fa-icon.with("\u{f27a}")
+#let fa-meta = fa-icon.with("\u{e49b}")
+#let fa-meteor = fa-icon.with("\u{f753}", solid: true)
+#let fa-microblog = fa-icon.with("\u{e01a}")
+#let fa-microchip = fa-icon.with("\u{f2db}", solid: true)
+#let fa-microphone = fa-icon.with("\u{f130}", solid: true)
+#let fa-microphone-lines = fa-icon.with("\u{f3c9}", solid: true)
+#let fa-microphone-alt = fa-icon.with("\u{f3c9}")
+#let fa-microphone-lines-slash = fa-icon.with("\u{f539}", solid: true)
+#let fa-microphone-alt-slash = fa-icon.with("\u{f539}")
+#let fa-microphone-slash = fa-icon.with("\u{f131}", solid: true)
+#let fa-microscope = fa-icon.with("\u{f610}", solid: true)
+#let fa-microsoft = fa-icon.with("\u{f3ca}")
+#let fa-mill-sign = fa-icon.with("\u{e1ed}", solid: true)
+#let fa-minimize = fa-icon.with("\u{f78c}", solid: true)
+#let fa-compress-arrows-alt = fa-icon.with("\u{f78c}")
+#let fa-mintbit = fa-icon.with("\u{e62f}")
+#let fa-minus = fa-icon.with("\u{f068}", solid: true)
+#let fa-subtract = fa-icon.with("\u{f068}")
+#let fa-mitten = fa-icon.with("\u{f7b5}", solid: true)
+#let fa-mix = fa-icon.with("\u{f3cb}")
+#let fa-mixcloud = fa-icon.with("\u{f289}")
+#let fa-mixer = fa-icon.with("\u{e056}")
+#let fa-mizuni = fa-icon.with("\u{f3cc}")
+#let fa-mobile = fa-icon.with("\u{f3ce}", solid: true)
+#let fa-mobile-android = fa-icon.with("\u{f3ce}")
+#let fa-mobile-phone = fa-icon.with("\u{f3ce}")
+#let fa-mobile-button = fa-icon.with("\u{f10b}", solid: true)
+#let fa-mobile-retro = fa-icon.with("\u{e527}", solid: true)
+#let fa-mobile-screen = fa-icon.with("\u{f3cf}", solid: true)
+#let fa-mobile-android-alt = fa-icon.with("\u{f3cf}")
+#let fa-mobile-screen-button = fa-icon.with("\u{f3cd}", solid: true)
+#let fa-mobile-alt = fa-icon.with("\u{f3cd}")
+#let fa-modx = fa-icon.with("\u{f285}")
+#let fa-monero = fa-icon.with("\u{f3d0}")
+#let fa-money-bill = fa-icon.with("\u{f0d6}", solid: true)
+#let fa-money-bill-1 = fa-icon.with("\u{f3d1}")
+#let fa-money-bill-alt = fa-icon.with("\u{f3d1}")
+#let fa-money-bill-1-wave = fa-icon.with("\u{f53b}", solid: true)
+#let fa-money-bill-wave-alt = fa-icon.with("\u{f53b}")
+#let fa-money-bill-transfer = fa-icon.with("\u{e528}", solid: true)
+#let fa-money-bill-trend-up = fa-icon.with("\u{e529}", solid: true)
+#let fa-money-bill-wave = fa-icon.with("\u{f53a}", solid: true)
+#let fa-money-bill-wheat = fa-icon.with("\u{e52a}", solid: true)
+#let fa-money-bills = fa-icon.with("\u{e1f3}", solid: true)
+#let fa-money-check = fa-icon.with("\u{f53c}", solid: true)
+#let fa-money-check-dollar = fa-icon.with("\u{f53d}", solid: true)
+#let fa-money-check-alt = fa-icon.with("\u{f53d}")
+#let fa-monument = fa-icon.with("\u{f5a6}", solid: true)
+#let fa-moon = fa-icon.with("\u{f186}")
+#let fa-mortar-pestle = fa-icon.with("\u{f5a7}", solid: true)
+#let fa-mosque = fa-icon.with("\u{f678}", solid: true)
+#let fa-mosquito = fa-icon.with("\u{e52b}", solid: true)
+#let fa-mosquito-net = fa-icon.with("\u{e52c}", solid: true)
+#let fa-motorcycle = fa-icon.with("\u{f21c}", solid: true)
+#let fa-mound = fa-icon.with("\u{e52d}", solid: true)
+#let fa-mountain = fa-icon.with("\u{f6fc}", solid: true)
+#let fa-mountain-city = fa-icon.with("\u{e52e}", solid: true)
+#let fa-mountain-sun = fa-icon.with("\u{e52f}", solid: true)
+#let fa-mug-hot = fa-icon.with("\u{f7b6}", solid: true)
+#let fa-mug-saucer = fa-icon.with("\u{f0f4}", solid: true)
+#let fa-coffee = fa-icon.with("\u{f0f4}")
+#let fa-music = fa-icon.with("\u{f001}", solid: true)
+#let fa-n = fa-icon.with("\u{4e}", solid: true)
+#let fa-naira-sign = fa-icon.with("\u{e1f6}", solid: true)
+#let fa-napster = fa-icon.with("\u{f3d2}")
+#let fa-neos = fa-icon.with("\u{f612}")
+#let fa-network-wired = fa-icon.with("\u{f6ff}", solid: true)
+#let fa-neuter = fa-icon.with("\u{f22c}", solid: true)
+#let fa-newspaper = fa-icon.with("\u{f1ea}")
+#let fa-nfc-directional = fa-icon.with("\u{e530}")
+#let fa-nfc-symbol = fa-icon.with("\u{e531}")
+#let fa-nimblr = fa-icon.with("\u{f5a8}")
+#let fa-node = fa-icon.with("\u{f419}")
+#let fa-node-js = fa-icon.with("\u{f3d3}")
+#let fa-not-equal = fa-icon.with("\u{f53e}", solid: true)
+#let fa-notdef = fa-icon.with("\u{e1fe}", solid: true)
+#let fa-note-sticky = fa-icon.with("\u{f249}")
+#let fa-sticky-note = fa-icon.with("\u{f249}")
+#let fa-notes-medical = fa-icon.with("\u{f481}", solid: true)
+#let fa-npm = fa-icon.with("\u{f3d4}")
+#let fa-ns8 = fa-icon.with("\u{f3d5}")
+#let fa-nutritionix = fa-icon.with("\u{f3d6}")
+#let fa-o = fa-icon.with("\u{4f}", solid: true)
+#let fa-object-group = fa-icon.with("\u{f247}")
+#let fa-object-ungroup = fa-icon.with("\u{f248}")
+#let fa-octopus-deploy = fa-icon.with("\u{e082}")
+#let fa-odnoklassniki = fa-icon.with("\u{f263}")
+#let fa-odysee = fa-icon.with("\u{e5c6}")
+#let fa-oil-can = fa-icon.with("\u{f613}", solid: true)
+#let fa-oil-well = fa-icon.with("\u{e532}", solid: true)
+#let fa-old-republic = fa-icon.with("\u{f510}")
+#let fa-om = fa-icon.with("\u{f679}", solid: true)
+#let fa-opencart = fa-icon.with("\u{f23d}")
+#let fa-openid = fa-icon.with("\u{f19b}")
+#let fa-opensuse = fa-icon.with("\u{e62b}")
+#let fa-opera = fa-icon.with("\u{f26a}")
+#let fa-optin-monster = fa-icon.with("\u{f23c}")
+#let fa-orcid = fa-icon.with("\u{f8d2}")
+#let fa-osi = fa-icon.with("\u{f41a}")
+#let fa-otter = fa-icon.with("\u{f700}", solid: true)
+#let fa-outdent = fa-icon.with("\u{f03b}", solid: true)
+#let fa-dedent = fa-icon.with("\u{f03b}")
+#let fa-p = fa-icon.with("\u{50}", solid: true)
+#let fa-padlet = fa-icon.with("\u{e4a0}")
+#let fa-page4 = fa-icon.with("\u{f3d7}")
+#let fa-pagelines = fa-icon.with("\u{f18c}")
+#let fa-pager = fa-icon.with("\u{f815}", solid: true)
+#let fa-paint-roller = fa-icon.with("\u{f5aa}", solid: true)
+#let fa-paintbrush = fa-icon.with("\u{f1fc}", solid: true)
+#let fa-paint-brush = fa-icon.with("\u{f1fc}")
+#let fa-palette = fa-icon.with("\u{f53f}", solid: true)
+#let fa-palfed = fa-icon.with("\u{f3d8}")
+#let fa-pallet = fa-icon.with("\u{f482}", solid: true)
+#let fa-panorama = fa-icon.with("\u{e209}", solid: true)
+#let fa-paper-plane = fa-icon.with("\u{f1d8}")
+#let fa-paperclip = fa-icon.with("\u{f0c6}", solid: true)
+#let fa-parachute-box = fa-icon.with("\u{f4cd}", solid: true)
+#let fa-paragraph = fa-icon.with("\u{f1dd}", solid: true)
+#let fa-passport = fa-icon.with("\u{f5ab}", solid: true)
+#let fa-paste = fa-icon.with("\u{f0ea}")
+#let fa-file-clipboard = fa-icon.with("\u{f0ea}")
+#let fa-patreon = fa-icon.with("\u{f3d9}")
+#let fa-pause = fa-icon.with("\u{f04c}", solid: true)
+#let fa-paw = fa-icon.with("\u{f1b0}", solid: true)
+#let fa-paypal = fa-icon.with("\u{f1ed}")
+#let fa-peace = fa-icon.with("\u{f67c}", solid: true)
+#let fa-pen = fa-icon.with("\u{f304}", solid: true)
+#let fa-pen-clip = fa-icon.with("\u{f305}", solid: true)
+#let fa-pen-alt = fa-icon.with("\u{f305}")
+#let fa-pen-fancy = fa-icon.with("\u{f5ac}", solid: true)
+#let fa-pen-nib = fa-icon.with("\u{f5ad}", solid: true)
+#let fa-pen-ruler = fa-icon.with("\u{f5ae}", solid: true)
+#let fa-pencil-ruler = fa-icon.with("\u{f5ae}")
+#let fa-pen-to-square = fa-icon.with("\u{f044}")
+#let fa-edit = fa-icon.with("\u{f044}")
+#let fa-pencil = fa-icon.with("\u{f303}", solid: true)
+#let fa-pencil-alt = fa-icon.with("\u{f303}")
+#let fa-people-arrows = fa-icon.with("\u{e068}", solid: true)
+#let fa-people-arrows-left-right = fa-icon.with("\u{e068}")
+#let fa-people-carry-box = fa-icon.with("\u{f4ce}", solid: true)
+#let fa-people-carry = fa-icon.with("\u{f4ce}")
+#let fa-people-group = fa-icon.with("\u{e533}", solid: true)
+#let fa-people-line = fa-icon.with("\u{e534}", solid: true)
+#let fa-people-pulling = fa-icon.with("\u{e535}", solid: true)
+#let fa-people-robbery = fa-icon.with("\u{e536}", solid: true)
+#let fa-people-roof = fa-icon.with("\u{e537}", solid: true)
+#let fa-pepper-hot = fa-icon.with("\u{f816}", solid: true)
+#let fa-perbyte = fa-icon.with("\u{e083}")
+#let fa-percent = fa-icon.with("\u{25}", solid: true)
+#let fa-percentage = fa-icon.with("\u{25}")
+#let fa-periscope = fa-icon.with("\u{f3da}")
+#let fa-person = fa-icon.with("\u{f183}", solid: true)
+#let fa-male = fa-icon.with("\u{f183}")
+#let fa-person-arrow-down-to-line = fa-icon.with("\u{e538}", solid: true)
+#let fa-person-arrow-up-from-line = fa-icon.with("\u{e539}", solid: true)
+#let fa-person-biking = fa-icon.with("\u{f84a}", solid: true)
+#let fa-biking = fa-icon.with("\u{f84a}")
+#let fa-person-booth = fa-icon.with("\u{f756}", solid: true)
+#let fa-person-breastfeeding = fa-icon.with("\u{e53a}", solid: true)
+#let fa-person-burst = fa-icon.with("\u{e53b}", solid: true)
+#let fa-person-cane = fa-icon.with("\u{e53c}", solid: true)
+#let fa-person-chalkboard = fa-icon.with("\u{e53d}", solid: true)
+#let fa-person-circle-check = fa-icon.with("\u{e53e}", solid: true)
+#let fa-person-circle-exclamation = fa-icon.with("\u{e53f}", solid: true)
+#let fa-person-circle-minus = fa-icon.with("\u{e540}", solid: true)
+#let fa-person-circle-plus = fa-icon.with("\u{e541}", solid: true)
+#let fa-person-circle-question = fa-icon.with("\u{e542}", solid: true)
+#let fa-person-circle-xmark = fa-icon.with("\u{e543}", solid: true)
+#let fa-person-digging = fa-icon.with("\u{f85e}", solid: true)
+#let fa-digging = fa-icon.with("\u{f85e}")
+#let fa-person-dots-from-line = fa-icon.with("\u{f470}", solid: true)
+#let fa-diagnoses = fa-icon.with("\u{f470}")
+#let fa-person-dress = fa-icon.with("\u{f182}", solid: true)
+#let fa-female = fa-icon.with("\u{f182}")
+#let fa-person-dress-burst = fa-icon.with("\u{e544}", solid: true)
+#let fa-person-drowning = fa-icon.with("\u{e545}", solid: true)
+#let fa-person-falling = fa-icon.with("\u{e546}", solid: true)
+#let fa-person-falling-burst = fa-icon.with("\u{e547}", solid: true)
+#let fa-person-half-dress = fa-icon.with("\u{e548}", solid: true)
+#let fa-person-harassing = fa-icon.with("\u{e549}", solid: true)
+#let fa-person-hiking = fa-icon.with("\u{f6ec}", solid: true)
+#let fa-hiking = fa-icon.with("\u{f6ec}")
+#let fa-person-military-pointing = fa-icon.with("\u{e54a}", solid: true)
+#let fa-person-military-rifle = fa-icon.with("\u{e54b}", solid: true)
+#let fa-person-military-to-person = fa-icon.with("\u{e54c}", solid: true)
+#let fa-person-praying = fa-icon.with("\u{f683}", solid: true)
+#let fa-pray = fa-icon.with("\u{f683}")
+#let fa-person-pregnant = fa-icon.with("\u{e31e}", solid: true)
+#let fa-person-rays = fa-icon.with("\u{e54d}", solid: true)
+#let fa-person-rifle = fa-icon.with("\u{e54e}", solid: true)
+#let fa-person-running = fa-icon.with("\u{f70c}", solid: true)
+#let fa-running = fa-icon.with("\u{f70c}")
+#let fa-person-shelter = fa-icon.with("\u{e54f}", solid: true)
+#let fa-person-skating = fa-icon.with("\u{f7c5}", solid: true)
+#let fa-skating = fa-icon.with("\u{f7c5}")
+#let fa-person-skiing = fa-icon.with("\u{f7c9}", solid: true)
+#let fa-skiing = fa-icon.with("\u{f7c9}")
+#let fa-person-skiing-nordic = fa-icon.with("\u{f7ca}", solid: true)
+#let fa-skiing-nordic = fa-icon.with("\u{f7ca}")
+#let fa-person-snowboarding = fa-icon.with("\u{f7ce}", solid: true)
+#let fa-snowboarding = fa-icon.with("\u{f7ce}")
+#let fa-person-swimming = fa-icon.with("\u{f5c4}", solid: true)
+#let fa-swimmer = fa-icon.with("\u{f5c4}")
+#let fa-person-through-window = fa-icon.with("\u{e5a9}", solid: true)
+#let fa-person-walking = fa-icon.with("\u{f554}", solid: true)
+#let fa-walking = fa-icon.with("\u{f554}")
+#let fa-person-walking-arrow-loop-left = fa-icon.with("\u{e551}", solid: true)
+#let fa-person-walking-arrow-right = fa-icon.with("\u{e552}", solid: true)
+#let fa-person-walking-dashed-line-arrow-right = fa-icon.with("\u{e553}", solid: true)
+#let fa-person-walking-luggage = fa-icon.with("\u{e554}", solid: true)
+#let fa-person-walking-with-cane = fa-icon.with("\u{f29d}", solid: true)
+#let fa-blind = fa-icon.with("\u{f29d}")
+#let fa-peseta-sign = fa-icon.with("\u{e221}", solid: true)
+#let fa-peso-sign = fa-icon.with("\u{e222}", solid: true)
+#let fa-phabricator = fa-icon.with("\u{f3db}")
+#let fa-phoenix-framework = fa-icon.with("\u{f3dc}")
+#let fa-phoenix-squadron = fa-icon.with("\u{f511}")
+#let fa-phone = fa-icon.with("\u{f095}", solid: true)
+#let fa-phone-flip = fa-icon.with("\u{f879}", solid: true)
+#let fa-phone-alt = fa-icon.with("\u{f879}")
+#let fa-phone-slash = fa-icon.with("\u{f3dd}", solid: true)
+#let fa-phone-volume = fa-icon.with("\u{f2a0}", solid: true)
+#let fa-volume-control-phone = fa-icon.with("\u{f2a0}")
+#let fa-photo-film = fa-icon.with("\u{f87c}", solid: true)
+#let fa-photo-video = fa-icon.with("\u{f87c}")
+#let fa-php = fa-icon.with("\u{f457}")
+#let fa-pied-piper = fa-icon.with("\u{f2ae}")
+#let fa-pied-piper-alt = fa-icon.with("\u{f1a8}")
+#let fa-pied-piper-hat = fa-icon.with("\u{f4e5}")
+#let fa-pied-piper-pp = fa-icon.with("\u{f1a7}")
+#let fa-piggy-bank = fa-icon.with("\u{f4d3}", solid: true)
+#let fa-pills = fa-icon.with("\u{f484}", solid: true)
+#let fa-pinterest = fa-icon.with("\u{f0d2}")
+#let fa-pinterest-p = fa-icon.with("\u{f231}")
+#let fa-pix = fa-icon.with("\u{e43a}")
+#let fa-pixiv = fa-icon.with("\u{e640}")
+#let fa-pizza-slice = fa-icon.with("\u{f818}", solid: true)
+#let fa-place-of-worship = fa-icon.with("\u{f67f}", solid: true)
+#let fa-plane = fa-icon.with("\u{f072}", solid: true)
+#let fa-plane-arrival = fa-icon.with("\u{f5af}", solid: true)
+#let fa-plane-circle-check = fa-icon.with("\u{e555}", solid: true)
+#let fa-plane-circle-exclamation = fa-icon.with("\u{e556}", solid: true)
+#let fa-plane-circle-xmark = fa-icon.with("\u{e557}", solid: true)
+#let fa-plane-departure = fa-icon.with("\u{f5b0}", solid: true)
+#let fa-plane-lock = fa-icon.with("\u{e558}", solid: true)
+#let fa-plane-slash = fa-icon.with("\u{e069}", solid: true)
+#let fa-plane-up = fa-icon.with("\u{e22d}", solid: true)
+#let fa-plant-wilt = fa-icon.with("\u{e5aa}", solid: true)
+#let fa-plate-wheat = fa-icon.with("\u{e55a}", solid: true)
+#let fa-play = fa-icon.with("\u{f04b}", solid: true)
+#let fa-playstation = fa-icon.with("\u{f3df}")
+#let fa-plug = fa-icon.with("\u{f1e6}", solid: true)
+#let fa-plug-circle-bolt = fa-icon.with("\u{e55b}", solid: true)
+#let fa-plug-circle-check = fa-icon.with("\u{e55c}", solid: true)
+#let fa-plug-circle-exclamation = fa-icon.with("\u{e55d}", solid: true)
+#let fa-plug-circle-minus = fa-icon.with("\u{e55e}", solid: true)
+#let fa-plug-circle-plus = fa-icon.with("\u{e55f}", solid: true)
+#let fa-plug-circle-xmark = fa-icon.with("\u{e560}", solid: true)
+#let fa-plus = fa-icon.with("\u{2b}", solid: true)
+#let fa-add = fa-icon.with("\u{2b}")
+#let fa-plus-minus = fa-icon.with("\u{e43c}", solid: true)
+#let fa-podcast = fa-icon.with("\u{f2ce}", solid: true)
+#let fa-poo = fa-icon.with("\u{f2fe}", solid: true)
+#let fa-poo-storm = fa-icon.with("\u{f75a}", solid: true)
+#let fa-poo-bolt = fa-icon.with("\u{f75a}")
+#let fa-poop = fa-icon.with("\u{f619}", solid: true)
+#let fa-power-off = fa-icon.with("\u{f011}", solid: true)
+#let fa-prescription = fa-icon.with("\u{f5b1}", solid: true)
+#let fa-prescription-bottle = fa-icon.with("\u{f485}", solid: true)
+#let fa-prescription-bottle-medical = fa-icon.with("\u{f486}", solid: true)
+#let fa-prescription-bottle-alt = fa-icon.with("\u{f486}")
+#let fa-print = fa-icon.with("\u{f02f}", solid: true)
+#let fa-product-hunt = fa-icon.with("\u{f288}")
+#let fa-pump-medical = fa-icon.with("\u{e06a}", solid: true)
+#let fa-pump-soap = fa-icon.with("\u{e06b}", solid: true)
+#let fa-pushed = fa-icon.with("\u{f3e1}")
+#let fa-puzzle-piece = fa-icon.with("\u{f12e}", solid: true)
+#let fa-python = fa-icon.with("\u{f3e2}")
+#let fa-q = fa-icon.with("\u{51}", solid: true)
+#let fa-qq = fa-icon.with("\u{f1d6}")
+#let fa-qrcode = fa-icon.with("\u{f029}", solid: true)
+#let fa-question = fa-icon.with("\u{3f}", solid: true)
+#let fa-quinscape = fa-icon.with("\u{f459}")
+#let fa-quora = fa-icon.with("\u{f2c4}")
+#let fa-quote-left = fa-icon.with("\u{f10d}", solid: true)
+#let fa-quote-left-alt = fa-icon.with("\u{f10d}")
+#let fa-quote-right = fa-icon.with("\u{f10e}", solid: true)
+#let fa-quote-right-alt = fa-icon.with("\u{f10e}")
+#let fa-r = fa-icon.with("\u{52}", solid: true)
+#let fa-r-project = fa-icon.with("\u{f4f7}")
+#let fa-radiation = fa-icon.with("\u{f7b9}", solid: true)
+#let fa-radio = fa-icon.with("\u{f8d7}", solid: true)
+#let fa-rainbow = fa-icon.with("\u{f75b}", solid: true)
+#let fa-ranking-star = fa-icon.with("\u{e561}", solid: true)
+#let fa-raspberry-pi = fa-icon.with("\u{f7bb}")
+#let fa-ravelry = fa-icon.with("\u{f2d9}")
+#let fa-react = fa-icon.with("\u{f41b}")
+#let fa-reacteurope = fa-icon.with("\u{f75d}")
+#let fa-readme = fa-icon.with("\u{f4d5}")
+#let fa-rebel = fa-icon.with("\u{f1d0}")
+#let fa-receipt = fa-icon.with("\u{f543}", solid: true)
+#let fa-record-vinyl = fa-icon.with("\u{f8d9}", solid: true)
+#let fa-rectangle-ad = fa-icon.with("\u{f641}", solid: true)
+#let fa-ad = fa-icon.with("\u{f641}")
+#let fa-rectangle-list = fa-icon.with("\u{f022}")
+#let fa-list-alt = fa-icon.with("\u{f022}")
+#let fa-rectangle-xmark = fa-icon.with("\u{f410}")
+#let fa-rectangle-times = fa-icon.with("\u{f410}")
+#let fa-times-rectangle = fa-icon.with("\u{f410}")
+#let fa-window-close = fa-icon.with("\u{f410}")
+#let fa-recycle = fa-icon.with("\u{f1b8}", solid: true)
+#let fa-red-river = fa-icon.with("\u{f3e3}")
+#let fa-reddit = fa-icon.with("\u{f1a1}")
+#let fa-reddit-alien = fa-icon.with("\u{f281}")
+#let fa-redhat = fa-icon.with("\u{f7bc}")
+#let fa-registered = fa-icon.with("\u{f25d}")
+#let fa-renren = fa-icon.with("\u{f18b}")
+#let fa-repeat = fa-icon.with("\u{f363}", solid: true)
+#let fa-reply = fa-icon.with("\u{f3e5}", solid: true)
+#let fa-mail-reply = fa-icon.with("\u{f3e5}")
+#let fa-reply-all = fa-icon.with("\u{f122}", solid: true)
+#let fa-mail-reply-all = fa-icon.with("\u{f122}")
+#let fa-replyd = fa-icon.with("\u{f3e6}")
+#let fa-republican = fa-icon.with("\u{f75e}", solid: true)
+#let fa-researchgate = fa-icon.with("\u{f4f8}")
+#let fa-resolving = fa-icon.with("\u{f3e7}")
+#let fa-restroom = fa-icon.with("\u{f7bd}", solid: true)
+#let fa-retweet = fa-icon.with("\u{f079}", solid: true)
+#let fa-rev = fa-icon.with("\u{f5b2}")
+#let fa-ribbon = fa-icon.with("\u{f4d6}", solid: true)
+#let fa-right-from-bracket = fa-icon.with("\u{f2f5}", solid: true)
+#let fa-sign-out-alt = fa-icon.with("\u{f2f5}")
+#let fa-right-left = fa-icon.with("\u{f362}", solid: true)
+#let fa-exchange-alt = fa-icon.with("\u{f362}")
+#let fa-right-long = fa-icon.with("\u{f30b}", solid: true)
+#let fa-long-arrow-alt-right = fa-icon.with("\u{f30b}")
+#let fa-right-to-bracket = fa-icon.with("\u{f2f6}", solid: true)
+#let fa-sign-in-alt = fa-icon.with("\u{f2f6}")
+#let fa-ring = fa-icon.with("\u{f70b}", solid: true)
+#let fa-road = fa-icon.with("\u{f018}", solid: true)
+#let fa-road-barrier = fa-icon.with("\u{e562}", solid: true)
+#let fa-road-bridge = fa-icon.with("\u{e563}", solid: true)
+#let fa-road-circle-check = fa-icon.with("\u{e564}", solid: true)
+#let fa-road-circle-exclamation = fa-icon.with("\u{e565}", solid: true)
+#let fa-road-circle-xmark = fa-icon.with("\u{e566}", solid: true)
+#let fa-road-lock = fa-icon.with("\u{e567}", solid: true)
+#let fa-road-spikes = fa-icon.with("\u{e568}", solid: true)
+#let fa-robot = fa-icon.with("\u{f544}", solid: true)
+#let fa-rocket = fa-icon.with("\u{f135}", solid: true)
+#let fa-rocketchat = fa-icon.with("\u{f3e8}")
+#let fa-rockrms = fa-icon.with("\u{f3e9}")
+#let fa-rotate = fa-icon.with("\u{f2f1}", solid: true)
+#let fa-sync-alt = fa-icon.with("\u{f2f1}")
+#let fa-rotate-left = fa-icon.with("\u{f2ea}", solid: true)
+#let fa-rotate-back = fa-icon.with("\u{f2ea}")
+#let fa-rotate-backward = fa-icon.with("\u{f2ea}")
+#let fa-undo-alt = fa-icon.with("\u{f2ea}")
+#let fa-rotate-right = fa-icon.with("\u{f2f9}", solid: true)
+#let fa-redo-alt = fa-icon.with("\u{f2f9}")
+#let fa-rotate-forward = fa-icon.with("\u{f2f9}")
+#let fa-route = fa-icon.with("\u{f4d7}", solid: true)
+#let fa-rss = fa-icon.with("\u{f09e}", solid: true)
+#let fa-feed = fa-icon.with("\u{f09e}")
+#let fa-ruble-sign = fa-icon.with("\u{f158}", solid: true)
+#let fa-rouble = fa-icon.with("\u{f158}")
+#let fa-rub = fa-icon.with("\u{f158}")
+#let fa-ruble = fa-icon.with("\u{f158}")
+#let fa-rug = fa-icon.with("\u{e569}", solid: true)
+#let fa-ruler = fa-icon.with("\u{f545}", solid: true)
+#let fa-ruler-combined = fa-icon.with("\u{f546}", solid: true)
+#let fa-ruler-horizontal = fa-icon.with("\u{f547}", solid: true)
+#let fa-ruler-vertical = fa-icon.with("\u{f548}", solid: true)
+#let fa-rupee-sign = fa-icon.with("\u{f156}", solid: true)
+#let fa-rupee = fa-icon.with("\u{f156}")
+#let fa-rupiah-sign = fa-icon.with("\u{e23d}", solid: true)
+#let fa-rust = fa-icon.with("\u{e07a}")
+#let fa-s = fa-icon.with("\u{53}", solid: true)
+#let fa-sack-dollar = fa-icon.with("\u{f81d}", solid: true)
+#let fa-sack-xmark = fa-icon.with("\u{e56a}", solid: true)
+#let fa-safari = fa-icon.with("\u{f267}")
+#let fa-sailboat = fa-icon.with("\u{e445}", solid: true)
+#let fa-salesforce = fa-icon.with("\u{f83b}")
+#let fa-sass = fa-icon.with("\u{f41e}")
+#let fa-satellite = fa-icon.with("\u{f7bf}", solid: true)
+#let fa-satellite-dish = fa-icon.with("\u{f7c0}", solid: true)
+#let fa-scale-balanced = fa-icon.with("\u{f24e}", solid: true)
+#let fa-balance-scale = fa-icon.with("\u{f24e}")
+#let fa-scale-unbalanced = fa-icon.with("\u{f515}", solid: true)
+#let fa-balance-scale-left = fa-icon.with("\u{f515}")
+#let fa-scale-unbalanced-flip = fa-icon.with("\u{f516}", solid: true)
+#let fa-balance-scale-right = fa-icon.with("\u{f516}")
+#let fa-schlix = fa-icon.with("\u{f3ea}")
+#let fa-school = fa-icon.with("\u{f549}", solid: true)
+#let fa-school-circle-check = fa-icon.with("\u{e56b}", solid: true)
+#let fa-school-circle-exclamation = fa-icon.with("\u{e56c}", solid: true)
+#let fa-school-circle-xmark = fa-icon.with("\u{e56d}", solid: true)
+#let fa-school-flag = fa-icon.with("\u{e56e}", solid: true)
+#let fa-school-lock = fa-icon.with("\u{e56f}", solid: true)
+#let fa-scissors = fa-icon.with("\u{f0c4}", solid: true)
+#let fa-cut = fa-icon.with("\u{f0c4}")
+#let fa-screenpal = fa-icon.with("\u{e570}")
+#let fa-screwdriver = fa-icon.with("\u{f54a}", solid: true)
+#let fa-screwdriver-wrench = fa-icon.with("\u{f7d9}", solid: true)
+#let fa-tools = fa-icon.with("\u{f7d9}")
+#let fa-scribd = fa-icon.with("\u{f28a}")
+#let fa-scroll = fa-icon.with("\u{f70e}", solid: true)
+#let fa-scroll-torah = fa-icon.with("\u{f6a0}", solid: true)
+#let fa-torah = fa-icon.with("\u{f6a0}")
+#let fa-sd-card = fa-icon.with("\u{f7c2}", solid: true)
+#let fa-searchengin = fa-icon.with("\u{f3eb}")
+#let fa-section = fa-icon.with("\u{e447}", solid: true)
+#let fa-seedling = fa-icon.with("\u{f4d8}", solid: true)
+#let fa-sprout = fa-icon.with("\u{f4d8}")
+#let fa-sellcast = fa-icon.with("\u{f2da}")
+#let fa-sellsy = fa-icon.with("\u{f213}")
+#let fa-server = fa-icon.with("\u{f233}", solid: true)
+#let fa-servicestack = fa-icon.with("\u{f3ec}")
+#let fa-shapes = fa-icon.with("\u{f61f}", solid: true)
+#let fa-triangle-circle-square = fa-icon.with("\u{f61f}")
+#let fa-share = fa-icon.with("\u{f064}", solid: true)
+#let fa-mail-forward = fa-icon.with("\u{f064}")
+#let fa-share-from-square = fa-icon.with("\u{f14d}")
+#let fa-share-square = fa-icon.with("\u{f14d}")
+#let fa-share-nodes = fa-icon.with("\u{f1e0}", solid: true)
+#let fa-share-alt = fa-icon.with("\u{f1e0}")
+#let fa-sheet-plastic = fa-icon.with("\u{e571}", solid: true)
+#let fa-shekel-sign = fa-icon.with("\u{f20b}", solid: true)
+#let fa-ils = fa-icon.with("\u{f20b}")
+#let fa-shekel = fa-icon.with("\u{f20b}")
+#let fa-sheqel = fa-icon.with("\u{f20b}")
+#let fa-sheqel-sign = fa-icon.with("\u{f20b}")
+#let fa-shield = fa-icon.with("\u{f132}", solid: true)
+#let fa-shield-blank = fa-icon.with("\u{f132}")
+#let fa-shield-cat = fa-icon.with("\u{e572}", solid: true)
+#let fa-shield-dog = fa-icon.with("\u{e573}", solid: true)
+#let fa-shield-halved = fa-icon.with("\u{f3ed}", solid: true)
+#let fa-shield-alt = fa-icon.with("\u{f3ed}")
+#let fa-shield-heart = fa-icon.with("\u{e574}", solid: true)
+#let fa-shield-virus = fa-icon.with("\u{e06c}", solid: true)
+#let fa-ship = fa-icon.with("\u{f21a}", solid: true)
+#let fa-shirt = fa-icon.with("\u{f553}", solid: true)
+#let fa-t-shirt = fa-icon.with("\u{f553}")
+#let fa-tshirt = fa-icon.with("\u{f553}")
+#let fa-shirtsinbulk = fa-icon.with("\u{f214}")
+#let fa-shoe-prints = fa-icon.with("\u{f54b}", solid: true)
+#let fa-shoelace = fa-icon.with("\u{e60c}")
+#let fa-shop = fa-icon.with("\u{f54f}", solid: true)
+#let fa-store-alt = fa-icon.with("\u{f54f}")
+#let fa-shop-lock = fa-icon.with("\u{e4a5}", solid: true)
+#let fa-shop-slash = fa-icon.with("\u{e070}", solid: true)
+#let fa-store-alt-slash = fa-icon.with("\u{e070}")
+#let fa-shopify = fa-icon.with("\u{e057}")
+#let fa-shopware = fa-icon.with("\u{f5b5}")
+#let fa-shower = fa-icon.with("\u{f2cc}", solid: true)
+#let fa-shrimp = fa-icon.with("\u{e448}", solid: true)
+#let fa-shuffle = fa-icon.with("\u{f074}", solid: true)
+#let fa-random = fa-icon.with("\u{f074}")
+#let fa-shuttle-space = fa-icon.with("\u{f197}", solid: true)
+#let fa-space-shuttle = fa-icon.with("\u{f197}")
+#let fa-sign-hanging = fa-icon.with("\u{f4d9}", solid: true)
+#let fa-sign = fa-icon.with("\u{f4d9}")
+#let fa-signal = fa-icon.with("\u{f012}", solid: true)
+#let fa-signal-5 = fa-icon.with("\u{f012}")
+#let fa-signal-perfect = fa-icon.with("\u{f012}")
+#let fa-signal-messenger = fa-icon.with("\u{e663}")
+#let fa-signature = fa-icon.with("\u{f5b7}", solid: true)
+#let fa-signs-post = fa-icon.with("\u{f277}", solid: true)
+#let fa-map-signs = fa-icon.with("\u{f277}")
+#let fa-sim-card = fa-icon.with("\u{f7c4}", solid: true)
+#let fa-simplybuilt = fa-icon.with("\u{f215}")
+#let fa-sink = fa-icon.with("\u{e06d}", solid: true)
+#let fa-sistrix = fa-icon.with("\u{f3ee}")
+#let fa-sitemap = fa-icon.with("\u{f0e8}", solid: true)
+#let fa-sith = fa-icon.with("\u{f512}")
+#let fa-sitrox = fa-icon.with("\u{e44a}")
+#let fa-sketch = fa-icon.with("\u{f7c6}")
+#let fa-skull = fa-icon.with("\u{f54c}", solid: true)
+#let fa-skull-crossbones = fa-icon.with("\u{f714}", solid: true)
+#let fa-skyatlas = fa-icon.with("\u{f216}")
+#let fa-skype = fa-icon.with("\u{f17e}")
+#let fa-slack = fa-icon.with("\u{f198}")
+#let fa-slack-hash = fa-icon.with("\u{f198}")
+#let fa-slash = fa-icon.with("\u{f715}", solid: true)
+#let fa-sleigh = fa-icon.with("\u{f7cc}", solid: true)
+#let fa-sliders = fa-icon.with("\u{f1de}", solid: true)
+#let fa-sliders-h = fa-icon.with("\u{f1de}")
+#let fa-slideshare = fa-icon.with("\u{f1e7}")
+#let fa-smog = fa-icon.with("\u{f75f}", solid: true)
+#let fa-smoking = fa-icon.with("\u{f48d}", solid: true)
+#let fa-snapchat = fa-icon.with("\u{f2ab}")
+#let fa-snapchat-ghost = fa-icon.with("\u{f2ab}")
+#let fa-snowflake = fa-icon.with("\u{f2dc}")
+#let fa-snowman = fa-icon.with("\u{f7d0}", solid: true)
+#let fa-snowplow = fa-icon.with("\u{f7d2}", solid: true)
+#let fa-soap = fa-icon.with("\u{e06e}", solid: true)
+#let fa-socks = fa-icon.with("\u{f696}", solid: true)
+#let fa-solar-panel = fa-icon.with("\u{f5ba}", solid: true)
+#let fa-sort = fa-icon.with("\u{f0dc}", solid: true)
+#let fa-unsorted = fa-icon.with("\u{f0dc}")
+#let fa-sort-down = fa-icon.with("\u{f0dd}", solid: true)
+#let fa-sort-desc = fa-icon.with("\u{f0dd}")
+#let fa-sort-up = fa-icon.with("\u{f0de}", solid: true)
+#let fa-sort-asc = fa-icon.with("\u{f0de}")
+#let fa-soundcloud = fa-icon.with("\u{f1be}")
+#let fa-sourcetree = fa-icon.with("\u{f7d3}")
+#let fa-spa = fa-icon.with("\u{f5bb}", solid: true)
+#let fa-space-awesome = fa-icon.with("\u{e5ac}")
+#let fa-spaghetti-monster-flying = fa-icon.with("\u{f67b}", solid: true)
+#let fa-pastafarianism = fa-icon.with("\u{f67b}")
+#let fa-speakap = fa-icon.with("\u{f3f3}")
+#let fa-speaker-deck = fa-icon.with("\u{f83c}")
+#let fa-spell-check = fa-icon.with("\u{f891}", solid: true)
+#let fa-spider = fa-icon.with("\u{f717}", solid: true)
+#let fa-spinner = fa-icon.with("\u{f110}", solid: true)
+#let fa-splotch = fa-icon.with("\u{f5bc}", solid: true)
+#let fa-spoon = fa-icon.with("\u{f2e5}", solid: true)
+#let fa-utensil-spoon = fa-icon.with("\u{f2e5}")
+#let fa-spotify = fa-icon.with("\u{f1bc}")
+#let fa-spray-can = fa-icon.with("\u{f5bd}", solid: true)
+#let fa-spray-can-sparkles = fa-icon.with("\u{f5d0}", solid: true)
+#let fa-air-freshener = fa-icon.with("\u{f5d0}")
+#let fa-square = fa-icon.with("\u{f0c8}")
+#let fa-square-arrow-up-right = fa-icon.with("\u{f14c}", solid: true)
+#let fa-external-link-square = fa-icon.with("\u{f14c}")
+#let fa-square-behance = fa-icon.with("\u{f1b5}")
+#let fa-behance-square = fa-icon.with("\u{f1b5}")
+#let fa-square-caret-down = fa-icon.with("\u{f150}")
+#let fa-caret-square-down = fa-icon.with("\u{f150}")
+#let fa-square-caret-left = fa-icon.with("\u{f191}")
+#let fa-caret-square-left = fa-icon.with("\u{f191}")
+#let fa-square-caret-right = fa-icon.with("\u{f152}")
+#let fa-caret-square-right = fa-icon.with("\u{f152}")
+#let fa-square-caret-up = fa-icon.with("\u{f151}")
+#let fa-caret-square-up = fa-icon.with("\u{f151}")
+#let fa-square-check = fa-icon.with("\u{f14a}")
+#let fa-check-square = fa-icon.with("\u{f14a}")
+#let fa-square-dribbble = fa-icon.with("\u{f397}")
+#let fa-dribbble-square = fa-icon.with("\u{f397}")
+#let fa-square-envelope = fa-icon.with("\u{f199}", solid: true)
+#let fa-envelope-square = fa-icon.with("\u{f199}")
+#let fa-square-facebook = fa-icon.with("\u{f082}")
+#let fa-facebook-square = fa-icon.with("\u{f082}")
+#let fa-square-font-awesome = fa-icon.with("\u{e5ad}")
+#let fa-square-font-awesome-stroke = fa-icon.with("\u{f35c}")
+#let fa-font-awesome-alt = fa-icon.with("\u{f35c}")
+#let fa-square-full = fa-icon.with("\u{f45c}")
+#let fa-square-git = fa-icon.with("\u{f1d2}")
+#let fa-git-square = fa-icon.with("\u{f1d2}")
+#let fa-square-github = fa-icon.with("\u{f092}")
+#let fa-github-square = fa-icon.with("\u{f092}")
+#let fa-square-gitlab = fa-icon.with("\u{e5ae}")
+#let fa-gitlab-square = fa-icon.with("\u{e5ae}")
+#let fa-square-google-plus = fa-icon.with("\u{f0d4}")
+#let fa-google-plus-square = fa-icon.with("\u{f0d4}")
+#let fa-square-h = fa-icon.with("\u{f0fd}", solid: true)
+#let fa-h-square = fa-icon.with("\u{f0fd}")
+#let fa-square-hacker-news = fa-icon.with("\u{f3af}")
+#let fa-hacker-news-square = fa-icon.with("\u{f3af}")
+#let fa-square-instagram = fa-icon.with("\u{e055}")
+#let fa-instagram-square = fa-icon.with("\u{e055}")
+#let fa-square-js = fa-icon.with("\u{f3b9}")
+#let fa-js-square = fa-icon.with("\u{f3b9}")
+#let fa-square-lastfm = fa-icon.with("\u{f203}")
+#let fa-lastfm-square = fa-icon.with("\u{f203}")
+#let fa-square-letterboxd = fa-icon.with("\u{e62e}")
+#let fa-square-minus = fa-icon.with("\u{f146}")
+#let fa-minus-square = fa-icon.with("\u{f146}")
+#let fa-square-nfi = fa-icon.with("\u{e576}", solid: true)
+#let fa-square-odnoklassniki = fa-icon.with("\u{f264}")
+#let fa-odnoklassniki-square = fa-icon.with("\u{f264}")
+#let fa-square-parking = fa-icon.with("\u{f540}", solid: true)
+#let fa-parking = fa-icon.with("\u{f540}")
+#let fa-square-pen = fa-icon.with("\u{f14b}", solid: true)
+#let fa-pen-square = fa-icon.with("\u{f14b}")
+#let fa-pencil-square = fa-icon.with("\u{f14b}")
+#let fa-square-person-confined = fa-icon.with("\u{e577}", solid: true)
+#let fa-square-phone = fa-icon.with("\u{f098}", solid: true)
+#let fa-phone-square = fa-icon.with("\u{f098}")
+#let fa-square-phone-flip = fa-icon.with("\u{f87b}", solid: true)
+#let fa-phone-square-alt = fa-icon.with("\u{f87b}")
+#let fa-square-pied-piper = fa-icon.with("\u{e01e}")
+#let fa-pied-piper-square = fa-icon.with("\u{e01e}")
+#let fa-square-pinterest = fa-icon.with("\u{f0d3}")
+#let fa-pinterest-square = fa-icon.with("\u{f0d3}")
+#let fa-square-plus = fa-icon.with("\u{f0fe}")
+#let fa-plus-square = fa-icon.with("\u{f0fe}")
+#let fa-square-poll-horizontal = fa-icon.with("\u{f682}", solid: true)
+#let fa-poll-h = fa-icon.with("\u{f682}")
+#let fa-square-poll-vertical = fa-icon.with("\u{f681}", solid: true)
+#let fa-poll = fa-icon.with("\u{f681}")
+#let fa-square-reddit = fa-icon.with("\u{f1a2}")
+#let fa-reddit-square = fa-icon.with("\u{f1a2}")
+#let fa-square-root-variable = fa-icon.with("\u{f698}", solid: true)
+#let fa-square-root-alt = fa-icon.with("\u{f698}")
+#let fa-square-rss = fa-icon.with("\u{f143}", solid: true)
+#let fa-rss-square = fa-icon.with("\u{f143}")
+#let fa-square-share-nodes = fa-icon.with("\u{f1e1}", solid: true)
+#let fa-share-alt-square = fa-icon.with("\u{f1e1}")
+#let fa-square-snapchat = fa-icon.with("\u{f2ad}")
+#let fa-snapchat-square = fa-icon.with("\u{f2ad}")
+#let fa-square-steam = fa-icon.with("\u{f1b7}")
+#let fa-steam-square = fa-icon.with("\u{f1b7}")
+#let fa-square-threads = fa-icon.with("\u{e619}")
+#let fa-square-tumblr = fa-icon.with("\u{f174}")
+#let fa-tumblr-square = fa-icon.with("\u{f174}")
+#let fa-square-twitter = fa-icon.with("\u{f081}")
+#let fa-twitter-square = fa-icon.with("\u{f081}")
+#let fa-square-up-right = fa-icon.with("\u{f360}", solid: true)
+#let fa-external-link-square-alt = fa-icon.with("\u{f360}")
+#let fa-square-upwork = fa-icon.with("\u{e67c}")
+#let fa-square-viadeo = fa-icon.with("\u{f2aa}")
+#let fa-viadeo-square = fa-icon.with("\u{f2aa}")
+#let fa-square-vimeo = fa-icon.with("\u{f194}")
+#let fa-vimeo-square = fa-icon.with("\u{f194}")
+#let fa-square-virus = fa-icon.with("\u{e578}", solid: true)
+#let fa-square-web-awesome = fa-icon.with("\u{e683}")
+#let fa-square-web-awesome-stroke = fa-icon.with("\u{e684}")
+#let fa-square-whatsapp = fa-icon.with("\u{f40c}")
+#let fa-whatsapp-square = fa-icon.with("\u{f40c}")
+#let fa-square-x-twitter = fa-icon.with("\u{e61a}")
+#let fa-square-xing = fa-icon.with("\u{f169}")
+#let fa-xing-square = fa-icon.with("\u{f169}")
+#let fa-square-xmark = fa-icon.with("\u{f2d3}", solid: true)
+#let fa-times-square = fa-icon.with("\u{f2d3}")
+#let fa-xmark-square = fa-icon.with("\u{f2d3}")
+#let fa-square-youtube = fa-icon.with("\u{f431}")
+#let fa-youtube-square = fa-icon.with("\u{f431}")
+#let fa-squarespace = fa-icon.with("\u{f5be}")
+#let fa-stack-exchange = fa-icon.with("\u{f18d}")
+#let fa-stack-overflow = fa-icon.with("\u{f16c}")
+#let fa-stackpath = fa-icon.with("\u{f842}")
+#let fa-staff-snake = fa-icon.with("\u{e579}", solid: true)
+#let fa-rod-asclepius = fa-icon.with("\u{e579}")
+#let fa-rod-snake = fa-icon.with("\u{e579}")
+#let fa-staff-aesculapius = fa-icon.with("\u{e579}")
+#let fa-stairs = fa-icon.with("\u{e289}", solid: true)
+#let fa-stamp = fa-icon.with("\u{f5bf}", solid: true)
+#let fa-stapler = fa-icon.with("\u{e5af}", solid: true)
+#let fa-star = fa-icon.with("\u{f005}")
+#let fa-star-and-crescent = fa-icon.with("\u{f699}", solid: true)
+#let fa-star-half = fa-icon.with("\u{f089}")
+#let fa-star-half-stroke = fa-icon.with("\u{f5c0}")
+#let fa-star-half-alt = fa-icon.with("\u{f5c0}")
+#let fa-star-of-david = fa-icon.with("\u{f69a}", solid: true)
+#let fa-star-of-life = fa-icon.with("\u{f621}", solid: true)
+#let fa-staylinked = fa-icon.with("\u{f3f5}")
+#let fa-steam = fa-icon.with("\u{f1b6}")
+#let fa-steam-symbol = fa-icon.with("\u{f3f6}")
+#let fa-sterling-sign = fa-icon.with("\u{f154}", solid: true)
+#let fa-gbp = fa-icon.with("\u{f154}")
+#let fa-pound-sign = fa-icon.with("\u{f154}")
+#let fa-stethoscope = fa-icon.with("\u{f0f1}", solid: true)
+#let fa-sticker-mule = fa-icon.with("\u{f3f7}")
+#let fa-stop = fa-icon.with("\u{f04d}", solid: true)
+#let fa-stopwatch = fa-icon.with("\u{f2f2}", solid: true)
+#let fa-stopwatch-20 = fa-icon.with("\u{e06f}", solid: true)
+#let fa-store = fa-icon.with("\u{f54e}", solid: true)
+#let fa-store-slash = fa-icon.with("\u{e071}", solid: true)
+#let fa-strava = fa-icon.with("\u{f428}")
+#let fa-street-view = fa-icon.with("\u{f21d}", solid: true)
+#let fa-strikethrough = fa-icon.with("\u{f0cc}", solid: true)
+#let fa-stripe = fa-icon.with("\u{f429}")
+#let fa-stripe-s = fa-icon.with("\u{f42a}")
+#let fa-stroopwafel = fa-icon.with("\u{f551}", solid: true)
+#let fa-stubber = fa-icon.with("\u{e5c7}")
+#let fa-studiovinari = fa-icon.with("\u{f3f8}")
+#let fa-stumbleupon = fa-icon.with("\u{f1a4}")
+#let fa-stumbleupon-circle = fa-icon.with("\u{f1a3}")
+#let fa-subscript = fa-icon.with("\u{f12c}", solid: true)
+#let fa-suitcase = fa-icon.with("\u{f0f2}", solid: true)
+#let fa-suitcase-medical = fa-icon.with("\u{f0fa}", solid: true)
+#let fa-medkit = fa-icon.with("\u{f0fa}")
+#let fa-suitcase-rolling = fa-icon.with("\u{f5c1}", solid: true)
+#let fa-sun = fa-icon.with("\u{f185}")
+#let fa-sun-plant-wilt = fa-icon.with("\u{e57a}", solid: true)
+#let fa-superpowers = fa-icon.with("\u{f2dd}")
+#let fa-superscript = fa-icon.with("\u{f12b}", solid: true)
+#let fa-supple = fa-icon.with("\u{f3f9}")
+#let fa-suse = fa-icon.with("\u{f7d6}")
+#let fa-swatchbook = fa-icon.with("\u{f5c3}", solid: true)
+#let fa-swift = fa-icon.with("\u{f8e1}")
+#let fa-symfony = fa-icon.with("\u{f83d}")
+#let fa-synagogue = fa-icon.with("\u{f69b}", solid: true)
+#let fa-syringe = fa-icon.with("\u{f48e}", solid: true)
+#let fa-t = fa-icon.with("\u{54}", solid: true)
+#let fa-table = fa-icon.with("\u{f0ce}", solid: true)
+#let fa-table-cells = fa-icon.with("\u{f00a}", solid: true)
+#let fa-th = fa-icon.with("\u{f00a}")
+#let fa-table-cells-column-lock = fa-icon.with("\u{e678}", solid: true)
+#let fa-table-cells-large = fa-icon.with("\u{f009}", solid: true)
+#let fa-th-large = fa-icon.with("\u{f009}")
+#let fa-table-cells-row-lock = fa-icon.with("\u{e67a}", solid: true)
+#let fa-table-columns = fa-icon.with("\u{f0db}", solid: true)
+#let fa-columns = fa-icon.with("\u{f0db}")
+#let fa-table-list = fa-icon.with("\u{f00b}", solid: true)
+#let fa-th-list = fa-icon.with("\u{f00b}")
+#let fa-table-tennis-paddle-ball = fa-icon.with("\u{f45d}", solid: true)
+#let fa-ping-pong-paddle-ball = fa-icon.with("\u{f45d}")
+#let fa-table-tennis = fa-icon.with("\u{f45d}")
+#let fa-tablet = fa-icon.with("\u{f3fb}", solid: true)
+#let fa-tablet-android = fa-icon.with("\u{f3fb}")
+#let fa-tablet-button = fa-icon.with("\u{f10a}", solid: true)
+#let fa-tablet-screen-button = fa-icon.with("\u{f3fa}", solid: true)
+#let fa-tablet-alt = fa-icon.with("\u{f3fa}")
+#let fa-tablets = fa-icon.with("\u{f490}", solid: true)
+#let fa-tachograph-digital = fa-icon.with("\u{f566}", solid: true)
+#let fa-digital-tachograph = fa-icon.with("\u{f566}")
+#let fa-tag = fa-icon.with("\u{f02b}", solid: true)
+#let fa-tags = fa-icon.with("\u{f02c}", solid: true)
+#let fa-tape = fa-icon.with("\u{f4db}", solid: true)
+#let fa-tarp = fa-icon.with("\u{e57b}", solid: true)
+#let fa-tarp-droplet = fa-icon.with("\u{e57c}", solid: true)
+#let fa-taxi = fa-icon.with("\u{f1ba}", solid: true)
+#let fa-cab = fa-icon.with("\u{f1ba}")
+#let fa-teamspeak = fa-icon.with("\u{f4f9}")
+#let fa-teeth = fa-icon.with("\u{f62e}", solid: true)
+#let fa-teeth-open = fa-icon.with("\u{f62f}", solid: true)
+#let fa-telegram = fa-icon.with("\u{f2c6}")
+#let fa-telegram-plane = fa-icon.with("\u{f2c6}")
+#let fa-temperature-arrow-down = fa-icon.with("\u{e03f}", solid: true)
+#let fa-temperature-down = fa-icon.with("\u{e03f}")
+#let fa-temperature-arrow-up = fa-icon.with("\u{e040}", solid: true)
+#let fa-temperature-up = fa-icon.with("\u{e040}")
+#let fa-temperature-empty = fa-icon.with("\u{f2cb}", solid: true)
+#let fa-temperature-0 = fa-icon.with("\u{f2cb}")
+#let fa-thermometer-0 = fa-icon.with("\u{f2cb}")
+#let fa-thermometer-empty = fa-icon.with("\u{f2cb}")
+#let fa-temperature-full = fa-icon.with("\u{f2c7}", solid: true)
+#let fa-temperature-4 = fa-icon.with("\u{f2c7}")
+#let fa-thermometer-4 = fa-icon.with("\u{f2c7}")
+#let fa-thermometer-full = fa-icon.with("\u{f2c7}")
+#let fa-temperature-half = fa-icon.with("\u{f2c9}", solid: true)
+#let fa-temperature-2 = fa-icon.with("\u{f2c9}")
+#let fa-thermometer-2 = fa-icon.with("\u{f2c9}")
+#let fa-thermometer-half = fa-icon.with("\u{f2c9}")
+#let fa-temperature-high = fa-icon.with("\u{f769}", solid: true)
+#let fa-temperature-low = fa-icon.with("\u{f76b}", solid: true)
+#let fa-temperature-quarter = fa-icon.with("\u{f2ca}", solid: true)
+#let fa-temperature-1 = fa-icon.with("\u{f2ca}")
+#let fa-thermometer-1 = fa-icon.with("\u{f2ca}")
+#let fa-thermometer-quarter = fa-icon.with("\u{f2ca}")
+#let fa-temperature-three-quarters = fa-icon.with("\u{f2c8}", solid: true)
+#let fa-temperature-3 = fa-icon.with("\u{f2c8}")
+#let fa-thermometer-3 = fa-icon.with("\u{f2c8}")
+#let fa-thermometer-three-quarters = fa-icon.with("\u{f2c8}")
+#let fa-tencent-weibo = fa-icon.with("\u{f1d5}")
+#let fa-tenge-sign = fa-icon.with("\u{f7d7}", solid: true)
+#let fa-tenge = fa-icon.with("\u{f7d7}")
+#let fa-tent = fa-icon.with("\u{e57d}", solid: true)
+#let fa-tent-arrow-down-to-line = fa-icon.with("\u{e57e}", solid: true)
+#let fa-tent-arrow-left-right = fa-icon.with("\u{e57f}", solid: true)
+#let fa-tent-arrow-turn-left = fa-icon.with("\u{e580}", solid: true)
+#let fa-tent-arrows-down = fa-icon.with("\u{e581}", solid: true)
+#let fa-tents = fa-icon.with("\u{e582}", solid: true)
+#let fa-terminal = fa-icon.with("\u{f120}", solid: true)
+#let fa-text-height = fa-icon.with("\u{f034}", solid: true)
+#let fa-text-slash = fa-icon.with("\u{f87d}", solid: true)
+#let fa-remove-format = fa-icon.with("\u{f87d}")
+#let fa-text-width = fa-icon.with("\u{f035}", solid: true)
+#let fa-the-red-yeti = fa-icon.with("\u{f69d}")
+#let fa-themeco = fa-icon.with("\u{f5c6}")
+#let fa-themeisle = fa-icon.with("\u{f2b2}")
+#let fa-thermometer = fa-icon.with("\u{f491}", solid: true)
+#let fa-think-peaks = fa-icon.with("\u{f731}")
+#let fa-threads = fa-icon.with("\u{e618}")
+#let fa-thumbs-down = fa-icon.with("\u{f165}")
+#let fa-thumbs-up = fa-icon.with("\u{f164}")
+#let fa-thumbtack = fa-icon.with("\u{f08d}", solid: true)
+#let fa-thumb-tack = fa-icon.with("\u{f08d}")
+#let fa-ticket = fa-icon.with("\u{f145}", solid: true)
+#let fa-ticket-simple = fa-icon.with("\u{f3ff}", solid: true)
+#let fa-ticket-alt = fa-icon.with("\u{f3ff}")
+#let fa-tiktok = fa-icon.with("\u{e07b}")
+#let fa-timeline = fa-icon.with("\u{e29c}", solid: true)
+#let fa-toggle-off = fa-icon.with("\u{f204}", solid: true)
+#let fa-toggle-on = fa-icon.with("\u{f205}", solid: true)
+#let fa-toilet = fa-icon.with("\u{f7d8}", solid: true)
+#let fa-toilet-paper = fa-icon.with("\u{f71e}", solid: true)
+#let fa-toilet-paper-slash = fa-icon.with("\u{e072}", solid: true)
+#let fa-toilet-portable = fa-icon.with("\u{e583}", solid: true)
+#let fa-toilets-portable = fa-icon.with("\u{e584}", solid: true)
+#let fa-toolbox = fa-icon.with("\u{f552}", solid: true)
+#let fa-tooth = fa-icon.with("\u{f5c9}", solid: true)
+#let fa-torii-gate = fa-icon.with("\u{f6a1}", solid: true)
+#let fa-tornado = fa-icon.with("\u{f76f}", solid: true)
+#let fa-tower-broadcast = fa-icon.with("\u{f519}", solid: true)
+#let fa-broadcast-tower = fa-icon.with("\u{f519}")
+#let fa-tower-cell = fa-icon.with("\u{e585}", solid: true)
+#let fa-tower-observation = fa-icon.with("\u{e586}", solid: true)
+#let fa-tractor = fa-icon.with("\u{f722}", solid: true)
+#let fa-trade-federation = fa-icon.with("\u{f513}")
+#let fa-trademark = fa-icon.with("\u{f25c}", solid: true)
+#let fa-traffic-light = fa-icon.with("\u{f637}", solid: true)
+#let fa-trailer = fa-icon.with("\u{e041}", solid: true)
+#let fa-train = fa-icon.with("\u{f238}", solid: true)
+#let fa-train-subway = fa-icon.with("\u{f239}", solid: true)
+#let fa-subway = fa-icon.with("\u{f239}")
+#let fa-train-tram = fa-icon.with("\u{e5b4}", solid: true)
+#let fa-transgender = fa-icon.with("\u{f225}", solid: true)
+#let fa-transgender-alt = fa-icon.with("\u{f225}")
+#let fa-trash = fa-icon.with("\u{f1f8}", solid: true)
+#let fa-trash-arrow-up = fa-icon.with("\u{f829}", solid: true)
+#let fa-trash-restore = fa-icon.with("\u{f829}")
+#let fa-trash-can = fa-icon.with("\u{f2ed}")
+#let fa-trash-alt = fa-icon.with("\u{f2ed}")
+#let fa-trash-can-arrow-up = fa-icon.with("\u{f82a}", solid: true)
+#let fa-trash-restore-alt = fa-icon.with("\u{f82a}")
+#let fa-tree = fa-icon.with("\u{f1bb}", solid: true)
+#let fa-tree-city = fa-icon.with("\u{e587}", solid: true)
+#let fa-trello = fa-icon.with("\u{f181}")
+#let fa-triangle-exclamation = fa-icon.with("\u{f071}", solid: true)
+#let fa-exclamation-triangle = fa-icon.with("\u{f071}")
+#let fa-warning = fa-icon.with("\u{f071}")
+#let fa-trophy = fa-icon.with("\u{f091}", solid: true)
+#let fa-trowel = fa-icon.with("\u{e589}", solid: true)
+#let fa-trowel-bricks = fa-icon.with("\u{e58a}", solid: true)
+#let fa-truck = fa-icon.with("\u{f0d1}", solid: true)
+#let fa-truck-arrow-right = fa-icon.with("\u{e58b}", solid: true)
+#let fa-truck-droplet = fa-icon.with("\u{e58c}", solid: true)
+#let fa-truck-fast = fa-icon.with("\u{f48b}", solid: true)
+#let fa-shipping-fast = fa-icon.with("\u{f48b}")
+#let fa-truck-field = fa-icon.with("\u{e58d}", solid: true)
+#let fa-truck-field-un = fa-icon.with("\u{e58e}", solid: true)
+#let fa-truck-front = fa-icon.with("\u{e2b7}", solid: true)
+#let fa-truck-medical = fa-icon.with("\u{f0f9}", solid: true)
+#let fa-ambulance = fa-icon.with("\u{f0f9}")
+#let fa-truck-monster = fa-icon.with("\u{f63b}", solid: true)
+#let fa-truck-moving = fa-icon.with("\u{f4df}", solid: true)
+#let fa-truck-pickup = fa-icon.with("\u{f63c}", solid: true)
+#let fa-truck-plane = fa-icon.with("\u{e58f}", solid: true)
+#let fa-truck-ramp-box = fa-icon.with("\u{f4de}", solid: true)
+#let fa-truck-loading = fa-icon.with("\u{f4de}")
+#let fa-tty = fa-icon.with("\u{f1e4}", solid: true)
+#let fa-teletype = fa-icon.with("\u{f1e4}")
+#let fa-tumblr = fa-icon.with("\u{f173}")
+#let fa-turkish-lira-sign = fa-icon.with("\u{e2bb}", solid: true)
+#let fa-try = fa-icon.with("\u{e2bb}")
+#let fa-turkish-lira = fa-icon.with("\u{e2bb}")
+#let fa-turn-down = fa-icon.with("\u{f3be}", solid: true)
+#let fa-level-down-alt = fa-icon.with("\u{f3be}")
+#let fa-turn-up = fa-icon.with("\u{f3bf}", solid: true)
+#let fa-level-up-alt = fa-icon.with("\u{f3bf}")
+#let fa-tv = fa-icon.with("\u{f26c}", solid: true)
+#let fa-television = fa-icon.with("\u{f26c}")
+#let fa-tv-alt = fa-icon.with("\u{f26c}")
+#let fa-twitch = fa-icon.with("\u{f1e8}")
+#let fa-twitter = fa-icon.with("\u{f099}")
+#let fa-typo3 = fa-icon.with("\u{f42b}")
+#let fa-u = fa-icon.with("\u{55}", solid: true)
+#let fa-uber = fa-icon.with("\u{f402}")
+#let fa-ubuntu = fa-icon.with("\u{f7df}")
+#let fa-uikit = fa-icon.with("\u{f403}")
+#let fa-umbraco = fa-icon.with("\u{f8e8}")
+#let fa-umbrella = fa-icon.with("\u{f0e9}", solid: true)
+#let fa-umbrella-beach = fa-icon.with("\u{f5ca}", solid: true)
+#let fa-uncharted = fa-icon.with("\u{e084}")
+#let fa-underline = fa-icon.with("\u{f0cd}", solid: true)
+#let fa-uniregistry = fa-icon.with("\u{f404}")
+#let fa-unity = fa-icon.with("\u{e049}")
+#let fa-universal-access = fa-icon.with("\u{f29a}", solid: true)
+#let fa-unlock = fa-icon.with("\u{f09c}", solid: true)
+#let fa-unlock-keyhole = fa-icon.with("\u{f13e}", solid: true)
+#let fa-unlock-alt = fa-icon.with("\u{f13e}")
+#let fa-unsplash = fa-icon.with("\u{e07c}")
+#let fa-untappd = fa-icon.with("\u{f405}")
+#let fa-up-down = fa-icon.with("\u{f338}", solid: true)
+#let fa-arrows-alt-v = fa-icon.with("\u{f338}")
+#let fa-up-down-left-right = fa-icon.with("\u{f0b2}", solid: true)
+#let fa-arrows-alt = fa-icon.with("\u{f0b2}")
+#let fa-up-long = fa-icon.with("\u{f30c}", solid: true)
+#let fa-long-arrow-alt-up = fa-icon.with("\u{f30c}")
+#let fa-up-right-and-down-left-from-center = fa-icon.with("\u{f424}", solid: true)
+#let fa-expand-alt = fa-icon.with("\u{f424}")
+#let fa-up-right-from-square = fa-icon.with("\u{f35d}", solid: true)
+#let fa-external-link-alt = fa-icon.with("\u{f35d}")
+#let fa-upload = fa-icon.with("\u{f093}", solid: true)
+#let fa-ups = fa-icon.with("\u{f7e0}")
+#let fa-upwork = fa-icon.with("\u{e641}")
+#let fa-usb = fa-icon.with("\u{f287}")
+#let fa-user = fa-icon.with("\u{f007}")
+#let fa-user-astronaut = fa-icon.with("\u{f4fb}", solid: true)
+#let fa-user-check = fa-icon.with("\u{f4fc}", solid: true)
+#let fa-user-clock = fa-icon.with("\u{f4fd}", solid: true)
+#let fa-user-doctor = fa-icon.with("\u{f0f0}", solid: true)
+#let fa-user-md = fa-icon.with("\u{f0f0}")
+#let fa-user-gear = fa-icon.with("\u{f4fe}", solid: true)
+#let fa-user-cog = fa-icon.with("\u{f4fe}")
+#let fa-user-graduate = fa-icon.with("\u{f501}", solid: true)
+#let fa-user-group = fa-icon.with("\u{f500}", solid: true)
+#let fa-user-friends = fa-icon.with("\u{f500}")
+#let fa-user-injured = fa-icon.with("\u{f728}", solid: true)
+#let fa-user-large = fa-icon.with("\u{f406}", solid: true)
+#let fa-user-alt = fa-icon.with("\u{f406}")
+#let fa-user-large-slash = fa-icon.with("\u{f4fa}", solid: true)
+#let fa-user-alt-slash = fa-icon.with("\u{f4fa}")
+#let fa-user-lock = fa-icon.with("\u{f502}", solid: true)
+#let fa-user-minus = fa-icon.with("\u{f503}", solid: true)
+#let fa-user-ninja = fa-icon.with("\u{f504}", solid: true)
+#let fa-user-nurse = fa-icon.with("\u{f82f}", solid: true)
+#let fa-user-pen = fa-icon.with("\u{f4ff}", solid: true)
+#let fa-user-edit = fa-icon.with("\u{f4ff}")
+#let fa-user-plus = fa-icon.with("\u{f234}", solid: true)
+#let fa-user-secret = fa-icon.with("\u{f21b}", solid: true)
+#let fa-user-shield = fa-icon.with("\u{f505}", solid: true)
+#let fa-user-slash = fa-icon.with("\u{f506}", solid: true)
+#let fa-user-tag = fa-icon.with("\u{f507}", solid: true)
+#let fa-user-tie = fa-icon.with("\u{f508}", solid: true)
+#let fa-user-xmark = fa-icon.with("\u{f235}", solid: true)
+#let fa-user-times = fa-icon.with("\u{f235}")
+#let fa-users = fa-icon.with("\u{f0c0}", solid: true)
+#let fa-users-between-lines = fa-icon.with("\u{e591}", solid: true)
+#let fa-users-gear = fa-icon.with("\u{f509}", solid: true)
+#let fa-users-cog = fa-icon.with("\u{f509}")
+#let fa-users-line = fa-icon.with("\u{e592}", solid: true)
+#let fa-users-rays = fa-icon.with("\u{e593}", solid: true)
+#let fa-users-rectangle = fa-icon.with("\u{e594}", solid: true)
+#let fa-users-slash = fa-icon.with("\u{e073}", solid: true)
+#let fa-users-viewfinder = fa-icon.with("\u{e595}", solid: true)
+#let fa-usps = fa-icon.with("\u{f7e1}")
+#let fa-ussunnah = fa-icon.with("\u{f407}")
+#let fa-utensils = fa-icon.with("\u{f2e7}", solid: true)
+#let fa-cutlery = fa-icon.with("\u{f2e7}")
+#let fa-v = fa-icon.with("\u{56}", solid: true)
+#let fa-vaadin = fa-icon.with("\u{f408}")
+#let fa-van-shuttle = fa-icon.with("\u{f5b6}", solid: true)
+#let fa-shuttle-van = fa-icon.with("\u{f5b6}")
+#let fa-vault = fa-icon.with("\u{e2c5}", solid: true)
+#let fa-vector-square = fa-icon.with("\u{f5cb}", solid: true)
+#let fa-venus = fa-icon.with("\u{f221}", solid: true)
+#let fa-venus-double = fa-icon.with("\u{f226}", solid: true)
+#let fa-venus-mars = fa-icon.with("\u{f228}", solid: true)
+#let fa-vest = fa-icon.with("\u{e085}", solid: true)
+#let fa-vest-patches = fa-icon.with("\u{e086}", solid: true)
+#let fa-viacoin = fa-icon.with("\u{f237}")
+#let fa-viadeo = fa-icon.with("\u{f2a9}")
+#let fa-vial = fa-icon.with("\u{f492}", solid: true)
+#let fa-vial-circle-check = fa-icon.with("\u{e596}", solid: true)
+#let fa-vial-virus = fa-icon.with("\u{e597}", solid: true)
+#let fa-vials = fa-icon.with("\u{f493}", solid: true)
+#let fa-viber = fa-icon.with("\u{f409}")
+#let fa-video = fa-icon.with("\u{f03d}", solid: true)
+#let fa-video-camera = fa-icon.with("\u{f03d}")
+#let fa-video-slash = fa-icon.with("\u{f4e2}", solid: true)
+#let fa-vihara = fa-icon.with("\u{f6a7}", solid: true)
+#let fa-vimeo = fa-icon.with("\u{f40a}")
+#let fa-vimeo-v = fa-icon.with("\u{f27d}")
+#let fa-vine = fa-icon.with("\u{f1ca}")
+#let fa-virus = fa-icon.with("\u{e074}", solid: true)
+#let fa-virus-covid = fa-icon.with("\u{e4a8}", solid: true)
+#let fa-virus-covid-slash = fa-icon.with("\u{e4a9}", solid: true)
+#let fa-virus-slash = fa-icon.with("\u{e075}", solid: true)
+#let fa-viruses = fa-icon.with("\u{e076}", solid: true)
+#let fa-vk = fa-icon.with("\u{f189}")
+#let fa-vnv = fa-icon.with("\u{f40b}")
+#let fa-voicemail = fa-icon.with("\u{f897}", solid: true)
+#let fa-volcano = fa-icon.with("\u{f770}", solid: true)
+#let fa-volleyball = fa-icon.with("\u{f45f}", solid: true)
+#let fa-volleyball-ball = fa-icon.with("\u{f45f}")
+#let fa-volume-high = fa-icon.with("\u{f028}", solid: true)
+#let fa-volume-up = fa-icon.with("\u{f028}")
+#let fa-volume-low = fa-icon.with("\u{f027}", solid: true)
+#let fa-volume-down = fa-icon.with("\u{f027}")
+#let fa-volume-off = fa-icon.with("\u{f026}", solid: true)
+#let fa-volume-xmark = fa-icon.with("\u{f6a9}", solid: true)
+#let fa-volume-mute = fa-icon.with("\u{f6a9}")
+#let fa-volume-times = fa-icon.with("\u{f6a9}")
+#let fa-vr-cardboard = fa-icon.with("\u{f729}", solid: true)
+#let fa-vuejs = fa-icon.with("\u{f41f}")
+#let fa-w = fa-icon.with("\u{57}", solid: true)
+#let fa-walkie-talkie = fa-icon.with("\u{f8ef}", solid: true)
+#let fa-wallet = fa-icon.with("\u{f555}", solid: true)
+#let fa-wand-magic = fa-icon.with("\u{f0d0}", solid: true)
+#let fa-magic = fa-icon.with("\u{f0d0}")
+#let fa-wand-magic-sparkles = fa-icon.with("\u{e2ca}", solid: true)
+#let fa-magic-wand-sparkles = fa-icon.with("\u{e2ca}")
+#let fa-wand-sparkles = fa-icon.with("\u{f72b}", solid: true)
+#let fa-warehouse = fa-icon.with("\u{f494}", solid: true)
+#let fa-watchman-monitoring = fa-icon.with("\u{e087}")
+#let fa-water = fa-icon.with("\u{f773}", solid: true)
+#let fa-water-ladder = fa-icon.with("\u{f5c5}", solid: true)
+#let fa-ladder-water = fa-icon.with("\u{f5c5}")
+#let fa-swimming-pool = fa-icon.with("\u{f5c5}")
+#let fa-wave-square = fa-icon.with("\u{f83e}", solid: true)
+#let fa-waze = fa-icon.with("\u{f83f}")
+#let fa-web-awesome = fa-icon.with("\u{e682}")
+#let fa-webflow = fa-icon.with("\u{e65c}")
+#let fa-weebly = fa-icon.with("\u{f5cc}")
+#let fa-weibo = fa-icon.with("\u{f18a}")
+#let fa-weight-hanging = fa-icon.with("\u{f5cd}", solid: true)
+#let fa-weight-scale = fa-icon.with("\u{f496}", solid: true)
+#let fa-weight = fa-icon.with("\u{f496}")
+#let fa-weixin = fa-icon.with("\u{f1d7}")
+#let fa-whatsapp = fa-icon.with("\u{f232}")
+#let fa-wheat-awn = fa-icon.with("\u{e2cd}", solid: true)
+#let fa-wheat-alt = fa-icon.with("\u{e2cd}")
+#let fa-wheat-awn-circle-exclamation = fa-icon.with("\u{e598}", solid: true)
+#let fa-wheelchair = fa-icon.with("\u{f193}", solid: true)
+#let fa-wheelchair-move = fa-icon.with("\u{e2ce}", solid: true)
+#let fa-wheelchair-alt = fa-icon.with("\u{e2ce}")
+#let fa-whiskey-glass = fa-icon.with("\u{f7a0}", solid: true)
+#let fa-glass-whiskey = fa-icon.with("\u{f7a0}")
+#let fa-whmcs = fa-icon.with("\u{f40d}")
+#let fa-wifi = fa-icon.with("\u{f1eb}", solid: true)
+#let fa-wifi-3 = fa-icon.with("\u{f1eb}")
+#let fa-wifi-strong = fa-icon.with("\u{f1eb}")
+#let fa-wikipedia-w = fa-icon.with("\u{f266}")
+#let fa-wind = fa-icon.with("\u{f72e}", solid: true)
+#let fa-window-maximize = fa-icon.with("\u{f2d0}")
+#let fa-window-minimize = fa-icon.with("\u{f2d1}")
+#let fa-window-restore = fa-icon.with("\u{f2d2}")
+#let fa-windows = fa-icon.with("\u{f17a}")
+#let fa-wine-bottle = fa-icon.with("\u{f72f}", solid: true)
+#let fa-wine-glass = fa-icon.with("\u{f4e3}", solid: true)
+#let fa-wine-glass-empty = fa-icon.with("\u{f5ce}", solid: true)
+#let fa-wine-glass-alt = fa-icon.with("\u{f5ce}")
+#let fa-wirsindhandwerk = fa-icon.with("\u{e2d0}")
+#let fa-wsh = fa-icon.with("\u{e2d0}")
+#let fa-wix = fa-icon.with("\u{f5cf}")
+#let fa-wizards-of-the-coast = fa-icon.with("\u{f730}")
+#let fa-wodu = fa-icon.with("\u{e088}")
+#let fa-wolf-pack-battalion = fa-icon.with("\u{f514}")
+#let fa-won-sign = fa-icon.with("\u{f159}", solid: true)
+#let fa-krw = fa-icon.with("\u{f159}")
+#let fa-won = fa-icon.with("\u{f159}")
+#let fa-wordpress = fa-icon.with("\u{f19a}")
+#let fa-wordpress-simple = fa-icon.with("\u{f411}")
+#let fa-worm = fa-icon.with("\u{e599}", solid: true)
+#let fa-wpbeginner = fa-icon.with("\u{f297}")
+#let fa-wpexplorer = fa-icon.with("\u{f2de}")
+#let fa-wpforms = fa-icon.with("\u{f298}")
+#let fa-wpressr = fa-icon.with("\u{f3e4}")
+#let fa-rendact = fa-icon.with("\u{f3e4}")
+#let fa-wrench = fa-icon.with("\u{f0ad}", solid: true)
+#let fa-x = fa-icon.with("\u{58}", solid: true)
+#let fa-x-ray = fa-icon.with("\u{f497}", solid: true)
+#let fa-x-twitter = fa-icon.with("\u{e61b}")
+#let fa-xbox = fa-icon.with("\u{f412}")
+#let fa-xing = fa-icon.with("\u{f168}")
+#let fa-xmark = fa-icon.with("\u{f00d}", solid: true)
+#let fa-close = fa-icon.with("\u{f00d}")
+#let fa-multiply = fa-icon.with("\u{f00d}")
+#let fa-remove = fa-icon.with("\u{f00d}")
+#let fa-times = fa-icon.with("\u{f00d}")
+#let fa-xmarks-lines = fa-icon.with("\u{e59a}", solid: true)
+#let fa-y = fa-icon.with("\u{59}", solid: true)
+#let fa-y-combinator = fa-icon.with("\u{f23b}")
+#let fa-yahoo = fa-icon.with("\u{f19e}")
+#let fa-yammer = fa-icon.with("\u{f840}")
+#let fa-yandex = fa-icon.with("\u{f413}")
+#let fa-yandex-international = fa-icon.with("\u{f414}")
+#let fa-yarn = fa-icon.with("\u{f7e3}")
+#let fa-yelp = fa-icon.with("\u{f1e9}")
+#let fa-yen-sign = fa-icon.with("\u{f157}", solid: true)
+#let fa-cny = fa-icon.with("\u{f157}")
+#let fa-jpy = fa-icon.with("\u{f157}")
+#let fa-rmb = fa-icon.with("\u{f157}")
+#let fa-yen = fa-icon.with("\u{f157}")
+#let fa-yin-yang = fa-icon.with("\u{f6ad}", solid: true)
+#let fa-yoast = fa-icon.with("\u{f2b1}")
+#let fa-youtube = fa-icon.with("\u{f167}")
+#let fa-z = fa-icon.with("\u{5a}", solid: true)
+#let fa-zhihu = fa-icon.with("\u{f63f}")

--- a/packages/preview/fontawesome/0.2.1/lib-impl.typ
+++ b/packages/preview/fontawesome/0.2.1/lib-impl.typ
@@ -1,0 +1,33 @@
+/// Render a Font Awesome icon by its name or unicode
+///
+/// Parameters:
+/// - `name`: The name of the icon
+///   - This can be name in string or unicode of the icon
+/// - `solid`: Whether to use the solid version of the icon
+/// - `fa-icon-map`: The map of icon names to unicode
+///   - Default is a map generated from FontAwesome metadata
+///   - *Not recommended* You can provide your own map to override it
+/// - `..args`: Additional arguments to pass to the `text` function
+///
+/// Returns: The rendered icon as a `text` element
+#let fa-icon(
+  name,
+  solid: false,
+  fa-icon-map: (:),
+  ..args,
+) = {
+  text(
+    font: (
+      "Font Awesome 6 Free" + if solid {
+        " Solid"
+      },
+      "Font Awesome 6 Brands",
+    ),
+    // TODO: We might need to check whether this is needed
+    weight: if solid { 900 } else { 400 },
+    // If the name is in the map, use the unicode from the map
+    // If not, pass the name and let the ligature feature handle it
+    fa-icon-map.at(name, default: name),
+    ..args,
+  )
+}

--- a/packages/preview/fontawesome/0.2.1/lib.typ
+++ b/packages/preview/fontawesome/0.2.1/lib.typ
@@ -1,0 +1,26 @@
+//! typst-fontawesome
+//!
+//! https://github.com/duskmoon314/typst-fontawesome
+
+// Implementation of `fa-icon`
+#import "lib-impl.typ": *
+
+// Generated icons
+#import "lib-gen.typ": *
+
+// Re-export the `fa-icon` function
+// The following doc comment is needed for lsp to show the documentation
+
+/// Render a Font Awesome icon by its name or unicode
+///
+/// Parameters:
+/// - `name`: The name of the icon
+///   - This can be name in string or unicode of the icon
+/// - `solid`: Whether to use the solid version of the icon
+/// - `fa-icon-map`: The map of icon names to unicode
+///   - Default is a map generated from FontAwesome metadata
+///   - *Not recommended* You can provide your own map to override it
+/// - `..args`: Additional arguments to pass to the `text` function
+///
+/// Returns: The rendered icon as a `text` element
+#let fa-icon = fa-icon.with(fa-icon-map: fa-icon-map)

--- a/packages/preview/fontawesome/0.2.1/typst.toml
+++ b/packages/preview/fontawesome/0.2.1/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fontawesome"
+version = "0.2.1"
+entrypoint = "lib.typ"
+authors = ["duskmoon (Campbell He) <kp.campbell.he@duskmoon314.com>"]
+license = "MIT"
+description = "A Typst library for Font Awesome icons through the desktop fonts."
+repository = "https://github.com/duskmoon314/typst-fontawesome"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

`fontawesome:0.2.1` adds a feature to find the icon's unicode in a generated map before leveraging the fonts' ligature feature.  This eases the use of icons in the Brands set.
