### PR TITLE
Update repo URLs and format typst.toml files for crudo, prequery, scrutinize, and stack-pointer

### DIFF
--- a/packages/preview/crudo/0.1.0/typst.toml
+++ b/packages/preview/crudo/0.1.0/typst.toml
@@ -1,3 +1,5 @@
+# for a description of available keys, see https://github.com/typst/packages/?tab=readme-ov-file#package-format
+
 [package]
 name = "crudo"
 version = "0.1.0"
@@ -7,10 +9,11 @@ authors = [
 ]
 license = "MIT"
 description = "Take slices from raw blocks"
-repository = "https://github.com/SillyFreak/typst-packages/tree/main/crudo"
+# homepage = ""
+repository = "https://github.com/SillyFreak/typst-crudo"
+keywords = ["raw", "code", "block"]
 categories = ["text", "scripting", "utility"]
 disciplines = []
-keywords = ["raw", "code", "block"]
 compiler = "0.9.0"
 exclude = [
   # docs and gallery are not needed in the final package

--- a/packages/preview/prequery/0.1.0/typst.toml
+++ b/packages/preview/prequery/0.1.0/typst.toml
@@ -1,3 +1,5 @@
+# for a description of available keys, see https://github.com/typst/packages/?tab=readme-ov-file#package-format
+
 [package]
 name = "prequery"
 version = "0.1.0"
@@ -7,11 +9,12 @@ authors = [
 ]
 license = "MIT"
 description = "library for extracting metadata for preprocessing from a typst document"
-repository = "https://github.com/SillyFreak/typst-packages/tree/main/prequery"
+# homepage = ""
+repository = "https://github.com/SillyFreak/typst-prequery"
+keywords = ["query", "metadata", "preprocessing"]
 categories = ["scripting", "utility"]
 disciplines = []
-keywords = ["query", "metadata", "preprocessing"]
-# compiler = ""
+# compiler = "0.11.0"
 exclude = [
   # docs and gallery are not needed in the final package
   "docs",

--- a/packages/preview/scrutinize/0.2.0/typst.toml
+++ b/packages/preview/scrutinize/0.2.0/typst.toml
@@ -1,3 +1,5 @@
+# for a description of available keys, see https://github.com/typst/packages/?tab=readme-ov-file#package-format
+
 [package]
 name = "scrutinize"
 version = "0.2.0"
@@ -7,10 +9,11 @@ authors = [
 ]
 license = "MIT"
 description = "A library for building exams, tests, etc. with Typst"
-repository = "https://github.com/SillyFreak/typst-packages/tree/main/scrutinize"
+# homepage = ""
+repository = "https://github.com/SillyFreak/typst-scrutinize"
+keywords = ["exam", "test", "school", "teaching"]
 categories = ["model", "scripting", "office"]
 disciplines = ["education"]
-keywords = ["exam", "test", "school", "teaching"]
 compiler = "0.11.0"
 exclude = [
   # docs and gallery are not needed in the final package

--- a/packages/preview/stack-pointer/0.1.0/typst.toml
+++ b/packages/preview/stack-pointer/0.1.0/typst.toml
@@ -1,3 +1,5 @@
+# for a description of available keys, see https://github.com/typst/packages/?tab=readme-ov-file#package-format
+
 [package]
 name = "stack-pointer"
 version = "0.1.0"
@@ -7,9 +9,12 @@ authors = [
 ]
 license = "MIT"
 description = "A library for visualizing the execution of (imperative) computer programs"
-repository = "https://github.com/SillyFreak/typst-packages/tree/main/stack-pointer"
-keywords = []
-# compiler = ""
+# homepage = ""
+repository = "https://github.com/SillyFreak/typst-stack-pointer"
+keywords = ["program", "execution"]
+categories = ["scripting", "presentation"]
+disciplines = ["computer-science"]
+# compiler = "0.9.0"
 exclude = [
   # docs and gallery are not needed in the final package
   "docs/*",


### PR DESCRIPTION
This PR makes some non-functional changes to my packages; most importantly, the repository URLs are updated to individual repos (they were previously all part of the same monorepo)

I made some other minor changes:
- bring the files' formatting in line with how I write them now (matching the [typst-package-template](https://github.com/typst-community/typst-package-template/)):
  - add an informative comment
  - add an unused line for the `homepage` key for completeness
  - move `keywords` key up
- for `stack-pointer`, add categories and disciplines
- for `prequery` and `stack-pointer`, fill the `compiler` key _in a comment_ with what I'd have put there had I thought about it before release.

None of these changes should impact the functionality of the packages in any way. The only effects should be improved presentation on Universe. If I should regardless exclude any changes, let me know.