### PR TITLE
numbly:0.1.0

### DIFF
--- a/packages/preview/numbly/0.1.0/LICENSE
+++ b/packages/preview/numbly/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 梦飞翔
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/numbly/0.1.0/README.md
+++ b/packages/preview/numbly/0.1.0/README.md
@@ -1,0 +1,43 @@
+# numbly
+
+A package that helps you to specify different numbering formats for different levels of headings.
+
+Suppose you want to specify the following numbering format for your document:
+
+- Appendix A. Guide
+  - A.1. Installation
+    - Step 1. Download
+    - Step 2. Install
+  - A.2. Usage
+
+You might use `if` to achieve this:
+
+```typst
+#set heading(numbering: (..nums) => {
+  nums = nums.pos()
+  if nums.len() == 1 {
+    return "Appendix " + numbering("A.", ..nums)
+  } else if nums.len() == 2 {
+    return numbering("A.1.", ..nums)
+  } else {
+    return "Step " + numbering("1.", nums.last())
+  }
+})
+
+= Guide
+== Installation
+=== Download
+=== Install
+== Usage
+```
+
+But with `numbly`, you can do this more easily:
+
+```typst
+#import "@preview/numbly:0.1.0": numbly
+#set heading(numbering: numbly(
+  "Appendix {1:A}.", // use {level:format} to specify the format
+  "{1:A}.{2}.", // if format is not specified, arabic numbers will be used
+  "Step {3}.", // here, we only want the 3rd level
+))
+```

--- a/packages/preview/numbly/0.1.0/lib.typ
+++ b/packages/preview/numbly/0.1.0/lib.typ
@@ -1,0 +1,31 @@
+#let numbly(..arr, default: "1.") = (..nums) => {
+  let arr = arr.pos()
+  nums = nums.pos()
+  if nums.len() > arr.len() {
+    if default == none {
+      return none
+    }
+    if type(default) == function {
+      return default(..nums)
+    }
+    return numbering(default, ..nums)
+  }
+  let format = arr.at(nums.len() - 1)
+  if format == none {
+    return none
+  }
+  if type(format) == function {
+    return format(..nums)
+  }
+  format.replace(
+    regex("\{(\d)(:(.+?))?\}"),
+    m => {
+      let (a, b, c) = m.captures
+      if b != none {
+        numbering(c, nums.at(int(a) - 1))
+      } else {
+        str(nums.at(int(a) - 1))
+      }
+    },
+  )
+}

--- a/packages/preview/numbly/0.1.0/typst.toml
+++ b/packages/preview/numbly/0.1.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "numbly"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["flaribbit <@flaribbit>"]
+license = "MIT"
+description = "A package that helps you to specify different numbering formats for different levels of headings."
+categories = ["utility"]
+keywords = ["numbering", "helper", "tool"]
+repository = "https://github.com/flaribbit/numbly"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: A package that helps you to specify different numbering formats for different levels of headings.

Suppose you want to specify the following numbering format for your document:

- Appendix A. Guide
  - A.1. Installation
    - Step 1. Download
    - Step 2. Install
  - A.2. Usage

You might use `if` to achieve this:

```typst
#set heading(numbering: (..nums) => {
  nums = nums.pos()
  if nums.len() == 1 {
    return "Appendix " + numbering("A.", ..nums)
  } else if nums.len() == 2 {
    return numbering("A.1.", ..nums)
  } else {
    return "Step " + numbering("1.", nums.last())
  }
})

= Guide
== Installation
=== Download
=== Install
== Usage
```

But with `numbly`, you can do this more easily:

```typst
#import "@preview/numbly:0.1.0": numbly
#set heading(numbering: numbly(
  "Appendix {1:A}.", // use {level:format} to specify the format
  "{1:A}.{2}.", // if format is not specified, arabic numbers will be used
  "Step {3}.", // here, we only want the 3rd level
))
```

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE
