### PR TITLE
quill:0.4.0

### DIFF
--- a/packages/preview/quill/0.4.0/LICENSE
+++ b/packages/preview/quill/0.4.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/quill/0.4.0/README.md
+++ b/packages/preview/quill/0.4.0/README.md
@@ -1,0 +1,189 @@
+<div align="center">
+  <img alt="Quill" src="docs/images/logo.svg" style="max-width: 100%; width: 300pt">
+</div>
+
+<div align="center">
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fquill%2Fmain%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/quill)
+[![Test Status](https://github.com/Mc-Zen/quill/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/quill/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/quill/blob/main/LICENSE)
+[![User Manual](https://img.shields.io/badge/manual-.pdf-purple)][guide]
+
+</div>
+
+
+**Quill** is a package for creating quantum circuit diagrams in [Typst](https://typst.app/). 
+
+
+_Note, that this package is in beta and may still be undergoing breaking changes. As new features like data types and scoped functions will be added to Typst, this package will be adapted to profit from the new paradigms._
+
+_Meanwhile, we suggest importing everything from the package in a local scope to avoid polluting the global namespace (see example below)._
+
+- [**Usage**](#basic-usage) _quick introduction_
+- [**Cheat sheet**](#cheat-sheet) _gallery for quickly viewing all kinds of gates_
+- [**Tequila**](#tequila) _building (sub-)circuits in a way similar to QASM or Qiskit_
+- [**Examples**](#examples)
+- [**Changelog**](#changelog)
+
+
+## Basic usage
+
+The function `quantum-circuit()` takes any number of positional gates and works somewhat similarly to the built-int Typst functions `table()` or `grid()`. A variety of different gate and instruction commands are available for adding elements and integers can be used to produce any number of empty cells (filled with the current wire style). A new wire is started by adding a `[\ ]` item. 
+
+```typ
+#{
+  import "@preview/quill:0.4.0": *
+
+  quantum-circuit(
+    lstick($|0〉$), $H$, ctrl(1), rstick($(|00〉+|11〉)/√2$, n: 2), [\ ],
+    lstick($|0〉$), 1, targ(), 1
+  )
+}
+```
+<h3 align="center">
+  <img alt="Bell Circuit" src="docs/images/bell.svg">
+</h3>
+
+Plain quantum gates — such as a Hadamard gate — can be written with the shorthand notation `$H$` instead of the more lengthy `gate($H$)`. The latter offers more options, however. 
+
+Refer to the [user guide][guide] for a full documentation of this package. You can also look up the documentation of any function by calling the help module, e.g., `help("gate")` in order to print the signature and description of the `gate` command, just where you are currently typing (powered by [tidy][tidy]). 
+
+## Cheat Sheet
+
+Instead of listing every featured gate (as is done in the [user guide][guide]), this gallery quickly showcases a large selection of possible gates and decorations that can be added to any quantum circuit. 
+
+<h3 align="center">
+  <img alt="Gallery" src="docs/images/gallery.svg" />
+</h3>
+
+
+## Tequila
+
+_Tequila_ is a submodule that adds a completely different way of building circuits. 
+
+```typ
+#import "@preview/quill:0.4.0" as quill: tequila as tq
+
+#quill.quantum-circuit(
+  ..tq.build(
+    tq.h(0),
+    tq.cx(0, 1),
+    tq.cx(0, 2),
+  ),
+  quill.gategroup(x: 2, y: 0, 3, 2)
+)
+```
+This is similar to how _QASM_ and _Qiskit_ work: gates are successively applied to the circuit which is then layed out automatically by packing gates as tightly as possible. We start by calling the `tq.build()` function and filling it with quantum operations. This returns a collection of gates which we expand into the circuit with the `..` syntax. 
+Now, we still have the option to add annotations, groups, slices, or even more gates via manual placement. 
+
+The syntax works analog to Qiskit. Available gates are `x`, `y`, `z`, `h`, `s`, `sdg`, `sx`, `sxdg`, `t`, `tdg`, `p`, `rx`, `ry`, `rz`, `u`, `cx`, `cz`, and `swap`. With `barrier`, an invisible barrier can be inserted to prevent gates on different qubits to be packed tightly. Finally, with `tq.gate` and `tq.mqgate`, a generic gate can be created. These two accept the same styling arguments as the normal `gate` (or `mqgate`).
+
+Also like Qiskit, all qubit arguments support ranges, e.g., `tq.h(range(5))` adds a Hadamard gate on the first five qubits and `tq.cx((0, 1), (1, 2))` adds two CX gates: one from qubit 0 to 1 and one from qubit 1 to 2. 
+
+With Tequila, it is easy to build templates for quantum circuits and to compose circuits of various building blocks. For this purpose, `tq.build()` and the built-in templates all feature optional `x` and `y` arguments to allow placing a subcircuit at an arbitrary position of the circuit. 
+As an example, Tequila provides a `tq.graph-state()` template for quickly drawing graph state preparation circuits. 
+
+The following example demonstrates how to compose multiple subcircuits. 
+
+
+```typ
+#import tequila as tq
+
+#quantum-circuit(
+  ..tq.graph-state((0, 1), (1, 2)),
+  ..tq.build(y: 3, 
+      tq.p($pi$, 0), 
+      tq.cx(0, (1, 2)), 
+    ),
+  ..tq.graph-state(x: 6, y: 2, invert: true, (0, 1), (0, 2)),
+  gategroup(x: 1, 3, 3),
+  gategroup(x: 1, y: 3, 3, 3),
+  gategroup(x: 6, y: 2, 3, 3),
+  slice(x: 5)
+)
+```
+<div align="center">
+  <img alt="Gallery" src="docs/images/composition.svg" />
+</div>
+
+
+## Examples
+
+Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview). The code for these examples can be found in the [example folder](./examples/) or in the [user guide][guide]. 
+
+<h3 align="center">
+  <img alt="Quantum teleportation circuit" src="docs/images/teleportation.svg">
+</h3>
+<h3 align="center">
+  <img alt="Quantum circuit for phase estimation" src="docs/images/phase-estimation.svg">
+</h3>
+<h3 align="center">
+  <img alt="Quantum fourier transformation circuit" src="docs/images/qft.svg">
+</h3>
+
+## Contribution
+
+If you spot an issue or have a suggestion, you are invited to [post it](https://github.com/Mc-Zen/quill/issues) or to contribute. In [architecture.md](docs/architecture.md), you can also find a description of the algorithm that forms the base of `quantum-circuit()`. 
+
+## Tests
+This package uses [typst-test](https://github.com/tingerrr/typst-test/) for running [tests](tests/). 
+
+
+## Changelog
+### v0.4.0
+- Alternative model for creating and composing circuits: [Tequila](#tequila). 
+
+### v0.3.0
+- New features
+  - Enable manual placement of gates, `gate($X$, x: 3, y: 1)`, similar to built-in `table()` in addition to automatic placement. This works for most elements, not only gates. 
+  - Add parameter `pad` to `lstick()` and `rstick()`. 
+  - Add parameter `fill-wires` to `quantum-circuit()`. All wires are filled unto the end (determined by the longest wire) by default (breaking change ⚠️). This behavior can be reverted by setting `fill-wires: false`. 
+  - `gategroup()` `slice()` and `annotate()` can now be placed above or below the circuit with `z: "above"` and `z: "below"`.
+  - `help()` command for quickly displaying the documentation of a given function, e.g., `help("gate")`. Powered by [tidy][tidy]. 
+- Improvements:
+  - Complete rework of circuit layout implementation
+    - allows transparent gates since wires are not drawn through gates anymore. The default fill is now `auto` and using `none` sets the background to transparent. 
+    - `midstick` is now transparent by default. 
+  - `setwire()` can now be used to override only partial wire settings, such as wire color `setwire(1, stroke: blue)`, width `setwire(1, stroke: 1pt)` or wire distance, all separately. Before, some settings were reset. 
+- Fixes:
+  - Fixed `lstick`/`rstick` when equation numbering is turned on. 
+- Removed:
+  - The already deprecated `scale-factor` (use `scale` instead)
+
+### v0.2.1
+- Improvements:
+  - Add `fill` parameter to `midstick()`. 
+  - Add `bend` parameter to `permute()`. 
+  - Add `separation` parameter to `permute()`. 
+- Fixes:
+  - With Typst 0.11.0, `scale()` now takes into account outer alignment. This broke the positioning of centered/right-aligned circuits, e.g., ones put into a `figure()`. 
+  - Change wires to be drawn all through `ctrl()`, making it consistent to `swap()` and `targ()`. 
+
+
+### v0.2.0
+- New features:
+  - Add arbitrary labels to any `gate` (also derived gates such as `meter`, `ctrl`, ...), `gategroup` or `slice` that can be anchored to any of the nine 2d alignments. 
+  - Add optional gate inputs and outputs for multi-qubit gates (see gallery).
+  - Implicit gates (breaking change ⚠️): a content item automatically becomes a gate, so you can just type `$H$` instead of `gate($H$)` (of course, the `gate()` function is still important in order to use the many available options). 
+- Other breaking changes ⚠️: 
+  - `slice()` has no `dx` and `dy` parameters anymore. Instead, labels are handled through `label` exactly as in `gate()`. Also the `wires` parameter is replaced with `n` for consistency with other multi-qubit gates. 
+  - Swap order of row and column parameters in `annotate()` to make it consistent with built-in Typst functions. 
+- Improvements: 
+  - Improve layout (allow row/column spacing and min lengths to be specified in em-lengths).
+  - Automatic bounds computation, even for labels. 
+  - Improve meter (allow multi-qubit gate meters and respect global (per-circuit) gate padding).d
+- Fixes:
+  - `lstick`/`rstick` braces broke with Typst 0.7.0.
+  - `lstick`/`rstick` bounds.
+- Documentation
+  - Add section on creating custom gates. 
+  - Add section on using labels. 
+  - Explain usage of `slice()` and `gategroup()`.
+
+### v0.1.0
+
+Initial Release
+
+
+[guide]: https://github.com/Mc-Zen/quill/releases/download/v0.4.0/quill-guide.pdf
+[tidy]: https://github.com/Mc-Zen/tidy

--- a/packages/preview/quill/0.4.0/docs/architecture.md
+++ b/packages/preview/quill/0.4.0/docs/architecture.md
@@ -1,0 +1,107 @@
+# Architecture
+
+The main algorithm used in `quantum-circuit` for circuit layout is quite intricate and is described here broadly for a better overview. The algorithm specifically takes care of the following things:
+- Not drawing wires through gates: this way we can also use transparent gates. 
+- Computing the bounding box of the circuit: it also treats labels that can be attached to almost anything. 
+- Computing the position of automatically placed items.
+- Custom spacing between rows and columns (so-called gutters). 
+- Correctly adjusting the wire distance according to the gate heights: especially for the case of multi-qubit gates. 
+
+
+## Notes
+### Differentiation between single-qubit and multi-qubit gates
+`quill` differentiates between ordinary single-qubit gates (such as a Hadmard gate) and multi-qubit-gates. The latter are generalized gates that can 
+a) span across multiple qubits,
+b) have a control wire towards some target qubit,
+c) have both. 
+
+This differentiation is used because multi-qubit gates require much more care and processing. 
+
+
+### Anatomy of a cell
+
+```
+          cell   gutter
+      ┌─────────┬──┐     ┐
+      │  ┌───┐  │  │     │
+wire ─┼──┤ H ├──┼──┼─    │ cell height
+      │  └───┘  │  │     │   ┐  
+      └─────────┴──┘     ┘   ┘ 0.5*row-spacing 
+      └─────────┘
+       cell width
+
+      └──┘
+ 0.5*column-spacing
+```
+A quantum circuit is made up of a matrix of cells. Gates are by default placed in the middle of a cell (exception for example `lstick`) and wires _always_ run through vertically centered through the cell. 
+
+The padding of the cell is determined by the value of `column-spacing` and `row-spacing`. These lengths can be specified in `quantum-circuit()` and are added to the size of the gate to compute a temporary cell size. The largest cell in a row and column determines the final cell width and height. If `equal-row-heights` is true, then all rows are resized to match the largest row. To the right of each cell (or rather column) is an optional gutter that has zero width by default. Additional row gutters can increase the spacing between rows. 
+
+As an example, this code 
+```typ
+#quantum-circuit(
+    1, $H$, 10pt, ctrl(1), 1, [\ ], 15pt
+    2, 5pt, $X$, 1
+)
+```
+produces a circuit according the following schematic:
+```
+           col 0        col 1  
+        ┌─────────┬──┬─────────┬┐  
+        │  ┌───┐  │  │         ││  
+wire 0 ─┼──┤ H ├──┼──┼────o────┼┼─ 
+        │  └───┘  │  │    │    ││  
+        ├─────────┼──┼────┼────┼┤  
+        ├─────────┼──┼────┼────┼┤   ← 15pt row gutter
+        │         │  │  ┌─┴─┐  ││  
+wire 1 ─┼─────────┼──┼──┤ X ├──┼┼─ 
+        │         │  │  └───┘  ││  
+        └─────────┴──┴─────────┴┘  
+                   ↑            ↑
+              10pt gutter   0pt gutter
+```
+Note, that the `5pt` gutter is overridden by the `10pt` gutter in the same column. 
+
+
+## Description of the `quantum-circuit()` layout algorithm
+
+The algorithm is roughly divided into two parts. First, we iterate over all children, determine their position and compute the layout. In the second step, the actual circuit is created by composing the different item groups:
+- decorations
+- horizontal and vertical wires
+- single-qubit-gates and multi-qubit gates. 
+
+### Preprocessing
+First, "auto"-gates are processed, i.e., we replace `str` and `content` items (like `$H$`) with gates. 
+
+### Build Matrix
+All gates are arranged in a grid — the _matrix_. By default, gates are placed automatically, advancing the column index but gates can also be explicitly placed in a specific cell. In the first pass through all children, we:
+- Determine the matrix position of automatically placed items. 
+- Add an entry to the matrix for each gate that contains the `size` of the gate, whether the gate is in `box` mode and some gutter value for optional spacing after the corresponding column. Empty cells simply have a size of 0. The matrix is automatically resized to accommodate for new gates. Each cell can only host one item. 
+- Store all column gutters (specified by `length` children after a gate).
+- Store row gutters separately (specified by `length` children after a `[\ ]`). 
+- Store all `setwire()` instructions in an array to be processed later. 
+- Put all normal (non-controlled or multi-qubit) gates in an array `single-qubit-gates`. 
+- Put multi-qubit-gates (including controlled gates) in an array `multi-qubit-gates`. 
+- Store all decorations (such as `slice`, `gategroup`, or `annotate`) together with their cell position in an array. 
+
+The matrix requires some post-processing to equalize the row lengths. The column gutters are computed as the maximum gutters per column across all rows. 
+
+### Process multi-qubit gates
+
+For all multi-qubit gates that have a `target`, a (vertical) control wire instruction is stored containing column, starting and target wire, as well as the wire style. 
+
+If a gate spans across multiple qubits, the size-hints `width` is unconditionally set to the width of the gate for all cells that the gate contains. This is important for wire placement. Additionally, if the `size-all-wires` parameter requires it, the cell height is set to the same value as well. 
+
+### Finish layout computation
+
+Now the necessary height of each row and the width of each column can be computed using the size hints stored in the matrix. In both cases the maximum value per column/row is used. For ease of access the center coordinates of each column and row is computed from the row heights, column widths and row/column gutters. 
+
+### Build circuit
+
+In this step, the circuit is crafted from the individual components. First, the decorations (`slice`, `gategroup`, `annotate`) are drawn on two layers (one below the circuit which is applied immediately and one above the circuit which is applied later on). Afterwards, the horizontal and verticals wires are drawn. Here, we need to take care not to drawn _through_ a gate and use the size hints from the matrix cells. Then, the gates are drawn and finally the second the decoration layer is applied. 
+
+Most items in the circuit feature the attachment of labels at each side. In order to accommodate for their size and to appropriately pad the circuit, the bounds of the circuit need to be updated for each item with labels. These contain gates, decorations, and vertical wires. 
+
+### Apply scaling and bounds extension
+
+Finally, the entire circuit is scaled according to the `scale` argument and padded with the bounds that were computed in the building step. 

--- a/packages/preview/quill/0.4.0/docs/images/bell.svg
+++ b/packages/preview/quill/0.4.0/docs/images/bell.svg
@@ -1,0 +1,290 @@
+<svg class="typst-doc" viewBox="0 0 190.3132 76.55799999999999" width="190.3132" height="76.55799999999999" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(-0 -0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0.87867963 0.87867963 C 1.4412888 0.31607053 2.2043505 0 3 0 L 187.3132 0 C 188.97005 0.00000000000000032750764 190.3132 1.3431457 190.3132 3 L 190.3132 73.558 C 190.3132 75.21485 188.97005 76.558 187.3132 76.558 L 3 76.558 C 1.3431457 76.558 0.000000000000000082243954 75.21485 0.00000000000000018369701 73.558 L 0.0000000000000045041286 3 C 0.000000000000004552848 2.2043505 0.31607053 1.4412888 0.87867963 0.87867963 Z "/>
+        </g>
+        <g transform="translate(6 6)">
+            <g class="typst-group">
+                <g transform="matrix(1.3 0 0 1.3 0 0)">
+                    <g transform="translate(23.67 4.000000000000001)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(45.39 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                </g>
+                                <g transform="translate(29.089999999999996 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.3 0 "/>
+                                </g>
+                                <g transform="translate(47.69 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 14 0 "/>
+                                </g>
+                                <g transform="translate(0 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(20.544999999999998 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.845 0 "/>
+                                </g>
+                                <g transform="translate(45.39 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.3 0 "/>
+                                </g>
+                                <g transform="translate(0 16.415)"/>
+                                <g transform="translate(-19.67 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(12 -0.0000000000000008881784197001252)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(16 3.999999999999999)"/>
+                                <g transform="translate(16 3.999999999999999)"/>
+                                <g transform="translate(16 10.829999999999998)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g3" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(25.089999999999996 10.829999999999998)"/>
+                                <g transform="translate(43.09 5.114999999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(61.69 7.414999999999999)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(0 -2.5)"/>
+                                            <g transform="translate(0 -2.5)"/>
+                                            <g transform="translate(0 -2.5)"/>
+                                            <g transform="translate(0 21.83)"/>
+                                            <g transform="translate(0 29.33)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g4" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(0 17.632499999999997)"/>
+                                            <g transform="translate(0 25.112499999999997)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(0 5.914999999999999)"/>
+                                            <g transform="translate(0 20.915)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(0 1.7174999999999976)"/>
+                                            <g transform="translate(0 9.197499999999998)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(0 -2.5)"/>
+                                            <g transform="translate(0 5)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g7" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(0 29.33)"/>
+                                            <g transform="translate(9.02 5.376999999999999)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(4 4)"/>
+                                                        <g transform="translate(4 0.3699999999999992)"/>
+                                                        <g transform="translate(5 0.3699999999999992)"/>
+                                                        <g transform="translate(5 0.3699999999999992)"/>
+                                                        <g transform="translate(5 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(6.946 0.9579999999999993)"/>
+                                                        <g transform="translate(6.946 0.9579999999999993)"/>
+                                                        <g transform="translate(6.946 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(10.446 0.9579999999999993)"/>
+                                                        <g transform="translate(10.446 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(13.946 0.3699999999999992)"/>
+                                                        <g transform="translate(13.946 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(16.669 1.5389999999999997)"/>
+                                                        <g transform="translate(16.669 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(22.115000000000002 0.3699999999999992)"/>
+                                                        <g transform="translate(22.115000000000002 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(24.061000000000003 0.9579999999999993)"/>
+                                                        <g transform="translate(24.061000000000003 0.9579999999999993)"/>
+                                                        <g transform="translate(24.061000000000003 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(27.561000000000003 0.9579999999999993)"/>
+                                                        <g transform="translate(27.561000000000003 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(31.061000000000003 0.3699999999999992)"/>
+                                                        <g transform="translate(31.061000000000003 5.619999999999999)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(14.485000000000001 9.29)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)"/>
+                                                                    <g transform="translate(0 0.3360000000000008)"/>
+                                                                    <g transform="translate(0 0.6160000000000008)">
+                                                                        <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                            <use xlink:href="#g10" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(5.8309999999999995 0.5040000000000008)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.336" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 3.983 0 "/>
+                                                                    </g>
+                                                                    <g transform="translate(5.8309999999999995 1.8550000000000004)"/>
+                                                                    <g transform="translate(5.8309999999999995 6.503000000000001)">
+                                                                        <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                            <use xlink:href="#g11" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(5 8.329999999999998)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.48" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 28.784 0 "/>
+                                                        </g>
+                                                        <g transform="translate(34.784000000000006 10.83)"/>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(0 43.245)"/>
+                                <g transform="translate(-19.67 26.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(41.09 29.944999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 4.3 C 0 1.9273288 1.9273288 0 4.3 0 C 6.6726713 0 8.6 1.9273288 8.6 4.3 C 8.6 6.6726713 6.6726713 8.6 4.3 8.6 C 1.9273288 8.6 0 6.6726713 0 4.3 "/>
+                                </g>
+                                <g transform="translate(45.39 38.544999999999995)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0.0000000000000005265981 -8.6 "/>
+                                </g>
+                                <g transform="translate(41.09 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 8.6 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0 0)"/>
+    </g>
+    <defs id="glyph">
+        <symbol id="g0" overflow="visible">
+            <path d="M 139 -250 C 152.33333 -250 159 -242 159 -226 L 159 726 C 159 742 152.33333 750 139 750 C 125.66667 750 119 742 119 726 L 119 -226 C 119 -242 125.66667 -250 139 -250 Z "/>
+        </symbol>
+        <symbol id="g1" overflow="visible">
+            <path d="M 249 -22 C 389.6667 -22 460 92 460 320 C 460 473.3333 428.3333 575 365 625 C 329.6667 652.3333 291.33334 666 250.00002 666 C 109.33334 666 39.000015 550.6667 39.000015 320 C 39.000015 136.38824 87.780106 -22 249.00002 -22 Z M 361 524 C 367.6667 489.3333 371 425.3333 371 332 C 371 240 367.3333 172 360 128 C 347.3333 48 310.3333 8 248.99998 8 C 225.66666 8 203.33331 16.666672 181.99998 34 C 155.33331 56.66667 138.66666 104 131.99998 176 C 129.33331 200.66667 127.999985 252.66667 127.999985 332 C 127.999985 419.3333 130.66666 479.66666 135.99998 513 C 144.66666 567.6667 162.99998 602.6667 190.99998 618 C 212.99998 630 232.33331 636 248.99998 636 C 313.54602 636 349.9783 582.78235 361 524 Z "/>
+        </symbol>
+        <symbol id="g2" overflow="visible">
+            <path d="M 278 242 C 278.6667 244 279 246.66667 279 250 C 279 253.33333 278.6667 256 278 258 L 98 735 C 94 745 86.66667 750 76 750 C 60.66667 750 53 742 53 726 C 53 722.6667 53.33333 720 54 718 L 231 250 L 54 -217 C 53.33333 -219 53 -222 53 -226 C 53 -242 60.66667 -250 76 -250 C 86.66667 -250 94 -245 98 -235 Z "/>
+        </symbol>
+        <symbol id="g3" overflow="visible">
+            <path d="M 881 668 C 881 678 875 683 863 683 L 736 680 L 609 683 C 593.0144 683 586 673.90576 586 659 C 586 651.6667 588.6667 647.3334 594 646.00006 C 604 644.66675 611.6667 644.00006 617 644.00006 C 647.6667 642.66675 665.5 641.50006 670.5 640.50006 C 675.5 639.50006 678 636.3334 678 631.00006 C 677.3333 628.3334 676 622.3334 674 613.00006 L 615 375.00006 L 321 375.00006 L 379 602.00006 C 384.3333 623.3334 393.3333 636.3334 406 641.00006 C 412.6667 643.00006 430 644.00006 458 644.00006 C 484.81168 644.00006 496 643.9177 496 668 C 496 678 490 683 478 683 L 351 680 L 223 683 C 207.01442 683 200 673.90576 200 659 C 200 651.6667 203 647.3334 209 646.00006 C 219 644.66675 226.66667 644.00006 232 644.00006 C 262.6667 642.66675 280.5 641.50006 285.5 640.50006 C 290.5 639.50006 293 636.3334 293 631.00006 C 293 629.00006 291.6667 623.00006 289 613.00006 L 156 82.00006 C 150.66667 60.00006 140.66667 46.666733 126 42.00006 C 119.33333 40.00006 100.66667 39.00006 70 39.00006 C 47.81862 39.00006 39 36.95552 39 15.000061 C 39 5.000061 45 0.000061035156 57 0.000061035156 L 183 3.000061 L 246 2.000061 C 256.65405 2.000061 299.017 0.000061035156 310 0.000061035156 C 326.3851 0.000061035156 334 8.337875 334 24.000061 C 334 34.00006 323.3333 39.00006 302 39.00006 C 262 39.00006 242 43.33339 242 52.00006 C 242 52.00006 243 54.666733 245 68.00006 L 312 336.00006 L 605 336.00006 L 538 68.00006 C 534.6667 52.666733 523 43.33339 503 40.00006 C 498.3333 39.33339 481.3333 39.00006 452 39.00006 C 433.3333 39.00006 424 31.000061 424 15.000061 C 424 5.000061 430 0.000061035156 442 0.000061035156 L 568 3.000061 L 631 2.000061 C 641.50757 2.000061 683.33905 0.000061035156 696 0.000061035156 C 712.38513 0.000061035156 720 8.337875 720 24.000061 C 720 34.00006 709.3333 39.00006 688 39.00006 C 647.3333 39.00006 627 43.33339 627 52.00006 C 627 52.00006 628 54.666733 630 68.00006 L 764 602.00006 C 769.3333 623.3334 778.3333 636.3334 791 641.00006 C 797 643.00006 814.3333 644.00006 843 644.00006 C 868.9501 644.00006 881 644.29517 881 668 Z "/>
+        </symbol>
+        <symbol id="g4" overflow="visible">
+            <path d="M 189 2 C 270.333 31.333008 341.333 79.33301 402 146 C 470.667 220 505 296.333 505 375 L 505 750 L 397 750 L 397 375 C 397 309.667 374.5 246 329.5 184 C 284.5 122 231 79.66699 169 57 C 156.33301 52.333008 150 43.333008 150 30 C 150 10 159.66699 0 179 0 C 181.66699 0 185 0.6669922 189 2 Z "/>
+        </symbol>
+        <symbol id="g5" overflow="visible">
+            <path d="M 397 0 L 505 0 L 505 748 L 397 748 Z "/>
+        </symbol>
+        <symbol id="g6" overflow="visible">
+            <path d="M 652 750 C 533.6797 685.76953 397 540.93066 397 377 L 397 0 L 505 0 L 505 377 C 505 447.667 526.333 516.333 569 583 C 613.667 652.333 668.333 698.667 733 722 C 745.667 726.667 752 736 752 750 C 752 764 745.667 773.333 733 778 C 668.333 801.333 613.667 847.667 569 917 C 526.333 983.667 505 1052.333 505 1123 L 505 1500 L 397 1500 L 397 1123 C 397 958.8906 533.5029 814.32715 652 750 Z "/>
+        </symbol>
+        <symbol id="g7" overflow="visible">
+            <path d="M 397 0 L 505 0 L 505 375 C 505 453.667 470.667 530 402 604 C 341.333 670.667 270.333 718.667 189 748 C 185 749.333 181.66699 750 179 750 C 159.66699 750 150 740 150 720 C 150 706.667 156.33301 697.667 169 693 C 231 670.333 284.5 628 329.5 566 C 374.5 504 397 440.333 397 375 Z "/>
+        </symbol>
+        <symbol id="g8" overflow="visible">
+            <path d="M 695 277 L 416 277 L 416 556 C 416 572 405 583 389 583 C 373 583 362 572 362 556 L 362 277 L 83 277 C 67 277 56 266 56 250 C 56 234 67 223 83 223 L 362 223 L 362 -56 C 362 -72 373 -83 389 -83 C 405 -83 416 -72 416 -56 L 416 223 L 695 223 C 711 223 722 234 722 250 C 722 263 708 277 695 277 Z "/>
+        </symbol>
+        <symbol id="g9" overflow="visible">
+            <path d="M 269 666 C 228.33333 624 168.33333 603 89 603 L 89 564 C 141 564 183.66667 572 217 588 L 217 82 C 217 64 212.5 52.33333 203.5 47 C 194.5 41.66667 170 39 130 39 L 95 39 L 95 0 C 120.33333 2 174.33333 3 257 3 C 339.6667 3 393.6667 2 419 0 L 419 39 L 384 39 C 342.6667 39 317.83334 41.66667 309.5 47 C 301.1667 52.33333 297 64 297 82 L 297 636 C 297 659.56604 295.16443 666 269 666 Z "/>
+        </symbol>
+        <symbol id="g10" overflow="visible">
+            <path d="M 847 -2 C 851 6.6666718 853 12.666672 853 16 C 853 32 845 40 829 40 C 819.6667 40 813 35.66667 809 27 C 666.3333 -259 595 -403 595 -405 L 595 -406 C 595 -412.6667 526.6667 -558.3334 390 -843.00006 L 217 -461.00006 C 212.33333 -450.33337 207 -445.00006 201 -445.00006 C 197.66667 -445.00006 192 -448.00006 184 -454.00006 L 86 -528.00006 C 77.33333 -534.66675 73 -540.3334 73 -545.00006 C 73 -555.00006 77.66667 -560.00006 87 -560.00006 C 89.66667 -560.00006 95 -557.00006 103 -551.00006 L 151 -516.00006 L 345 -943.00006 C 349.6667 -954.3334 357 -960.00006 367 -960.00006 C 379 -960.00006 387.3333 -955.3334 392 -946.00006 Z "/>
+        </symbol>
+        <symbol id="g11" overflow="visible">
+            <path d="M 119 424 C 150.79085 424 175 448.20844 175 480 C 175 516 156.33333 534.6667 119 536 C 141.3666 583.0876 190.544 621 256 621 C 344.1449 621 402 555.2719 402 467 C 402 419 384.6667 372.6667 350 328 C 332.6667 305.3333 319.6667 289.3333 311 280 L 74 45 C 60.69464 33.357803 63 29.960907 63 0 L 475 0 L 506 188 L 464 188 C 456.6667 134.66667 448.6667 104.33333 440 97 C 435.3333 93.66667 403.66666 92 345 92 L 175 92 C 241.66667 151.33333 304.3333 204.33333 363 251 C 407.6667 286.3333 440 317.3333 460 344 C 490 382.6667 505 423.6667 505 467 C 505 529 480.6667 578 432 614 C 388.6667 647.3333 335 664 271 664 C 216.33333 664 168.66667 648 128 616 C 84.66667 581.3333 63 537 63 483 C 63 448.5313 88.20494 424 119 424 Z "/>
+        </symbol>
+    </defs>
+    <defs id="clip-path"/>
+</svg>

--- a/packages/preview/quill/0.4.0/docs/images/composition.svg
+++ b/packages/preview/quill/0.4.0/docs/images/composition.svg
@@ -1,0 +1,401 @@
+<svg class="typst-doc" viewBox="0 0 201.04 176.14999999999998" width="201.04pt" height="176.14999999999998pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(-0 -0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0 3 C 0 1.3431457 1.3431457 0 3 0 L 198.04 0 C 199.69685 0 201.04 1.3431457 201.04 3 L 201.04 173.15 C 201.04 174.80685 199.69685 176.15 198.04 176.15 L 3 176.15 C 1.3431457 176.15 0 174.80685 0 173.15 Z "/>
+        </g>
+        <g transform="translate(6 6)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 0)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 10)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(6 -6)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 80.49 L 82.75 80.49 L 82.75 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(6 74.49000000000001)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 75.66 L 82.75 75.66 L 82.75 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(112.75 47.65999999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 80.49 L 62.29 80.49 L 62.29 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(100.75 -6)">
+                                                            <path class="typst-shape" fill="none" stroke="#ff4136" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 3" d="M 0 0 L 0.00000000000000956143 156.15 "/>
+                                                        </g>
+                                                        <g transform="translate(0 7.414999999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18.23 0 "/>
+                                                        </g>
+                                                        <g transform="translate(35.31999999999999 7.414999999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 145.72 0 "/>
+                                                        </g>
+                                                        <g transform="translate(0 34.245)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18.23 0 "/>
+                                                        </g>
+                                                        <g transform="translate(35.31999999999999 34.245)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 145.72 0 "/>
+                                                        </g>
+                                                        <g transform="translate(0 61.07499999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18.23 0 "/>
+                                                        </g>
+                                                        <g transform="translate(35.31999999999999 61.07499999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 116.63 0 "/>
+                                                        </g>
+                                                        <g transform="translate(169.03999999999996 61.07499999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                                        </g>
+                                                        <g transform="translate(0 87.905)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                                        </g>
+                                                        <g transform="translate(41.55 87.905)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 110.4 0 "/>
+                                                        </g>
+                                                        <g transform="translate(169.03999999999996 87.905)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                                        </g>
+                                                        <g transform="translate(0 114.73499999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 151.95 0 "/>
+                                                        </g>
+                                                        <g transform="translate(169.03999999999996 114.73499999999999)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                                        </g>
+                                                        <g transform="translate(0 139.14999999999998)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 181.04 0 "/>
+                                                        </g>
+                                                        <g transform="translate(57.849999999999994 7.414999999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(78.45 34.245)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(57.849999999999994 87.905)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(78.45 87.905)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 51.245 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(121.05 61.07499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(137.65 61.07499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 53.66 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(94.75 61.07499999999999)">
+                                                            <g class="typst-group">
+                                                                <g/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(18.23 -0.0000000000000008881784197001252)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g483DE0C2AEC5949F646340C0095FD267" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(18.23 26.83)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g483DE0C2AEC5949F646340C0095FD267" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(18.23 53.65999999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g483DE0C2AEC5949F646340C0095FD267" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(94.75 139.14999999999998)">
+                                                            <g class="typst-group">
+                                                                <g/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(11.999999999999998 80.49)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 29.55 14.83 L 29.55 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g17922C09E485AEC9A39D5F7447FF0E25" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(11.82 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#gF1BD90AF504628586F2A5F80F37F6B14" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(15.71 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#gE5441337FA5D55A67E8F0C95C94FA548" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(21.66 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#gFA2483D08A1C41F3B6F12474B1DE2B19" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(53.55 110.43499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 4.3 C 0 1.9273288 1.9273288 0 4.3 0 C 6.6726713 0 8.6 1.9273288 8.6 4.3 C 8.6 6.6726713 6.6726713 8.6 4.3 8.6 C 1.9273288 8.6 0 6.6726713 0 4.3 "/>
+                                                                    </g>
+                                                                    <g transform="translate(4.3 8.6)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0.0000000000000005265981 -8.6 "/>
+                                                                    </g>
+                                                                    <g transform="translate(0 4.3)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 8.6 0 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(74.15 134.84999999999997)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 4.3 C 0 1.9273288 1.9273288 0 4.3 0 C 6.6726713 0 8.6 1.9273288 8.6 4.3 C 8.6 6.6726713 6.6726713 8.6 4.3 8.6 C 1.9273288 8.6 0 6.6726713 0 4.3 "/>
+                                                                    </g>
+                                                                    <g transform="translate(4.3 8.6)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0.0000000000000005265981 -8.6 "/>
+                                                                    </g>
+                                                                    <g transform="translate(0 4.3)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 8.6 0 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(181.04 114.73499999999999)">
+                                                            <g class="typst-group">
+                                                                <g/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(151.95 53.65999999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g483DE0C2AEC5949F646340C0095FD267" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(151.95 80.49)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g483DE0C2AEC5949F646340C0095FD267" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(151.95 107.31999999999998)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                                                    </g>
+                                                                    <g transform="translate(4 10.83)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g483DE0C2AEC5949F646340C0095FD267" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(55.55 5.114999999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(55.55 31.944999999999997)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(76.15 31.944999999999997)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(76.15 58.77499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(55.55 85.605)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(76.15 85.605)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(118.75 58.77499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(135.35 58.77499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(118.75 85.605)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(135.35 112.43499999999999)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(-0 -0)">
+                                                                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <defs id="glyph">
+        <symbol id="g483DE0C2AEC5949F646340C0095FD267" overflow="visible">
+            <path d="M 8.809999 6.68 C 8.809999 6.7799997 8.75 6.83 8.63 6.83 L 7.3599997 6.7999997 L 6.0899997 6.83 C 5.93 6.83 5.8599997 6.74 5.8599997 6.5899997 C 5.8599997 6.52 5.89 6.47 5.94 6.46 C 6.04 6.45 6.12 6.44 6.17 6.44 C 6.48 6.43 6.6499996 6.41 6.7 6.3999996 C 6.75 6.39 6.7799997 6.3599997 6.7799997 6.31 C 6.77 6.2799997 6.7599998 6.22 6.74 6.1299996 L 6.15 3.75 L 3.21 3.75 L 3.79 6.02 C 3.84 6.23 3.9299998 6.3599997 4.06 6.41 C 4.13 6.43 4.2999997 6.44 4.58 6.44 C 4.85 6.44 4.96 6.44 4.96 6.68 C 4.96 6.7799997 4.9 6.83 4.7799997 6.83 L 3.51 6.7999997 L 2.23 6.83 C 2.07 6.83 2 6.74 2 6.5899997 C 2 6.52 2.03 6.47 2.09 6.46 C 2.19 6.45 2.27 6.44 2.32 6.44 C 2.6299999 6.43 2.81 6.41 2.86 6.3999996 C 2.9099998 6.39 2.9299998 6.3599997 2.9299998 6.31 C 2.9299998 6.29 2.9199998 6.23 2.8899999 6.1299996 L 1.56 0.82 C 1.51 0.59999996 1.41 0.47 1.26 0.42 C 1.1899999 0.39999998 1.01 0.39 0.7 0.39 C 0.48 0.39 0.39 0.37 0.39 0.14999999 C 0.39 0.049999997 0.45 0 0.57 0 L 1.8299999 0.03 L 2.46 0.02 C 2.57 0.02 2.99 0 3.1 0 C 3.26 0 3.34 0.08 3.34 0.24 C 3.34 0.34 3.23 0.39 3.02 0.39 C 2.62 0.39 2.4199998 0.42999998 2.4199998 0.52 C 2.4199998 0.52 2.4299998 0.55 2.45 0.68 L 3.12 3.36 L 6.0499997 3.36 L 5.38 0.68 C 5.35 0.53 5.23 0.42999998 5.0299997 0.39999998 C 4.98 0.39 4.81 0.39 4.52 0.39 C 4.33 0.39 4.24 0.31 4.24 0.14999999 C 4.24 0.049999997 4.2999997 0 4.42 0 L 5.68 0.03 L 6.31 0.02 C 6.42 0.02 6.83 0 6.96 0 C 7.12 0 7.2 0.08 7.2 0.24 C 7.2 0.34 7.0899997 0.39 6.8799996 0.39 C 6.47 0.39 6.27 0.42999998 6.27 0.52 C 6.27 0.52 6.2799997 0.55 6.2999997 0.68 L 7.64 6.02 C 7.69 6.23 7.7799997 6.3599997 7.91 6.41 C 7.97 6.43 8.139999 6.44 8.429999 6.44 C 8.69 6.44 8.809999 6.44 8.809999 6.68 Z "/>
+        </symbol>
+        <symbol id="g17922C09E485AEC9A39D5F7447FF0E25" overflow="visible">
+            <path d="M 5.5499997 6.83 L 2.35 6.83 C 2.12 6.83 2.01 6.8199997 2.01 6.6 C 2.01 6.49 2.12 6.44 2.34 6.44 C 2.54 6.44 2.9399998 6.47 2.9399998 6.31 C 2.9399998 6.29 2.9299998 6.23 2.8999999 6.1299996 L 1.5799999 0.82 C 1.52 0.59999996 1.42 0.47 1.28 0.42 C 1.2099999 0.39999998 1.03 0.39 0.71999997 0.39 C 0.5 0.39 0.39999998 0.37 0.39999998 0.16 C 0.39999998 0.049999997 0.45999998 0 0.59 0 L 1.8399999 0.03 L 2.48 0.02 C 2.59 0.02 2.99 0 3.12 0 C 3.28 0 3.36 0.08 3.36 0.24 C 3.36 0.34 3.25 0.39 3.04 0.39 C 2.6399999 0.39 2.44 0.42999998 2.44 0.52 C 2.44 0.52 2.45 0.55 2.47 0.68 L 3.07 3.12 L 4.72 3.12 C 5.37 3.12 5.99 3.32 6.5699997 3.7099998 C 7.22 4.14 7.54 4.67 7.54 5.2999997 C 7.54 6.29 6.6 6.83 5.5499997 6.83 Z M 5.24 6.44 C 6.1099997 6.44 6.54 6.14 6.54 5.54 C 6.54 4.98 6.2599998 4.23 5.97 3.97 C 5.5899997 3.6299999 5.0899997 3.46 4.47 3.46 L 3.1299999 3.46 L 3.79 6.1 C 3.87 6.44 3.87 6.44 4.29 6.44 Z "/>
+        </symbol>
+        <symbol id="gF1BD90AF504628586F2A5F80F37F6B14" overflow="visible">
+            <path d="M 3.1799998 -2.48 C 3.27 -2.48 3.32 -2.4299998 3.32 -2.34 C 3.32 -2.31 3.3 -2.27 3.27 -2.23 C 2.75 -1.8299999 2.33 -1.17 2.02 -0.26 C 1.75 0.53 1.61 1.31 1.61 2.08 L 1.61 2.9199998 C 1.61 3.6899998 1.75 4.47 2.02 5.2599998 C 2.33 6.17 2.75 6.83 3.27 7.23 C 3.3 7.2599998 3.32 7.2999997 3.32 7.3399997 C 3.32 7.43 3.27 7.48 3.1799998 7.48 C 3.1699998 7.48 3.1399999 7.47 3.11 7.45 C 2.51 6.99 2.01 6.31 1.5999999 5.4 C 1.2099999 4.5299997 1.01 3.7099998 1.01 2.9199998 L 1.01 2.08 C 1.01 1.29 1.2099999 0.47 1.5999999 -0.39999998 C 2.01 -1.31 2.51 -1.99 3.11 -2.45 C 3.1399999 -2.47 3.1699998 -2.48 3.1799998 -2.48 Z "/>
+        </symbol>
+        <symbol id="gE5441337FA5D55A67E8F0C95C94FA548" overflow="visible">
+            <path d="M 5.24 4.31 L 1.9399999 4.31 C 1.53 4.31 1.17 4.15 0.88 3.84 C 0.74 3.6899998 0.26999998 3.05 0.26999998 2.9199998 C 0.31 2.85 0.31 2.79 0.42999998 2.79 C 0.5 2.79 0.56 2.83 0.62 2.9199998 C 0.94 3.4099998 1.35 3.6599998 1.8399999 3.6599998 L 2.35 3.6599998 C 2.12 2.79 1.6999999 1.7199999 1.1 0.45 C 1.05 0.32999998 1.02 0.24 1.02 0.19 C 1.02 -0.01 1.13 -0.11 1.3399999 -0.11 C 1.53 -0.11 1.67 0 1.76 0.21 C 1.9399999 0.78 2.07 1.22 2.1399999 1.52 L 2.69 3.6599998 L 3.72 3.6599998 C 3.4499998 2.47 3.31 1.64 3.31 1.17 C 3.31 0.68 3.4199998 -0.11 3.79 -0.11 C 4 -0.11 4.23 0.089999996 4.23 0.29999998 C 4.23 0.35 4.21 0.42999998 4.17 0.53 C 3.98 1 3.8899999 1.53 3.8899999 2.1399999 C 3.8899999 2.61 3.9499998 3.12 4.06 3.6599998 L 5.15 3.6599998 C 5.5 3.6599998 5.67 3.78 5.67 4.0299997 C 5.67 4.2599998 5.49 4.31 5.24 4.31 Z "/>
+        </symbol>
+        <symbol id="gFA2483D08A1C41F3B6F12474B1DE2B19" overflow="visible">
+            <path d="M 0.78 -2.45 C 1.38 -1.99 1.88 -1.31 2.29 -0.39999998 C 2.6799998 0.47 2.8799999 1.29 2.8799999 2.08 L 2.8799999 2.9199998 C 2.8799999 3.7099998 2.6799998 4.5299997 2.29 5.4 C 1.88 6.31 1.38 6.99 0.78 7.45 C 0.75 7.47 0.71999997 7.48 0.71 7.48 C 0.62 7.48 0.57 7.43 0.57 7.3399997 C 0.57 7.2999997 0.59 7.2599998 0.62 7.23 C 1.14 6.83 1.56 6.17 1.87 5.2599998 C 2.1399999 4.47 2.28 3.6899998 2.28 2.9199998 L 2.28 2.08 C 2.28 1.31 2.1399999 0.53 1.87 -0.26 C 1.56 -1.17 1.14 -1.8299999 0.62 -2.23 C 0.59 -2.27 0.57 -2.31 0.57 -2.34 C 0.57 -2.4299998 0.62 -2.48 0.71 -2.48 C 0.71999997 -2.48 0.75 -2.47 0.78 -2.45 Z "/>
+        </symbol>
+    </defs>
+</svg>

--- a/packages/preview/quill/0.4.0/docs/images/gallery.svg
+++ b/packages/preview/quill/0.4.0/docs/images/gallery.svg
@@ -1,0 +1,2198 @@
+<svg class="typst-doc" viewBox="0 0 510.237 659.028" width="680.316" height="878.704" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path class="typst-shape" fill="#fff" d="M0 3a3 3 0 0 1 3-3h504.237a3 3 0 0 1 3 3v653.028a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3Z"/>
+  <path class="typst-shape" fill="none" stroke="#000" d="M6 5.5v33.83M6 38.33v42.498M6 79.828v45.66M6 124.488v30.092M6 153.58v29M6 181.58v82.66M6 263.24v33.83M6 296.07v49M6 344.07v37.164M6 380.234v51M6 430.234v55.83M6 485.064v55.83M6 539.894v32.63M6 571.524v82.004M78.055 5.5v33.83M78.055 38.33v42.498M78.055 79.828v45.66M78.055 124.488v30.092M78.055 153.58v29M78.055 181.58v82.66M78.055 263.24v33.83M78.055 296.07v49M78.055 344.07v37.164M78.055 380.234v51M78.055 430.234v55.83M78.055 485.064v55.83M78.055 539.894v32.63M78.055 571.524v82.004M78.055 5.5v33.83M78.055 38.33v42.498M78.055 79.828v45.66M78.055 124.488v30.092M78.055 153.58v29M78.055 181.58v82.66M78.055 263.24v33.83M78.055 296.07v49M78.055 344.07v37.164M78.055 380.234v51M78.055 430.234v55.83M78.055 485.064v55.83M78.055 539.894v32.63M78.055 571.524v82.004M150.11 5.5v33.83M150.11 38.33v42.498M150.11 79.828v45.66M150.11 124.488v30.092M150.11 153.58v29M150.11 181.58v82.66M150.11 263.24v33.83M150.11 296.07v49M150.11 344.07v37.164M150.11 380.234v51M150.11 430.234v55.83M150.11 485.064v55.83M150.11 539.894v32.63M150.11 571.524v82.004M150.11 5.5v33.83M150.11 38.33v42.498M150.11 79.828v45.66M150.11 124.488v30.092M150.11 153.58v29M150.11 181.58v82.66M150.11 263.24v33.83M150.11 296.07v49M150.11 344.07v37.164M150.11 380.234v51M150.11 430.234v55.83M150.11 485.064v55.83M150.11 539.894v32.63M150.11 571.524v82.004M243.78 5.5v33.83M243.78 38.33v42.498M243.78 79.828v45.66M243.78 124.488v30.092M243.78 153.58v29M243.78 181.58v82.66M243.78 263.24v33.83M243.78 296.07v49M243.78 344.07v37.164M243.78 380.234v51M243.78 430.234v55.83M243.78 485.064v55.83M243.78 539.894v32.63M243.78 571.524v82.004M246.28 5.5v33.83M246.28 38.33v42.498M246.28 79.828v45.66M246.28 124.488v30.092M246.28 153.58v29M246.28 181.58v82.66M246.28 263.24v33.83M246.28 296.07v49M246.28 344.07v37.164M246.28 380.234v51M246.28 430.234v55.83M246.28 485.064v55.83M246.28 539.894v32.63M246.28 571.524v82.004M325.541 5.5v33.83M325.541 38.33v42.498M325.541 79.828v45.66M325.541 124.488v30.092M325.541 153.58v29M325.541 181.58v82.66M325.541 263.24v33.83M325.541 296.07v49M325.541 344.07v37.164M325.541 380.234v51M325.541 430.234v55.83M325.541 485.064v55.83M325.541 539.894v32.63M325.541 571.524v82.004M325.541 5.5v33.83M325.541 38.33v42.498M325.541 79.828v45.66M325.541 124.488v30.092M325.541 153.58v29M325.541 181.58v82.66M325.541 263.24v33.83M325.541 296.07v49M325.541 344.07v37.164M325.541 380.234v51M325.541 430.234v55.83M325.541 485.064v55.83M325.541 539.894v32.63M325.541 571.524v82.004M397.596 5.5v33.83M397.596 38.33v42.498M397.596 79.828v45.66M397.596 124.488v30.092M397.596 153.58v29M397.596 181.58v82.66M397.596 263.24v33.83M397.596 296.07v49M397.596 344.07v37.164M397.596 380.234v51M397.596 430.234v55.83M397.596 485.064v55.83M397.596 539.894v32.63M397.596 571.524v82.004M397.596 5.5v33.83M397.596 38.33v42.498M397.596 79.828v45.66M397.596 124.488v30.092M397.596 153.58v29M397.596 181.58v82.66M397.596 263.24v33.83M397.596 296.07v49M397.596 344.07v37.164M397.596 380.234v51M397.596 430.234v55.83M397.596 485.064v55.83M397.596 539.894v32.63M397.596 571.524v82.004M504.237 5.5v33.83M504.237 38.33v42.498M504.237 79.828v45.66M504.237 124.488v30.092M504.237 153.58v29M504.237 181.58v82.66M504.237 263.24v33.83M504.237 296.07v49M504.237 344.07v37.164M504.237 380.234v51M504.237 430.234v55.83M504.237 485.064v55.83M504.237 539.894v32.63M504.237 571.524v82.004M5.5 6h73.055M77.555 6h73.055M149.61 6h94.67M245.78 6h80.261M325.041 6h73.055M397.096 6h107.641M5.5 38.83h73.055M77.555 38.83h73.055M149.61 38.83h94.67M245.78 38.83h80.261M325.041 38.83h73.055M397.096 38.83h107.641M5.5 38.83h73.055M77.555 38.83h73.055M149.61 38.83h94.67M245.78 38.83h80.261M325.041 38.83h73.055M397.096 38.83h107.641M5.5 80.328h73.055M77.555 80.328h73.055M149.61 80.328h94.67M245.78 80.328h80.261M325.041 80.328h73.055M397.096 80.328h107.641M5.5 80.328h73.055M77.555 80.328h73.055M149.61 80.328h94.67M245.78 80.328h80.261M325.041 80.328h73.055M397.096 80.328h107.641M5.5 124.988h73.055M77.555 124.988h73.055M149.61 124.988h94.67M245.78 124.988h80.261M325.041 124.988h73.055M397.096 124.988h107.641M5.5 124.988h73.055M77.555 124.988h73.055M149.61 124.988h94.67M245.78 124.988h80.261M325.041 124.988h73.055M397.096 124.988h107.641M5.5 154.08h73.055M77.555 154.08h73.055M149.61 154.08h94.67M245.78 154.08h80.261M325.041 154.08h73.055M397.096 154.08h107.641M5.5 154.08h73.055M77.555 154.08h73.055M149.61 154.08h94.67M245.78 154.08h80.261M325.041 154.08h73.055M397.096 154.08h107.641M5.5 182.08h73.055M77.555 182.08h73.055M149.61 182.08h94.67M245.78 182.08h80.261M325.041 182.08h73.055M397.096 182.08h107.641M5.5 182.08h73.055M77.555 182.08h73.055M149.61 182.08h94.67M245.78 182.08h80.261M325.041 182.08h73.055M397.096 182.08h107.641M5.5 263.74h73.055M77.555 263.74h73.055M149.61 263.74h94.67M245.78 263.74h80.261M325.041 263.74h73.055M397.096 263.74h107.641M5.5 263.74h73.055M77.555 263.74h73.055M149.61 263.74h94.67M245.78 263.74h80.261M325.041 263.74h73.055M397.096 263.74h107.641M5.5 296.57h73.055M77.555 296.57h73.055M149.61 296.57h94.67M245.78 296.57h80.261M325.041 296.57h73.055M397.096 296.57h107.641M5.5 296.57h73.055M77.555 296.57h73.055M149.61 296.57h94.67M245.78 296.57h80.261M325.041 296.57h73.055M397.096 296.57h107.641M5.5 344.57h73.055M77.555 344.57h73.055M149.61 344.57h94.67M245.78 344.57h80.261M325.041 344.57h73.055M397.096 344.57h107.641M5.5 344.57h73.055M77.555 344.57h73.055M149.61 344.57h94.67M245.78 344.57h80.261M325.041 344.57h73.055M397.096 344.57h107.641M5.5 380.734h73.055M77.555 380.734h73.055M149.61 380.734h94.67M245.78 380.734h80.261M325.041 380.734h73.055M397.096 380.734h107.641M5.5 380.734h73.055M77.555 380.734h73.055M149.61 380.734h94.67M245.78 380.734h80.261M325.041 380.734h73.055M397.096 380.734h107.641M5.5 430.734h73.055M77.555 430.734h73.055M149.61 430.734h94.67M245.78 430.734h80.261M325.041 430.734h73.055M397.096 430.734h107.641M5.5 430.734h73.055M77.555 430.734h73.055M149.61 430.734h94.67M245.78 430.734h80.261M325.041 430.734h73.055M397.096 430.734h107.641M5.5 485.564h73.055M77.555 485.564h73.055M149.61 485.564h94.67M245.78 485.564h80.261M325.041 485.564h73.055M397.096 485.564h107.641M5.5 485.564h73.055M77.555 485.564h73.055M149.61 485.564h94.67M245.78 485.564h80.261M325.041 485.564h73.055M397.096 485.564h107.641M5.5 540.394h73.055M77.555 540.394h73.055M149.61 540.394h94.67M245.78 540.394h80.261M325.041 540.394h73.055M397.096 540.394h107.641M5.5 540.394h73.055M77.555 540.394h73.055M149.61 540.394h94.67M245.78 540.394h80.261M325.041 540.394h73.055M397.096 540.394h107.641M5.5 572.024h73.055M77.555 572.024h73.055M149.61 572.024h94.67M245.78 572.024h80.261M325.041 572.024h73.055M397.096 572.024h107.641M5.5 572.024h73.055M77.555 572.024h73.055M149.61 572.024h94.67M245.78 572.024h80.261M325.041 572.024h73.055M397.096 572.024h107.641M5.5 653.028h73.055M77.555 653.028h73.055M149.61 653.028h94.67M245.78 653.028h80.261M325.041 653.028h73.055M397.096 653.028h107.641"/>
+  <g class="typst-text" transform="matrix(1 0 0 -1 14.235 26.035)">
+    <use xlink:href="#a"/>
+    <use xlink:href="#b" x="7.686"/>
+    <use xlink:href="#c" x="13.229"/>
+    <use xlink:href="#d" x="17.316"/>
+    <use xlink:href="#e" x="26.001"/>
+    <use xlink:href="#f" x="31.023"/>
+    <use xlink:href="#g" x="36.674"/>
+    <use xlink:href="#e" x="42.174"/>
+    <use xlink:href="#h" x="47.196"/>
+    <use xlink:href="#i" x="50.671"/>
+  </g>
+  <g class="typst-group">
+    <g class="typst-group">
+      <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M93.537 22.415h12M122.627 22.415h12"/>
+      <g class="typst-group">
+        <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M105.537 15v14.83h17.09V15Z"/>
+        <use xlink:href="#j" class="typst-text" transform="matrix(1 0 0 -1 109.537 25.83)"/>
+      </g>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 159.859 25.758)" fill="#4b69c6">
+      <use xlink:href="#k"/>
+      <use xlink:href="#l" x="5.298"/>
+      <use xlink:href="#m" x="10.596"/>
+      <use xlink:href="#n" x="15.894"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 181.051 25.758)"/>
+    <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 186.35 25.758)"/>
+    <use xlink:href="#q" class="typst-text" transform="matrix(1 0 0 -1 191.647 25.758)"/>
+    <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 196.945 25.758)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 202.243 25.758)">
+      <use xlink:href="#r"/>
+      <use xlink:href="#s" x="5.298"/>
+    </g>
+    <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 218.137 25.758)"/>
+    <use xlink:href="#q" class="typst-text" transform="matrix(1 0 0 -1 223.435 25.758)"/>
+    <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 228.733 25.758)"/>
+  </g>
+  <g class="typst-text" transform="matrix(1 0 0 -1 260.398 26.035)">
+    <use xlink:href="#t"/>
+    <use xlink:href="#b" x="6.456"/>
+    <use xlink:href="#u" x="11.999"/>
+    <use xlink:href="#v" x="17.837"/>
+    <use xlink:href="#w" x="23.799"/>
+    <use xlink:href="#g" x="32.114"/>
+    <use xlink:href="#e" x="37.614"/>
+    <use xlink:href="#h" x="42.636"/>
+    <use xlink:href="#i" x="46.111"/>
+  </g>
+  <g class="typst-group">
+    <g class="typst-group">
+      <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M341.174 22.415h12M369.964 22.415h12"/>
+      <g class="typst-group">
+        <path class="typst-shape" fill="#fff" d="M353.174 22.415A7.415 7.415 0 0 1 360.589 15h1.96a7.415 7.415 0 0 1 0 14.83h-1.96a7.415 7.415 0 0 1-7.415-7.415Z"/>
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M360.589 15h1.96a7.415 7.415 0 0 1 0 14.83h-1.96a7.415 7.415 0 1 1 0-14.83"/>
+        <use xlink:href="#x" class="typst-text" transform="matrix(1 0 0 -1 357.174 25.83)"/>
+      </g>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 427.075 19.555)" fill="#4b69c6">
+      <use xlink:href="#k"/>
+      <use xlink:href="#l" x="5.298"/>
+      <use xlink:href="#m" x="10.596"/>
+      <use xlink:href="#n" x="15.894"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 448.267 19.555)"/>
+    <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 453.565 19.555)"/>
+    <use xlink:href="#y" class="typst-text" transform="matrix(1 0 0 -1 458.864 19.555)"/>
+    <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 464.162 19.555)"/>
+    <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 469.46 19.555)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 416.48 31.96)">
+      <use xlink:href="#z"/>
+      <use xlink:href="#l" x="5.298"/>
+      <use xlink:href="#A" x="10.596"/>
+      <use xlink:href="#B" x="15.894"/>
+      <use xlink:href="#C" x="21.192"/>
+      <use xlink:href="#D" x="26.49"/>
+    </g>
+    <use xlink:href="#E" class="typst-text" transform="matrix(1 0 0 -1 448.267 31.96)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 458.864 31.96)" fill="#b60157">
+      <use xlink:href="#F"/>
+      <use xlink:href="#G" x="5.298"/>
+      <use xlink:href="#G" x="10.596"/>
+      <use xlink:href="#H" x="15.894"/>
+    </g>
+    <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 480.056 31.96)"/>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 20.538 56.004)">
+      <use xlink:href="#I"/>
+      <use xlink:href="#J" x="7.708"/>
+      <use xlink:href="#K" x="11.424"/>
+      <use xlink:href="#L" x="15.71"/>
+      <use xlink:href="#e" x="21.624"/>
+      <use xlink:href="#M" x="26.646"/>
+      <use xlink:href="#i" x="32.425"/>
+      <use xlink:href="#w" x="37.415"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 32.572 70.394)">
+      <use xlink:href="#g"/>
+      <use xlink:href="#e" x="5.5"/>
+      <use xlink:href="#h" x="10.522"/>
+      <use xlink:href="#i" x="13.997"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M94.132 59.579h12M122.032 59.579h12"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" d="M106.132 52.164h8.485a7.415 7.415 0 1 1 0 14.83h-8.485Z"/>
+          <path class="typst-shape" d="m106.482 52.514-.7-.7h8.835a7.765 7.765 0 0 1 0 15.53h-8.835v-15.53l.7.7v14.13h8.135a7.065 7.065 0 0 0 0-14.13Z"/>
+          <use xlink:href="#N" class="typst-text" transform="matrix(1 0 0 -1 110.132 62.994)"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 173.104 50.516)" fill="#4b69c6">
+        <use xlink:href="#k"/>
+        <use xlink:href="#l" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#n" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 194.296 50.516)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 199.594 50.516)"/>
+      <use xlink:href="#O" class="typst-text" transform="matrix(1 0 0 -1 204.892 50.516)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 210.19 50.516)"/>
+      <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 215.488 50.516)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 178.402 62.922)">
+        <use xlink:href="#z"/>
+        <use xlink:href="#l" x="5.298"/>
+        <use xlink:href="#A" x="10.596"/>
+        <use xlink:href="#B" x="15.894"/>
+        <use xlink:href="#C" x="21.192"/>
+        <use xlink:href="#D" x="26.49"/>
+        <use xlink:href="#E" x="31.788"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 159.859 75.328)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 165.157 75.328)">
+          <use xlink:href="#z"/>
+          <use xlink:href="#B" x="5.298"/>
+          <use xlink:href="#k" x="10.596"/>
+          <use xlink:href="#P" x="15.894"/>
+          <use xlink:href="#m" x="21.192"/>
+        </g>
+        <use xlink:href="#E" class="typst-text" transform="matrix(1 0 0 -1 191.647 75.328)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 202.243 75.328)" fill="#b60157">
+          <use xlink:href="#F"/>
+          <use xlink:href="#G" x="5.298"/>
+          <use xlink:href="#G" x="10.596"/>
+          <use xlink:href="#H" x="15.894"/>
+        </g>
+        <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 223.435 75.328)"/>
+        <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 228.733 75.328)"/>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 272.601 63.199)">
+      <use xlink:href="#Q"/>
+      <use xlink:href="#i" x="9.228"/>
+      <use xlink:href="#h" x="14.142"/>
+      <use xlink:href="#i" x="17.617"/>
+      <use xlink:href="#c" x="22.532"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M338.446 59.579h12M372.691 59.579h12"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M350.446 52.164v14.83h22.245v-14.83Z"/>
+          <g class="typst-group">
+            <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M354.446 63.677s1.425-4.781 7.123-4.781 7.122 4.78 7.122 4.78M361.569 64.36l5.698-6.147"/>
+            <path class="typst-shape" d="m369.85 55.426-3.61 1.835 2.053 1.904 1.557-3.74Z"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 432.373 62.922)" fill="#4b69c6">
+      <use xlink:href="#R"/>
+      <use xlink:href="#n" x="5.298"/>
+      <use xlink:href="#m" x="10.596"/>
+      <use xlink:href="#n" x="15.894"/>
+      <use xlink:href="#z" x="21.192"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 458.864 62.922)">
+      <use xlink:href="#o"/>
+      <use xlink:href="#r" x="5.298"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 17.052 99.083)">
+      <use xlink:href="#Q"/>
+      <use xlink:href="#i" x="9.228"/>
+      <use xlink:href="#h" x="14.142"/>
+      <use xlink:href="#i" x="17.617"/>
+      <use xlink:href="#c" x="22.532"/>
+      <use xlink:href="#S" x="29.369"/>
+      <use xlink:href="#T" x="37.582"/>
+      <use xlink:href="#h" x="40.563"/>
+      <use xlink:href="#L" x="44.038"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 31.395 113.473)">
+      <use xlink:href="#f"/>
+      <use xlink:href="#e" x="2.9"/>
+      <use xlink:href="#U" x="7.922"/>
+      <use xlink:href="#i" x="13.449"/>
+      <use xlink:href="#f" x="18.364"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M90.96 108.573h12M125.205 108.573h12"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M102.96 101.158v14.83h22.245v-14.83Z"/>
+          <g class="typst-group">
+            <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M106.96 112.67s1.424-4.78 7.122-4.78 7.123 4.78 7.123 4.78M114.082 113.354l5.698-6.147"/>
+            <path class="typst-shape" d="m122.363 104.42-3.61 1.835 2.054 1.903 1.556-3.738Z"/>
+          </g>
+        </g>
+        <g class="typst-group">
+          <use xlink:href="#V" class="typst-text" transform="matrix(1 0 0 -1 106.857 96.158)"/>
+          <use xlink:href="#W" class="typst-text" transform="matrix(1 0 0 -1 109.637 96.158)"/>
+          <use xlink:href="#X" class="typst-text" transform="matrix(1 0 0 -1 117.417 96.158)"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 165.157 99.798)" fill="#4b69c6">
+      <use xlink:href="#R"/>
+      <use xlink:href="#n" x="5.298"/>
+      <use xlink:href="#m" x="10.596"/>
+      <use xlink:href="#n" x="15.894"/>
+      <use xlink:href="#z" x="21.192"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 191.647 99.798)">
+      <use xlink:href="#o"/>
+      <use xlink:href="#Y" x="5.298"/>
+      <use xlink:href="#l" x="10.596"/>
+      <use xlink:href="#Z" x="15.894"/>
+      <use xlink:href="#n" x="21.192"/>
+      <use xlink:href="#Y" x="26.49"/>
+      <use xlink:href="#E" x="31.788"/>
+    </g>
+    <g class="typst-group">
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 171.561 112.204)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 176.86 112.204)" fill="#4b69c6">
+        <use xlink:href="#Y"/>
+        <use xlink:href="#z" x="5.298"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 187.456 112.204)"/>
+      <use xlink:href="#aa" class="typst-text" transform="matrix(1 0 0 -1 192.754 112.204)"/>
+      <use xlink:href="#ab" class="typst-text" transform="matrix(1 0 0 -1 198.052 112.204)"/>
+      <use xlink:href="#ac" class="typst-text" transform="matrix(1 0 0 -1 203.35 112.204)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 206.435 112.204)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 211.733 112.204)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 217.031 112.204)"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 261.972 106.278)">
+      <use xlink:href="#ad"/>
+      <use xlink:href="#L" x="6.08"/>
+      <use xlink:href="#e" x="11.994"/>
+      <use xlink:href="#K" x="17.016"/>
+      <use xlink:href="#i" x="21.302"/>
+      <use xlink:href="#g" x="28.966"/>
+      <use xlink:href="#e" x="34.466"/>
+      <use xlink:href="#h" x="39.488"/>
+      <use xlink:href="#i" x="42.963"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M341.269 106.723h20.3M361.569 106.723h20.3"/>
+        <g class="typst-group">
+          <g class="typst-group">
+            <path class="typst-shape" d="M359.269 106.723c0-1.27 1.03-2.3 2.3-2.3 1.269 0 2.3 1.03 2.3 2.3 0 1.269-1.031 2.3-2.3 2.3-1.27 0-2.3-1.031-2.3-2.3"/>
+          </g>
+        </g>
+        <g class="typst-group">
+          <use xlink:href="#ae" class="typst-text" transform="matrix(1 0 0 -1 364.869 100.423)"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 424.426 106)" fill="#4b69c6">
+        <use xlink:href="#af"/>
+        <use xlink:href="#P" x="5.298"/>
+        <use xlink:href="#l" x="10.596"/>
+        <use xlink:href="#D" x="15.894"/>
+        <use xlink:href="#n" x="21.192"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 450.916 106)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 456.214 106)"/>
+      <use xlink:href="#ag" class="typst-text" transform="matrix(1 0 0 -1 461.513 106)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 466.81 106)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 472.109 106)"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 24.762 143.154)">
+      <use xlink:href="#ah"/>
+      <use xlink:href="#b" x="7.106"/>
+      <use xlink:href="#v" x="12.649"/>
+      <use xlink:href="#h" x="18.611"/>
+      <use xlink:href="#c" x="22.086"/>
+      <use xlink:href="#b" x="26.087"/>
+      <use xlink:href="#f" x="31.63"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M99.782 139.534h14.3M114.082 139.534h14.3"/>
+        <g class="typst-group">
+          <path class="typst-shape" d="M111.782 139.534c0-1.27 1.031-2.3 2.3-2.3 1.27 0 2.3 1.03 2.3 2.3 0 1.269-1.03 2.3-2.3 2.3-1.269 0-2.3-1.031-2.3-2.3"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 178.402 142.877)" fill="#4b69c6">
+      <use xlink:href="#ai"/>
+      <use xlink:href="#m" x="5.298"/>
+      <use xlink:href="#z" x="10.596"/>
+      <use xlink:href="#Y" x="15.894"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 199.594 142.877)"/>
+    <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 204.892 142.877)"/>
+    <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 210.19 142.877)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 256.284 143.154)">
+      <use xlink:href="#aj"/>
+      <use xlink:href="#M" x="7.718"/>
+      <use xlink:href="#i" x="13.498"/>
+      <use xlink:href="#v" x="18.412"/>
+      <use xlink:href="#ak" x="27.124"/>
+      <use xlink:href="#b" x="31.829"/>
+      <use xlink:href="#v" x="37.372"/>
+      <use xlink:href="#h" x="43.334"/>
+      <use xlink:href="#c" x="46.809"/>
+      <use xlink:href="#b" x="50.811"/>
+      <use xlink:href="#f" x="56.354"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M347.269 139.534h14.3M361.569 139.534h14.3"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M359.269 139.534c0-1.27 1.03-2.3 2.3-2.3 1.269 0 2.3 1.03 2.3 2.3 0 1.269-1.031 2.3-2.3 2.3-1.27 0-2.3-1.031-2.3-2.3"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 416.48 136.674)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 437.671 136.674)"/>
+      <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 442.97 136.674)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 448.267 136.674)">
+        <use xlink:href="#s"/>
+        <use xlink:href="#al" x="10.596"/>
+        <use xlink:href="#af" x="15.894"/>
+        <use xlink:href="#n" x="21.192"/>
+        <use xlink:href="#am" x="26.49"/>
+        <use xlink:href="#E" x="31.788"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 437.671 149.08)" fill="#d73a49">
+        <use xlink:href="#m"/>
+        <use xlink:href="#z" x="5.298"/>
+        <use xlink:href="#C" x="10.596"/>
+        <use xlink:href="#n" x="15.894"/>
+      </g>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 458.864 149.08)"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 27.515 171.7)">
+      <use xlink:href="#an"/>
+      <use xlink:href="#e" x="6.026"/>
+      <use xlink:href="#c" x="11.048"/>
+      <use xlink:href="#g" x="15.136"/>
+      <use xlink:href="#i" x="20.636"/>
+      <use xlink:href="#h" x="25.55"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M97.782 168.08h16.3M114.082 168.08h16.3"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M109.782 168.08c0-2.373 1.928-4.3 4.3-4.3 2.373 0 4.3 1.927 4.3 4.3 0 2.372-1.927 4.3-4.3 4.3a4.303 4.303 0 0 1-4.3-4.3M114.082 172.38v-8.6M109.782 168.08h8.6"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 181.051 171.423)" fill="#4b69c6">
+      <use xlink:href="#m"/>
+      <use xlink:href="#l" x="5.298"/>
+      <use xlink:href="#z" x="10.596"/>
+      <use xlink:href="#k" x="15.894"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 202.243 171.423)">
+      <use xlink:href="#o"/>
+      <use xlink:href="#r" x="5.298"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 259.163 171.7)">
+      <use xlink:href="#ao"/>
+      <use xlink:href="#S" x="5.333"/>
+      <use xlink:href="#e" x="13.546"/>
+      <use xlink:href="#M" x="18.568"/>
+      <use xlink:href="#h" x="27.022"/>
+      <use xlink:href="#e" x="30.497"/>
+      <use xlink:href="#c" x="35.519"/>
+      <use xlink:href="#g" x="39.606"/>
+      <use xlink:href="#i" x="45.106"/>
+      <use xlink:href="#h" x="50.021"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M346.069 168.08h15.5M361.569 168.08h15.5"/>
+        <g class="typst-group">
+          <g class="typst-group">
+            <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="m358.069 164.58 7 7M365.069 164.58l-7 7"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 432.373 171.423)" fill="#4b69c6">
+      <use xlink:href="#D"/>
+      <use xlink:href="#ap" x="5.298"/>
+      <use xlink:href="#l" x="10.596"/>
+      <use xlink:href="#af" x="15.894"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 453.565 171.423)"/>
+    <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 458.864 171.423)"/>
+    <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 464.162 171.423)"/>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 14.063 219.335)">
+      <use xlink:href="#ad"/>
+      <use xlink:href="#i" x="5.946"/>
+      <use xlink:href="#c" x="10.86"/>
+      <use xlink:href="#d" x="14.948"/>
+      <use xlink:href="#u" x="23.633"/>
+      <use xlink:href="#h" x="29.471"/>
+      <use xlink:href="#e" x="32.946"/>
+      <use xlink:href="#h" x="37.968"/>
+      <use xlink:href="#T" x="41.443"/>
+      <use xlink:href="#b" x="44.424"/>
+      <use xlink:href="#v" x="49.967"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 32.572 233.725)">
+      <use xlink:href="#g"/>
+      <use xlink:href="#e" x="5.5"/>
+      <use xlink:href="#h" x="10.522"/>
+      <use xlink:href="#i" x="13.997"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M87.082 200.91h12M129.082 200.91h12M87.082 222.91h12M129.082 222.91h12M87.082 244.91h12M129.082 244.91h12"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" d="M99.082 198.91v48h30v-48Z"/>
+          <path class="typst-shape" fill="none" stroke="#fff" stroke-width="3" d="M99.082 200.91c15 0 15 44 30 44"/>
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M98.982 200.91c15 0 15.2 44 30.2 44"/>
+          <path class="typst-shape" fill="none" stroke="#fff" stroke-width="3" d="M99.082 222.91c15 0 15-22 30-22"/>
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M98.982 222.91c15 0 15.2-22 30.2-22"/>
+          <path class="typst-shape" fill="none" stroke="#fff" stroke-width="3" d="M99.082 244.91c15 0 15-22 30-22"/>
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M98.982 244.91c15 0 15.2-22 30.2-22"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 159.859 226.253)" fill="#4b69c6">
+        <use xlink:href="#af"/>
+        <use xlink:href="#n" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#R" x="15.894"/>
+        <use xlink:href="#C" x="21.192"/>
+        <use xlink:href="#m" x="26.49"/>
+        <use xlink:href="#n" x="31.788"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 196.945 226.253)"/>
+      <use xlink:href="#aq" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 202.243 226.253)"/>
+      <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 207.541 226.253)"/>
+      <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 212.84 226.253)"/>
+      <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 218.137 226.253)"/>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 223.435 226.253)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 228.733 226.253)"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 260.218 219.335)">
+      <use xlink:href="#Q"/>
+      <use xlink:href="#u" x="9.228"/>
+      <use xlink:href="#f" x="15.066"/>
+      <use xlink:href="#h" x="17.966"/>
+      <use xlink:href="#T" x="21.441"/>
+      <use xlink:href="#J" x="24.422"/>
+      <use xlink:href="#ar" x="28.139"/>
+      <use xlink:href="#u" x="33.671"/>
+      <use xlink:href="#U" x="39.51"/>
+      <use xlink:href="#T" x="44.929"/>
+      <use xlink:href="#h" x="47.91"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 276.455 233.725)">
+      <use xlink:href="#g"/>
+      <use xlink:href="#e" x="5.5"/>
+      <use xlink:href="#h" x="10.522"/>
+      <use xlink:href="#i" x="13.997"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M341.629 198.495h12M369.509 198.495h12M341.629 222.91h12M369.509 222.91h12M341.629 247.325h12M369.509 247.325h12"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M353.629 191.08v63.66h15.88v-63.66Z"/>
+          <use xlink:href="#as" class="typst-text" transform="matrix(1 0 0 -1 357.629 226.325)"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 405.883 226.253)" fill="#4b69c6">
+        <use xlink:href="#R"/>
+        <use xlink:href="#at" x="5.298"/>
+        <use xlink:href="#k" x="10.596"/>
+        <use xlink:href="#l" x="15.894"/>
+        <use xlink:href="#m" x="21.192"/>
+        <use xlink:href="#n" x="26.49"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 437.671 226.253)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 442.97 226.253)"/>
+      <use xlink:href="#au" class="typst-text" transform="matrix(1 0 0 -1 448.267 226.253)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 453.565 226.253)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 458.864 226.253)">
+        <use xlink:href="#s"/>
+        <use xlink:href="#am" x="10.596"/>
+        <use xlink:href="#E" x="15.894"/>
+      </g>
+      <use xlink:href="#av" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 485.354 226.253)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 490.652 226.253)"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 30.04 283.775)">
+      <use xlink:href="#f"/>
+      <use xlink:href="#K" x="2.9"/>
+      <use xlink:href="#h" x="7.187"/>
+      <use xlink:href="#T" x="10.662"/>
+      <use xlink:href="#ak" x="13.643"/>
+      <use xlink:href="#aw" x="18.348"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M112.732 280.155h24"/>
+        <g class="typst-group">
+          <g class="typst-group">
+            <use xlink:href="#V" class="typst-text" transform="matrix(1 0 0 -1 95.432 283.57)"/>
+            <use xlink:href="#ax" class="typst-text" transform="matrix(1 0 0 -1 98.212 283.57)"/>
+            <use xlink:href="#X" class="typst-text" transform="matrix(1 0 0 -1 104.842 283.57)"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 158.316 283.498)" fill="#4b69c6">
+        <use xlink:href="#Y"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#B" x="15.894"/>
+        <use xlink:href="#ai" x="21.192"/>
+        <use xlink:href="#ay" x="26.49"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 190.105 283.498)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 195.403 283.498)"/>
+      <use xlink:href="#aa" class="typst-text" transform="matrix(1 0 0 -1 200.7 283.498)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 205.999 283.498)" fill="#8b41b1">
+        <use xlink:href="#af"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#B" x="10.596"/>
+      </g>
+      <use xlink:href="#ac" class="typst-text" transform="matrix(1 0 0 -1 221.893 283.498)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 224.978 283.498)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 230.276 283.498)"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 273.33 283.775)">
+      <use xlink:href="#c"/>
+      <use xlink:href="#K" x="4.087"/>
+      <use xlink:href="#h" x="8.374"/>
+      <use xlink:href="#T" x="11.849"/>
+      <use xlink:href="#ak" x="14.83"/>
+      <use xlink:href="#aw" x="19.535"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M338.919 280.155h12M350.919 280.155h12"/>
+        <g class="typst-group">
+          <g class="typst-group">
+            <use xlink:href="#V" class="typst-text" transform="matrix(1 0 0 -1 366.919 283.57)"/>
+            <use xlink:href="#ax" class="typst-text" transform="matrix(1 0 0 -1 369.699 283.57)"/>
+            <use xlink:href="#X" class="typst-text" transform="matrix(1 0 0 -1 376.329 283.57)"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 412.288 283.498)" fill="#4b69c6">
+        <use xlink:href="#z"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#B" x="15.894"/>
+        <use xlink:href="#ai" x="21.192"/>
+        <use xlink:href="#ay" x="26.49"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 444.076 283.498)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 449.374 283.498)"/>
+      <use xlink:href="#aa" class="typst-text" transform="matrix(1 0 0 -1 454.672 283.498)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 459.97 283.498)" fill="#8b41b1">
+        <use xlink:href="#af"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#B" x="10.596"/>
+      </g>
+      <use xlink:href="#ac" class="typst-text" transform="matrix(1 0 0 -1 475.864 283.498)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 478.95 283.498)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 484.247 283.498)"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 16.335 316.995)">
+      <use xlink:href="#Q"/>
+      <use xlink:href="#u" x="9.228"/>
+      <use xlink:href="#f" x="15.066"/>
+      <use xlink:href="#h" x="17.966"/>
+      <use xlink:href="#T" x="21.441"/>
+      <use xlink:href="#J" x="24.422"/>
+      <use xlink:href="#ar" x="28.139"/>
+      <use xlink:href="#u" x="33.671"/>
+      <use xlink:href="#U" x="39.51"/>
+      <use xlink:href="#T" x="44.929"/>
+      <use xlink:href="#h" x="47.91"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 30.04 331.385)">
+      <use xlink:href="#f"/>
+      <use xlink:href="#K" x="2.9"/>
+      <use xlink:href="#h" x="7.187"/>
+      <use xlink:href="#T" x="10.662"/>
+      <use xlink:href="#ak" x="13.643"/>
+      <use xlink:href="#aw" x="18.348"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M116.482 310.57h24M116.482 330.57h24"/>
+        <g class="typst-group">
+          <use xlink:href="#az" class="typst-text" transform="matrix(1 0 0 -1 108.982 322.57)"/>
+          <g class="typst-group">
+            <use xlink:href="#V" class="typst-text" transform="matrix(1 0 0 -1 91.682 323.985)"/>
+            <use xlink:href="#ax" class="typst-text" transform="matrix(1 0 0 -1 94.462 323.985)"/>
+            <use xlink:href="#X" class="typst-text" transform="matrix(1 0 0 -1 101.092 323.985)"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 158.316 317.71)" fill="#4b69c6">
+        <use xlink:href="#Y"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#B" x="15.894"/>
+        <use xlink:href="#ai" x="21.192"/>
+        <use xlink:href="#ay" x="26.49"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 190.105 317.71)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 195.403 317.71)"/>
+      <use xlink:href="#aa" class="typst-text" transform="matrix(1 0 0 -1 200.7 317.71)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 205.999 317.71)" fill="#8b41b1">
+        <use xlink:href="#af"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#B" x="10.596"/>
+      </g>
+      <use xlink:href="#ac" class="typst-text" transform="matrix(1 0 0 -1 221.893 317.71)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 224.978 317.71)"/>
+      <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 230.276 317.71)"/>
+      <use xlink:href="#am" class="typst-text" transform="matrix(1 0 0 -1 183.7 330.116)"/>
+      <use xlink:href="#E" class="typst-text" transform="matrix(1 0 0 -1 188.998 330.116)"/>
+      <use xlink:href="#aq" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 199.594 330.116)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 204.892 330.116)"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 260.218 316.995)">
+      <use xlink:href="#Q"/>
+      <use xlink:href="#u" x="9.228"/>
+      <use xlink:href="#f" x="15.066"/>
+      <use xlink:href="#h" x="17.966"/>
+      <use xlink:href="#T" x="21.441"/>
+      <use xlink:href="#J" x="24.422"/>
+      <use xlink:href="#ar" x="28.139"/>
+      <use xlink:href="#u" x="33.671"/>
+      <use xlink:href="#U" x="39.51"/>
+      <use xlink:href="#T" x="44.929"/>
+      <use xlink:href="#h" x="47.91"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 273.33 331.385)">
+      <use xlink:href="#c"/>
+      <use xlink:href="#K" x="4.087"/>
+      <use xlink:href="#h" x="8.374"/>
+      <use xlink:href="#T" x="11.849"/>
+      <use xlink:href="#ak" x="14.83"/>
+      <use xlink:href="#aw" x="19.535"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M336.279 310.57h12M348.279 310.57h12M336.279 330.57h24"/>
+        <g class="typst-group">
+          <use xlink:href="#aA" class="typst-text" transform="matrix(1 0 0 -1 360.279 322.57)"/>
+          <g class="typst-group">
+            <use xlink:href="#V" class="typst-text" transform="matrix(1 0 0 -1 369.559 323.985)"/>
+            <use xlink:href="#ax" class="typst-text" transform="matrix(1 0 0 -1 372.339 323.985)"/>
+            <use xlink:href="#X" class="typst-text" transform="matrix(1 0 0 -1 378.969 323.985)"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 412.288 317.71)" fill="#4b69c6">
+        <use xlink:href="#z"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#B" x="15.894"/>
+        <use xlink:href="#ai" x="21.192"/>
+        <use xlink:href="#ay" x="26.49"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 444.076 317.71)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 449.374 317.71)"/>
+      <use xlink:href="#aa" class="typst-text" transform="matrix(1 0 0 -1 454.672 317.71)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 459.97 317.71)" fill="#8b41b1">
+        <use xlink:href="#af"/>
+        <use xlink:href="#D" x="5.298"/>
+        <use xlink:href="#B" x="10.596"/>
+      </g>
+      <use xlink:href="#ac" class="typst-text" transform="matrix(1 0 0 -1 475.864 317.71)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 478.95 317.71)"/>
+      <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 484.247 317.71)"/>
+      <g class="typst-group">
+        <use xlink:href="#am" class="typst-text" transform="matrix(1 0 0 -1 405.883 330.116)"/>
+        <use xlink:href="#E" class="typst-text" transform="matrix(1 0 0 -1 411.181 330.116)"/>
+        <use xlink:href="#aq" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 421.777 330.116)"/>
+        <use xlink:href="#s" class="typst-text" transform="matrix(1 0 0 -1 427.075 330.116)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 437.671 330.116)">
+          <use xlink:href="#Z"/>
+          <use xlink:href="#z" x="5.298"/>
+          <use xlink:href="#l" x="10.596"/>
+          <use xlink:href="#ai" x="15.894"/>
+          <use xlink:href="#n" x="21.192"/>
+        </g>
+        <use xlink:href="#E" class="typst-text" transform="matrix(1 0 0 -1 464.162 330.116)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 474.758 330.116)" fill="#298e0d">
+          <use xlink:href="#aB"/>
+          <use xlink:href="#aC" x="5.298"/>
+          <use xlink:href="#aB" x="10.596"/>
+        </g>
+        <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 490.652 330.116)"/>
+      </g>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 22.874 366.272)">
+      <use xlink:href="#d"/>
+      <use xlink:href="#T" x="8.685"/>
+      <use xlink:href="#w" x="11.666"/>
+      <use xlink:href="#K" x="17.23"/>
+      <use xlink:href="#h" x="21.517"/>
+      <use xlink:href="#T" x="24.992"/>
+      <use xlink:href="#ak" x="27.973"/>
+      <use xlink:href="#aw" x="32.678"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M88.343 362.652h12M127.821 362.652h12"/>
+        <g class="typst-group">
+          <g class="typst-text" transform="matrix(1 0 0 -1 104.343 365.943)">
+            <use xlink:href="#aD"/>
+            <use xlink:href="#aE" x="5.068"/>
+            <use xlink:href="#aF" x="9.536"/>
+            <use xlink:href="#aG" x="14.102"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 154.56 365.995)" fill="#4b69c6">
+      <use xlink:href="#R"/>
+      <use xlink:href="#B" x="5.298"/>
+      <use xlink:href="#A" x="10.596"/>
+      <use xlink:href="#D" x="15.894"/>
+      <use xlink:href="#m" x="21.192"/>
+      <use xlink:href="#B" x="26.49"/>
+      <use xlink:href="#ai" x="31.788"/>
+      <use xlink:href="#ay" x="37.086"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 196.945 365.995)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 202.243 365.995)" fill="#298e0d">
+      <use xlink:href="#aB"/>
+      <use xlink:href="#aH" x="5.298"/>
+      <use xlink:href="#n" x="10.596"/>
+      <use xlink:href="#l" x="15.894"/>
+      <use xlink:href="#P" x="21.192"/>
+      <use xlink:href="#aB" x="26.49"/>
+    </g>
+    <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 234.032 365.995)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 258.06 366.272)">
+      <use xlink:href="#aI"/>
+      <use xlink:href="#T" x="10.458"/>
+      <use xlink:href="#c" x="13.438"/>
+      <use xlink:href="#i" x="17.44"/>
+      <use xlink:href="#U" x="25.104"/>
+      <use xlink:href="#u" x="30.524"/>
+      <use xlink:href="#v" x="36.362"/>
+      <use xlink:href="#w" x="42.324"/>
+      <use xlink:href="#f" x="47.889"/>
+      <use xlink:href="#i" x="50.789"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M349.569 362.652h12M361.569 362.652h12"/>
+        <g class="typst-group">
+          <use xlink:href="#aJ" class="typst-text" transform="matrix(1 0 0 -1 362.569 358.177)"/>
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="m361.569 358.652-5 8"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 429.724 365.995)" fill="#4b69c6">
+      <use xlink:href="#am"/>
+      <use xlink:href="#ap" x="5.298"/>
+      <use xlink:href="#B" x="10.596"/>
+      <use xlink:href="#z" x="15.894"/>
+      <use xlink:href="#n" x="21.192"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 456.214 365.995)"/>
+    <use xlink:href="#aK" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 461.513 365.995)"/>
+    <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 466.81 365.995)"/>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 18.035 402.159)">
+      <use xlink:href="#ah"/>
+      <use xlink:href="#b" x="7.106"/>
+      <use xlink:href="#v" x="12.649"/>
+      <use xlink:href="#h" x="18.611"/>
+      <use xlink:href="#c" x="22.086"/>
+      <use xlink:href="#b" x="26.087"/>
+      <use xlink:href="#f" x="31.63"/>
+      <use xlink:href="#f" x="34.531"/>
+      <use xlink:href="#i" x="37.431"/>
+      <use xlink:href="#w" x="42.421"/>
+    </g>
+    <use xlink:href="#aL" class="typst-text" transform="matrix(1 0 0 -1 29.741 416.549)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 34.72 416.549)">
+      <use xlink:href="#J"/>
+      <use xlink:href="#g" x="3.717"/>
+      <use xlink:href="#e" x="9.217"/>
+      <use xlink:href="#h" x="14.239"/>
+      <use xlink:href="#i" x="17.714"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M99.782 394.734h14.3M114.082 394.734h14.3M99.782 416.734h14.3M114.082 416.734h14.3M114.082 394.734v22"/>
+        <g class="typst-group">
+          <path class="typst-shape" d="M111.782 394.734c0-1.27 1.031-2.3 2.3-2.3 1.27 0 2.3 1.03 2.3 2.3 0 1.269-1.03 2.3-2.3 2.3-1.269 0-2.3-1.031-2.3-2.3"/>
+        </g>
+        <g class="typst-group">
+          <path class="typst-shape" d="M111.782 416.734c0-1.27 1.031-2.3 2.3-2.3 1.27 0 2.3 1.03 2.3 2.3 0 1.269-1.03 2.3-2.3 2.3-1.269 0-2.3-1.031-2.3-2.3"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 178.402 394.964)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 199.594 394.964)"/>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 204.892 394.964)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 210.19 394.964)"/>
+      <use xlink:href="#aM" class="typst-text" transform="matrix(1 0 0 -1 193.921 409.354)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 178.402 423.19)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 199.594 423.19)"/>
+      <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 204.892 423.19)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 210.19 423.19)"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 261.918 402.159)">
+      <use xlink:href="#ah"/>
+      <use xlink:href="#b" x="7.106"/>
+      <use xlink:href="#v" x="12.649"/>
+      <use xlink:href="#h" x="18.611"/>
+      <use xlink:href="#c" x="22.086"/>
+      <use xlink:href="#b" x="26.087"/>
+      <use xlink:href="#f" x="31.63"/>
+      <use xlink:href="#f" x="34.531"/>
+      <use xlink:href="#i" x="37.431"/>
+      <use xlink:href="#w" x="42.421"/>
+    </g>
+    <use xlink:href="#aN" class="typst-text" transform="matrix(1 0 0 -1 273.19 416.549)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 279.039 416.549)">
+      <use xlink:href="#J"/>
+      <use xlink:href="#g" x="3.717"/>
+      <use xlink:href="#e" x="9.217"/>
+      <use xlink:href="#h" x="14.239"/>
+      <use xlink:href="#i" x="17.714"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M345.269 394.734h16.3M361.569 394.734h16.3M345.269 416.734h16.3M361.569 416.734h16.3M361.569 394.734v22"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M357.269 416.734c0-2.373 1.927-4.3 4.3-4.3 2.372 0 4.3 1.927 4.3 4.3 0 2.372-1.928 4.3-4.3 4.3a4.303 4.303 0 0 1-4.3-4.3M361.569 421.034v-8.6M357.269 416.734h8.6"/>
+        </g>
+        <g class="typst-group">
+          <path class="typst-shape" d="M359.269 394.734c0-1.27 1.03-2.3 2.3-2.3 1.269 0 2.3 1.03 2.3 2.3 0 1.269-1.031 2.3-2.3 2.3-1.27 0-2.3-1.031-2.3-2.3"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 432.373 394.964)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 453.565 394.964)"/>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 458.864 394.964)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 464.162 394.964)"/>
+      <use xlink:href="#aM" class="typst-text" transform="matrix(1 0 0 -1 447.893 409.354)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 435.022 423.19)" fill="#4b69c6">
+        <use xlink:href="#m"/>
+        <use xlink:href="#l" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#k" x="15.894"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 456.214 423.19)">
+        <use xlink:href="#o"/>
+        <use xlink:href="#r" x="5.298"/>
+      </g>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 29.891 454.574)">
+      <use xlink:href="#ao"/>
+      <use xlink:href="#S" x="5.333"/>
+      <use xlink:href="#e" x="13.546"/>
+      <use xlink:href="#M" x="18.568"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 31.054 468.964)">
+      <use xlink:href="#g" x="3.035"/>
+      <use xlink:href="#e" x="8.535"/>
+      <use xlink:href="#h" x="13.557"/>
+      <use xlink:href="#i" x="17.032"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M98.582 447.149h15.5M114.082 447.149h15.5M98.582 469.149h15.5M114.082 469.149h15.5M114.082 447.149v22"/>
+        <g class="typst-group">
+          <g class="typst-group">
+            <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="m110.582 465.649 7 7M117.582 465.649l-7 7"/>
+          </g>
+        </g>
+        <g class="typst-group">
+          <g class="typst-group">
+            <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="m110.582 443.649 7 7M117.582 443.649l-7 7"/>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 178.402 447.379)" fill="#4b69c6">
+        <use xlink:href="#D"/>
+        <use xlink:href="#ap" x="5.298"/>
+        <use xlink:href="#l" x="10.596"/>
+        <use xlink:href="#af" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 199.594 447.379)"/>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 204.892 447.379)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 210.19 447.379)"/>
+      <use xlink:href="#aM" class="typst-text" transform="matrix(1 0 0 -1 193.921 461.769)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 178.402 475.605)" fill="#4b69c6">
+        <use xlink:href="#m"/>
+        <use xlink:href="#l" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#k" x="15.894"/>
+        <use xlink:href="#y" x="21.192"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 204.892 475.605)">
+        <use xlink:href="#o"/>
+        <use xlink:href="#r" x="5.298"/>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 261.918 454.574)">
+      <use xlink:href="#ah"/>
+      <use xlink:href="#b" x="7.106"/>
+      <use xlink:href="#v" x="12.649"/>
+      <use xlink:href="#h" x="18.611"/>
+      <use xlink:href="#c" x="22.086"/>
+      <use xlink:href="#b" x="26.087"/>
+      <use xlink:href="#f" x="31.63"/>
+      <use xlink:href="#f" x="34.531"/>
+      <use xlink:href="#i" x="37.431"/>
+      <use xlink:href="#w" x="42.421"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 262.455 468.964)">
+      <use xlink:href="#aO"/>
+      <use xlink:href="#e" x="8.03"/>
+      <use xlink:href="#w" x="13.052"/>
+      <use xlink:href="#e" x="18.616"/>
+      <use xlink:href="#d" x="23.638"/>
+      <use xlink:href="#e" x="32.323"/>
+      <use xlink:href="#c" x="37.345"/>
+      <use xlink:href="#w" x="41.347"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M341.024 447.149h12M370.114 447.149h12M341.024 471.564h20.545M361.569 471.564h20.545M361.569 454.564v17"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M353.024 439.734v14.83h17.09v-14.83Z"/>
+          <use xlink:href="#j" class="typst-text" transform="matrix(1 0 0 -1 357.024 450.564)"/>
+        </g>
+        <g class="typst-group">
+          <path class="typst-shape" d="M359.269 471.564c0-1.27 1.03-2.3 2.3-2.3 1.269 0 2.3 1.03 2.3 2.3 0 1.269-1.031 2.3-2.3 2.3-1.27 0-2.3-1.031-2.3-2.3"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 397.936 447.379)" fill="#4b69c6">
+        <use xlink:href="#R"/>
+        <use xlink:href="#at" x="5.298"/>
+        <use xlink:href="#k" x="10.596"/>
+        <use xlink:href="#l" x="15.894"/>
+        <use xlink:href="#m" x="21.192"/>
+        <use xlink:href="#n" x="26.49"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 429.724 447.379)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 435.022 447.379)"/>
+      <use xlink:href="#q" class="typst-text" transform="matrix(1 0 0 -1 440.32 447.379)"/>
+      <use xlink:href="#p" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 445.618 447.379)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 450.916 447.379)">
+        <use xlink:href="#s"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#l" x="10.596"/>
+        <use xlink:href="#z" x="15.894"/>
+        <use xlink:href="#k" x="21.192"/>
+        <use xlink:href="#n" x="26.49"/>
+        <use xlink:href="#m" x="31.788"/>
+        <use xlink:href="#E" x="37.086"/>
+      </g>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 493.3 447.379)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 498.599 447.379)"/>
+      <use xlink:href="#aM" class="typst-text" transform="matrix(1 0 0 -1 447.893 461.769)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 432.373 475.605)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 453.565 475.605)"/>
+      <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 458.864 475.605)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 464.162 475.605)"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 30.555 502.209)">
+      <use xlink:href="#ad"/>
+      <use xlink:href="#f" x="6.08"/>
+      <use xlink:href="#e" x="8.98"/>
+      <use xlink:href="#T" x="14.002"/>
+      <use xlink:href="#v" x="16.983"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 25.296 516.599)">
+      <use xlink:href="#aP"/>
+      <use xlink:href="#i" x="5.376"/>
+      <use xlink:href="#c" x="10.291"/>
+      <use xlink:href="#h" x="14.378"/>
+      <use xlink:href="#T" x="17.854"/>
+      <use xlink:href="#ak" x="20.834"/>
+      <use xlink:href="#e" x="25.54"/>
+      <use xlink:href="#f" x="30.562"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 31.973 530.99)">
+      <use xlink:href="#S"/>
+      <use xlink:href="#T" x="8.212"/>
+      <use xlink:href="#c" x="11.193"/>
+      <use xlink:href="#i" x="15.195"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M102.082 501.979h12M114.082 501.979h12M102.082 523.979h24M114.082 501.979v22"/>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 162.508 510.119)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 183.7 510.119)"/>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 188.998 510.119)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 194.296 510.119)">
+        <use xlink:href="#s"/>
+        <use xlink:href="#D" x="10.596"/>
+        <use xlink:href="#P" x="15.894"/>
+        <use xlink:href="#al" x="21.192"/>
+        <use xlink:href="#ap" x="26.49"/>
+        <use xlink:href="#aQ" x="31.788"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 167.806 522.525)">
+        <use xlink:href="#A"/>
+        <use xlink:href="#al" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#E" x="15.894"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 194.296 522.525)" fill="#d73a49">
+        <use xlink:href="#aR"/>
+        <use xlink:href="#l" x="5.298"/>
+        <use xlink:href="#Y" x="10.596"/>
+        <use xlink:href="#D" x="15.894"/>
+        <use xlink:href="#n" x="21.192"/>
+      </g>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 220.786 522.525)"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 266.717 509.404)">
+      <use xlink:href="#Q"/>
+      <use xlink:href="#i" x="9.228"/>
+      <use xlink:href="#h" x="14.142"/>
+      <use xlink:href="#i" x="17.617"/>
+      <use xlink:href="#c" x="22.532"/>
+      <use xlink:href="#h" x="29.369"/>
+      <use xlink:href="#b" x="32.844"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 267.507 523.794)">
+      <use xlink:href="#ak"/>
+      <use xlink:href="#f" x="4.705"/>
+      <use xlink:href="#e" x="7.605"/>
+      <use xlink:href="#K" x="12.627"/>
+      <use xlink:href="#K" x="16.914"/>
+      <use xlink:href="#T" x="21.2"/>
+      <use xlink:href="#ak" x="24.181"/>
+      <use xlink:href="#e" x="28.886"/>
+      <use xlink:href="#f" x="33.908"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M338.446 501.979h12M372.691 501.979h12M338.446 525.394h23.123M338.446 527.394h23.123M361.569 525.394h23.122M361.569 527.394h23.122"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M360.569 509.394v17M362.569 509.394v17"/>
+        </g>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M350.446 494.564v14.83h22.245v-14.83Z"/>
+          <g class="typst-group">
+            <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M354.446 506.077s1.425-4.781 7.123-4.781 7.122 4.78 7.122 4.78M361.569 506.76l5.698-6.147"/>
+            <path class="typst-shape" d="m369.85 497.826-3.61 1.835 2.053 1.903 1.557-3.738Z"/>
+          </g>
+        </g>
+        <g class="typst-group">
+          <path class="typst-shape" d="M359.269 526.394c0-1.27 1.03-2.3 2.3-2.3 1.269 0 2.3 1.03 2.3 2.3 0 1.269-1.031 2.3-2.3 2.3-1.27 0-2.3-1.031-2.3-2.3"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 408.532 502.209)" fill="#4b69c6">
+        <use xlink:href="#R"/>
+        <use xlink:href="#n" x="5.298"/>
+        <use xlink:href="#m" x="10.596"/>
+        <use xlink:href="#n" x="15.894"/>
+        <use xlink:href="#z" x="21.192"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 435.022 502.209)">
+        <use xlink:href="#o"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#l" x="10.596"/>
+        <use xlink:href="#z" x="15.894"/>
+        <use xlink:href="#k" x="21.192"/>
+        <use xlink:href="#n" x="26.49"/>
+        <use xlink:href="#m" x="31.788"/>
+        <use xlink:href="#E" x="37.086"/>
+      </g>
+      <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 482.705 502.209)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 488.003 502.209)"/>
+      <use xlink:href="#aM" class="typst-text" transform="matrix(1 0 0 -1 447.893 516.599)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 432.373 530.435)" fill="#4b69c6">
+        <use xlink:href="#ai"/>
+        <use xlink:href="#m" x="5.298"/>
+        <use xlink:href="#z" x="10.596"/>
+        <use xlink:href="#Y" x="15.894"/>
+      </g>
+      <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 453.565 530.435)"/>
+      <use xlink:href="#G" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 458.864 530.435)"/>
+      <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 464.162 530.435)"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 22.423 552.634)">
+      <use xlink:href="#ah"/>
+      <use xlink:href="#f" x="7.106"/>
+      <use xlink:href="#e" x="10.006"/>
+      <use xlink:href="#K" x="15.028"/>
+      <use xlink:href="#K" x="19.314"/>
+      <use xlink:href="#T" x="23.601"/>
+      <use xlink:href="#ak" x="26.582"/>
+      <use xlink:href="#e" x="31.287"/>
+      <use xlink:href="#f" x="36.309"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 31.973 567.024)">
+      <use xlink:href="#S"/>
+      <use xlink:href="#T" x="8.212"/>
+      <use xlink:href="#c" x="11.193"/>
+      <use xlink:href="#i" x="15.195"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M102.082 555.209h24M102.082 557.209h24"/>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 170.455 559.552)" fill="#4b69c6">
+      <use xlink:href="#D"/>
+      <use xlink:href="#n" x="5.298"/>
+      <use xlink:href="#m" x="10.596"/>
+      <use xlink:href="#ap" x="15.894"/>
+      <use xlink:href="#B" x="21.192"/>
+      <use xlink:href="#z" x="26.49"/>
+      <use xlink:href="#n" x="31.788"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 207.541 559.552)"/>
+    <use xlink:href="#aq" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 212.84 559.552)"/>
+    <use xlink:href="#r" class="typst-text" transform="matrix(1 0 0 -1 218.137 559.552)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 260.52 559.83)">
+      <use xlink:href="#ao"/>
+      <use xlink:href="#h" x="5.333"/>
+      <use xlink:href="#aS" x="8.809"/>
+      <use xlink:href="#f" x="14.47"/>
+      <use xlink:href="#i" x="17.37"/>
+      <use xlink:href="#w" x="22.36"/>
+      <use xlink:href="#S" x="30.674"/>
+      <use xlink:href="#T" x="38.887"/>
+      <use xlink:href="#c" x="41.868"/>
+      <use xlink:href="#i" x="45.869"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#2ecc40" stroke-width=".7" d="M349.569 556.209h24"/>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 403.234 553.349)" fill="#4b69c6">
+      <use xlink:href="#D"/>
+      <use xlink:href="#n" x="5.298"/>
+      <use xlink:href="#m" x="10.596"/>
+      <use xlink:href="#ap" x="15.894"/>
+      <use xlink:href="#B" x="21.192"/>
+      <use xlink:href="#z" x="26.49"/>
+      <use xlink:href="#n" x="31.788"/>
+    </g>
+    <use xlink:href="#o" class="typst-text" transform="matrix(1 0 0 -1 440.32 553.349)"/>
+    <use xlink:href="#F" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 445.618 553.349)"/>
+    <g class="typst-text" transform="matrix(1 0 0 -1 450.916 553.349)">
+      <use xlink:href="#s"/>
+      <use xlink:href="#D" x="10.596"/>
+      <use xlink:href="#m" x="15.894"/>
+      <use xlink:href="#z" x="21.192"/>
+      <use xlink:href="#al" x="26.49"/>
+      <use xlink:href="#ay" x="31.788"/>
+      <use xlink:href="#n" x="37.086"/>
+      <use xlink:href="#E" x="42.384"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 435.022 565.755)">
+      <use xlink:href="#k"/>
+      <use xlink:href="#z" x="5.298"/>
+      <use xlink:href="#n" x="10.596"/>
+      <use xlink:href="#n" x="15.894"/>
+      <use xlink:href="#am" x="21.192"/>
+      <use xlink:href="#r" x="26.49"/>
+    </g>
+  </g>
+  <g class="typst-group">
+    <g class="typst-text" transform="matrix(1 0 0 -1 27.8 616.146)">
+      <use xlink:href="#aT"/>
+      <use xlink:href="#e" x="5.806"/>
+      <use xlink:href="#U" x="10.828"/>
+      <use xlink:href="#i" x="16.355"/>
+      <use xlink:href="#f" x="21.27"/>
+      <use xlink:href="#K" x="24.17"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".7" d="M94.011 612.526h12M121.921 612.526h12"/>
+        <g class="typst-group">
+          <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".7" d="M106.011 605.111v14.83h15.91v-14.83Z"/>
+          <use xlink:href="#aU" class="typst-text" transform="matrix(1 0 0 -1 110.011 615.941)"/>
+        </g>
+        <g class="typst-group">
+          <use xlink:href="#aV" class="typst-text" transform="matrix(1 0 0 -1 111.503 601.111)"/>
+          <use xlink:href="#aV" class="typst-text" transform="matrix(1 0 0 -1 111.503 630.523)"/>
+          <use xlink:href="#aF" class="typst-text" transform="matrix(1 0 0 -1 97.446 601.111)"/>
+          <use xlink:href="#aW" class="typst-text" transform="matrix(1 0 0 -1 129.876 605.111)"/>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 157.21 584.758)" fill="#4b69c6">
+        <use xlink:href="#aX"/>
+        <use xlink:href="#aY" x="3.179"/>
+        <use xlink:href="#aZ" x="6.358"/>
+        <use xlink:href="#ba" x="9.536"/>
+      </g>
+      <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 169.925 584.758)"/>
+      <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 173.104 584.758)"/>
+      <use xlink:href="#bd" class="typst-text" transform="matrix(1 0 0 -1 176.283 584.758)"/>
+      <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 179.462 584.758)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 182.64 584.758)">
+        <use xlink:href="#be"/>
+        <use xlink:href="#bf" x="6.358"/>
+        <use xlink:href="#aY" x="9.536"/>
+        <use xlink:href="#bg" x="12.715"/>
+        <use xlink:href="#ba" x="15.894"/>
+        <use xlink:href="#bf" x="19.073"/>
+        <use xlink:href="#bh" x="22.252"/>
+        <use xlink:href="#bb" x="28.609"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 157.21 592.201)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 160.389 592.201)">
+          <use xlink:href="#bi"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bk" x="6.358"/>
+          <use xlink:href="#aZ" x="9.536"/>
+          <use xlink:href="#ba" x="12.715"/>
+          <use xlink:href="#bk" x="15.894"/>
+          <use xlink:href="#aZ" x="19.073"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 182.64 592.201)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 188.998 592.201)" fill="#298e0d">
+          <use xlink:href="#bl"/>
+          <use xlink:href="#bg" x="3.179"/>
+          <use xlink:href="#bl" x="6.358"/>
+        </g>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 198.535 592.201)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 201.713 592.201)">
+          <use xlink:href="#bm"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bn" x="6.358"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 211.25 592.201)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 214.429 592.201)">
+          <use xlink:href="#aZ"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bm" x="6.358"/>
+        </g>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 223.965 592.201)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 227.144 592.201)"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 157.21 599.645)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 160.389 599.645)">
+          <use xlink:href="#bi"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bk" x="6.358"/>
+          <use xlink:href="#aZ" x="9.536"/>
+          <use xlink:href="#ba" x="12.715"/>
+          <use xlink:href="#bk" x="15.894"/>
+          <use xlink:href="#aZ" x="19.073"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 182.64 599.645)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 185.82 599.645)" fill="#298e0d">
+          <use xlink:href="#bl"/>
+          <use xlink:href="#bg" x="3.179"/>
+          <use xlink:href="#bl" x="6.358"/>
+        </g>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 195.356 599.645)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 198.535 599.645)">
+          <use xlink:href="#bm"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bn" x="6.358"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 208.071 599.645)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 211.25 599.645)">
+          <use xlink:href="#bg"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#aZ" x="6.358"/>
+          <use xlink:href="#aZ" x="9.536"/>
+          <use xlink:href="#bj" x="12.715"/>
+          <use xlink:href="#bp" x="15.894"/>
+        </g>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 230.323 599.645)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 233.502 599.645)"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 157.21 607.088)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 163.568 607.088)">
+          <use xlink:href="#bi"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bk" x="6.358"/>
+          <use xlink:href="#aZ" x="9.536"/>
+          <use xlink:href="#ba" x="12.715"/>
+          <use xlink:href="#bk" x="15.894"/>
+          <use xlink:href="#aZ" x="19.073"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 185.82 607.088)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 192.177 607.088)" fill="#298e0d">
+          <use xlink:href="#bl"/>
+          <use xlink:href="#aY" x="3.179"/>
+          <use xlink:href="#bl" x="6.358"/>
+        </g>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 201.713 607.088)"/>
+      </g>
+      <g class="typst-group">
+        <g class="typst-text" transform="matrix(1 0 0 -1 163.568 614.532)">
+          <use xlink:href="#bm"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bn" x="6.358"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 173.104 614.532)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 179.462 614.532)">
+          <use xlink:href="#bf"/>
+          <use xlink:href="#ba" x="3.179"/>
+          <use xlink:href="#bq" x="6.358"/>
+          <use xlink:href="#aZ" x="9.536"/>
+        </g>
+        <use xlink:href="#br" fill="#d73a49" class="typst-text" transform="matrix(1 0 0 -1 195.356 614.532)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 201.713 614.532)">
+          <use xlink:href="#aZ"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bm" x="6.358"/>
+        </g>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 214.429 614.532)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 217.608 614.532)"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 157.21 621.975)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 163.568 621.975)">
+          <use xlink:href="#bi"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bk" x="6.358"/>
+          <use xlink:href="#aZ" x="9.536"/>
+          <use xlink:href="#ba" x="12.715"/>
+          <use xlink:href="#bk" x="15.894"/>
+          <use xlink:href="#aZ" x="19.073"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 185.82 621.975)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 192.177 621.975)" fill="#298e0d">
+          <use xlink:href="#bl"/>
+          <use xlink:href="#bi" x="3.179"/>
+          <use xlink:href="#bl" x="6.358"/>
+        </g>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 201.713 621.975)"/>
+      </g>
+      <g class="typst-group">
+        <g class="typst-text" transform="matrix(1 0 0 -1 163.568 629.419)">
+          <use xlink:href="#bm"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bn" x="6.358"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 173.104 629.419)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 179.462 629.419)">
+          <use xlink:href="#bs"/>
+          <use xlink:href="#bt" x="3.179"/>
+          <use xlink:href="#aX" x="6.358"/>
+          <use xlink:href="#bu" x="9.536"/>
+          <use xlink:href="#aZ" x="12.715"/>
+        </g>
+        <use xlink:href="#br" fill="#d73a49" class="typst-text" transform="matrix(1 0 0 -1 198.535 629.419)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 204.892 629.419)">
+          <use xlink:href="#aZ"/>
+          <use xlink:href="#bj" x="3.179"/>
+          <use xlink:href="#bm" x="6.358"/>
+        </g>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 214.429 629.419)"/>
+      </g>
+      <g class="typst-group">
+        <g class="typst-text" transform="matrix(1 0 0 -1 163.568 636.862)">
+          <use xlink:href="#bv"/>
+          <use xlink:href="#bw" x="3.179"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 169.925 636.862)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 176.283 636.862)" fill="#b60157">
+          <use xlink:href="#bx"/>
+          <use xlink:href="#bm" x="3.179"/>
+          <use xlink:href="#aZ" x="6.358"/>
+        </g>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 185.82 636.862)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 192.177 636.862)">
+          <use xlink:href="#bv"/>
+          <use xlink:href="#by" x="3.179"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 198.535 636.862)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 204.892 636.862)" fill="#b60157">
+          <use xlink:href="#bz"/>
+          <use xlink:href="#bx" x="3.179"/>
+          <use xlink:href="#bA" x="6.358"/>
+        </g>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 217.608 636.862)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 220.786 636.862)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 157.21 644.306)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 160.389 644.306)"/>
+      </g>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 259.942 608.951)">
+      <use xlink:href="#bB"/>
+      <use xlink:href="#e" x="7.53"/>
+      <use xlink:href="#h" x="12.552"/>
+      <use xlink:href="#i" x="16.027"/>
+      <use xlink:href="#T" x="23.692"/>
+      <use xlink:href="#v" x="26.673"/>
+      <use xlink:href="#M" x="32.635"/>
+      <use xlink:href="#u" x="38.339"/>
+      <use xlink:href="#h" x="44.177"/>
+      <use xlink:href="#K" x="47.652"/>
+    </g>
+    <g class="typst-text" transform="matrix(1 0 0 -1 259.182 623.341)">
+      <use xlink:href="#e"/>
+      <use xlink:href="#v" x="5.022"/>
+      <use xlink:href="#w" x="10.984"/>
+      <use xlink:href="#b" x="19.298"/>
+      <use xlink:href="#u" x="24.841"/>
+      <use xlink:href="#h" x="30.68"/>
+      <use xlink:href="#M" x="34.155"/>
+      <use xlink:href="#u" x="39.859"/>
+      <use xlink:href="#h" x="45.697"/>
+      <use xlink:href="#K" x="49.172"/>
+    </g>
+    <g class="typst-group">
+      <g class="typst-group">
+        <path class="typst-shape" fill="none" stroke="#000" stroke-width=".5599999999999999" d="M331.969 592.994h9.6M381.569 592.994h9.6M331.969 612.526h9.6M381.569 612.526h9.6M331.969 632.058h9.6M381.569 632.058h9.6"/>
+        <g class="typst-group">
+          <g class="typst-group">
+            <path class="typst-shape" fill="#fff" stroke="#000" stroke-width=".5599999999999999" d="M341.569 587.062v50.928h40v-50.928Z"/>
+            <use xlink:href="#as" class="typst-text" transform="matrix(.8 0 0 -.8 358.417 615.258)"/>
+          </g>
+          <g class="typst-group">
+            <use xlink:href="#bC" class="typst-text" transform="matrix(.8 0 0 -.8 341.569 614.126)"/>
+            <use xlink:href="#bD" class="typst-text" transform="matrix(.8 0 0 -.8 341.569 610.837)"/>
+            <use xlink:href="#bE" class="typst-text" transform="matrix(.8 0 0 -.8 341.569 607.56)"/>
+            <use xlink:href="#bD" class="typst-text" transform="matrix(.8 0 0 -.8 341.569 599.47)"/>
+            <use xlink:href="#bF" class="typst-text" transform="matrix(.8 0 0 -.8 341.569 596.194)"/>
+          </g>
+          <g class="typst-group">
+            <use xlink:href="#bG" class="typst-text" transform="matrix(.8 0 0 -.8 347.341 604.946)"/>
+          </g>
+          <g class="typst-group">
+            <use xlink:href="#bH" class="typst-text" transform="matrix(.8 0 0 -.8 344.769 634.244)"/>
+          </g>
+          <g class="typst-group">
+            <use xlink:href="#bI" class="typst-text" transform="matrix(.8 0 0 -.8 375.796 614.126)"/>
+            <use xlink:href="#bJ" class="typst-text" transform="matrix(.8 0 0 -.8 375.796 610.837)"/>
+            <use xlink:href="#bK" class="typst-text" transform="matrix(.8 0 0 -.8 375.796 607.56)"/>
+            <use xlink:href="#bJ" class="typst-text" transform="matrix(.8 0 0 -.8 375.796 599.47)"/>
+            <use xlink:href="#bL" class="typst-text" transform="matrix(.8 0 0 -.8 375.796 596.194)"/>
+          </g>
+          <g class="typst-group">
+            <use xlink:href="#bG" class="typst-text" transform="matrix(.8 0 0 -.8 372.135 604.946)"/>
+          </g>
+          <g class="typst-group">
+            <use xlink:href="#bH" class="typst-text" transform="matrix(.8 0 0 -.8 354.852 634.244)"/>
+            <use xlink:href="#bM" class="typst-text" transform="matrix(.8 0 0 -.8 359.59 634.244)"/>
+            <g class="typst-group">
+              <use xlink:href="#bN" class="typst-text" transform="matrix(.8 0 0 -.8 366.017 634.244)"/>
+              <use xlink:href="#bO" class="typst-text" transform="matrix(.8 0 0 -.8 369.729 634.244)"/>
+              <use xlink:href="#bG" class="typst-text" transform="matrix(.8 0 0 -.8 372.218 634.244)"/>
+              <use xlink:href="#bP" class="typst-text" transform="matrix(.8 0 0 -.8 375.879 634.244)"/>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g class="typst-group">
+      <g class="typst-text" transform="matrix(1 0 0 -1 403.234 581.036)" fill="#4b69c6">
+        <use xlink:href="#bp"/>
+        <use xlink:href="#bQ" x="3.179"/>
+        <use xlink:href="#aX" x="6.358"/>
+        <use xlink:href="#aY" x="9.536"/>
+        <use xlink:href="#aZ" x="12.715"/>
+        <use xlink:href="#ba" x="15.894"/>
+      </g>
+      <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 422.307 581.036)"/>
+      <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 425.486 581.036)"/>
+      <use xlink:href="#bR" class="typst-text" transform="matrix(1 0 0 -1 428.665 581.036)"/>
+      <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 431.843 581.036)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 435.022 581.036)">
+        <use xlink:href="#be"/>
+        <use xlink:href="#bk" x="6.358"/>
+        <use xlink:href="#bh" x="9.536"/>
+      </g>
+      <use xlink:href="#bS" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 450.916 581.036)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 454.095 581.036)">
+        <use xlink:href="#be"/>
+        <use xlink:href="#bT" x="6.358"/>
+        <use xlink:href="#bt" x="9.536"/>
+        <use xlink:href="#bv" x="12.715"/>
+        <use xlink:href="#aZ" x="15.894"/>
+        <use xlink:href="#bu" x="19.073"/>
+        <use xlink:href="#bh" x="22.252"/>
+      </g>
+      <g class="typst-text" transform="matrix(1 0 0 -1 482.705 581.036)" fill="#b60157">
+        <use xlink:href="#bz"/>
+        <use xlink:href="#ba" x="3.179"/>
+        <use xlink:href="#bp" x="6.358"/>
+      </g>
+      <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 492.241 581.036)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 409.592 588.48)">
+        <use xlink:href="#bt"/>
+        <use xlink:href="#bk" x="3.179"/>
+        <use xlink:href="#bm" x="6.358"/>
+        <use xlink:href="#bU" x="9.536"/>
+        <use xlink:href="#aZ" x="12.715"/>
+        <use xlink:href="#bn" x="15.894"/>
+      </g>
+      <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 428.665 588.48)"/>
+      <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 435.022 588.48)"/>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 415.95 595.923)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 419.128 595.923)">
+          <use xlink:href="#bQ"/>
+          <use xlink:href="#bU" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#bt" x="9.536"/>
+          <use xlink:href="#aZ" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 435.022 595.923)"/>
+        <use xlink:href="#bx" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 438.201 595.923)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 441.38 595.923)"/>
+        <use xlink:href="#bk" class="typst-text" transform="matrix(1 0 0 -1 447.738 595.923)"/>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 450.916 595.923)"/>
+        <use xlink:href="#bV" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 454.095 595.923)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 457.274 595.923)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 463.632 595.923)">
+          <use xlink:href="#bf"/>
+          <use xlink:href="#aY" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#ba" x="9.536"/>
+          <use xlink:href="#bf" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 479.526 595.923)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 482.705 595.923)"/>
+        <use xlink:href="#by" class="typst-text" transform="matrix(1 0 0 -1 485.884 595.923)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 489.062 595.923)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 492.241 595.923)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 495.42 595.923)"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 415.95 603.366)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 419.128 603.366)">
+          <use xlink:href="#bQ"/>
+          <use xlink:href="#bU" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#bt" x="9.536"/>
+          <use xlink:href="#aZ" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 435.022 603.366)"/>
+        <use xlink:href="#bV" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 438.201 603.366)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 441.38 603.366)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 447.738 603.366)">
+          <use xlink:href="#bf"/>
+          <use xlink:href="#aY" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#ba" x="9.536"/>
+          <use xlink:href="#bf" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 463.632 603.366)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 469.99 603.366)"/>
+        <use xlink:href="#bw" class="typst-text" transform="matrix(1 0 0 -1 473.168 603.366)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 476.347 603.366)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 479.526 603.366)"/>
+      </g>
+      <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 409.592 610.81)"/>
+      <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 412.77 610.81)"/>
+      <g class="typst-text" transform="matrix(1 0 0 -1 409.592 618.254)">
+        <use xlink:href="#bj"/>
+        <use xlink:href="#bU" x="3.179"/>
+        <use xlink:href="#aZ" x="6.358"/>
+        <use xlink:href="#bm" x="9.536"/>
+        <use xlink:href="#bU" x="12.715"/>
+        <use xlink:href="#aZ" x="15.894"/>
+        <use xlink:href="#bn" x="19.073"/>
+      </g>
+      <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 431.843 618.254)"/>
+      <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 438.201 618.254)"/>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 415.95 625.697)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 419.128 625.697)">
+          <use xlink:href="#bQ"/>
+          <use xlink:href="#bU" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#bt" x="9.536"/>
+          <use xlink:href="#aZ" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 435.022 625.697)"/>
+        <use xlink:href="#bx" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 438.201 625.697)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 441.38 625.697)"/>
+        <use xlink:href="#bk" class="typst-text" transform="matrix(1 0 0 -1 447.738 625.697)"/>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 450.916 625.697)"/>
+        <use xlink:href="#bV" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 454.095 625.697)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 457.274 625.697)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 463.632 625.697)">
+          <use xlink:href="#bf"/>
+          <use xlink:href="#aY" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#ba" x="9.536"/>
+          <use xlink:href="#bf" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 479.526 625.697)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 482.705 625.697)"/>
+        <use xlink:href="#by" class="typst-text" transform="matrix(1 0 0 -1 485.884 625.697)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 489.062 625.697)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 492.241 625.697)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 495.42 625.697)"/>
+      </g>
+      <g class="typst-group">
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 415.95 633.14)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 419.128 633.14)">
+          <use xlink:href="#bQ"/>
+          <use xlink:href="#bU" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#bt" x="9.536"/>
+          <use xlink:href="#aZ" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 435.022 633.14)"/>
+        <use xlink:href="#bV" fill="#b60157" class="typst-text" transform="matrix(1 0 0 -1 438.201 633.14)"/>
+        <use xlink:href="#be" class="typst-text" transform="matrix(1 0 0 -1 441.38 633.14)"/>
+        <g class="typst-text" transform="matrix(1 0 0 -1 447.738 633.14)">
+          <use xlink:href="#bf"/>
+          <use xlink:href="#aY" x="3.179"/>
+          <use xlink:href="#bg" x="6.358"/>
+          <use xlink:href="#ba" x="9.536"/>
+          <use xlink:href="#bf" x="12.715"/>
+        </g>
+        <use xlink:href="#bh" class="typst-text" transform="matrix(1 0 0 -1 463.632 633.14)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 466.81 633.14)"/>
+        <use xlink:href="#bw" class="typst-text" transform="matrix(1 0 0 -1 469.99 633.14)"/>
+        <use xlink:href="#bW" class="typst-text" transform="matrix(1 0 0 -1 473.168 633.14)"/>
+        <use xlink:href="#bq" class="typst-text" transform="matrix(1 0 0 -1 476.347 633.14)"/>
+        <use xlink:href="#bb" class="typst-text" transform="matrix(1 0 0 -1 479.526 633.14)"/>
+        <use xlink:href="#by" class="typst-text" transform="matrix(1 0 0 -1 482.705 633.14)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 485.884 633.14)"/>
+        <use xlink:href="#bc" fill="#298e0d" class="typst-text" transform="matrix(1 0 0 -1 489.062 633.14)"/>
+        <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 492.241 633.14)"/>
+      </g>
+      <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 409.592 640.584)"/>
+      <use xlink:href="#bo" class="typst-text" transform="matrix(1 0 0 -1 403.234 648.028)"/>
+    </g>
+  </g>
+  <defs>
+    <symbol id="a" overflow="visible">
+      <path d="M6.118 5.634q0 .387-.035.588-.035.202-.167.317-.131.116-.274.148-.142.032-.48.064-.054.043-.057.178-.002.134.057.188.966-.022 1.219-.022.327 0 1.23.022.043-.054.043-.186 0-.131-.043-.18-.618-.064-.787-.239-.17-.174-.17-.878V.231q0-.338-.252-.338-.241 0-.44.263l-3.84 4.85q-.274.365-.371.36-.086 0-.091-.537V1.46q0-.387.035-.588.034-.202.166-.317.132-.116.274-.148.142-.032.48-.07.044-.053.046-.185.003-.132-.045-.174Q1.692 0 1.396 0q-.284 0-1.23-.021Q.114.02.11.153.107.285.167.338.784.403.953.58q.17.177.17.88v4.588q-.054.242-.296.462-.242.22-.575.241Q.2 6.794.2 6.93q0 .134.053.188l1.488-.022L5.51 2.31q.473-.607.527-.607.075 0 .08.333v3.598Z"/>
+    </symbol>
+    <symbol id="b" overflow="visible">
+      <path d="M.451 2.256q0 1.09.607 1.805.655.768 1.724.768.79 0 1.335-.39.545-.39.76-.929.215-.54.215-1.157 0-1.15-.715-1.848-.628-.618-1.616-.612-1.101 0-1.706.714-.604.714-.604 1.649Zm2.165 2.186q-1.22 0-1.22-1.934 0-.354.084-.717.083-.362.247-.714Q1.89.725 2.199.5q.31-.226.718-.226.483 0 .856.397.373.398.373 1.332 0 1.177-.408 1.808-.408.63-1.122.63Z"/>
+    </symbol>
+    <symbol id="c" overflow="visible">
+      <path d="M1.934 3.937q0-.054.035-.075.034-.022.088.054.22.376.545.644.325.269.674.269.317 0 .49-.17.171-.169.171-.357 0-.21-.158-.381-.159-.172-.358-.172-.204 0-.397.258-.107.14-.285.14-.134 0-.505-.538-.263-.397-.263-.735V1.343q0-.66.148-.809.148-.147.755-.196.053-.053.053-.185T2.874-.02Q2.105 0 1.542 0 1.058 0 .285-.021.242.02.242.153q0 .132.043.185.537.033.676.188.14.156.14.817v2.143q0 .462-.126.583-.126.12-.588.163-.065.188-.022.312.817.107 1.348.317.086 0 .135-.086.053-.134.086-.838Z"/>
+    </symbol>
+    <symbol id="d" overflow="visible">
+      <path d="M1.87 3.937q.01-.145.133 0 .79.892 1.67.892.42 0 .72-.229.301-.228.382-.577.027-.107.118-.005.768.81 1.815.81.672 0 .903-.45.23-.452.23-1.3V1.343q0-.66.116-.814.116-.153.588-.19.043-.054.043-.186T8.545-.02Q7.928 0 7.412 0q-.57 0-1.122-.021-.043.042-.043.174 0 .132.043.185.45.033.566.194.116.16.116.81v1.934q0 .527-.164.755-.164.228-.492.228-.79 0-1.455-.73.01-.134.01-.44V1.342q0-.66.11-.814.11-.153.54-.19.043-.054.043-.18 0-.127-.043-.18Q4.974 0 4.441 0 3.874 0 3.32-.021q-.043.053-.043.185 0 .131.043.174.462.033.572.188.11.156.11.817v1.912q0 .999-.725 1.004-.526 0-1.187-.65-.188-.198-.188-.462V1.343q0-.457.065-.655.064-.2.182-.258.119-.06.435-.092.049-.048.049-.18 0-.131-.049-.18Q1.923 0 1.472 0 .945 0 .285-.021.242.02.242.153q0 .132.043.185.483.033.617.194.135.16.135.81v2.144q0 .462-.13.583-.128.12-.59.163-.065.188-.022.312.817.107 1.354.317.086 0 .134-.086.054-.124.086-.838Z"/>
+    </symbol>
+    <symbol id="e" overflow="visible">
+      <path d="m3.223 2.562-.87-.23q-1.048-.264-1.042-1.21 0-.295.201-.54.201-.244.588-.244.376 0 .967.49.156.123.156.284v1.45Zm0-2.036H3.2l-.22-.172q-.596-.461-1.198-.461Q.397-.107.397 1.08q0 .547.5.966.5.42 1.316.629l.945.23q.065.022.065.13 0 1.428-.892 1.428-.365 0-.623-.115Q1.45 4.232 1.45 4q0-.155.022-.214.032-.065.037-.2 0-.123-.15-.249t-.37-.126q-.387 0-.382.397 0 .462.567.841.566.379 1.248.379 1.66 0 1.66-1.859V1.354q0-.231.005-.363.006-.132.038-.287.032-.156.105-.22.072-.065.18-.065.198 0 .408.177.156-.086.188-.3-.42-.409-1.048-.403-.375 0-.529.163-.153.164-.206.47Z"/>
+    </symbol>
+    <symbol id="f" overflow="visible">
+      <path d="M1.047 1.343V6.15q0 .607-.11.738-.11.132-.599.164-.123.124-.064.328.977.075 1.541.3.145 0 .145-.112-.043-.44-.048-1.155v-5.07q0-.66.14-.82.14-.158.655-.185.043-.053.043-.185T2.707-.02Q1.982 0 1.482 0q-.461 0-1.23-.021Q.2.02.2.153q0 .132.053.185.516.022.656.183t.14.822Z"/>
+    </symbol>
+    <symbol id="g" overflow="visible">
+      <path d="M3.507 3.067q0 .682-.274 1.053-.274.37-.79.37-.88 0-.88-1.17 0-.307.032-.532.032-.226.132-.462.1-.237.314-.363.215-.126.542-.126.924 0 .924 1.23ZM1.45-.107q-.338-.409-.338-1.037 0-.494.462-.782.462-.287.86-.287.515 0 .998.134.484.135.82.42.335.284.335.66 0 .21-.12.352-.122.142-.439.33-.338.188-1.332.183-.053 0-.33-.016-.277-.017-.475-.017-.242.006-.44.06Zm3.432 4.366q-.21 0-.306.194-.086.134-.22.134-.097 0-.236-.089-.14-.088-.204-.174.472-.484.472-1.144 0-.768-.545-1.225Q3.298 1.5 2.53 1.5q-.607 0-1 .23-.198-.273-.198-.639 0-.317.21-.472.209-.156.494-.156l.327.021q.44.054.741.054 1.166 0 1.606-.36.484-.397.484-.891 0-.57-.467-1.018-.468-.449-1.169-.666-.7-.218-1.458-.218-.736 0-1.24.296-.506.295-.506.956 0 .79.897 1.332Q.747.22.747.816q0 .296.131.61.132.314.352.497-.57.548-.57 1.235 0 .736.562 1.203.561.468 1.319.468.682 0 1.144-.307.198.264.529.411.33.148.572.148.22 0 .362-.115.143-.116.143-.293 0-.167-.127-.29-.126-.124-.282-.124Z"/>
+    </symbol>
+    <symbol id="h" overflow="visible">
+      <path d="M.473 4.721h.505q0 .42-.006.693-.005.274-.01.357l-.011.137q-.006.054-.006.086 0 .08.242.15.193.054.376.156.183.097.242.102.086 0 .086-.096-.043-.44-.043-1.16V4.72h1.32q.087 0 .087-.07v-.22q0-.145-.263-.14H1.848V1.51q0-.537.078-.776.077-.239.287-.239.505 0 .902.312.167-.011.194-.188-.65-.725-1.483-.725-.848 0-.848 1.085v3.314h-.65q-.054 0-.054.064v.145q0 .22.199.22Z"/>
+    </symbol>
+    <symbol id="i" overflow="visible">
+      <path d="m1.364 3.104 1.993.033q.166 0 .161.15 0 .629-.268.892-.269.263-.645.263-.145 0-.285-.038-.14-.037-.343-.158-.205-.121-.371-.416-.167-.296-.242-.726ZM4.25 1.021q.188-.011.23-.172-.735-.956-1.874-.956-1.09 0-1.681.703-.516.596-.516 1.628 0 1.165.698 1.874.699.71 1.499.71 1.858 0 1.858-1.913 0-.188-.204-.188l-2.927.022q0-.924.35-1.51.483-.79 1.202-.79.462 0 .755.132t.61.46Z"/>
+    </symbol>
+    <symbol id="j" overflow="visible">
+      <path d="M8.81 6.68c0 .1-.06.15-.18.15L7.36 6.8l-1.27.03c-.16 0-.23-.09-.23-.24 0-.07.03-.12.08-.13.1-.01.18-.02.23-.02.31-.01.48-.03.53-.04.05-.01.08-.04.08-.09-.01-.03-.02-.09-.04-.18l-.59-2.38H3.21l.58 2.27c.05.21.14.34.27.39.07.02.24.03.52.03.27 0 .38 0 .38.24 0 .1-.06.15-.18.15L3.51 6.8l-1.28.03c-.16 0-.23-.09-.23-.24 0-.07.03-.12.09-.13.1-.01.18-.02.23-.02.31-.01.49-.03.54-.04.05-.01.07-.04.07-.09a.84.84 0 0 0-.04-.18L1.56.82c-.05-.22-.15-.35-.3-.4C1.19.4 1.01.39.7.39.48.39.39.37.39.15.39.05.45 0 .57 0l1.26.03.63-.01c.11 0 .53-.02.64-.02.16 0 .24.08.24.24 0 .1-.11.15-.32.15-.4 0-.6.04-.6.13 0 0 .01.03.03.16l.67 2.68h2.93L5.38.68C5.35.53 5.23.43 5.03.4 4.98.39 4.81.39 4.52.39c-.19 0-.28-.08-.28-.24 0-.1.06-.15.18-.15l1.26.03.63-.01c.11 0 .52-.02.65-.02.16 0 .24.08.24.24 0 .1-.11.15-.32.15-.41 0-.61.04-.61.13 0 0 .01.03.03.16l1.34 5.34c.05.21.14.34.27.39.06.02.23.03.52.03.26 0 .38 0 .38.24Z"/>
+    </symbol>
+    <symbol id="k" overflow="visible">
+      <path d="M3.687 2.445q0 .89-.29 1.351-.29.462-.845.462-.58 0-.885-.462-.305-.462-.305-1.351 0-.89.307-1.356.308-.466.892-.466.546 0 .836.468.29.469.29 1.354Zm.79-2.136q0-1.082-.511-1.641-.511-.559-1.504-.559-.326 0-.683.06-.357.06-.713.177v.782q.42-.198.764-.292.344-.095.632-.095.64 0 .933.348.292.348.292 1.104V.765Q3.497.36 3.17.163q-.326-.197-.795-.197-.842 0-1.345.674Q.53 1.315.53 2.445q0 1.134.502 1.809.503.675 1.345.675.464 0 .787-.185.322-.185.524-.572v.623h.79V.31Z"/>
+    </symbol>
+    <symbol id="l" overflow="visible">
+      <path d="M3.016 2.42h-.262q-.692 0-1.042-.244-.35-.242-.35-.724 0-.434.262-.674.262-.24.726-.24.654 0 1.027.452.374.454.378 1.253v.176h-.739Zm1.534.326V0h-.795v.713Q3.502.283 3.117.08q-.384-.204-.934-.204-.735 0-1.173.415Q.57.705.57 1.4q0 .804.54 1.221.539.417 1.583.417h1.061v.125q-.004.575-.292.835t-.92.26q-.403 0-.816-.116-.412-.116-.803-.34v.791q.438.168.84.252.402.084.78.084.597 0 1.02-.177.424-.176.686-.528.163-.215.232-.53.068-.317.068-.948Z"/>
+    </symbol>
+    <symbol id="m" overflow="visible">
+      <path d="M2.638 6.179V4.812h1.796v-.614H2.638V1.586q0-.533.202-.744.202-.21.705-.21h.89V0h-.967q-.89 0-1.255.357-.365.356-.365 1.229v2.612H.563v.614h1.285V6.18h.79Z"/>
+    </symbol>
+    <symbol id="n" overflow="visible">
+      <path d="M4.778 2.604v-.387H1.354v-.026q0-.786.41-1.216.41-.43 1.158-.43.378 0 .79.121.413.12.881.365V.245q-.45-.185-.87-.277-.419-.093-.81-.093-1.121 0-1.753.673Q.53 1.22.53 2.402q0 1.152.618 1.839.619.688 1.65.688.92 0 1.45-.624.531-.623.531-1.701Zm-.79.232q-.018.696-.33 1.06-.31.362-.895.362-.572 0-.941-.378-.37-.378-.438-1.048l2.604.004Z"/>
+    </symbol>
+    <symbol id="o" overflow="visible">
+      <path d="M3.803 6.677q-.572-.98-.853-1.953-.282-.973-.282-1.961 0-.984.282-1.96.281-.975.853-1.963h-.688Q2.466-.138 2.148.83q-.318.97-.318 1.932 0 .958.318 1.93.318.97.967 1.984h.688Z"/>
+    </symbol>
+    <symbol id="p" overflow="visible">
+      <path d="M2.973 2.492V.627q.473.013.74.262.266.25.266.68 0 .399-.24.62-.241.222-.766.303Zm-.43.817v1.774q-.446-.017-.697-.258-.252-.24-.252-.644 0-.37.234-.585.234-.214.716-.287Zm.43-4.602h-.43L2.54 0q-.438.021-.87.12-.431.1-.853.275v.774q.43-.267.866-.408.436-.142.862-.15v1.967q-.86.133-1.294.524-.434.391-.434 1.036 0 .675.454 1.076.453.402 1.274.462v1.01h.43l.004-1.01q.34-.021.687-.086.348-.064.71-.176v-.743q-.366.184-.712.285-.346.101-.69.119V3.223q.886-.134 1.35-.55.464-.417.464-1.079 0-.662-.5-1.104-.501-.443-1.31-.481l-.004-1.302Z"/>
+    </symbol>
+    <symbol id="q" overflow="visible">
+      <path d="M.589 6.415h.872v-2.63h2.376v2.63h.872V0h-.872v3.055H1.461V0H.589v6.415Z"/>
+    </symbol>
+    <symbol id="r" overflow="visible">
+      <path d="M1.495 6.677h.688q.649-1.014.967-1.985.318-.97.318-1.93 0-.966-.318-1.937-.318-.971-.967-1.985h-.688q.572.997.853 1.972.282.976.282 1.95 0 .98-.282 1.956-.281.975-.853 1.96Z"/>
+    </symbol>
+    <symbol id="s" overflow="visible">
+      <path d="M2.157 1.302H3.24v-.89l-.847-1.645h-.661L2.157.413v.889Z"/>
+    </symbol>
+    <symbol id="t" overflow="visible">
+      <path d="M2.992 6.8q-.913 0-.913-.704V3.577h.526q.892 0 1.37.363.478.362.478 1.318 0 1.542-1.461 1.542Zm-.913-5.457q0-.66.171-.82.172-.158.785-.185.043-.053.043-.185T3.035-.02Q2.068 0 1.617 0q-.44 0-1.429-.021Q.134.02.134.153q0 .132.054.185.618.022.787.183.169.161.169.822v4.41q0 .66-.17.819-.168.158-.786.18-.054.042-.054.177 0 .134.054.188 1.037-.022 1.418-.022.188 0 .644.038.457.037.731.037.65 0 1.101-.099.451-.1.8-.427.586-.548.586-1.375 0-.757-.478-1.235-.478-.478-.989-.645l1.392-2.31q.252-.418.483-.633.23-.215.57-.215.075-.145.01-.263-.156-.075-.462-.075-.848 0-1.45.977L3.368 2.782q-.135.22-.392.32-.258.1-.897.1v-1.86Z"/>
+    </symbol>
+    <symbol id="u" overflow="visible">
+      <path d="M2.385-.107q-.758 0-1.088.421-.33.422-.33 1.072v2.11q0 .516-.137.683-.137.166-.545.198-.043.043-.043.175t.043.19q.746-.02 1.122-.02.274 0 .387.02.086 0 .086-.07-.043-.805-.043-1.132V1.542q0-.65.268-.892.269-.242.613-.242.494 0 1.1.527.178.155.173.43v2.12q0 .527-.132.7-.131.171-.55.192-.054.043-.054.175t.054.19q.746-.02 1.122-.02.274 0 .387.02.086 0 .086-.07-.043-.805-.043-1.132V1.429q0-.43.15-.594.15-.164.656-.207.053-.053.053-.153 0-.099-.053-.147-.881-.097-1.3-.435-.097-.043-.21 0-.096.376-.118.644-.01.054-.067.051-.056-.003-.1-.04-.816-.655-1.487-.655Z"/>
+    </symbol>
+    <symbol id="v" overflow="visible">
+      <path d="M2.025 3.937q.779.892 1.805.892.628 0 .913-.376.295-.398.295-1.472V1.343q0-.65.126-.803.127-.153.61-.202.043-.053.043-.185T5.774-.02Q5.114 0 4.608 0q-.462 0-1.122-.021-.043.053-.043.185 0 .131.043.174.451.043.566.2.116.155.116.805v1.67q0 .586-.129.849-.21.397-.585.397-.672 0-1.343-.65-.188-.21-.188-.462V1.343q0-.65.115-.803.116-.153.556-.202.043-.053.046-.185.003-.132-.046-.174Q1.934 0 1.5 0 .95 0 .285-.021.242.02.242.153q0 .132.043.185Q.8.381.929.532q.13.15.13.81v2.144q0 .462-.127.583-.126.12-.594.163-.064.188-.021.312.816.107 1.353.317.086 0 .135-.086.064-.134.086-.838 0-.145.134 0Z"/>
+    </symbol>
+    <symbol id="w" overflow="visible">
+      <path d="M3.797 1.364v2.09q0 .252-.035.357-.034.105-.153.239-.338.397-.891.392-.66 0-1.026-.548-.317-.451-.317-1.46 0-.968.363-1.497.362-.529.845-.529.43 0 1.037.527.177.155.177.43Zm-.123-.81q-.806-.661-1.375-.661-.87 0-1.37.647-.5.647-.5 1.694 0 1.177.758 1.934.693.66 1.649.66.166 0 .365-.048.199-.048.341-.094.143-.045.153-.045.097 0 .102.102V6.15q0 .354-.018.529-.02.175-.14.258-.12.083-.185.088-.065.006-.366.027-.123.124-.064.328.977.075 1.541.3.145 0 .145-.112-.043-.44-.048-1.155V1.43q0-.43.15-.594.15-.164.656-.207.053-.053.053-.153 0-.099-.053-.147-.881-.097-1.3-.435-.097-.043-.21 0-.096.386-.118.644-.01.054-.067.054-.056 0-.1-.038Z"/>
+    </symbol>
+    <symbol id="x" overflow="visible">
+      <path d="M8.34 6.83c-.17 0-.76-.03-.93-.03-.2 0-.9.03-1.1.03-.15 0-.23-.08-.23-.24 0-.09.05-.14.16-.15.24-.03.36-.11.36-.26 0-.09-.06-.2-.18-.33L4.86 4.17c-.29.68-.57 1.35-.86 2.03.01.02.02.04.05.06.09.1.26.16.5.18.16.02.24.1.24.23 0 .11-.06.16-.19.16-.24 0-1.01-.03-1.25-.03-.21 0-.9.03-1.11.03-.15 0-.22-.08-.22-.24 0-.1.09-.15.27-.15.45 0 .59 0 .71-.29l1.16-2.73-2.08-2.23c-.03-.03-.07-.07-.12-.1C1.55.66 1.08.42.53.39.36.38.27.29.27.14.3.05.31 0 .44 0c.17 0 .76.03.93.03.21 0 .9-.03 1.11-.03.15 0 .22.08.22.24 0 .09-.05.14-.16.15-.24.02-.36.11-.36.26 0 .1.09.24.26.42.62.66 1.25 1.32 1.86 1.99.34-.81.69-1.61 1.02-2.43a.23.23 0 0 0-.05-.07C5.18.47 5.02.42 4.78.39c-.15-.02-.23-.1-.23-.23 0-.11.06-.16.19-.16l1.25.03C6.2.03 6.9 0 7.08 0c.15 0 .23.08.23.23 0 .1-.07.15-.22.16-.31 0-.51.01-.58.05-.07.04-.15.16-.23.36L5.01 3.83c.68.72 1.19 1.26 1.52 1.63.24.25.4.42.49.49.37.31.78.47 1.23.49.21.01.26.06.26.25-.03.09-.04.14-.17.14Z"/>
+    </symbol>
+    <symbol id="y" overflow="visible">
+      <path d="M.37 6.415h.932l1.41-2.419 1.434 2.42h.933l-1.92-3.017L5.215 0h-.932L2.711 2.763 1.014 0H.077l2.149 3.399L.37 6.415Z"/>
+    </symbol>
+    <symbol id="z" overflow="visible">
+      <path d="M4.963 3.82q-.254.198-.516.288-.262.09-.576.09-.739 0-1.13-.464-.39-.464-.39-1.34V0h-.796v4.813h.795V3.87q.198.512.608.785t.974.273q.292 0 .545-.074.254-.073.486-.227V3.82Z"/>
+    </symbol>
+    <symbol id="A" overflow="visible">
+      <path d="M3.687 4.198v2.488h.79V0h-.79v.606Q3.489.249 3.16.062q-.328-.187-.758-.187-.872 0-1.373.677-.5.677-.5 1.867 0 1.173.502 1.841.503.669 1.371.669.434 0 .765-.187.33-.187.52-.544ZM1.362 2.402q0-.92.292-1.388.292-.468.864-.468.571 0 .87.472.299.473.299 1.384 0 .915-.299 1.386-.299.47-.87.47-.572 0-.864-.468-.292-.469-.292-1.388Z"/>
+    </symbol>
+    <symbol id="B" overflow="visible">
+      <path d="M1.1 4.813h2.024V.614h1.568V0H.765v.614h1.568v3.584H1.1v.614Zm1.233 1.873h.79V5.685h-.79v1Z"/>
+    </symbol>
+    <symbol id="C" overflow="visible">
+      <path d="M.838 1.822v2.982h.79V1.822q0-.649.23-.954.23-.305.712-.305.558 0 .855.393.296.393.296 1.128v2.72h.795V0h-.795v.722Q3.511.305 3.147.09 2.784-.125 2.3-.125q-.74 0-1.1.484Q.838.842.838 1.822Z"/>
+    </symbol>
+    <symbol id="D" overflow="visible">
+      <path d="M4.18 4.645V3.87q-.339.198-.682.297-.344.099-.7.099-.538 0-.802-.174t-.264-.53q0-.323.197-.482.198-.16.984-.31l.318-.06q.589-.111.892-.447.303-.335.303-.872 0-.713-.507-1.115t-1.41-.402q-.356 0-.747.076Q1.37.026.915.176v.817q.443-.228.847-.342.404-.114.765-.114.524 0 .812.213.288.213.288.595 0 .55-1.053.76l-.035.01-.296.06q-.683.132-.997.448-.314.316-.314.862 0 .692.469 1.068.468.376 1.336.376.387 0 .743-.071.357-.071.7-.213Z"/>
+    </symbol>
+    <symbol id="E" overflow="visible">
+      <path d="M2.101 4.568h1.083V3.266H2.101v1.302Zm0-3.257h1.083V0H2.101v1.31Z"/>
+    </symbol>
+    <symbol id="F" overflow="visible">
+      <path d="M1.16.73h1.35v4.903l-1.453-.326v.79l1.444.318h.868V.73H4.7V0H1.16v.73Z"/>
+    </symbol>
+    <symbol id="G" overflow="visible">
+      <path d="M2.075 3.223q0 .236.166.408.165.172.397.172.24 0 .413-.172.172-.172.172-.408 0-.241-.17-.409-.17-.167-.415-.167-.24 0-.401.163-.162.163-.162.413Zm.572 2.62q-.606 0-.905-.652-.298-.654-.298-1.99 0-1.332.298-1.985.299-.653.905-.653.61 0 .909.653.298.653.298 1.985 0 1.336-.298 1.99-.299.653-.91.653Zm0 .688q1.027 0 1.553-.842.527-.842.527-2.488 0-1.641-.527-2.483-.526-.843-1.553-.843T1.096.718Q.57 1.56.57 3.2q0 1.646.525 2.488.524.842 1.55.842Z"/>
+    </symbol>
+    <symbol id="H" overflow="visible">
+      <path d="M2.99 1.37q0-.334.226-.562.226-.228.561-.228.33 0 .56.23.23.23.23.56 0 .332-.231.564-.232.232-.559.232-.335 0-.56-.228-.226-.228-.226-.567Zm-.58 0q0 .58.396.978.395.398.971.398.275 0 .522-.103.247-.104.445-.301.197-.202.305-.451.107-.25.107-.52 0-.572-.4-.971-.399-.4-.979-.4-.584 0-.975.393t-.391.978Zm-1.89.628-.15.413 4.477 1.796.176-.413L.52 1.998Zm.202 2.78q0-.34.225-.565.226-.225.566-.225.33 0 .562.23.232.23.232.56 0 .331-.232.56-.232.23-.563.23-.33 0-.56-.227-.23-.228-.23-.563Zm-.58 0q0 .58.395.978.395.397.975.397.276 0 .527-.103t.445-.296q.193-.194.298-.445.106-.252.106-.53 0-.577-.4-.974-.4-.398-.976-.398-.58 0-.975.396-.395.395-.395.975Z"/>
+    </symbol>
+    <symbol id="I" overflow="visible">
+      <path d="M2.1.924q0-.296.226-.433.225-.137.972-.137.628 0 1.112.127.483.126.902.421.419.296.645.857.225.561.225 1.367 0 .671-.164 1.286T5.5 5.567q-.354.54-.991.857-.636.317-1.485.317-.924 0-.924-.537V.924Zm-.473 6.171q.178 0 .777.011.598.01 1.039.01 1.584 0 2.69-1.092Q7.24 4.93 7.24 3.389q0-.967-.335-1.668-.336-.7-.892-1.063T4.869.137Q4.28-.021 3.642-.021q-.661 0-1.276.01Q1.751 0 1.638 0 1.068 0 .21-.021.156.02.156.153q0 .132.053.185.618.022.787.183.17.161.17.822v4.41q0 .66-.17.819-.169.158-.787.18-.053.042-.053.177 0 .134.053.188.881-.022 1.418-.022Z"/>
+    </symbol>
+    <symbol id="J" overflow="visible">
+      <path d="M2.981 2.455H.607q-.167 0-.167.21 0 .155.09.303.088.147.184.147h2.412q.156 0 .15-.22 0-.107-.099-.274-.1-.166-.196-.166Z"/>
+    </symbol>
+    <symbol id="K" overflow="visible">
+      <path d="M.526 1.52q.054.054.172.054T.87 1.53Q1.047.784 1.3.518q.252-.266.779-.266.354 0 .644.2.29.198.29.569 0 .365-.225.585-.226.22-.897.494-.661.274-.935.594-.274.32-.274.905 0 .515.462.872.462.358 1.09.358.253 0 .516-.038t.556-.1q.293-.061.368-.072-.022-.585-.065-1.165-.053-.054-.177-.054-.123 0-.177.043-.054.328-.18.548-.126.22-.298.314t-.298.126q-.126.032-.245.032-.295 0-.534-.19-.24-.191-.24-.513 0-.414.25-.604.25-.191.852-.417 1.29-.478 1.29-1.46 0-.387-.184-.675Q3.486.317 3.201.17 2.917.021 2.64-.043q-.277-.064-.54-.064-.537 0-.999.118-.075.021-.22.021Q.773.032.607 0 .602.575.527 1.52Z"/>
+    </symbol>
+    <symbol id="L" overflow="visible">
+      <path d="M1.837 3.147V1.343q0-.468.056-.664.057-.196.175-.255t.424-.086q.049-.048.051-.18.003-.131-.05-.18Q1.874 0 1.406 0 .924 0 .2-.021.15.027.15.159.15.29.2.338q.274.02.395.048.12.027.222.131.102.105.127.288.024.182.024.537V6.15q0 .354-.016.529-.016.175-.137.258-.121.083-.188.088-.067.006-.363.027Q.14 7.176.2 7.38q.977.075 1.541.3.145 0 .14-.112-.043-.44-.043-1.155l-.01-2.476q0-.134.09-.021.011.016.017.021.805.892 1.874.892.629 0 .913-.376.296-.387.296-1.472V1.343q0-.65.126-.803.126-.153.61-.202.042-.053.042-.185T5.752-.02Q5.027 0 4.587 0q-.505 0-1.123-.021-.043.053-.043.185 0 .131.043.174.452.043.567.2.115.155.115.805v1.67q0 .586-.128.849-.2.397-.586.397-.746 0-1.407-.65-.188-.204-.188-.462Z"/>
+    </symbol>
+    <symbol id="M" overflow="visible">
+      <path d="M1.923 3.642q-.177-.22-.172-.484V1.155q0-.29.046-.398.045-.107.217-.263.258-.23.779-.23.44 0 .76.182t.483.494q.164.311.237.642.072.33.072.706 0 .902-.378 1.47-.38.566-.932.566-.231 0-.562-.204-.33-.204-.55-.478Zm-.21.408q.011-.167.124-.049.736.828 1.51.828.826 0 1.385-.672.559-.671.559-1.574 0-1.289-.812-2.078-.65-.618-1.622-.612-.537 0-.956.166-.086.043-.118.032-.032-.01-.032-.112v-1.187q0-.661.148-.817.147-.156.754-.188.054-.054.054-.185 0-.132-.054-.175-.725.022-1.332.022-.462 0-1.235-.022-.043.043-.043.175 0 .131.043.185.516.022.655.183.14.16.14.822v4.694q0 .462-.126.583-.127.12-.588.163-.065.188-.022.312.816.107 1.354.317.085 0 .128-.086.054-.129.086-.725Z"/>
+    </symbol>
+    <symbol id="N" overflow="visible">
+      <path d="M6.64 6.8c-.18 0-.8.03-.99.03-.15 0-.23-.08-.23-.23 0-.11.06-.16.19-.16.21 0 .32-.06.32-.18 0-.11-.09-.26-.26-.45L3.42 3.22 2.36 6.09c-.03.08-.05.13-.06.16 0 .13.18.19.54.19.19 0 .28.08.28.24 0 .1-.06.15-.19.15L1.68 6.8c-.22 0-.92.03-1.1.03-.15 0-.23-.08-.23-.24 0-.1.09-.15.27-.15.18 0 .33-.02.42-.04.19-.05.2-.08.26-.27l1.22-3.25c.03-.07.04-.12.04-.15l-.21-.83c-.12-.51-.2-.83-.24-.96C2.04.67 1.97.51 1.9.46 1.83.41 1.6.39 1.22.39 1 .38.91.37.91.15c0-.1.06-.15.18-.15l1.25.03L3.6 0c.15-.01.23.07.23.24 0 .07-.03.12-.08.13-.1.01-.18.02-.23.02-.33.01-.53.03-.58.06-.02.01-.03.03-.03.07 0 .04.05.25.14.62l.35 1.39c.03.13.07.23.13.29l2.45 2.82.13.13c.26.26.5.44.71.53.17.08.36.13.57.14.18.02.23.07.23.23 0 .11-.06.16-.17.16-.15 0-.66-.03-.81-.03Z"/>
+    </symbol>
+    <symbol id="O" overflow="visible">
+      <path d="M.159 6.415h.924l1.564-2.831 1.56 2.831h.932L3.081 2.88V0h-.872v2.879L.159 6.415Z"/>
+    </symbol>
+    <symbol id="P" overflow="visible">
+      <path d="M4.516 2.982V0h-.795v2.982q0 .649-.228.954-.227.305-.713.305-.554 0-.853-.393-.298-.393-.298-1.128V0H.838v6.686h.79V4.09q.211.412.572.625.36.213.855.213.735 0 1.098-.484.363-.483.363-1.463Z"/>
+    </symbol>
+    <symbol id="Q" overflow="visible">
+      <path d="m7.289 1.278-.28 4.598h-.027L4.512.054q-.086-.167-.156-.161-.097 0-.167.16l-2.277 5.71h-.021l-.42-4.41q-.042-.515.09-.74.13-.226.641-.275.043-.053.043-.185T2.202-.02Q1.542 0 1.166 0 .88 0 .22-.021.177.02.177.153q0 .132.043.185.451.038.613.253.16.215.209.741l.44 4.533q.054.607-.053.73-.108.124-.693.156-.054.043-.054.178 0 .134.054.188l1.595-.022L4.587 1.51q.054-.145.089-.145.034 0 .099.156l2.331 5.575 1.44.022q.053-.054.056-.186.002-.131-.057-.18-.542-.032-.666-.177-.123-.145-.086-.612l.328-4.63q.016-.263.03-.392.013-.129.053-.26.04-.132.08-.178.041-.045.146-.088.105-.043.215-.054.11-.01.32-.022.053-.053.053-.185T8.964-.02Q8.24 0 7.767 0 7.4 0 6.59-.021q-.053.042-.053.174 0 .132.053.185.215.011.306.02.092.007.2.045.107.037.136.08.03.043.057.164.026.121.021.25-.005.129-.021.381Z"/>
+    </symbol>
+    <symbol id="R" overflow="visible">
+      <path d="M2.905 4.323q.146.309.371.457.226.149.544.149.58 0 .818-.45.239-.449.239-1.69V0h-.722v2.754q0 1.019-.114 1.266-.114.247-.414.247-.344 0-.47-.264-.128-.265-.128-1.249V0h-.722v2.754q0 1.032-.122 1.272-.123.24-.44.24-.314 0-.437-.263-.122-.265-.122-1.249V0H.468v4.813h.718V4.4q.142.258.354.393.213.136.484.136.326 0 .543-.15.217-.151.338-.456Z"/>
+    </symbol>
+    <symbol id="S" overflow="visible">
+      <path d="M2.234 4.377q-.381-.021-.443-.182t.11-.553l.881-2.267q.075-.188.116-.231.04-.043.078.005.037.049.112.247l.774 1.95-.07.172q-.091.231-.145.344-.054.113-.153.247-.1.134-.228.193-.13.06-.317.075-.043.043-.043.175t.043.19q.66-.02.967-.02.44 0 1.1.02.044-.053.044-.187 0-.135-.043-.178-.43-.032-.497-.158t.094-.513l.95-2.406q.065-.172.113-.167.049.006.13.21L6.73 3.63q.075.182.094.28.019.096-.008.214t-.188.177q-.161.06-.457.075-.053.043-.053.175t.053.19q.661-.02 1.123-.02.354 0 .79.02.053-.053.056-.187.003-.135-.057-.178-.386-.021-.58-.212-.193-.19-.349-.577L5.72.097q-.086-.231-.252-.231-.167 0-.263.22L4.07 2.814 2.96.107q-.107-.241-.263-.241-.166 0-.263.22L.993 3.642q-.177.435-.332.566-.156.132-.537.17-.054.042-.057.174-.003.132.057.19.569-.02.999-.02.45 0 1.111.02.054-.053.054-.187 0-.135-.054-.178Z"/>
+    </symbol>
+    <symbol id="T" overflow="visible">
+      <path d="M.988 6.59q0 .2.188.363.188.164.387.164.21 0 .368-.183t.158-.387q0-.188-.174-.36-.175-.171-.395-.171-.199 0-.365.182-.167.183-.167.392Zm1.005-5.247q0-.66.131-.814.132-.153.658-.19.054-.054.054-.186T2.782-.02Q2.057 0 1.563 0 1.058 0 .328-.021.285.02.285.153q0 .132.043.185.526.043.66.194.135.15.135.81v2.144q0 .462-.127.583-.126.12-.588.163-.064.188-.021.312 1.02.134 1.504.317.145 0 .145-.075-.043-.704-.043-1.252V1.343Z"/>
+    </symbol>
+    <symbol id="U" overflow="visible">
+      <path d="M1.912 3.99q-.188-.166-.183-.461V.779q.42-.516.79-.516.757 0 1.155.61.397.61.397 1.592 0 .79-.357 1.335-.357.545-.867.545-.537 0-.935-.354Zm-.075.344q.548.495 1.23.495.757 0 1.353-.605.597-.604.597-1.56 0-1.23-.76-2-.76-.771-1.674-.771-.644 0-.966.268-.092.075-.153.073-.062-.003-.148-.1-.08-.091-.258-.268-.166 0-.242.134Q.86.21.86.779v5.37q0 .355-.016.53-.016.175-.137.258-.12.083-.188.088l-.362.027q-.124.124-.07.328.977.075 1.541.3.145 0 .145-.112-.043-.44-.043-1.155V4.388q0-.15.108-.054Z"/>
+    </symbol>
+    <symbol id="V" overflow="visible">
+      <path d="M1.39-2.5c.13 0 .2.08.2.24v9.52c0 .16-.07.24-.2.24s-.2-.08-.2-.24v-9.52c0-.16.07-.24.2-.24Z"/>
+    </symbol>
+    <symbol id="W" overflow="visible">
+      <path d="M6.98-.37H4.13v2.63h2.85c.16 0 .24.08.24.24 0 .16-.08.24-.24.24H4.13v2.85c0 .16-.08.24-.24.24-.16 0-.24-.08-.24-.24V2.74H.8c-.16 0-.24-.08-.24-.24 0-.16.08-.24.24-.24h2.85V-.37H.8C.64-.37.56-.45.56-.6c0-.16.08-.24.24-.24h6.18c.16 0 .24.08.24.24 0 .12-.11.23-.24.23Z"/>
+    </symbol>
+    <symbol id="X" overflow="visible">
+      <path d="M2.78 2.42c.01.02.01.05.01.08s0 .06-.01.08L.98 7.35c-.04.1-.11.15-.22.15-.15 0-.23-.08-.23-.24 0-.03 0-.06.01-.08L2.31 2.5.54-2.17c-.01-.02-.01-.05-.01-.09 0-.16.08-.24.23-.24.11 0 .18.05.22.15Z"/>
+    </symbol>
+    <symbol id="Y" overflow="visible">
+      <path d="M2.746 1.745q0-.533.195-.804.196-.27.578-.27h.924V0H3.442q-.71 0-1.098.455-.389.456-.389 1.29v4.37H.687v.618h2.059V1.745Z"/>
+    </symbol>
+    <symbol id="Z" overflow="visible">
+      <path d="M3.945 2.402q0 .92-.293 1.388-.292.468-.863.468-.576 0-.873-.47-.296-.47-.296-1.386 0-.911.296-1.384.297-.472.873-.472.571 0 .863.468.293.468.293 1.388ZM1.62 4.198q.189.352.522.541.333.19.771.19.868 0 1.367-.669.498-.668.498-1.84 0-1.191-.5-1.868-.501-.677-1.373-.677-.43 0-.759.187-.328.187-.526.544V0H.83v6.686h.79V4.198Z"/>
+    </symbol>
+    <symbol id="aa" overflow="visible">
+      <path d="M3.016 6.725v-8.8h-.739v8.8h.74Z"/>
+    </symbol>
+    <symbol id="ab" overflow="visible">
+      <path d="M.378.73H4.92V0H.378v.73Zm2.63 4.302V3.618H4.92v-.73H3.008V1.46h-.722v1.427H.378v.73h1.908v1.414h.722Z"/>
+    </symbol>
+    <symbol id="ac" overflow="visible">
+      <path d="m1.938 2.269.026.038-.026.035q-.447.696-.995 1.712T.086 5.861q.043.107.198.107.404-.846 1.024-1.766.621-.92 1.176-1.564l.287-.33-.287-.336Q1.929 1.328 1.308.408.688-.512.284-1.354q-.15 0-.198.104.31.79.857 1.806.548 1.017.995 1.713Z"/>
+    </symbol>
+    <symbol id="ad" overflow="visible">
+      <path d="M2.079 6.096V3.53q.198-.054.838-.054.816 0 1.227.403.41.403.41 1.268 0 .956-.418 1.305-.42.349-1.101.349-.956 0-.956-.704Zm-.935-.344q0 .661-.17.82-.168.158-.786.18-.054.042-.054.177 0 .134.054.188.88-.022 1.418-.022.22 0 .76.038.54.037.75.037.714 0 1.23-.185.515-.185.767-.489.253-.303.357-.582.105-.28.105-.57 0-.386-.131-.754-.132-.368-.411-.715-.28-.346-.814-.558-.534-.213-1.249-.213-.548 0-.891.108v-1.87q0-.65.21-.808.209-.158.912-.196.054-.053.054-.185T3.2-.02Q2.101 0 1.617 0q-.44 0-1.429-.021Q.134.02.134.153q0 .132.054.185.618.022.787.183.169.161.169.822v4.41Z"/>
+    </symbol>
+    <symbol id="ae" overflow="visible">
+      <path d="M3.1 4.42c-.69 0-1.31-.3-1.86-.89C.69 2.94.41 2.29.41 1.59c0-.98.66-1.7 1.64-1.7.69 0 1.37.27 2.05.8.15-.53.46-.8.92-.8.36 0 .87.38.87.74 0 .09-.05.13-.16.13-.07 0-.13-.04-.16-.12-.08-.21-.29-.46-.52-.46-.17 0-.26.32-.26.97 0 .14.03.25.09.32.27.33.51.71.7 1.13.25.54.4.94.44 1.2v.04c-.03.07-.09.1-.16.1-.05-.01-.11-.09-.18-.23-.21-.72-.5-1.34-.89-1.85v.5c0 1.16-.58 2.06-1.69 2.06Zm.93-2.31c0-.59.01-.95.02-1.08C3.4.46 2.74.18 2.07.18c-.57 0-.85.35-.85 1.04 0 .58.33 1.66.56 2.02.38.59.82.89 1.31.89.31 0 .52-.12.65-.36.07-.12.12-.24.17-.35.08-.23.12-.84.12-1.31Z"/>
+    </symbol>
+    <symbol id="af" overflow="visible">
+      <path d="M1.611.606V-1.83H.816v6.643h.795v-.615q.198.357.527.544.328.187.758.187.872 0 1.369-.675.496-.675.496-1.87 0-1.172-.498-1.84-.499-.669-1.367-.669-.438 0-.767.187t-.518.544Zm2.32 1.796q0 .92-.29 1.388-.29.468-.86.468-.577 0-.873-.47-.297-.47-.297-1.386 0-.911.297-1.384.296-.472.872-.472.572 0 .862.468.29.468.29 1.388Z"/>
+    </symbol>
+    <symbol id="ag" overflow="visible">
+      <path d="m3.291 2.239-.189.992Q2.91 4.245 2.148 4.25q-.42.004-.683-.473-.33-.589-.33-1.375 0-.945.317-1.397.331-.46.696-.46.572 0 .881.916l.262.778Zm.443 1.315.425 1.259h.705l-.88-2.609.171-.94q.039-.211.19-.387Q4.52.67 4.657.67h.378V0h-.473q-.404 0-.765.36-.176.181-.249.56Q3.352.45 2.956.069q-.193-.18-.808-.176-.85.008-1.34.653Q.3 1.216.3 2.402q0 1.276.541 1.856.615.649 1.306.662 1.332.021 1.586-1.366Z"/>
+    </symbol>
+    <symbol id="ah" overflow="visible">
+      <path d="M3.926-.107q-1.692 0-2.605.999T.408 3.41q0 .859.306 1.622.307.762.86 1.273 1.02.934 2.363.934.79 0 1.544-.244.755-.245.868-.255.166-.913.241-1.703-.21-.107-.365-.054-.558 1.848-2.406 1.848-.962 0-1.756-.978-.656-.805-.656-2.234 0-1.267.72-2.275Q2.847.338 3.916.338q.768 0 1.37.282.6.282 1.18.922.167 0 .253-.167Q5.586-.107 3.926-.107Z"/>
+    </symbol>
+    <symbol id="ai" overflow="visible">
+      <path d="M4.559.245Q4.241.06 3.904-.032q-.338-.093-.69-.093-1.117 0-1.747.67-.63.671-.63 1.857t.63 1.856q.63.67 1.747.67.348 0 .679-.09.33-.09.666-.279v-.83q-.314.28-.63.405-.315.124-.715.124-.743 0-1.143-.481t-.4-1.375q0-.89.402-1.373T3.214.546q.413 0 .74.126.326.127.605.394V.245Z"/>
+    </symbol>
+    <symbol id="aj" overflow="visible">
+      <path d="M3.642 6.843q-.903 0-1.542-.814-.64-.814-.64-2.43 0-1.52.772-2.417.77-.897 1.84-.897.966 0 1.581.843t.615 2.283q0 1.606-.747 2.519-.746.913-1.88.913ZM7.326 3.62q0-1.375-.682-2.342Q6.182.618 5.465.255q-.717-.362-1.614-.362-1.45 0-2.446.966-.997.967-.997 2.552 0 1.649.913 2.739.913 1.09 2.466 1.09 1.53 0 2.535-.98 1.004-.98 1.004-2.64Z"/>
+    </symbol>
+    <symbol id="ak" overflow="visible">
+      <path d="M4.377.999q-.386-.64-.813-.873-.427-.233-.98-.233-1.021 0-1.598.652-.578.653-.578 1.743 0 1.112.693 1.826.693.715 1.563.715.779 0 1.23-.29.451-.29.451-.752 0-.231-.172-.36-.172-.13-.365-.13-.376 0-.419.398-.021.242-.072.379-.051.137-.226.263-.174.126-.486.126-.548 0-.9-.52-.351-.522-.351-1.413 0-.946.43-1.523Q2.212.43 2.824.43q.758 0 1.321.725.178-.022.231-.156Z"/>
+    </symbol>
+    <symbol id="al" overflow="visible">
+      <path d="M2.647 4.258q-.602 0-.911-.468-.31-.469-.31-1.388 0-.915.31-1.386.31-.47.91-.47.607 0 .916.47.31.47.31 1.386 0 .92-.31 1.388-.31.468-.915.468Zm0 .67q1.001 0 1.532-.648.53-.65.53-1.878 0-1.233-.528-1.88-.529-.647-1.534-.647-1.001 0-1.53.647Q.59 1.17.59 2.402q0 1.229.528 1.878.529.649 1.53.649Z"/>
+    </symbol>
+    <symbol id="am" overflow="visible">
+      <path d="M4.516 2.982V0h-.795v2.982q0 .649-.228.954-.227.305-.713.305-.554 0-.853-.393-.298-.393-.298-1.128V0H.838v4.813h.79V4.09q.211.412.572.625.36.213.855.213.735 0 1.098-.484.363-.483.363-1.463Z"/>
+    </symbol>
+    <symbol id="an" overflow="visible">
+      <path d="M3.851 1.343q0-.66.185-.82.186-.158.879-.185.053-.053.056-.185.003-.132-.056-.174Q3.813 0 3.389 0q-.462 0-1.541-.021-.043.042-.043.174 0 .132.043.185.693.022.88.183.189.161.189.822v4.232q0 .537-.116.814-.115.277-.405.277h-.538q-.569 0-.934-.264Q.559 6.14.408 5.5q-.241 0-.376.054.22.945.274 1.595 0 .032.048.032 1.112-.086 2.563-.086h.945q1.46 0 2.465.086.032 0 .032-.032.011-.725.14-1.563-.124-.054-.37-.054-.135.618-.508.876t-1.023.258h-.242q-.285 0-.395-.28-.11-.28-.11-.843v-4.2Z"/>
+    </symbol>
+    <symbol id="ao" overflow="visible">
+      <path d="M4.34 6.94q.15-.758.199-1.419-.135-.102-.36-.064-.097.312-.202.532-.104.22-.287.438-.183.217-.47.327-.287.11-.669.11-.478 0-.84-.381-.363-.381-.363-.849 0-.263.13-.5.128-.236.29-.386.16-.15.44-.306.279-.156.445-.223.167-.067.446-.175.381-.145.666-.3.285-.156.559-.392.274-.237.416-.572.142-.336.142-.755 0-.521-.279-1-.28-.477-.752-.773-.58-.36-1.359-.36-.52 0-1.093.127Q.827.145.516.145q-.167.693-.22 1.67.171.092.36.033Q.998.285 2.582.285q.661 0 1.018.346.357.347.357 1.007 0 .312-.096.564-.097.253-.22.406-.124.153-.36.295-.237.142-.382.207-.145.064-.419.166-.413.156-.717.32-.303.164-.598.408-.296.245-.452.58-.155.336-.155.75 0 .848.615 1.377.615.53 1.48.53.628 0 1.082-.14.453-.14.604-.162Z"/>
+    </symbol>
+    <symbol id="ap" overflow="visible">
+      <path d="M0 4.813h.782L1.62.922l.687 2.484h.675L3.678.924l.838 3.889h.782L4.172 0h-.756l-.77 2.638L1.883 0h-.756L0 4.813Z"/>
+    </symbol>
+    <symbol id="aq" overflow="visible">
+      <path d="M1.603.73H4.55V0H.653v.73q.804.847 1.405 1.496.602.649.83.915.43.524.58.849.15.324.15.664 0 .537-.316.842-.316.305-.866.305-.39 0-.82-.142-.43-.142-.911-.43v.877q.442.21.87.318.427.107.844.107.941 0 1.515-.5.573-.5.573-1.313 0-.413-.19-.825-.192-.413-.622-.911-.24-.28-.698-.773Q2.54 1.714 1.603.73Z"/>
+    </symbol>
+    <symbol id="ar" overflow="visible">
+      <path d="M3.54 4.05q-.36.403-.865.403-.64 0-.991-.537-.352-.538-.352-1.418 0-.597.153-1.029.153-.432.406-.658.252-.226.513-.33.26-.105.523-.105.446 0 .725.145.102.054.13.113.026.059.026.215v2.53q0 .209-.056.351-.057.143-.212.32Zm.268-5.27V0q0 .167-.054.172-.053.005-.247-.113-.295-.172-.843-.166-1.09 0-1.684.746-.593.747-.593 1.638 0 1.09.663 1.821.663.73 1.668.73.746 0 1.24-.322.103-.059.156-.032.054.027.167.177.156.21.23.21.167 0 .162-.274V-1.22q0-.66.134-.817.134-.155.66-.177.054-.054.054-.185 0-.132-.053-.175-.725.022-1.22.022-.461 0-1.235-.022-.043.043-.043.175 0 .131.043.185.527.022.66.177.135.156.135.817Z"/>
+    </symbol>
+    <symbol id="as" overflow="visible">
+      <path d="M6.42 6.8c-.19 0-.83.03-1.02.03-.15 0-.22-.08-.22-.24 0-.09.07-.14.21-.15.43 0 .64-.13.64-.39 0-.06-.01-.13-.03-.2l-.89-3.53c-.15-.57-.44-1.06-.87-1.48C3.77.39 3.25.17 2.69.17c-.74 0-1.17.5-1.17 1.24l.01.09c0 .19.03.41.1.67l.96 3.85c.05.21.14.34.27.39.06.02.23.03.52.03.26 0 .37 0 .37.24 0 .1-.06.15-.17.15L2.31 6.8l-1.27.03c-.16 0-.23-.09-.23-.24 0-.07.03-.12.08-.13.1-.01.18-.02.23-.02.31-.01.49-.03.54-.04.05-.01.07-.04.07-.09 0-.02-.01-.09-.04-.2L.74 2.3c-.05-.19-.07-.38-.07-.58C.67.57 1.5-.22 2.65-.22c.65 0 1.25.25 1.8.76.53.48.87 1.04 1.03 1.69l.88 3.51c.13.51.41.69 1.03.7.14.01.21.09.21.24v.04c-.03.07-.08.11-.17.11-.19 0-.82-.03-1.01-.03Z"/>
+    </symbol>
+    <symbol id="at" overflow="visible">
+      <path d="M1.427 2.385q0-.92.29-1.388.29-.468.861-.468.572 0 .866.47.294.47.294 1.386 0 .915-.294 1.386-.294.47-.866.47-.571 0-.861-.468-.29-.469-.29-1.388ZM3.738.597Q3.545.241 3.216.05q-.329-.19-.762-.19-.864 0-1.365.667-.5.669-.5 1.842 0 1.194.498 1.869.499.674 1.367.674.43 0 .758-.187.329-.187.526-.543v.614h.795v-6.643h-.795V.597Z"/>
+    </symbol>
+    <symbol id="au" overflow="visible">
+      <path d="M.632 2.462v3.953h.872V2.067q0-.469.026-.668.025-.2.09-.308.137-.253.397-.382t.63-.129q.374 0 .632.129.257.129.4.382.064.108.09.305.025.198.025.662v4.357h.868V2.462q0-.984-.122-1.399Q4.417.65 4.116.378 3.833.125 3.468 0q-.366-.125-.821-.125-.451 0-.817.125-.365.125-.653.378-.296.267-.42.69-.125.423-.125 1.394Z"/>
+    </symbol>
+    <symbol id="av" overflow="visible">
+      <path d="M3.334 3.433q.632-.167.967-.595.335-.427.335-1.068 0-.885-.595-1.39-.595-.505-1.648-.505-.442 0-.902.082T.589.193v.864q.438-.228.863-.34.426-.111.847-.111.713 0 1.096.322.382.322.382.928 0 .559-.382.888-.383.328-1.036.328h-.662v.714h.662q.597 0 .932.262.336.262.336.73 0 .494-.312.759-.311.264-.887.264-.383 0-.79-.086-.41-.086-.856-.258v.8q.52.137.926.206.406.068.72.068.936 0 1.497-.47.56-.47.56-1.248 0-.529-.293-.881-.295-.353-.858-.499Z"/>
+    </symbol>
+    <symbol id="aw" overflow="visible">
+      <path d="M.945 1.343V6.15q0 .354-.016.529-.016.175-.137.258-.12.083-.188.088l-.362.027q-.124.124-.065.328.978.075 1.536.3.145 0 .145-.112-.043-.44-.043-1.155V2.578q.355.048.747.339.397.295.88.902.055.064.09.137.034.072.056.169.021.097-.078.17-.1.072-.32.082-.043.043-.043.175t.043.19q.505-.02 1.08-.02.451 0 .956.02.054-.053.054-.187 0-.135-.054-.178-.768-.075-1.155-.483l-.967-.999q-.042-.043-.048-.113 0-.053.08-.156l1.45-1.82q.2-.253.404-.336.204-.083.542-.132.054-.053.054-.185T5.532-.02Q5.092 0 4.63 0q-.242 0-.682-.021-.043 0-.043.053-.022.177-.462.774l-.8 1.074q-.178.236-.355.36-.145.048-.473.059v-.956q0-.65.105-.809.105-.158.465-.196.053-.053.056-.185.003-.132-.056-.174Q1.88 0 1.385 0 .936 0 .21-.021.156.02.156.153q0 .132.053.185.484.033.61.188.126.156.126.817Z"/>
+    </symbol>
+    <symbol id="ax" overflow="visible">
+      <path d="M5.34 3.93c0-.09.05-.19.16-.3.23-.22.35-.49.35-.81 0-.29-.09-.6-.28-.95C5.22 1.2 4.76.72 4.21.43 3.88.26 3.55.18 3.22.17l1.62 6.46c.02.09.03.14.03.16 0 .1-.05.15-.16.15a.18.18 0 0 1-.11-.03.802.802 0 0 1-.07-.2L2.9.19c-.71.09-1.06.45-1.06 1.07 0 .27.18.88.53 1.83.07.2.11.37.11.5 0 .5-.35.85-.85.85-.45 0-.79-.25-1.04-.75-.2-.4-.3-.67-.3-.81 0-.09.05-.14.16-.14.13 0 .15.06.19.2.23.8.55 1.2.96 1.2.14 0 .21-.09.21-.27 0-.16-.07-.44-.22-.84-.32-.85-.48-1.41-.48-1.69 0-.87.57-1.35 1.71-1.44-.08-.35-.15-.64-.21-.86-.15-.57-.23-.89-.23-.96.03-.08.04-.13.17-.13l.1.04c.06.16.11.31.14.44l.36 1.44c.82.01 1.54.37 2.16 1.08.33.37.57.77.73 1.2.21.55.31 1.07.31 1.56s-.16.73-.47.73c-.26 0-.54-.25-.54-.51Z"/>
+    </symbol>
+    <symbol id="ay" overflow="visible">
+      <path d="M1.014 6.686h.816V2.814l2.076 1.998h.962L2.973 3 5.165 0h-.967L2.419 2.484l-.589-.555V0h-.816v6.686Z"/>
+    </symbol>
+    <symbol id="az" overflow="visible">
+      <path d="M1.97 2.5C3 3 4.25 4.13 4.25 5.49v5.98c0 .54.21 1.06.64 1.56.4.47.87.79 1.4.96.13.04.19.12.19.25 0 .17-.09.26-.26.26-.03 0-.05 0-.07-.01-.72-.23-1.36-.6-1.92-1.11-.65-.61-.98-1.24-.98-1.91V5.49c0-.59-.2-1.15-.6-1.68-.4-.53-.88-.89-1.44-1.06-.13-.04-.19-.12-.19-.25s.06-.21.19-.25c.56-.17 1.04-.53 1.44-1.06.4-.53.6-1.09.6-1.68v-5.98c0-.67.33-1.3.98-1.91.56-.51 1.2-.88 1.92-1.11.02-.01.04-.01.07-.01.17 0 .26.09.26.26 0 .13-.06.21-.19.25-.53.17-1 .49-1.4.96-.43.5-.64 1.02-.64 1.56v5.98C4.25.87 3 2 1.97 2.5Z"/>
+    </symbol>
+    <symbol id="aA" overflow="visible">
+      <path d="M.51-9.5h2.44v24H.51c-.21 0-.32-.11-.32-.33 0-.22.11-.33.32-.33h1.8V-8.84H.51c-.21 0-.32-.11-.32-.33 0-.22.11-.33.32-.33Z"/>
+    </symbol>
+    <symbol id="aB" overflow="visible">
+      <path d="M3.846 6.415V4.03h-.748v2.385h.748Zm-1.646 0V4.03h-.748v2.385H2.2Z"/>
+    </symbol>
+    <symbol id="aC" overflow="visible">
+      <path d="M3.309 6.686V-1.16H1.487v.614h1.031v6.617H1.487v.615h1.822Z"/>
+    </symbol>
+    <symbol id="aD" overflow="visible">
+      <path d="M2.041-1.602q-.41-.717-.972-.717-.2 0-.334.105T.6-1.948q0 .132.124.28.125.15.315.15.049 0 .134-.015.086-.015.154-.015.342 0 .503.288.24.489.39.918.123.342-.14.943L.946 3.232q-.19.445-.334.577-.144.131-.452.17-.039.04-.039.16 0 .119.04.173.4-.02.81-.02.39 0 1.128.02.039-.05.039-.171 0-.122-.04-.162-.39-.029-.441-.183-.052-.153.114-.466l.89-2.08q.121-.283.238-.01l.992 2.29q.112.24-.035.33-.146.09-.449.12-.049.039-.049.158 0 .12.05.174.6-.02.91-.02.31 0 .71.02.05-.05.05-.171 0-.122-.05-.162-.341-.039-.495-.173-.154-.134-.315-.466Q3.486 1.758 2.45-.742q-.21-.498-.41-.86Z"/>
+    </symbol>
+    <symbol id="aE" overflow="visible">
+      <path d="m1.24 2.822 1.812.03q.151 0 .146.136 0 .572-.244.81-.244.24-.586.24-.132 0-.259-.034t-.312-.144q-.186-.11-.337-.379-.151-.268-.22-.659ZM3.862.928q.171-.01.21-.157-.669-.869-1.704-.869-.991 0-1.528.64-.469.542-.469 1.48 0 1.06.635 1.704.635.644 1.362.644 1.69 0 1.69-1.738 0-.171-.186-.171l-2.661.02q0-.84.317-1.373.44-.717 1.094-.717.42 0 .686.12.266.119.554.417Z"/>
+    </symbol>
+    <symbol id="aF" overflow="visible">
+      <path d="m2.93 2.33-.791-.21q-.952-.24-.948-1.1 0-.268.184-.49.183-.222.534-.222.342 0 .88.444.14.112.14.259v1.318Zm0-1.851h-.02l-.2-.157q-.542-.42-1.089-.42-1.26 0-1.26 1.08 0 .497.454.878.455.381 1.197.572l.86.21q.058.02.058.117 0 1.299-.81 1.299-.333 0-.567-.105-.235-.105-.235-.315 0-.142.02-.196.03-.058.034-.18 0-.113-.137-.227Q1.1 2.92.898 2.92q-.351 0-.346.361 0 .42.515.764.515.345 1.135.345 1.509 0 1.509-1.69V1.23q0-.21.005-.33.005-.119.034-.26.03-.142.095-.2.066-.06.164-.06.18 0 .37.162.142-.078.172-.273-.381-.372-.952-.367-.342 0-.481.15-.14.148-.188.427Z"/>
+    </symbol>
+    <symbol id="aG" overflow="visible">
+      <path d="M1.67 2.861v-1.64q0-.425.051-.603.051-.179.159-.232.107-.054.386-.078.044-.044.046-.164.002-.12-.046-.164-.562.02-.987.02Q.84 0 .181-.02.137.024.137.144q0 .12.044.164.249.02.359.044.11.024.202.12.093.094.115.26.022.166.022.489v4.37q0 .322-.015.48-.014.16-.124.235-.11.076-.171.08-.061.006-.33.025-.112.112-.058.298.888.068 1.401.273.132 0 .127-.102-.04-.4-.04-1.05L1.66 3.58q0-.123.083-.02l.015.02q.732.81 1.704.81.571 0 .83-.342.269-.352.269-1.338V1.22q0-.59.114-.73.115-.138.554-.182.04-.05.04-.169 0-.12-.04-.159Q4.57 0 4.17 0q-.458 0-1.02-.02Q3.11.03 3.11.15q0 .12.04.159.41.039.515.18.105.142.105.733v1.518q0 .532-.118.772-.18.361-.532.361-.679 0-1.28-.59-.17-.186-.17-.42Z"/>
+    </symbol>
+    <symbol id="aH" overflow="visible">
+      <path d="M3.687 1.547q-.198-.503-.503-1.324Q2.759-.91 2.612-1.16q-.197-.335-.494-.503-.296-.167-.691-.167H.79v.661h.468q.348 0 .546.202.197.202.502 1.044L.447 4.813h.838L2.71 1.047l1.405 3.764h.838L3.687 1.547Z"/>
+    </symbol>
+    <symbol id="aI" overflow="visible">
+      <path d="M8.91 6.214q.033.097.033.175 0 .078-.022.134-.021.057-.088.094-.067.038-.121.06-.054.02-.159.037-.104.016-.177.021l-.19.016q-.043.043-.043.178 0 .134.043.188.88-.022 1.208-.022.317 0 .956.022.054-.054.054-.186 0-.131-.054-.18-.419-.021-.62-.185-.202-.164-.325-.48L7.192.155q-.097-.285-.25-.288-.153-.002-.255.299L5.425 3.819q-.108.306-.156.306-.064 0-.188-.274L3.443.167q-.134-.296-.285-.301-.145 0-.241.3L.849 6.119q-.145.43-.272.52-.126.092-.513.113-.043.043-.043.178 0 .134.043.188.64-.022 1.026-.022.548 0 1.273.022.054-.054.057-.186.002-.131-.057-.18-.338-.021-.486-.107-.148-.086-.062-.354l1.606-4.861.049-.011 1.423 3.223q.097.22.102.386 0 .097-.08.339l-.253.73q-.22.618-.924.655-.043.043-.043.178 0 .134.043.188.704-.022 1.101-.022.473 0 1.375.022.054-.054.054-.186 0-.131-.054-.18-.155-.01-.225-.021-.07-.01-.19-.054-.122-.043-.143-.104l-.062-.183q-.04-.12.051-.293l1.51-4.646.037-.01L8.91 6.213Z"/>
+    </symbol>
+    <symbol id="aJ" overflow="visible">
+      <path d="M2.232 1.323q0 .547-.224.805t-.586.258q-.441 0-.889-.168L.77 4.235q.407-.034.755-.034.42 0 1.149.075l.051-.027-.113-.476q-.427-.04-.735-.04-.239 0-.82.06l-.14-1.168q.287.113.687.113.567 0 .91-.378.344-.378.344-.91 0-.667-.417-1.098-.417-.43-1.07-.43-.32 0-.656.162Q.38.246.38.448q0 .106.08.183.081.077.184.077Q.83.708 1 .482q.007-.014.041-.058.035-.045.05-.067.015-.022.05-.056.034-.034.061-.051.027-.018.07-.043.043-.026.09-.033.045-.007.1-.007.321 0 .545.334.224.333.224.822Z"/>
+    </symbol>
+    <symbol id="aK" overflow="visible">
+      <path d="M.89 6.415h3.248v-.73H1.68V4.108q.185.069.372.1.187.033.376.033.997 0 1.581-.589.584-.588.584-1.594 0-1.014-.612-1.598-.612-.585-1.674-.585-.51 0-.934.07Q.95.012.614.15v.881q.396-.215.795-.32.4-.105.817-.105.717 0 1.106.378.39.378.39 1.074 0 .688-.403 1.07-.401.383-1.119.383-.348 0-.679-.08-.33-.08-.632-.238v3.222Z"/>
+    </symbol>
+    <symbol id="aL" overflow="visible">
+      <path d="M1.692 5.06H3.83q.145 0 .424.01.28.011.322.011.065 0 .065-.054 0-.096-.21-.397Q3.223 2.98 1.703.65q-.086-.124-.06-.21.027-.086.215-.086l1.31.043q.243.011.43.092.189.08.336.268.148.188.237.35.088.16.217.467.167.01.296-.075Q4.399.532 4.334 0H.57Q.403 0 .41.107q0 .065.074.188Q2.234 3.002 3.31 4.453q.188.252-.022.257L1.74 4.662q-.639-.021-.924-1.01-.134-.021-.29.033.156.827.167 1.45 0 .032.043.037.558-.112.956-.112Z"/>
+    </symbol>
+    <symbol id="aM" overflow="visible">
+      <path d="M2.75 4.786q0 .096.137.196t.228.1q.188 0 .183-.151V3.035h1.939q.156 0 .156-.188 0-.086-.1-.223t-.201-.137H3.298V.725q0-.097-.126-.185Q3.045.45 2.927.45q-.177 0-.177.167v1.869H.827q-.166 0-.166.177 0 .124.088.247.089.124.186.124H2.75v1.75Z"/>
+    </symbol>
+    <symbol id="aN" overflow="visible">
+      <path d="m2.191 4.222.715-1.064q.107-.177.22-.021l.757 1.074q.188.295.127.384-.062.089-.411.126-.054.054-.057.185-.002.132.057.175.617-.021.999-.021.397 0 .859.021.043-.043.043-.175 0-.131-.043-.185-.354-.021-.596-.156-.242-.134-.548-.515l-.994-1.268q-.064-.075 0-.177l1.09-1.493q.339-.494.538-.62.199-.127.617-.154.043-.053.043-.185T5.564-.02Q4.995 0 4.512 0q-.473 0-1.177-.021-.053.042-.056.174-.003.132.056.185.22.022.301.062.08.04.065.177-.016.137-.215.411l-.672.946q-.053.075-.09.077-.038.003-.119-.099L1.848.838Q1.67.553 1.727.465q.056-.089.395-.127.053-.053.056-.185.003-.132-.056-.174Q1.504 0 1.133 0 .747 0 .285-.021.242.02.242.153q0 .132.043.185Q.65.36.88.483q.23.124.548.538l.993 1.278q.054.075-.01.177L1.354 3.97q-.473.704-1.037.752-.054.054-.054.185 0 .132.054.175.618-.021 1.015-.021.559 0 1.198.021.043-.043.043-.175 0-.131-.043-.185-.408-.043-.467-.123-.06-.08.128-.376Z"/>
+    </symbol>
+    <symbol id="aO" overflow="visible">
+      <path d="M6.8 1.343q0-.66.169-.82.17-.158.787-.185.054-.053.054-.185T7.756-.02Q6.789 0 6.338 0q-.44 0-1.434-.021Q4.86.02 4.86.153q0 .132.043.185.617.022.79.183.171.161.171.822v2.186H2.1V1.343q0-.66.172-.82.172-.158.784-.185.043-.053.046-.185.002-.132-.046-.174Q2.09 0 1.638 0 1.176 0 .21-.021.156.02.156.153q0 .132.053.185.618.022.787.183.17.161.17.822v4.41q0 .66-.17.819-.169.158-.787.18-.053.042-.053.177 0 .134.053.188.838-.022 1.418-.022.597 0 1.43.022.042-.054.045-.186.002-.131-.046-.18-.618-.021-.787-.18-.169-.158-.169-.819V3.991h3.765v1.761q0 .661-.172.82-.172.158-.79.18-.042.042-.042.177 0 .134.043.188.967-.022 1.423-.022.527 0 1.429.022.054-.054.054-.186 0-.131-.054-.18-.618-.021-.787-.18-.17-.158-.17-.819v-4.41Z"/>
+    </symbol>
+    <symbol id="aP" overflow="visible">
+      <path d="M3.577 4.377q-.054.043-.056.175-.003.132.056.19.548-.02 1.01-.02.328 0 .768.02.054-.053.056-.187.003-.135-.056-.178-.419-.037-.588-.209-.17-.172-.352-.602L2.949.124Q2.84-.13 2.686-.134q-.188 0-.274.23L1.004 3.578q-.182.462-.327.607-.145.145-.553.193-.054.043-.057.175-.003.132.057.19.66-.02 1.02-.02.387 0 1.112.02.054-.053.054-.187 0-.135-.054-.178-.414-.053-.465-.198-.05-.145.121-.537l.795-2.122q.134-.338.204-.352.07-.013.204.314l.886 2.16q.178.419.097.56-.08.143-.52.175Z"/>
+    </symbol>
+    <symbol id="aQ" overflow="visible">
+      <path d="M1.53 2.763h2.238v-.705H1.53v.705Z"/>
+    </symbol>
+    <symbol id="aR" overflow="visible">
+      <path d="M4.568 6.686v-.657H3.67q-.426 0-.591-.175-.166-.174-.166-.616v-.426h1.655v-.614H2.913V0h-.79v4.198H.838v.614h1.285v.336q0 .79.363 1.164.363.374 1.132.374h.95Z"/>
+    </symbol>
+    <symbol id="aS" overflow="visible">
+      <path d="M2.245-1.762q-.451-.79-1.069-.79-.22 0-.368.116-.147.116-.147.293 0 .145.137.309t.346.164q.054 0 .148-.017.094-.016.169-.016.376 0 .553.317.263.537.43 1.01Q2.578 0 2.288.661L1.042 3.556q-.21.488-.368.633-.158.145-.497.188-.043.043-.043.175t.043.19q.44-.02.892-.02.43 0 1.24.02.044-.053.044-.187 0-.135-.043-.178-.43-.032-.487-.201-.056-.17.127-.513l.977-2.288q.135-.312.263-.01l1.09 2.518q.124.263-.037.363-.161.1-.494.131-.054.043-.054.175t.054.19q.66-.02 1.002-.02.34 0 .781.02.054-.053.054-.187 0-.135-.054-.178-.376-.043-.545-.19-.17-.148-.346-.513-.806-1.74-1.945-4.49-.23-.548-.45-.946Z"/>
+    </symbol>
+    <symbol id="aT" overflow="visible">
+      <path d="M1.638 0Q1.068 0 .21-.021.156.02.156.153q0 .132.053.185.618.022.787.183.17.161.17.822v4.41q0 .66-.17.819-.169.158-.787.18-.053.042-.053.177 0 .134.053.188 1.01-.022 1.418-.022.44 0 1.43.022.042-.054.045-.186.002-.131-.046-.18-.618-.021-.787-.18-.169-.158-.169-.819V1.198q0-.42.148-.594t.48-.174h.693q.806 0 1.206.378.4.379.588 1.061.188.032.36-.054Q5.468.86 5.291-.02 4.275 0 3.98 0H1.638Z"/>
+    </symbol>
+    <symbol id="aU" overflow="visible">
+      <path d="M3.06-.24c.29 0 .6.05.93.14-.03-.38-.04-.62-.04-.71 0-.75.29-1.13.86-1.13.61 0 1.08.49 1.31.94.25.52.38.86.38 1.02 0 .09-.05.14-.15.14-.07 0-.12-.04-.15-.13-.15-.46-.56-.93-1.12-.93-.51 0-.58.41-.66.96.84.33 1.55.9 2.12 1.72.57.82.86 1.67.86 2.56 0 .79-.23 1.43-.7 1.94s-1.09.77-1.86.77c-.53 0-1.06-.13-1.59-.4-1.08-.53-1.87-1.37-2.38-2.5-.25-.57-.38-1.13-.38-1.7C.49.88 1.51-.24 3.06-.24Zm3.39 4.9c0-.61-.15-1.31-.45-2.12C5.65 1.61 5.11.92 4.36.48c-.04.22-.1.42-.18.6-.13.3-.37.45-.72.45-.55 0-1.05-.5-1.05-1.05 0-.09.01-.18.03-.25-.67.31-1 .94-1 1.9 0 .42.08.93.25 1.53.35 1.27.98 2.17 1.89 2.7.43.24.83.36 1.2.36 1.1 0 1.67-.91 1.67-2.06ZM3.46 1.23c.37 0 .56-.27.56-.8 0-.09-.03-.14-.09-.16-.28-.12-.55-.18-.81-.18-.28 0-.42.13-.42.39 0 .38.38.75.76.75Z"/>
+    </symbol>
+    <symbol id="aV" overflow="visible">
+      <path d="M1.738 3.628q-.17-.151-.166-.42v-2.5q.381-.469.718-.469.689 0 1.05.554.361.555.361 1.448 0 .718-.325 1.214-.324.495-.788.495-.488 0-.85-.322Zm-.068.312q.498.45 1.118.45.689 0 1.23-.55.543-.549.543-1.418 0-1.118-.691-1.819-.691-.7-1.521-.7-.586 0-.88.243-.082.069-.138.066-.057-.002-.135-.09Q1.123.04.962-.122.81-.122.742 0q.04.19.04.708v4.883q0 .322-.015.48-.015.16-.125.235-.11.076-.17.08-.062.006-.33.025-.113.112-.064.298.889.068 1.401.273.132 0 .132-.102-.039-.4-.039-1.05V3.99q0-.137.098-.05Z"/>
+    </symbol>
+    <symbol id="aW" overflow="visible">
+      <path d="M3.98.908q-.352-.58-.74-.793-.388-.213-.891-.213-.928 0-1.453.594-.525.593-.525 1.584 0 1.01.63 1.66.63.65 1.42.65.709 0 1.119-.264.41-.264.41-.684 0-.21-.156-.327-.156-.117-.332-.117-.342 0-.38.361-.02.22-.067.345-.046.124-.205.239-.159.115-.442.115-.498 0-.818-.474-.32-.474-.32-1.284 0-.86.391-1.384.39-.525.947-.525.689 0 1.202.659.16-.02.21-.142Z"/>
+    </symbol>
+    <symbol id="aX" overflow="visible">
+      <path d="M2.212 1.467q0 .534-.174.81-.174.278-.507.278-.348 0-.53-.277Q.816 2 .816 1.467t.185-.813q.184-.28.535-.28.327 0 .501.28.174.282.174.813ZM2.686.186q0-.65-.306-.985-.307-.335-.903-.335-.196 0-.41.036-.214.036-.428.105v.47Q.892-.642 1.1-.7q.206-.056.378-.056.384 0 .56.208.175.21.175.663v.343q-.113-.242-.31-.361-.195-.119-.476-.119-.506 0-.807.405Q.317.79.317 1.467q0 .68.302 1.085.301.405.807.405.278 0 .472-.11.193-.112.314-.344v.374h.474V.186Z"/>
+    </symbol>
+    <symbol id="aY" overflow="visible">
+      <path d="M1.81 1.451h-.157q-.415 0-.626-.145Q.817 1.16.817.87q0-.26.158-.404.157-.145.435-.145.392 0 .616.272.225.272.227.752v.105H1.81Zm.92.196V0h-.477v.428Q2.101.17 1.87.048q-.23-.123-.56-.123-.441 0-.704.249Q.343.423.343.84q0 .483.323.733.324.25.95.25h.637v.075q-.002.345-.175.5-.173.157-.552.157-.242 0-.49-.07-.247-.07-.482-.203v.474q.263.1.504.15.241.051.468.051.359 0 .613-.106.254-.105.41-.317.099-.129.14-.318.041-.19.041-.569Z"/>
+    </symbol>
+    <symbol id="aZ" overflow="visible">
+      <path d="M1.583 3.707v-.82h1.078V2.52H1.583V.95q0-.32.121-.446T2.127.38h.534V0h-.58q-.534 0-.753.214-.22.214-.22.737V2.52h-.77v.369h.77v.82h.475Z"/>
+    </symbol>
+    <symbol id="ba" overflow="visible">
+      <path d="M2.867 1.562V1.33H.812v-.015q0-.472.246-.73.247-.258.695-.258.227 0 .475.073.247.072.528.219V.147q-.27-.11-.522-.166-.251-.056-.486-.056-.673 0-1.052.404Q.317.732.317 1.44q0 .691.371 1.104.372.412.99.412.552 0 .87-.374.319-.374.319-1.02Zm-.474.14q-.01.417-.198.635-.187.218-.537.218-.343 0-.565-.227-.222-.227-.263-.629l1.563.003Z"/>
+    </symbol>
+    <symbol id="bb" overflow="visible">
+      <path d="M2.282 4.006q-.343-.587-.512-1.171Q1.6 2.25 1.6 1.658q0-.59.169-1.176.169-.585.512-1.178h-.413q-.39.613-.58 1.195-.19.581-.19 1.159 0 .575.19 1.157.19.583.58 1.191h.413Z"/>
+    </symbol>
+    <symbol id="bc" overflow="visible">
+      <path d="M1.784 1.495V.376q.284.008.444.158.16.15.16.407 0 .24-.145.373-.144.132-.459.181Zm-.258.49V3.05q-.268-.01-.419-.155-.15-.144-.15-.386 0-.222.14-.351.14-.129.43-.173Zm.258-2.761h-.258L1.524 0q-.263.013-.522.072-.26.06-.512.165v.464q.258-.16.52-.245.261-.085.516-.09v1.18q-.515.08-.776.315-.26.235-.26.622 0 .405.272.646.272.24.764.277v.606h.258l.003-.606q.203-.013.412-.052.209-.039.426-.106v-.446q-.22.111-.427.172-.208.06-.414.07v-1.11q.531-.08.81-.33.278-.25.278-.648 0-.397-.3-.662-.3-.266-.785-.289l-.003-.781Z"/>
+    </symbol>
+    <symbol id="bd" overflow="visible">
+      <path d="m1.689-.07-.052-.002q-.033-.003-.054-.003-.645 0-.963.495-.318.495-.318 1.5 0 1.009.318 1.504.318.495.968.495.652 0 .97-.495.32-.495.32-1.503 0-.758-.177-1.221-.177-.463-.535-.648l.515-.49-.389-.258-.603.626Zm.644 1.99q0 .849-.174 1.212-.174.364-.57.364-.395 0-.57-.364Q.847 2.77.847 1.921q0-.846.174-1.21.174-.363.568-.363.397 0 .571.362.174.363.174 1.21Z"/>
+    </symbol>
+    <symbol id="be" overflow="visible">
+      <path d="M1.294.781h.65V.247L1.436-.74h-.397l.255.987v.534Z"/>
+    </symbol>
+    <symbol id="bf" overflow="visible">
+      <path d="M1.647 1.047q0-.32.118-.482.117-.163.346-.163h.555V0h-.6q-.426 0-.66.273-.233.274-.233.774v2.622h-.76v.37h1.234V1.048Z"/>
+    </symbol>
+    <symbol id="bg" overflow="visible">
+      <path d="M2.367 1.441q0 .552-.176.833-.175.28-.518.28-.345 0-.523-.281Q.972 1.99.972 1.44q0-.546.178-.83.178-.284.523-.284.343 0 .518.281.176.281.176.833ZM.972 2.52q.113.211.313.325.2.113.463.113.52 0 .82-.4.299-.402.299-1.106 0-.714-.3-1.12-.3-.406-.824-.406-.258 0-.455.112Q1.09.15.972.364V0H.498v4.012h.474V2.519Z"/>
+    </symbol>
+    <symbol id="bh" overflow="visible">
+      <path d="M1.26 2.74h.65v-.78h-.65v.78Zm0-1.954h.65V0h-.65v.786Z"/>
+    </symbol>
+    <symbol id="bi" overflow="visible">
+      <path d="M2.735.147q-.19-.11-.393-.166-.202-.056-.414-.056-.67 0-1.048.402Q.503.73.503 1.441q0 .712.377 1.114.378.402 1.048.402.21 0 .408-.054.198-.054.4-.168v-.497q-.189.167-.378.242-.19.075-.43.075-.446 0-.685-.289-.24-.289-.24-.825 0-.534.24-.824.242-.29.685-.29.248 0 .444.076.196.077.363.236V.147Z"/>
+    </symbol>
+    <symbol id="bj" overflow="visible">
+      <path d="M1.588 2.555q-.36 0-.546-.281-.186-.281-.186-.833 0-.549.186-.831.185-.283.546-.283.364 0 .55.283.185.282.185.831 0 .552-.186.833-.185.28-.549.28Zm0 .402q.6 0 .92-.39.318-.388.318-1.126 0-.74-.317-1.128-.318-.388-.92-.388-.602 0-.919.388Q.353.701.353 1.441q0 .738.317 1.127.317.39.918.39Z"/>
+    </symbol>
+    <symbol id="bk" overflow="visible">
+      <path d="M2.71 1.79V0h-.477v1.79q0 .389-.137.572-.137.183-.428.183-.333 0-.512-.236t-.179-.677V0H.503v2.888h.474v-.434q.126.248.343.375.217.128.513.128.44 0 .659-.29.218-.29.218-.878Z"/>
+    </symbol>
+    <symbol id="bl" overflow="visible">
+      <path d="M2.307 3.85V2.417H1.86V3.85h.448Zm-.987 0V2.417H.871V3.85h.449Z"/>
+    </symbol>
+    <symbol id="bm" overflow="visible">
+      <path d="M.967.364v-1.462H.49v3.986h.477v-.37q.118.215.316.327.197.112.455.112.523 0 .82-.405.299-.404.299-1.121 0-.704-.3-1.105-.299-.4-.82-.4-.262 0-.46.111Q1.08.15.967.364ZM2.359 1.44q0 .552-.174.833-.174.28-.517.28-.345 0-.523-.281Q.967 1.99.967 1.44q0-.546.178-.83.178-.284.523-.284.343 0 .517.281t.174.833Z"/>
+    </symbol>
+    <symbol id="bn" overflow="visible">
+      <path d="M2.509 2.787v-.464q-.204.118-.41.178-.207.06-.42.06-.323 0-.481-.105-.159-.105-.159-.319 0-.193.119-.288.118-.096.59-.186l.19-.036q.354-.067.536-.268.181-.201.181-.524 0-.428-.304-.669-.304-.24-.845-.24-.214 0-.449.044Q.822.015.549.106v.49Q.815.459 1.057.39q.242-.069.459-.069.314 0 .487.128t.173.357q0 .33-.632.456l-.02.005-.178.037q-.41.08-.598.269-.189.19-.189.517 0 .415.281.64.281.226.802.226.232 0 .446-.042.214-.043.42-.128Z"/>
+    </symbol>
+    <symbol id="bo" overflow="visible">
+      <path d="M.897 4.006h.413q.389-.608.58-1.19.19-.583.19-1.158 0-.58-.19-1.163-.191-.583-.58-1.191H.897q.343.598.512 1.183.169.586.169 1.17 0 .589-.17 1.174-.168.585-.51 1.175Z"/>
+    </symbol>
+    <symbol id="bp" overflow="visible">
+      <path d="M1.743 2.594q.087.185.223.274.135.09.326.09.348 0 .491-.27.143-.27.143-1.015V0h-.433v1.653q0 .61-.068.759-.069.148-.25.148-.205 0-.281-.158-.076-.159-.076-.75V0h-.434v1.653q0 .618-.073.763-.073.144-.264.144-.188 0-.262-.158-.073-.159-.073-.75V0H.28v2.888h.43V2.64q.086.155.213.236.128.081.29.081.196 0 .326-.09t.203-.273Z"/>
+    </symbol>
+    <symbol id="bq" overflow="visible">
+      <path d="M2.74 4.012v-.395h-.538q-.256 0-.355-.104-.099-.105-.099-.37v-.255h.993v-.37h-.993V0h-.474v2.519H.503v.369h.77v.2q0 .475.218.7.218.224.68.224h.57Z"/>
+    </symbol>
+    <symbol id="br" overflow="visible">
+      <path d="M1.805 3.019V1.874h1.147v-.438H1.805V.291h-.433v1.145H.227v.438h1.145V3.02h.433Z"/>
+    </symbol>
+    <symbol id="bs" overflow="visible">
+      <path d="M2.978 2.292q-.152.119-.31.173-.157.054-.345.054-.444 0-.678-.279-.235-.278-.235-.804V0H.933v2.888h.477v-.565q.119.307.365.47.246.164.584.164.175 0 .327-.044.153-.044.292-.136v-.485Z"/>
+    </symbol>
+    <symbol id="bt" overflow="visible">
+      <path d="M.66 2.888h1.214V.368h.941V0H.46v.369h.94v2.15H.66v.369Zm.74 1.124h.474V3.41H1.4v.6Z"/>
+    </symbol>
+    <symbol id="bu" overflow="visible">
+      <path d="M2.71 1.79V0h-.477v1.79q0 .389-.137.572-.137.183-.428.183-.333 0-.512-.236t-.179-.677V0H.503v4.012h.474V2.454q.126.248.343.375.217.128.513.128.44 0 .659-.29.218-.29.218-.878Z"/>
+    </symbol>
+    <symbol id="bv" overflow="visible">
+      <path d="M2.212 2.519v1.493h.474V0h-.474v.364Q2.093.15 1.896.037 1.7-.075 1.441-.075q-.523 0-.824.406-.3.406-.3 1.12 0 .704.302 1.105.301.401.822.401.26 0 .46-.112.198-.112.311-.326ZM.817 1.44q0-.552.176-.833.175-.28.518-.28t.522.283q.179.284.179.83 0 .55-.18.832-.178.282-.521.282t-.518-.281Q.817 1.993.817 1.44Z"/>
+    </symbol>
+    <symbol id="bw" overflow="visible">
+      <path d="M2.212.928Q2.093.626 1.91.134q-.255-.68-.342-.83-.12-.201-.297-.302-.178-.1-.415-.1H.474v.397h.281q.21 0 .328.12.118.122.301.627L.268 2.888h.503L1.627.629l.843 2.259h.503L2.212.928Z"/>
+    </symbol>
+    <symbol id="bx" overflow="visible">
+      <path d="M1.245 1.934q0 .141.1.245.099.103.238.103.144 0 .247-.103.104-.104.104-.245 0-.145-.102-.245t-.249-.1q-.144 0-.241.097-.097.098-.097.248Zm.343 1.572q-.363 0-.543-.392-.179-.391-.179-1.193 0-.8.18-1.191.179-.392.542-.392.366 0 .545.392.18.391.18 1.19 0 .803-.18 1.194-.179.392-.545.392Zm0 .413q.616 0 .932-.506.316-.505.316-1.492 0-.985-.316-1.49-.316-.506-.932-.506-.616 0-.93.506Q.342.936.342 1.92q0 .987.314 1.492.315.506.931.506Z"/>
+    </symbol>
+    <symbol id="by" overflow="visible">
+      <path d="M2.882 2.888 1.85 1.506 2.983 0h-.55l-.845 1.158L.745 0h-.55L1.33 1.506.296 2.888h.526l.766-1.045.76 1.045h.534Z"/>
+    </symbol>
+    <symbol id="bz" overflow="visible">
+      <path d="M.534 3.85h1.949v-.44H1.008v-.945q.11.04.223.06.112.02.226.02.598 0 .948-.354.351-.353.351-.956 0-.609-.367-.96-.368-.35-1.005-.35-.306 0-.56.041Q.57.008.369.09V.62Q.606.489.846.427q.24-.063.49-.063.43 0 .663.226.234.227.234.645 0 .412-.241.642-.241.23-.672.23-.209 0-.407-.048-.199-.048-.38-.143v1.933Z"/>
+    </symbol>
+    <symbol id="bA" overflow="visible">
+      <path d="M1.794.822q0-.2.136-.337.135-.137.336-.137.199 0 .337.138t.138.336q0 .199-.14.338-.139.14-.335.14-.2 0-.336-.137t-.136-.34Zm-.348 0q0 .348.238.587.237.238.582.238.165 0 .313-.061.149-.062.267-.18.119-.122.183-.272.065-.15.065-.312 0-.342-.24-.582Q2.614 0 2.266 0q-.35 0-.585.236t-.235.586ZM.312 1.2l-.09.247 2.686 1.078.106-.248L.312 1.2Zm.121 1.668q0-.204.135-.34.136-.134.34-.134.198 0 .337.137.14.138.14.337 0 .198-.14.336-.139.138-.338.138-.198 0-.336-.136-.138-.137-.138-.338Zm-.348 0q0 .348.237.586.237.239.586.239.164 0 .315-.062t.267-.178q.116-.116.18-.267.063-.15.063-.318 0-.346-.24-.584-.24-.239-.586-.239-.348 0-.585.238-.237.237-.237.585Z"/>
+    </symbol>
+    <symbol id="bB" overflow="visible">
+      <path d="M4.146 7.24q.538 0 .951-.1.414-.098.76-.23.347-.132.578-.17.209-.934.252-1.691-.188-.075-.36-.065-.123.42-.266.704-.142.285-.4.572t-.677.435q-.419.148-.993.148-1 0-1.765-.924-.765-.924-.765-2.32 0-.758.293-1.502.292-.743.918-1.278.626-.534 1.453-.534 1.268 0 1.703.419v1.68q0 .307-.191.398-.19.092-.706.135-.043.053-.046.196-.003.142.046.196.966-.022 1.359-.022.45 0 .982.022.054-.054.054-.196 0-.143-.054-.196-.263-.022-.384-.137-.12-.116-.12-.395V1.112q0-.167.171-.306-1.068-.913-3.066-.913-1.553 0-2.509.988T.408 3.378q0 1.155.556 2.058.556.902 1.402 1.353.846.451 1.78.451Z"/>
+    </symbol>
+    <symbol id="bC" overflow="visible">
+      <path d="M1.512.016a4.193 4.193 0 0 1 1.704 1.152c.552.592.824 1.2.824 1.832v3h-.864V3c0-.52-.176-1.032-.536-1.528C2.28.976 1.848.64 1.352.456 1.248.416 1.2.344 1.2.24c0-.16.08-.24.232-.24.024 0 .048.008.08.016Z"/>
+    </symbol>
+    <symbol id="bD" overflow="visible">
+      <path d="M3.176 0h.864v5.984h-.864Z"/>
+    </symbol>
+    <symbol id="bE" overflow="visible">
+      <path d="M5.216 6c-.944-.512-2.04-1.672-2.04-2.984V0h.864v3.016c0 .568.168 1.112.512 1.648.36.552.792.928 1.312 1.112.104.04.152.112.152.224s-.048.184-.152.224c-.52.184-.952.56-1.312 1.112-.344.536-.512 1.08-.512 1.648V12h-.864V8.984c0-1.312 1.096-2.472 2.04-2.984Z"/>
+    </symbol>
+    <symbol id="bF" overflow="visible">
+      <path d="M3.176 0h.864v3c0 .632-.272 1.24-.824 1.832a4.193 4.193 0 0 1-1.704 1.152c-.032.008-.056.016-.08.016-.152 0-.232-.08-.232-.24 0-.104.048-.176.152-.216.496-.184.928-.52 1.288-1.016S3.176 3.52 3.176 3Z"/>
+    </symbol>
+    <symbol id="bG" overflow="visible">
+      <path d="M4.216 2.984c0 .368-.36.552-.76.552-.344 0-.616-.184-.824-.552-.168.368-.448.552-.856.552-.392 0-.712-.184-.968-.544C.592 2.68.48 2.448.48 2.296c0-.072.04-.112.12-.112.072 0 .12.04.136.112.152.464.488 1.008 1.024 1.008.264 0 .392-.168.392-.496 0-.168-.144-.792-.424-1.864-.136-.536-.376-.8-.72-.8a.737.737 0 0 0-.304.064c.208.08.312.224.312.432S.912.952.696.952A.475.475 0 0 1 .232.464c0-.368.376-.552.768-.552.336 0 .608.184.824.552.152-.368.44-.552.856-.552.384 0 .704.184.96.544.216.312.328.544.328.696 0 .072-.04.112-.12.112-.072 0-.112-.04-.136-.112C3.576.696 3.216.144 2.696.144c-.264 0-.4.16-.4.488 0 .104.04.328.128.688l.272 1.08c.152.6.4.904.752.904a.737.737 0 0 0 .304-.064c-.216-.072-.32-.216-.32-.432 0-.208.112-.312.328-.312.256 0 .456.232.456.488Z"/>
+    </symbol>
+    <symbol id="bH" overflow="visible">
+      <path d="M1.304 3.536c-.36 0-.64-.2-.84-.6-.152-.312-.232-.528-.232-.648 0-.072.04-.112.128-.112.112 0 .12.048.152.168.184.632.44.952.768.952.104 0 .16-.072.16-.216 0-.128-.04-.312-.128-.544C1.008 1.712.856 1.16.856.864c0-.608.376-.968.992-.968.264 0 .512.096.736.288-.28-1.056-.72-1.584-1.32-1.584-.272 0-.456.088-.552.264.32.016.48.168.48.456 0 .2-.104.304-.32.304C.576-.376.4-.624.4-.92c0-.44.4-.72.864-.72.92 0 1.672.848 1.872 1.632l.752 3.024a.772.772 0 0 1 .032.192c0 .16-.088.24-.256.24a.344.344 0 0 1-.304-.184 5.891 5.891 0 0 1-.112-.432L2.736.776c-.08-.288-.504-.648-.864-.648-.304 0-.456.2-.456.608 0 .336.136.848.4 1.536.104.28.16.472.16.584 0 .392-.28.68-.672.68Z"/>
+    </symbol>
+    <symbol id="bI" overflow="visible">
+      <path d="M5.784 0c.152 0 .232.08.232.24 0 .104-.048.176-.152.216-.496.184-.928.52-1.288 1.016S4.04 2.48 4.04 3v3h-.864V3c0-.632.272-1.24.824-1.832A4.193 4.193 0 0 1 5.704.016C5.736.008 5.76 0 5.784 0Z"/>
+    </symbol>
+    <symbol id="bJ" overflow="visible">
+      <path d="M3.176 0h.864v5.984h-.864Z"/>
+    </symbol>
+    <symbol id="bK" overflow="visible">
+      <path d="M2 6c.944.512 2.04 1.672 2.04 2.984V12h-.864V8.984c0-.568-.168-1.112-.512-1.648-.36-.552-.792-.928-1.312-1.112C1.248 6.184 1.2 6.112 1.2 6s.048-.184.152-.224c.52-.184.952-.56 1.312-1.112.344-.536.512-1.08.512-1.648V0h.864v3.016C4.04 4.328 2.944 5.488 2 6Z"/>
+    </symbol>
+    <symbol id="bL" overflow="visible">
+      <path d="M5.864 5.544c.104.04.152.112.152.216 0 .16-.08.24-.232.24-.024 0-.048-.008-.08-.016A4.193 4.193 0 0 1 4 4.832c-.552-.592-.824-1.2-.824-1.832V0h.864v3c0 .52.176 1.032.536 1.528.36.496.792.832 1.288 1.016Z"/>
+    </symbol>
+    <symbol id="bM" overflow="visible">
+      <path d="M.384 1.992A2.735 2.735 0 0 1 3.12-.744a2.735 2.735 0 0 1 2.736 2.736A2.735 2.735 0 0 1 3.12 4.728 2.735 2.735 0 0 1 .384 1.992Zm5.088.2H3.304v2.16a2.377 2.377 0 0 0 2.168-2.16Zm-4.72 0a2.377 2.377 0 0 0 2.168 2.16v-2.16Zm0-.384H2.92V-.368A2.38 2.38 0 0 0 .752 1.808Zm4.72 0A2.38 2.38 0 0 0 3.304-.368v2.176Z"/>
+    </symbol>
+    <symbol id="bN" overflow="visible">
+      <path d="M4.416 5.064c0 .352-.344.576-.72.576-.496 0-.84-.32-1.024-.952-.04-.144-.128-.552-.256-1.224h-.52c-.176 0-.264-.008-.264-.176 0-.088.08-.128.248-.128h.48L1.776.064a9.366 9.366 0 0 0-.24-1.016c-.096-.296-.232-.448-.408-.448a.544.544 0 0 0-.304.088c.256.04.384.192.384.448 0 .208-.104.312-.32.312-.272 0-.464-.24-.464-.512 0-.352.328-.576.704-.576.2 0 .384.08.536.248.256.264.456.64.6 1.144.088.312.168.616.224.92l.464 2.488h.656c.184 0 .264.008.264.192 0 .072-.08.112-.24.112h-.616c.048.328.272 1.536.344 1.688.08.168.192.248.336.248a.57.57 0 0 0 .312-.088c-.248-.056-.376-.2-.376-.448 0-.208.104-.312.32-.312.272 0 .464.24.464.512Z"/>
+    </symbol>
+    <symbol id="bO" overflow="visible">
+      <path d="M2.544-1.984c.072 0 .112.04.112.112 0 .024-.016.056-.04.088-.416.32-.752.848-1 1.576a5.77 5.77 0 0 0-.328 1.872v.672c0 .616.112 1.24.328 1.872.248.728.584 1.256 1 1.576.024.024.04.056.04.088 0 .072-.04.112-.112.112a.14.14 0 0 1-.056-.024c-.48-.368-.88-.912-1.208-1.64C.968 3.624.808 2.968.808 2.336v-.672c0-.632.16-1.288.472-1.984.328-.728.728-1.272 1.208-1.64a.14.14 0 0 1 .056-.024Z"/>
+    </symbol>
+    <symbol id="bP" overflow="visible">
+      <path d="M.624-1.96c.48.368.88.912 1.208 1.64.312.696.472 1.352.472 1.984v.672c0 .632-.16 1.288-.472 1.984-.328.728-.728 1.272-1.208 1.64a.14.14 0 0 1-.056.024c-.072 0-.112-.04-.112-.112 0-.032.016-.064.04-.088.416-.32.752-.848 1-1.576a5.77 5.77 0 0 0 .328-1.872v-.672a5.77 5.77 0 0 0-.328-1.872c-.248-.728-.584-1.256-1-1.576-.024-.032-.04-.064-.04-.088 0-.072.04-.112.112-.112a.14.14 0 0 1 .056.024Z"/>
+    </symbol>
+    <symbol id="bQ" overflow="visible">
+      <path d="M.856 1.43q0-.55.174-.832.174-.28.517-.28t.52.281q.176.283.176.832 0 .549-.177.831-.176.283-.52.283-.342 0-.516-.281T.856 1.43ZM2.243.359Q2.127.144 1.93.03q-.197-.115-.458-.115-.518 0-.818.4-.3.402-.3 1.106 0 .716.298 1.121.3.405.82.405.258 0 .455-.112t.316-.326v.368h.477v-3.986h-.477V.358Z"/>
+    </symbol>
+    <symbol id="bR" overflow="visible">
+      <path d="M.379 1.477V3.85h.523V1.24q0-.28.016-.4Q.933.72.972.654q.082-.152.238-.23.156-.077.378-.077.224 0 .38.077.154.078.239.23.039.064.054.183.015.118.015.397v2.614h.521V1.477q0-.59-.073-.839Q2.65.39 2.47.227 2.3.075 2.08 0q-.219-.075-.492-.075-.27 0-.49.075Q.88.075.706.227.53.387.454.64q-.075.254-.075.836Z"/>
+    </symbol>
+    <symbol id="bS" overflow="visible">
+      <path d="M2 2.06q.38-.1.58-.357.202-.257.202-.64 0-.532-.357-.835-.357-.303-.989-.303-.266 0-.541.05Q.619.022.353.115v.518Q.616.498.871.431q.256-.067.508-.067.428 0 .658.193.23.193.23.557 0 .335-.23.532t-.622.197h-.397v.428h.397q.359 0 .56.158.2.157.2.438 0 .296-.186.455-.187.158-.532.158-.23 0-.475-.051-.245-.052-.513-.155v.48q.312.082.556.123.243.042.432.042.562 0 .898-.283.337-.282.337-.748 0-.318-.177-.529-.177-.211-.514-.3Z"/>
+    </symbol>
+    <symbol id="bT" overflow="visible">
+      <path d="M0 2.888h.47L.971.554l.412 1.49h.405l.418-1.49.503 2.334h.469L2.503 0H2.05l-.462 1.583L1.13 0H.675L0 2.888Z"/>
+    </symbol>
+    <symbol id="bU" overflow="visible">
+      <path d="M.503 1.093v1.79h.474v-1.79q0-.39.138-.572.138-.183.427-.183.335 0 .513.236t.178.676v1.632h.477V0h-.477v.433q-.127-.25-.345-.379-.217-.129-.509-.129-.443 0-.66.29-.216.29-.216.878Z"/>
+    </symbol>
+    <symbol id="bV" overflow="visible">
+      <path d="M.962.438H2.73V0H.392v.438q.482.508.843.897.36.39.498.55.257.314.348.509.09.194.09.398 0 .322-.19.505t-.52.183q-.234 0-.492-.085-.257-.085-.546-.257v.526q.265.126.522.19.256.065.506.065.565 0 .91-.3.343-.301.343-.788 0-.248-.114-.495-.115-.248-.373-.547-.144-.167-.419-.464Q1.524 1.03.962.438Z"/>
+    </symbol>
+    <symbol id="bW" overflow="visible">
+      <path d="M1.59 3.047q.284 0 .53-.103.244-.103.448-.307.203-.203.304-.448.1-.245.1-.534 0-.28-.1-.526-.1-.245-.304-.448Q2.364.48 2.119.376 1.874.273 1.59.273q-.284 0-.53.103Q.816.48.612.681q-.204.203-.304.448t-.1.526q0 .289.1.534.1.245.304.448.204.204.449.307.245.103.53.103Zm0-.363q-.21 0-.394-.078-.178-.077-.327-.224Q.717 2.23.643 2.05.57 1.87.57 1.655q0-.206.073-.387.074-.18.226-.332.15-.147.327-.224.183-.078.393-.078.21 0 .391.078.18.077.33.224.152.152.226.332.073.18.073.387 0 .214-.073.395-.074.18-.226.332-.15.147-.33.224-.18.078-.39.078Zm-.182-.134h.36v-.714h.712v-.361H1.77V.768h-.361v.707h-.71v.36h.71v.715Z"/>
+    </symbol>
+  </defs>
+</svg>

--- a/packages/preview/quill/0.4.0/docs/images/logo.svg
+++ b/packages/preview/quill/0.4.0/docs/images/logo.svg
@@ -1,0 +1,173 @@
+<svg class="typst-doc" viewBox="0 0 239.6381640625 61.412031228417966" width="239.6381640625" height="61.412031228417966" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(1 1)">
+            <path class="typst-shape" fill="#ffffff" d="M 0.87867963 0.87867963 C 1.4412888 0.31607053 2.2043505 0 3 0 L 234.63817 0 C 236.29501 0.00000000000000032750764 237.63817 1.3431457 237.63817 3 L 237.63817 56.412033 C 237.63817 58.068886 236.29501 59.412033 234.63817 59.412033 L 3 59.412033 C 1.3431457 59.412033 0.000000000000000082243954 58.068886 0.00000000000000018369701 56.412033 L 0.0000000000000034542406 3 C 0.0000000000000035029602 2.2043505 0.31607053 1.4412888 0.87867963 0.87867963 Z "/>
+        </g>
+        <g transform="translate(41.3 12.5)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(9 -3.5)">
+                        <path class="typst-shape" fill="#cce3f7" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 3" d="M 0 0 L 0 43.412033 L 120.09316 43.412033 L 120.09316 0 Z "/>
+                    </g>
+                    <g transform="translate(0 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
+                    </g>
+                    <g transform="translate(66.7931640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
+                    </g>
+                    <g transform="translate(46.4931640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.3 0 "/>
+                    </g>
+                    <g transform="translate(69.0931640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
+                    </g>
+                    <g transform="translate(87.0931640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 33 0 "/>
+                    </g>
+                    <g transform="translate(148.2156640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
+                    </g>
+                    <g transform="translate(150.2156640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
+                    </g>
+                    <g transform="translate(120.0931640625 7.414999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1225 0 "/>
+                    </g>
+                    <g transform="translate(0 28.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
+                    </g>
+                    <g transform="translate(0 30.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
+                    </g>
+                    <g transform="translate(66.7931640625 29.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 0 "/>
+                    </g>
+                    <g transform="translate(32.24658203125 28.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 34.54658 0 "/>
+                    </g>
+                    <g transform="translate(32.24658203125 30.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 34.54658 0 "/>
+                    </g>
+                    <g transform="translate(69.0931640625 28.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
+                    </g>
+                    <g transform="translate(69.0931640625 30.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
+                    </g>
+                    <g transform="translate(87.0931640625 29.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.9" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="0.9 4" d="M 0 0 L 33 0 "/>
+                    </g>
+                    <g transform="translate(149.2156640625 29.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 0 "/>
+                    </g>
+                    <g transform="translate(120.0931640625 28.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1225 0 "/>
+                    </g>
+                    <g transform="translate(120.0931640625 30.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1225 0 "/>
+                    </g>
+                    <g transform="translate(151.5156640625 28.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 26.8225 0 "/>
+                    </g>
+                    <g transform="translate(151.5156640625 30.121015625)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 26.8225 0 "/>
+                    </g>
+                    <g transform="translate(0 0)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 94.29317 26.962812 C 94.29317 26.962812 95.79317 13.683 115.79317 -1.317 "/>
+                    </g>
+                    <g transform="translate(0 0)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 95.79317 13.683 115.79317 -1.317 "/>
+                    </g>
+                    <g transform="translate(0 0)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 98.79317 13.683 115.79317 -1.317 "/>
+                    </g>
+                    <g transform="translate(0 0)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 101.79317 17.683 115.79317 -1.317 "/>
+                    </g>
+                    <g transform="translate(0 16.415)"/>
+                    <g transform="translate(-21.3 -0.0000000000000008881784197001252)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(4 4)"/>
+                                <g transform="translate(4 3.33)"/>
+                                <g transform="translate(4 3.33)"/>
+                                <g transform="translate(4 10.83)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g0" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(6.78 3.8900000000000006)"/>
+                                <g transform="translate(6.78 10.83)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g1" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(13.41 3.33)"/>
+                                <g transform="translate(13.41 10.83)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g2" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(17.3 10.83)"/>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(18 0.12398437499999915)">
+                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0.58578646 0.58578646 C 0.9608592 0.21071368 1.4695671 0 2 0 L 26.493164 0 C 27.597734 0.00000000000000017746116 28.493164 0.8954305 28.493164 2 L 28.493164 12.582031 C 28.493164 13.686601 27.597734 14.582031 26.493164 14.582031 L 2 14.582031 C 0.8954305 14.582031 0.000000000000000054829306 13.686601 0.00000000000000012246469 12.582031 L 0.00000000000000077042723 2 C 0.00000000000000080290687 1.4695671 0.21071368 0.9608592 0.58578646 0.58578646 Z "/>
+                    </g>
+                    <g transform="translate(22 10.706015625)">
+                        <g class="typst-text" transform="scale(0.0048828125 -0.0048828125)">
+                            <use xlink:href="#g3" x="0" fill="#000000"/>
+                            <use xlink:href="#g4" x="2562" fill="#000000"/>
+                            <use xlink:href="#g5" x="3117" fill="#000000"/>
+                            <use xlink:href="#g5" x="3657" fill="#000000"/>
+                        </g>
+                    </g>
+                    <g transform="translate(64.4931640625 5.114999999999999)">
+                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                    </g>
+                    <g transform="translate(138.0931640625 -0.0000000000000008881784197001252)">
+                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 22.245 14.83 L 22.245 0 Z "/>
+                    </g>
+                    <g transform="translate(142.0931640625 3.999999999999999)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 7.513 C 0 7.513 1.4245 2.732 7.1225 2.732 C 12.8205 2.732 14.245 7.513 14.245 7.513 "/>
+                    </g>
+                    <g transform="translate(149.2156640625 12.195999999999998)">
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 5.698 -6.147 "/>
+                    </g>
+                    <g transform="translate(142.0931640625 3.999999999999999)">
+                        <path class="typst-shape" fill="#000000" d="M 15.403605 -0.73803514 C 15.403605 -0.73803514 11.793697 1.0973295 11.793697 1.0973295 C 11.793697 1.0973295 13.847302 3.0006704 13.847302 3.0006704 C 13.847302 3.0006704 15.403605 -0.73803514 15.403605 -0.73803514 Z "/>
+                    </g>
+                    <g transform="translate(64.4931640625 26.821015624999998)">
+                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                    </g>
+                    <g transform="translate(146.91566406249999 26.821015624999998)">
+                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0 0)"/>
+    </g>
+    <defs id="glyph">
+        <symbol id="g0" overflow="visible">
+            <path d="M 139 -250 C 152.33333 -250 159 -242 159 -226 L 159 726 C 159 742 152.33333 750 139 750 C 125.66667 750 119 742 119 726 L 119 -226 C 119 -242 125.66667 -250 139 -250 Z "/>
+        </symbol>
+        <symbol id="g1" overflow="visible">
+            <path d="M 534 393 C 534 383.6667 539.3333 373.6667 550 363 C 573.3333 341 585 314 585 282 C 585 253.33333 575.6667 221.66667 557 187 C 521.6667 119.66667 476.33334 71.66667 421 43 C 387.6667 26.333328 354.6667 17.666672 322 17 L 484 663 C 486 671.6667 487 677 487 679 C 487 689 481.6667 694 471 694 C 466.3333 694 462.66666 693 460 691 C 456 683 453.6667 676.3333 453 671 L 290 19 C 219.33333 28.333328 184 64 184 126 C 184 153.33333 201.66667 214.33333 237 309 C 244.33333 329 248 345.6667 248 359 C 248 408.5749 212.90883 444 163 444 C 118.33333 444 83.66667 419 59 369 C 39 329 29 302 29 288 C 29 278.6667 34.33333 274 45 274 C 58.389786 274 59.966278 279.882 64 294 C 87.33333 374 119.33333 414 160 414 C 174 414 181 405 181 387 C 181 371 173.66667 343 159 303 C 127 218.33333 111 162 111 134 C 111 46.66667 168 -1.3333282 282 -10 C 274 -45.33333 267 -74 261 -96 C 245.66667 -152.66667 238 -184.66667 238 -192 C 240.70691 -200.12073 241.86992 -205 255 -205 L 265 -201 C 271 -185 275.6667 -170.33333 279 -157 L 315 -13 C 397 -11.666672 469 24.333328 531 95 C 563.6667 131.66667 588 171.66667 604 215 C 624.6667 270.3333 635 322.3333 635 371 C 635 419.6667 619.3333 444 588 444 C 562.25916 444 534 418.5208 534 393 Z "/>
+        </symbol>
+        <symbol id="g2" overflow="visible">
+            <path d="M 278 242 C 278.6667 244 279 246.66667 279 250 C 279 253.33333 278.6667 256 278 258 L 98 735 C 94 745 86.66667 750 76 750 C 60.66667 750 53 742 53 726 C 53 722.6667 53.33333 720 54 718 L 231 250 L 54 -217 C 53.33333 -219 53 -222 53 -226 C 53 -242 60.66667 -250 76 -250 C 86.66667 -250 94 -245 98 -235 Z "/>
+        </symbol>
+        <symbol id="g3" overflow="visible">
+            <path d="M 1171 -250 Q 1316 -307 1409.5 -328.5 Q 1503 -350 1616 -350 Q 1696 -350 1807.5 -317.5 Q 1919 -285 2017 -229 L 2052 -266 Q 1954 -356 1808.5 -409.5 Q 1663 -463 1503 -463 Q 1257 -463 1030 -369 Q 837 -291 734 -261 Q 631 -231 528 -231 Q 481 -231 428 -273 Q 396 -310 365 -354 L 283 -313 Q 377 -184 520 -80 Q 570 -43 625 -15 Q 387 16 231.5 191.5 Q 76 367 76 635 Q 76 942 246 1145 Q 416 1348 705 1348 Q 990 1348 1177 1165.5 Q 1364 983 1364 674 Q 1364 418 1237 238 Q 1089 28 827 -12 Q 706 -45 580 -135 Q 570 -142 560 -150 Q 592 -146 623 -145 Q 903 -146 1171 -250 Z M 678 1274 Q 510 1274 391 1122.5 Q 272 971 272 670 Q 272 387 415.5 220 Q 559 53 758 53 Q 938 53 1052.5 210 Q 1167 367 1167 635 Q 1167 934 1028 1104 Q 889 1274 678 1274 Z M 1921 -20 Q 1780 -20 1718.5 58.5 Q 1657 137 1657 258 L 1657 651 Q 1657 747 1631.5 778 Q 1606 809 1530 815 Q 1520 823 1520 847.5 Q 1520 872 1530 883 Q 1669 879 1739 879 Q 1790 879 1810 883 Q 1826 883 1827 870 Q 1819 720 1819 659 L 1819 287 Q 1819 166 1869 121 Q 1919 76 1982 76 Q 2072 76 2187 174 Q 2220 203 2220 254 L 2220 649 Q 2220 747 2195.5 779 Q 2171 811 2093 815 Q 2085 823 2085 847.5 Q 2085 872 2093 883 Q 2232 879 2302 879 Q 2353 879 2374 883 Q 2390 883 2390 870 Q 2382 720 2382 659 L 2382 266 Q 2382 186 2409.5 155.5 Q 2437 125 2531 117 Q 2539 107 2539.5 88.5 Q 2540 70 2531 61 Q 2367 43 2290 -20 Q 2272 -28 2251 -20 Q 2233 50 2228 100 Q 2226 110 2216 109.5 Q 2206 109 2198 102 Q 2048 -20 1921 -20 Z "/>
+        </symbol>
+        <symbol id="g4" overflow="visible">
+            <path d="M 184 1227 Q 184 1264 219 1294.5 Q 254 1325 291 1325 Q 330 1325 359.5 1291 Q 389 1257 389 1219 Q 389 1184 356.5 1152 Q 324 1120 283 1120 Q 246 1120 215 1154 Q 184 1188 184 1227 Z M 371 250 Q 371 127 395.5 98.5 Q 420 70 518 63 Q 528 53 528 28.5 Q 528 4 518 -4 Q 383 0 291 0 Q 197 0 61 -4 Q 53 4 53 28.5 Q 53 53 61 63 Q 159 71 184 99 Q 209 127 209 250 L 209 649 Q 209 735 185.5 757.5 Q 162 780 76 788 Q 64 823 72 846 Q 262 871 352 905 Q 379 905 379 891 Q 371 760 371 658 L 371 250 Z "/>
+        </symbol>
+        <symbol id="g5" overflow="visible">
+            <path d="M 195 250 L 195 1145 Q 195 1258 174.5 1282.5 Q 154 1307 63 1313 Q 40 1336 51 1374 Q 233 1388 338 1430 Q 365 1430 365 1409 Q 357 1327 356 1194 L 356 250 Q 356 127 382 97.5 Q 408 68 504 63 Q 512 53 512 28.5 Q 512 4 504 -4 Q 369 0 276 0 Q 190 0 47 -4 Q 37 4 37 28.5 Q 37 53 47 63 Q 143 67 169 97 Q 195 127 195 250 Z "/>
+        </symbol>
+    </defs>
+    <defs id="clip-path"/>
+</svg>

--- a/packages/preview/quill/0.4.0/docs/images/phase-estimation.svg
+++ b/packages/preview/quill/0.4.0/docs/images/phase-estimation.svg
@@ -1,0 +1,1004 @@
+<svg class="typst-doc" viewBox="0 0 481.74768750000004 197.9403" width="481.74768750000004" height="197.9403" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(-0 -0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0.87867963 0.87867963 C 1.4412888 0.31607053 2.2043505 0 3 0 L 478.74768 0 C 480.40454 0.00000000000000032750764 481.74768 1.3431457 481.74768 3 L 481.74768 194.9403 C 481.74768 196.59715 480.40454 197.9403 478.74768 197.9403 L 3 197.9403 C 1.3431457 197.9403 0.000000000000000082243954 196.59715 0.00000000000000018369701 194.9403 L 0.000000000000011936651 3 C 0.0000000000000119853705 2.2043505 0.31607053 1.4412888 0.87867963 0.87867963 Z "/>
+        </g>
+        <g transform="translate(6 6)">
+            <g class="typst-group">
+                <g transform="matrix(1.3 0 0 1.3 0 0)">
+                    <g transform="translate(70.904375 4.000000000000001)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(33 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(62.09 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 120.66 0 "/>
+                                </g>
+                                <g transform="translate(182.75 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(238.585 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 118.7605 "/>
+                                </g>
+                                <g transform="translate(211.12 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(240.88500000000002 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 25.165 0 "/>
+                                </g>
+                                <g transform="translate(33 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(62.09 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 60.33 0 "/>
+                                </g>
+                                <g transform="translate(158.64 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 81.9305 "/>
+                                </g>
+                                <g transform="translate(122.42000000000002 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 36.22 0 "/>
+                                </g>
+                                <g transform="translate(160.94 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 21.81 0 "/>
+                                </g>
+                                <g transform="translate(182.75 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(211.12 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(238.585 44.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(33 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(62.09 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(122.42000000000002 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 55.1005 "/>
+                                </g>
+                                <g transform="translate(86.2 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 36.22 0 "/>
+                                </g>
+                                <g transform="translate(124.72000000000001 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 58.03 0 "/>
+                                </g>
+                                <g transform="translate(182.75 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(211.12 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(238.585 71.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(33 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(86.2 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 28.2705 "/>
+                                </g>
+                                <g transform="translate(62.09 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(88.5 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 94.25 0 "/>
+                                </g>
+                                <g transform="translate(182.75 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(211.12 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(238.585 97.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(33 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(33 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(33 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(33 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.545 0 "/>
+                                </g>
+                                <g transform="translate(53.545 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.655 0 "/>
+                                </g>
+                                <g transform="translate(53.545 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.655 0 "/>
+                                </g>
+                                <g transform="translate(53.545 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.655 0 "/>
+                                </g>
+                                <g transform="translate(53.545 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.655 0 "/>
+                                </g>
+                                <g transform="translate(98.31 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(98.31 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(98.31 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(98.31 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(134.53000000000003 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(134.53000000000003 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(134.53000000000003 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(134.53000000000003 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.11 0 "/>
+                                </g>
+                                <g transform="translate(170.75 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(170.75 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(170.75 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(170.75 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(182.75 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(182.75 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(182.75 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(182.75 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.185 0 "/>
+                                </g>
+                                <g transform="translate(211.12 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(211.12 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(211.12 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(211.12 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.465 0 "/>
+                                </g>
+                                <g transform="translate(254.05 122.2755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(254.05 124.8755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(254.05 127.4755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(254.05 130.0755)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 12 0 "/>
+                                </g>
+                                <g transform="translate(-58.404765624999996 7.414999999999999)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(59.884765625 -2.5)"/>
+                                            <g transform="translate(59.884765625 -2.5)"/>
+                                            <g transform="translate(59.884765625 -2.5)"/>
+                                            <g transform="translate(59.884765625 85.49000000000001)"/>
+                                            <g transform="translate(59.884765625 92.99000000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 78.54786464088399)"/>
+                                            <g transform="translate(59.884765625 86.02786464088399)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 71.962682320442)"/>
+                                            <g transform="translate(59.884765625 79.442682320442)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 65.37750000000001)"/>
+                                            <g transform="translate(59.884765625 72.85750000000002)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 58.792317679558025)"/>
+                                            <g transform="translate(59.884765625 66.27231767955803)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 52.20713535911604)"/>
+                                            <g transform="translate(59.884765625 59.68713535911604)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 37.74500000000001)"/>
+                                            <g transform="translate(59.884765625 52.74500000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 30.802864640883982)"/>
+                                            <g transform="translate(59.884765625 38.282864640883986)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 24.217682320441998)"/>
+                                            <g transform="translate(59.884765625 31.697682320442)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 17.63250000000001)"/>
+                                            <g transform="translate(59.884765625 25.11250000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 11.047317679558024)"/>
+                                            <g transform="translate(59.884765625 18.527317679558024)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 4.462135359116036)"/>
+                                            <g transform="translate(59.884765625 11.942135359116037)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 -2.499999999999986)"/>
+                                            <g transform="translate(59.884765625 5.000000000000014)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.884765625 92.99000000000001)"/>
+                                            <g transform="translate(0 31.288984375000005)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(4 10.58203125)">
+                                                            <g class="typst-text" transform="scale(0.0048828125 -0.0048828125)">
+                                                                <use xlink:href="#g4" x="0" fill="#000000"/>
+                                                                <use xlink:href="#g5" x="993" fill="#000000"/>
+                                                                <use xlink:href="#g6" x="1548" fill="#000000"/>
+                                                                <use xlink:href="#g7" x="2309" fill="#000000"/>
+                                                                <use xlink:href="#g8" x="3107" fill="#000000"/>
+                                                                <use xlink:href="#g6" x="4266" fill="#000000"/>
+                                                                <use xlink:href="#g9" x="5011" fill="#000000"/>
+                                                                <use xlink:href="#g10" x="5926" fill="#000000"/>
+                                                                <use xlink:href="#g5" x="6950" fill="#000000"/>
+                                                                <use xlink:href="#g7" x="7505" fill="#000000"/>
+                                                                <use xlink:href="#g8" x="8303" fill="#000000"/>
+                                                                <use xlink:href="#g9" x="8950" fill="#000000"/>
+                                                                <use xlink:href="#g6" x="9865" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(14.372734375 17.08203125)"/>
+                                                        <g transform="translate(14.372734375 17.65203125)"/>
+                                                        <g transform="translate(14.372734375 23.91203125)">
+                                                            <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                                <use xlink:href="#g11" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(17.982734375 23.91203125)"/>
+                                                        <g transform="translate(17.982734375 23.91203125)">
+                                                            <g class="typst-text" transform="scale(0.0048828125 -0.0048828125)">
+                                                                <use xlink:href="#g12" x="512" fill="#000000"/>
+                                                                <use xlink:href="#g13" x="1542" fill="#000000"/>
+                                                                <use xlink:href="#g14" x="2629" fill="#000000"/>
+                                                                <use xlink:href="#g5" x="3638" fill="#000000"/>
+                                                                <use xlink:href="#g8" x="4193" fill="#000000"/>
+                                                                <use xlink:href="#g7" x="4840" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(33 16.415)"/>
+                                <g transform="translate(13.329999999999998 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(45 -0.0000000000000008881784197001252)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(49 3.999999999999999)"/>
+                                <g transform="translate(49 3.999999999999999)"/>
+                                <g transform="translate(49 10.829999999999998)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g18" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(58.089999999999996 10.829999999999998)"/>
+                                <g transform="translate(194.75 2.884999999999999)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(198.75 6.884999999999999)"/>
+                                <g transform="translate(198.75 6.884999999999999)"/>
+                                <g transform="translate(198.75 7.944999999999999)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g19" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(198.75 7.944999999999999)"/>
+                                <g transform="translate(236.285 5.114999999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(266.05 16.415)"/>
+                                <g transform="translate(266.05 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(33 53.245)"/>
+                                <g transform="translate(13.329999999999998 36.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(45 36.83)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(49 40.83)"/>
+                                <g transform="translate(49 40.83)"/>
+                                <g transform="translate(49 47.66)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g18" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(58.089999999999996 47.66)"/>
+                                <g transform="translate(156.33999999999997 41.945)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(194.75 39.714999999999996)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(198.75 43.714999999999996)"/>
+                                <g transform="translate(198.75 43.714999999999996)"/>
+                                <g transform="translate(198.75 44.775)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g19" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(198.75 44.775)"/>
+                                <g transform="translate(266.05 53.245)"/>
+                                <g transform="translate(266.05 36.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(33 80.07499999999999)"/>
+                                <g transform="translate(13.329999999999998 63.65999999999999)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(45 63.65999999999999)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(49 67.66)"/>
+                                <g transform="translate(49 67.66)"/>
+                                <g transform="translate(49 74.49)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g18" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(58.089999999999996 74.49)"/>
+                                <g transform="translate(120.12000000000002 68.77499999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(194.75 66.54499999999999)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(198.75 70.54499999999999)"/>
+                                <g transform="translate(198.75 70.54499999999999)"/>
+                                <g transform="translate(198.75 71.60499999999999)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g19" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(198.75 71.60499999999999)"/>
+                                <g transform="translate(266.05 80.07499999999999)"/>
+                                <g transform="translate(266.05 63.65999999999999)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(33 106.905)"/>
+                                <g transform="translate(13.329999999999998 90.49)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(45 90.49)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(49 94.49)"/>
+                                <g transform="translate(49 94.49)"/>
+                                <g transform="translate(49 101.32)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g18" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(58.089999999999996 101.32)"/>
+                                <g transform="translate(83.9 95.605)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(194.75 93.375)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(198.75 97.375)"/>
+                                <g transform="translate(198.75 97.375)"/>
+                                <g transform="translate(198.75 98.435)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g19" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(198.75 98.435)"/>
+                                <g transform="translate(266.05 106.905)"/>
+                                <g transform="translate(266.05 90.49)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.67 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(-66.904375 118.884484375)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(70.734375 -1.708984375)"/>
+                                            <g transform="translate(70.734375 -1.708984375)"/>
+                                            <g transform="translate(70.734375 -1.708984375)"/>
+                                            <g transform="translate(70.734375 9.791015625)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g20" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(70.734375 16.291015625)"/>
+                                            <g transform="translate(4 10.58203125)">
+                                                <g class="typst-text" transform="scale(0.0048828125 -0.0048828125)">
+                                                    <use xlink:href="#g21" x="0" fill="#000000"/>
+                                                    <use xlink:href="#g9" x="993" fill="#000000"/>
+                                                    <use xlink:href="#g22" x="1922" fill="#000000"/>
+                                                    <use xlink:href="#g23" x="2798" fill="#000000"/>
+                                                    <use xlink:href="#g24" x="3830" fill="#000000"/>
+                                                    <use xlink:href="#g25" x="4940" fill="#000000"/>
+                                                    <use xlink:href="#g6" x="6488" fill="#000000"/>
+                                                    <use xlink:href="#g9" x="7233" fill="#000000"/>
+                                                    <use xlink:href="#g10" x="8148" fill="#000000"/>
+                                                    <use xlink:href="#g5" x="9172" fill="#000000"/>
+                                                    <use xlink:href="#g7" x="9727" fill="#000000"/>
+                                                    <use xlink:href="#g8" x="10525" fill="#000000"/>
+                                                    <use xlink:href="#g9" x="11172" fill="#000000"/>
+                                                    <use xlink:href="#g6" x="12087" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(33 135.1755)"/>
+                                <g transform="translate(12.61 118.7605)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 6.41)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g26" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(12.5 3.33)"/>
+                                            <g transform="translate(12.5 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(16.39 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(74.09 117.32)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 17.711 L 24.22 17.711 L 24.22 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 6.671000000000001)"/>
+                                            <g transform="translate(4 13.501000000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g27" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.879999999999999 4.000000000000001)"/>
+                                            <g transform="translate(11.879999999999999 5.223000000000001)"/>
+                                            <g transform="translate(11.879999999999999 9.871000000000002)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g28" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.863 4.000000000000002)"/>
+                                            <g transform="translate(15.863 7.330000000000002)">
+                                                <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                    <use xlink:href="#g29" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 13.711000000000002)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(110.31000000000002 117.32)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 17.711 L 24.22 17.711 L 24.22 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 6.671000000000001)"/>
+                                            <g transform="translate(4 13.501000000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g27" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.879999999999999 4.000000000000001)"/>
+                                            <g transform="translate(11.879999999999999 5.223000000000001)"/>
+                                            <g transform="translate(11.879999999999999 9.871000000000002)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g28" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.863 4.000000000000002)"/>
+                                            <g transform="translate(15.863 7.330000000000002)">
+                                                <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                    <use xlink:href="#g30" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 13.711000000000002)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(146.52999999999997 117.32)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 17.711 L 24.22 17.711 L 24.22 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 6.671000000000001)"/>
+                                            <g transform="translate(4 13.501000000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g27" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.879999999999999 4.000000000000001)"/>
+                                            <g transform="translate(11.879999999999999 5.223000000000001)"/>
+                                            <g transform="translate(11.879999999999999 9.871000000000002)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g28" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.863 4.000000000000002)"/>
+                                            <g transform="translate(15.863 7.330000000000002)">
+                                                <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                    <use xlink:href="#g31" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 13.711000000000002)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(194.75 121.6455)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(198.75 125.6455)"/>
+                                <g transform="translate(198.75 125.6455)"/>
+                                <g transform="translate(198.75 126.7055)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g19" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(198.75 126.7055)"/>
+                                <g transform="translate(223.12 117.32)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 17.711 L 30.93 17.711 L 30.93 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 6.671000000000001)"/>
+                                            <g transform="translate(4 13.501000000000001)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g27" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.879999999999999 4.000000000000001)"/>
+                                            <g transform="translate(11.879999999999999 5.223000000000001)"/>
+                                            <g transform="translate(11.879999999999999 9.871000000000002)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g28" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.863 4.000000000000002)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 0.20000000000000018)"/>
+                                                        <g transform="translate(0 3.33)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g32" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(2.82 1.95)"/>
+                                                        <g transform="translate(2.82 3.33)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g33" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(6.71 0)"/>
+                                                        <g transform="translate(6.71 3.33)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g30" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 13.711000000000002)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(266.05 135.1755)"/>
+                                <g transform="translate(266.05 118.7605)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 6.41)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g26" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(12.5 3.33)"/>
+                                            <g transform="translate(12.5 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(16.39 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0 0)"/>
+    </g>
+    <defs id="glyph">
+        <symbol id="g0" overflow="visible">
+            <path d="M 723 0 C 742.333 0 752 10 752 30 C 752 43.333008 745.667 52.333008 733 57 C 671 79.66699 617.5 122 572.5 184 C 527.5 246 505 309.667 505 375 L 505 750 L 397 750 L 397 375 C 397 296.333 431.333 220 500 146 C 560.667 79.33301 631.667 31.333008 713 2 C 717 0.6669922 720.333 0 723 0 Z "/>
+        </symbol>
+        <symbol id="g1" overflow="visible">
+            <path d="M 397 0 L 505 0 L 505 748 L 397 748 Z "/>
+        </symbol>
+        <symbol id="g2" overflow="visible">
+            <path d="M 250 750 C 368.3203 814.23047 505 959.06934 505 1123 L 505 1500 L 397 1500 L 397 1123 C 397 1052.333 375.667 983.667 333 917 C 288.333 847.667 233.66699 801.333 169 778 C 156.33301 773.333 150 764 150 750 C 150 736 156.33301 726.667 169 722 C 233.66699 698.667 288.333 652.333 333 583 C 375.667 516.333 397 447.667 397 377 L 397 0 L 505 0 L 505 377 C 505 541.1094 368.49707 685.67285 250 750 Z "/>
+        </symbol>
+        <symbol id="g3" overflow="visible">
+            <path d="M 733 693 C 745.667 697.667 752 706.667 752 720 C 752 740 742.333 750 723 750 C 720.333 750 717 749.333 713 748 C 631.667 718.667 560.667 670.667 500 604 C 431.333 530 397 453.667 397 375 L 397 0 L 505 0 L 505 375 C 505 440.333 527.5 504 572.5 566 C 617.5 628 671 670.333 733 693 Z "/>
+        </symbol>
+        <symbol id="g4" overflow="visible">
+            <path d="M 580 662 L 389 662 L 389 250 Q 389 127 421 97.5 Q 453 68 567 63 Q 577 53 577.5 28.5 Q 578 4 567 -4 Q 424 0 303 0 Q 180 0 37 -4 Q 29 4 29 28.5 Q 29 53 37 63 Q 152 67 183.5 97 Q 215 127 215 250 L 215 1071 Q 215 1194 183.5 1223.5 Q 152 1253 37 1257 Q 29 1265 29 1290 Q 29 1315 37 1325 Q 201 1321 301 1321 L 824 1321 Q 878 1321 920 1329 Q 927 1329 928 1323 Q 950 1205 973 1026 Q 946 1016 909 1016 Q 884 1096 855.5 1139 Q 827 1182 763.5 1210.5 Q 700 1239 596 1239 L 504 1239 Q 434 1239 411.5 1214.5 Q 389 1190 389 1108 L 389 739 L 580 739 Q 705 739 733.5 763.5 Q 762 788 766 879 Q 774 889 798.5 889 Q 823 889 834 879 Q 830 773 829 702 Q 829 624 834 522 Q 824 512 799 512 Q 774 512 766 522 Q 762 577 753.5 601 Q 745 625 704.5 643.5 Q 664 662 580 662 Z "/>
+        </symbol>
+        <symbol id="g5" overflow="visible">
+            <path d="M 184 1227 Q 184 1264 219 1294.5 Q 254 1325 291 1325 Q 330 1325 359.5 1291 Q 389 1257 389 1219 Q 389 1184 356.5 1152 Q 324 1120 283 1120 Q 246 1120 215 1154 Q 184 1188 184 1227 Z M 371 250 Q 371 127 395.5 98.5 Q 420 70 518 63 Q 528 53 528 28.5 Q 528 4 518 -4 Q 383 0 291 0 Q 197 0 61 -4 Q 53 4 53 28.5 Q 53 53 61 63 Q 159 71 184 99 Q 209 127 209 250 L 209 649 Q 209 735 185.5 757.5 Q 162 780 76 788 Q 64 823 72 846 Q 262 871 352 905 Q 379 905 379 891 Q 371 760 371 658 L 371 250 Z "/>
+        </symbol>
+        <symbol id="g6" overflow="visible">
+            <path d="M 360 733 Q 360 723 366.5 719 Q 373 715 383 729 Q 424 799 484.5 849 Q 545 899 610 899 Q 669 899 701 867.5 Q 733 836 733 801 Q 733 762 703.5 730 Q 674 698 637 698 Q 599 698 563 746 Q 543 772 510 772 Q 485 772 416 672 Q 367 598 367 535 L 367 250 Q 367 127 394.5 99.5 Q 422 72 535 63 Q 545 53 545 28.5 Q 545 4 535 -4 Q 392 0 287 0 Q 197 0 53 -4 Q 45 4 45 28.5 Q 45 53 53 63 Q 153 69 179 98 Q 205 127 205 250 L 205 649 Q 205 735 181.5 757.5 Q 158 780 72 788 Q 60 823 68 846 Q 220 866 319 905 Q 335 905 344 889 Q 354 864 360 733 Z "/>
+        </symbol>
+        <symbol id="g7" overflow="visible">
+            <path d="M 98 283 Q 108 293 130 293 Q 152 293 162 285 Q 195 146 242 96.5 Q 289 47 387 47 Q 453 47 507 84 Q 561 121 561 190 Q 561 258 519 299 Q 477 340 352 391 Q 229 442 178 501.5 Q 127 561 127 670 Q 127 766 213 832.5 Q 299 899 416 899 Q 463 899 512 892 Q 561 885 615.5 873.5 Q 670 862 684 860 Q 680 751 672 643 Q 662 633 639 633 Q 616 633 606 641 Q 596 702 572.5 743 Q 549 784 517 801.5 Q 485 819 461.5 825 Q 438 831 416 831 Q 361 831 316.5 795.5 Q 272 760 272 700 Q 272 623 318.5 587.5 Q 365 552 477 510 Q 717 421 717 238 Q 717 166 683 112.5 Q 649 59 596 31.5 Q 543 4 491.5 -8 Q 440 -20 391 -20 Q 291 -20 205 2 Q 191 6 164 6 Q 144 6 113 0 Q 112 107 98 283 Z "/>
+        </symbol>
+        <symbol id="g8" overflow="visible">
+            <path d="M 88 879 L 182 879 Q 182 957 181 1008 Q 180 1059 179 1074.5 Q 178 1090 177 1100 Q 176 1110 176 1116 Q 176 1131 221 1144 Q 257 1154 291 1173 Q 325 1191 336 1192 Q 352 1192 352 1174 Q 344 1092 344 958 L 344 879 L 590 879 Q 606 879 606 866 L 606 825 Q 606 798 557 799 L 344 799 L 344 281 Q 344 181 358.5 136.5 Q 373 92 412 92 Q 506 92 580 150 Q 611 148 616 115 Q 495 -20 340 -20 Q 182 -20 182 182 L 182 799 L 61 799 Q 51 799 51 811 L 51 838 Q 51 879 88 879 Z "/>
+        </symbol>
+        <symbol id="g9" overflow="visible">
+            <path d="M 254 578 L 625 584 Q 656 584 655 612 Q 655 729 605 778 Q 555 827 485 827 Q 458 827 432 820 Q 406 813 368 790.5 Q 330 768 299 713 Q 268 658 254 578 Z M 791 190 Q 826 188 834 158 Q 697 -20 485 -20 Q 282 -20 172 111 Q 76 222 76 414 Q 76 631 206 763 Q 336 895 485 895 Q 831 895 831 539 Q 831 504 793 504 L 248 508 Q 248 336 313 227 Q 403 80 537 80 Q 623 80 677.5 104.5 Q 732 129 791 190 Z "/>
+        </symbol>
+        <symbol id="g10" overflow="visible">
+            <path d="M 653 571 Q 653 698 602 767 Q 551 836 455 836 Q 291 836 291 618 Q 291 561 297 519 Q 303 477 321.5 433 Q 340 389 380 365.5 Q 420 342 481 342 Q 653 342 653 571 Z M 270 -20 Q 207 -96 207 -213 Q 207 -305 293 -358.5 Q 379 -412 453 -412 Q 549 -412 639 -387 Q 729 -362 791.5 -309 Q 854 -256 854 -186 Q 854 -147 831.5 -120.5 Q 809 -94 750 -59 Q 687 -24 502 -25 Q 492 -25 440.5 -28 Q 389 -31 352 -31 Q 307 -30 270 -20 Z M 909 793 Q 870 793 852 829 Q 836 854 811 854 Q 793 854 767 837.5 Q 741 821 729 805 Q 817 715 817 592 Q 817 449 715.5 364 Q 614 279 471 279 Q 358 279 285 322 Q 248 271 248 203 Q 248 144 287 115 Q 326 86 379 86 L 440 90 Q 522 100 578 100 Q 795 100 877 33 Q 967 -41 967 -133 Q 967 -239 880 -322.5 Q 793 -406 662.5 -446.5 Q 532 -487 391 -487 Q 254 -487 160 -432 Q 66 -377 66 -254 Q 66 -107 233 -6 Q 139 41 139 152 Q 139 207 163.5 265.5 Q 188 324 229 358 Q 123 460 123 588 Q 123 725 227.5 812 Q 332 899 473 899 Q 600 899 686 842 Q 723 891 784.5 918.5 Q 846 946 891 946 Q 932 946 958.5 924.5 Q 985 903 985 870 Q 985 839 961.5 816 Q 938 793 909 793 Z "/>
+        </symbol>
+        <symbol id="g11" overflow="visible">
+            <path d="M 330 419 C 330 428.3333 319.6667 433 299 433 L 218 433 C 244 537 257 591 257 595 C 257 615.6667 246.33333 626 225 626 C 202.33333 626 188 613 182 587 L 145 433 L 56 433 C 33.69197 433 23 432.28314 23 411 C 23 400.3333 33.33333 395 54 395 L 135 395 C 86.33333 200.33333 62 96.66667 62 84 C 62 28.287582 100.26053 -11 156 -11 C 194 -11 227.33333 6.3333282 256 41 C 280 69.66667 297.3333 97.66667 308 125 C 312 135.66667 314 142.33333 314 145 C 314 154.33333 309 159 299 159 C 291 159 285 153.66667 281 143 C 247 60.33333 205.66667 19 157 19 C 139.66667 19 131 32.66667 131 60 C 131 75.33333 133 91 137 107 L 208 395 L 297 395 C 322.8777 395 330 397.33197 330 419 Z "/>
+        </symbol>
+        <symbol id="g12" overflow="visible">
+            <path d="M 659 754 Q 592 829 498 829 Q 379 829 313.5 729 Q 248 629 248 465 Q 248 354 276.5 273.5 Q 305 193 352 151 Q 399 109 447.5 89.5 Q 496 70 545 70 Q 628 70 680 97 Q 699 107 704 118 Q 709 129 709 158 L 709 629 Q 709 668 698.5 694.5 Q 688 721 659 754 Z M 709 -227 L 709 0 Q 709 31 699 32 Q 689 33 653 11 Q 598 -21 496 -20 Q 293 -20 182.5 119 Q 72 258 72 424 Q 72 627 195.5 763 Q 319 899 506 899 Q 645 899 737 839 Q 756 828 766 833 Q 776 838 797 866 Q 826 905 840 905 Q 871 905 870 854 L 870 -227 Q 870 -350 895 -379 Q 920 -408 1018 -412 Q 1028 -422 1028 -446.5 Q 1028 -471 1018 -479 Q 883 -475 791 -475 Q 705 -475 561 -479 Q 553 -471 553 -446.5 Q 553 -422 561 -412 Q 659 -408 684 -379 Q 709 -350 709 -227 Z "/>
+        </symbol>
+        <symbol id="g13" overflow="visible">
+            <path d="M 444 -20 Q 303 -20 241.5 58.5 Q 180 137 180 258 L 180 651 Q 180 747 154.5 778 Q 129 809 53 815 Q 45 823 45 847.5 Q 45 872 53 883 Q 192 879 262 879 Q 313 879 334 883 Q 350 883 350 870 Q 342 720 342 659 L 342 287 Q 342 166 392 121 Q 442 76 506 76 Q 598 76 711 174 Q 744 203 743 254 L 743 649 Q 743 747 718.5 779 Q 694 811 616 815 Q 606 823 606 847.5 Q 606 872 616 883 Q 755 879 825 879 Q 876 879 897 883 Q 913 883 913 870 Q 905 720 905 659 L 905 266 Q 905 186 933 155.5 Q 961 125 1055 117 Q 1065 107 1065 88.5 Q 1065 70 1055 61 Q 891 43 813 -20 Q 795 -28 774 -20 Q 756 50 752 100 Q 750 110 739.5 109.5 Q 729 109 721 102 Q 569 -20 444 -20 Z "/>
+        </symbol>
+        <symbol id="g14" overflow="visible">
+            <path d="M 356 743 Q 321 712 322 657 L 322 145 Q 400 49 469 49 Q 610 49 684 162.5 Q 758 276 758 459 Q 758 606 691.5 707.5 Q 625 809 530 809 Q 430 809 356 743 Z M 342 807 Q 444 899 571 899 Q 712 899 823 786.5 Q 934 674 934 496 Q 934 267 792.5 123.5 Q 651 -20 481 -20 Q 361 -20 301 30 Q 284 44 272.5 43.5 Q 261 43 245 25 Q 230 8 197 -25 Q 166 -25 152 0 Q 160 39 160 145 L 160 1145 Q 160 1211 157 1243.5 Q 154 1276 131.5 1291.5 Q 109 1307 96.5 1308 Q 84 1309 29 1313 Q 6 1336 16 1374 Q 198 1388 303 1430 Q 330 1430 330 1409 Q 322 1327 322 1194 L 322 817 Q 322 789 342 807 Z "/>
+        </symbol>
+        <symbol id="g15" overflow="visible">
+            <path d="M 139 -250 C 152.33333 -250 159 -242 159 -226 L 159 726 C 159 742 152.33333 750 139 750 C 125.66667 750 119 742 119 726 L 119 -226 C 119 -242 125.66667 -250 139 -250 Z "/>
+        </symbol>
+        <symbol id="g16" overflow="visible">
+            <path d="M 249 -22 C 389.6667 -22 460 92 460 320 C 460 473.3333 428.3333 575 365 625 C 329.6667 652.3333 291.33334 666 250.00002 666 C 109.33334 666 39.000015 550.6667 39.000015 320 C 39.000015 136.38824 87.780106 -22 249.00002 -22 Z M 361 524 C 367.6667 489.3333 371 425.3333 371 332 C 371 240 367.3333 172 360 128 C 347.3333 48 310.3333 8 248.99998 8 C 225.66666 8 203.33331 16.666672 181.99998 34 C 155.33331 56.66667 138.66666 104 131.99998 176 C 129.33331 200.66667 127.999985 252.66667 127.999985 332 C 127.999985 419.3333 130.66666 479.66666 135.99998 513 C 144.66666 567.6667 162.99998 602.6667 190.99998 618 C 212.99998 630 232.33331 636 248.99998 636 C 313.54602 636 349.9783 582.78235 361 524 Z "/>
+        </symbol>
+        <symbol id="g17" overflow="visible">
+            <path d="M 278 242 C 278.6667 244 279 246.66667 279 250 C 279 253.33333 278.6667 256 278 258 L 98 735 C 94 745 86.66667 750 76 750 C 60.66667 750 53 742 53 726 C 53 722.6667 53.33333 720 54 718 L 231 250 L 54 -217 C 53.33333 -219 53 -222 53 -226 C 53 -242 60.66667 -250 76 -250 C 86.66667 -250 94 -245 98 -235 Z "/>
+        </symbol>
+        <symbol id="g18" overflow="visible">
+            <path d="M 881 668 C 881 678 875 683 863 683 L 736 680 L 609 683 C 593.0144 683 586 673.90576 586 659 C 586 651.6667 588.6667 647.3334 594 646.00006 C 604 644.66675 611.6667 644.00006 617 644.00006 C 647.6667 642.66675 665.5 641.50006 670.5 640.50006 C 675.5 639.50006 678 636.3334 678 631.00006 C 677.3333 628.3334 676 622.3334 674 613.00006 L 615 375.00006 L 321 375.00006 L 379 602.00006 C 384.3333 623.3334 393.3333 636.3334 406 641.00006 C 412.6667 643.00006 430 644.00006 458 644.00006 C 484.81168 644.00006 496 643.9177 496 668 C 496 678 490 683 478 683 L 351 680 L 223 683 C 207.01442 683 200 673.90576 200 659 C 200 651.6667 203 647.3334 209 646.00006 C 219 644.66675 226.66667 644.00006 232 644.00006 C 262.6667 642.66675 280.5 641.50006 285.5 640.50006 C 290.5 639.50006 293 636.3334 293 631.00006 C 293 629.00006 291.6667 623.00006 289 613.00006 L 156 82.00006 C 150.66667 60.00006 140.66667 46.666733 126 42.00006 C 119.33333 40.00006 100.66667 39.00006 70 39.00006 C 47.81862 39.00006 39 36.95552 39 15.000061 C 39 5.000061 45 0.000061035156 57 0.000061035156 L 183 3.000061 L 246 2.000061 C 256.65405 2.000061 299.017 0.000061035156 310 0.000061035156 C 326.3851 0.000061035156 334 8.337875 334 24.000061 C 334 34.00006 323.3333 39.00006 302 39.00006 C 262 39.00006 242 43.33339 242 52.00006 C 242 52.00006 243 54.666733 245 68.00006 L 312 336.00006 L 605 336.00006 L 538 68.00006 C 534.6667 52.666733 523 43.33339 503 40.00006 C 498.3333 39.33339 481.3333 39.00006 452 39.00006 C 433.3333 39.00006 424 31.000061 424 15.000061 C 424 5.000061 430 0.000061035156 442 0.000061035156 L 568 3.000061 L 631 2.000061 C 641.50757 2.000061 683.33905 0.000061035156 696 0.000061035156 C 712.38513 0.000061035156 720 8.337875 720 24.000061 C 720 34.00006 709.3333 39.00006 688 39.00006 C 647.3333 39.00006 627 43.33339 627 52.00006 C 627 52.00006 628 54.666733 630 68.00006 L 764 602.00006 C 769.3333 623.3334 778.3333 636.3334 791 641.00006 C 797 643.00006 814.3333 644.00006 843 644.00006 C 868.9501 644.00006 881 644.29517 881 668 Z "/>
+        </symbol>
+        <symbol id="g19" overflow="visible">
+            <path d="M 751 53 C 751 82.61751 724.8598 106 695 106 C 664.3368 106 638 83.12465 638 53 C 638 22.871582 664.3305 0 695 0 C 725.4052 0 751 22.515701 751 53 Z M 475 53 C 475 82.61751 448.8598 106 419 106 C 388.2974 106 363 83.13408 363 53 C 363 22.862122 388.2914 0 419 0 C 449.4052 0 475 22.515701 475 53 Z M 200 53 C 200 83.12842 173.66951 106 143 106 C 113.143845 106 87 82.61595 87 53 C 87 23.382492 113.14021 0 143 0 C 173.37909 0 200 22.515701 200 53 Z "/>
+        </symbol>
+        <symbol id="g20" overflow="visible">
+            <path d="M 192 250 C 277.3756 285.28857 378 366.54395 378 474 L 378 922 C 378 1013.9199 469.67728 1089.0513 552 1106 C 563.3333 1108.6666 569 1116 569 1128 C 569 1142.6666 561.6667 1150 547 1150 L 543 1150 C 431.4652 1126.2692 288 1041.3568 288 922 L 288 474 C 288 373.12457 200.1433 290.19928 114 272 C 102.66667 269.3333 97 262 97 250 C 97 238 102.66667 230.66667 114 228 C 200.09164 209.81163 288 126.84326 288 26 L 288 -422 C 288 -541.4332 431.33252 -626.24097 543 -650 L 547 -650 C 561.6667 -650 569 -642.6667 569 -628 C 569 -616 563.3333 -608.6667 552 -606 C 469.74756 -589.0657 378 -513.8827 378 -422 L 378 26 C 378 133.548 277.5086 214.65643 191.99998 250 Z "/>
+        </symbol>
+        <symbol id="g21" overflow="visible">
+            <path d="M 808 1292 Q 836 1151 845 1028 Q 820 1009 778 1016 Q 760 1074 740.5 1115 Q 721 1156 687 1196.5 Q 653 1237 599.5 1257.5 Q 546 1278 475 1278 Q 386 1278 318.5 1207 Q 251 1136 251 1049 Q 251 1000 275 956 Q 299 912 329 884 Q 359 856 411 827 Q 463 798 494 785.5 Q 525 773 577 753 Q 648 726 701 697 Q 754 668 805 624 Q 856 580 882.5 517.5 Q 909 455 909 377 Q 909 280 857 191 Q 805 102 717 47 Q 609 -20 464 -20 Q 367 -20 260.5 3.5 Q 154 27 96 27 Q 65 156 55 338 Q 87 355 122 344 Q 186 53 481 53 Q 604 53 670.5 117.5 Q 737 182 737 305 Q 737 363 719 410 Q 701 457 678 485.5 Q 655 514 611 540.5 Q 567 567 540 579 Q 513 591 462 610 Q 385 639 328.5 669.5 Q 272 700 217 745.5 Q 162 791 133 853.5 Q 104 916 104 993 Q 104 1151 218.5 1249.5 Q 333 1348 494 1348 Q 611 1348 695.5 1322 Q 780 1296 808 1292 Z "/>
+        </symbol>
+        <symbol id="g22" overflow="visible">
+            <path d="M 815 186 Q 743 67 663.5 23.5 Q 584 -20 481 -20 Q 291 -20 183.5 101.5 Q 76 223 76 426 Q 76 633 205 766 Q 334 899 496 899 Q 641 899 725 845 Q 809 791 809 705 Q 809 662 777 638 Q 745 614 709 614 Q 639 614 631 688 Q 627 733 617.5 758.5 Q 608 784 575.5 807.5 Q 543 831 485 831 Q 383 831 317.5 734 Q 252 637 252 471 Q 252 295 332 187.5 Q 412 80 526 80 Q 667 80 772 215 Q 805 211 815 186 Z "/>
+        </symbol>
+        <symbol id="g23" overflow="visible">
+            <path d="M 84 420 Q 84 623 197 756 Q 319 899 518 899 Q 665 899 766.5 826.5 Q 868 754 908 653.5 Q 948 553 948 438 Q 948 224 815 94 Q 698 -21 514 -20 Q 309 -20 196.5 113 Q 84 246 84 420 Z M 487 827 Q 260 827 260 467 Q 260 401 275.5 333.5 Q 291 266 321.5 200.5 Q 352 135 409.5 93 Q 467 51 543 51 Q 633 51 702.5 125 Q 772 199 772 373 Q 772 592 696 709.5 Q 620 827 487 827 Z "/>
+        </symbol>
+        <symbol id="g24" overflow="visible">
+            <path d="M 377 733 Q 522 899 713 899 Q 830 899 883 829 Q 938 755 938 555 L 938 250 Q 938 129 961.5 100.5 Q 985 72 1075 63 Q 1083 53 1083 28.5 Q 1083 4 1075 -4 Q 952 0 858 0 Q 772 0 649 -4 Q 641 6 641 30.5 Q 641 55 649 63 Q 733 71 754.5 100 Q 776 129 776 250 L 776 561 Q 776 670 752 719 Q 713 793 643 793 Q 518 793 393 672 Q 358 633 358 586 L 358 250 Q 358 129 379.5 100.5 Q 401 72 483 63 Q 491 53 491.5 28.5 Q 492 4 483 -4 Q 360 0 279 0 Q 177 0 53 -4 Q 45 4 45 28.5 Q 45 53 53 63 Q 149 71 173 99 Q 197 127 197 250 L 197 649 Q 197 735 173.5 757.5 Q 150 780 63 788 Q 51 823 59 846 Q 211 866 311 905 Q 327 905 336 889 Q 348 864 352 733 Q 352 706 377 733 Z "/>
+        </symbol>
+        <symbol id="g25" overflow="visible">
+            <path d="M 707 254 L 707 643 Q 707 690 700.5 709.5 Q 694 729 672 754 Q 609 828 506 827 Q 383 827 315 725 Q 256 641 256 453 Q 256 273 323.5 174.5 Q 391 76 481 76 Q 561 76 674 174 Q 707 203 707 254 Z M 684 103 Q 534 -20 428 -20 Q 266 -20 173 100.5 Q 80 221 80 416 Q 80 635 221 776 Q 350 899 528 899 Q 559 899 596 890 Q 633 881 659.5 872.5 Q 686 864 688 864 Q 706 864 707 883 L 707 1145 Q 707 1211 703.5 1243.5 Q 700 1276 677.5 1291.5 Q 655 1307 643 1308 Q 631 1309 575 1313 Q 552 1336 563 1374 Q 745 1388 850 1430 Q 877 1430 877 1409 Q 869 1327 868 1194 L 868 266 Q 868 186 896 155.5 Q 924 125 1018 117 Q 1028 107 1028 88.5 Q 1028 70 1018 61 Q 854 43 776 -20 Q 758 -28 737 -20 Q 719 52 715 100 Q 713 110 702.5 110 Q 692 110 684 103 Z "/>
+        </symbol>
+        <symbol id="g26" overflow="visible">
+            <path d="M 543 144 C 543 153.33333 537.6667 158 527 158 C 518.3333 158 512.6666 151 509.99994 137 C 505.33325 117.66667 499.6666 98.66667 492.99994 80 C 479.66663 38.66667 461.99994 18 439.99994 18 C 421.99994 18 412.99994 32 412.99994 60 C 412.99994 77.33333 419.66663 111 432.99994 161 L 459.99994 267 C 469.28546 303.2135 476.82324 328.11652 482.99994 359 L 488.99994 386 C 490.99994 393.3333 491.99994 398.3333 491.99994 401 C 491.99994 421 480.99994 431 458.99994 431 C 436.99994 431 422.99994 418.6667 416.99994 394 L 342.99994 98 C 342.33325 95.33333 337.99994 88 329.99994 76 C 313.54077 49.665344 274.87836 18 234.99992 18 C 196.99992 18 177.99992 43.66667 177.99992 95 C 177.99992 135.66667 195.6666 202 230.99992 294 C 242.33325 324 247.99992 345 247.99992 357 C 247.99992 406.90573 212.57352 442 162.99992 442 C 118.33325 442 83.33325 417 57.999924 367 C 38.666595 327.6667 28.999924 301 28.999924 287 C 28.999924 277.6667 34.333252 273 44.999924 273 C 58.38971 273 59.9662 278.882 63.999924 293 C 87.33325 373 119.33325 413 159.99992 413 C 173.99992 413 180.99992 403.3333 180.99992 384 C 180.99992 369.3333 175.33325 347.66666 163.99992 319 C 125.99992 217.66667 106.99992 148.33333 106.99992 111 C 106.99992 33.823532 154.90106 -11 231.99992 -11 C 275.33325 -11 313.6666 9.333328 346.99994 50 C 360.99994 9.333328 390.99994 -11 436.99994 -11 C 506.0888 -11 527.2742 69.864426 542.9999 144 Z "/>
+        </symbol>
+        <symbol id="g27" overflow="visible">
+            <path d="M 642 680 C 622.9425 680 559.0759 683 540.00006 683 C 525.3334 683 518.00006 675 518.00006 659 C 518.00006 649.6667 525.00006 644.6667 539.00006 644 C 581.66675 644 603.00006 631 603.00006 605 C 603.00006 599 602.00006 592.3333 600.00006 585 L 511.00006 232 C 496.33337 175.33333 467.33337 126 424.00006 84 C 376.66675 39.33333 325.00006 17 269.00006 17 C 195.34427 17 152.00006 67.18353 152.00006 141 L 153.00006 150 C 153.00006 168.66667 156.33339 191 163.00006 217 L 259.00006 602 C 264.33337 623.3333 273.33337 636.3333 286.00006 641 C 292.00006 643 309.33337 644 338.00006 644 C 364.0448 644 375.00006 644.2581 375.00006 668 C 375.00006 678 369.33337 683 358.00006 683 L 231.00006 680 L 104.00006 683 C 88.01448 683 81.00006 673.90576 81.00006 659 C 81.00006 651.6667 83.66673 647.3334 89.00006 646.00006 C 99.00006 644.66675 106.66673 644.00006 112.00006 644.00006 C 142.66673 642.66675 160.50006 641.50006 165.50006 640.50006 C 170.50006 639.50006 173.00006 636.3334 173.00006 631.00006 C 173.00006 629.00006 171.66673 622.3334 169.00006 611.00006 L 74.00006 230.00006 C 69.33339 211.33339 67.00006 192.00006 67.00006 172.00006 C 67.00006 57.386932 150.15604 -21.999939 265.00006 -21.999939 C 329.66675 -21.999939 389.66675 3.3333893 445.00006 54.00006 C 497.66675 102.00006 532.00006 158.33339 548.00006 223.00006 L 636.00006 574.00006 C 648.69385 624.7751 676.52466 642.58014 739.0001 644 C 753.0001 644.6667 760.0001 652.6667 760.0001 668 L 760.0001 672 C 757.33344 679.3333 751.66675 683 743.00006 683 C 723.8364 683 661.1816 680 642.0001 680 Z "/>
+        </symbol>
+        <symbol id="g28" overflow="visible">
+            <path d="M 119 424 C 150.79085 424 175 448.20844 175 480 C 175 516 156.33333 534.6667 119 536 C 141.3666 583.0876 190.544 621 256 621 C 344.1449 621 402 555.2719 402 467 C 402 419 384.6667 372.6667 350 328 C 332.6667 305.3333 319.6667 289.3333 311 280 L 74 45 C 60.69464 33.357803 63 29.960907 63 0 L 475 0 L 506 188 L 464 188 C 456.6667 134.66667 448.6667 104.33333 440 97 C 435.3333 93.66667 403.66666 92 345 92 L 175 92 C 241.66667 151.33333 304.3333 204.33333 363 251 C 407.6667 286.3333 440 317.3333 460 344 C 490 382.6667 505 423.6667 505 467 C 505 529 480.6667 578 432 614 C 388.6667 647.3333 335 664 271 664 C 216.33333 664 168.66667 648 128 616 C 84.66667 581.3333 63 537 63 483 C 63 448.5313 88.20494 424 119 424 Z "/>
+        </symbol>
+        <symbol id="g29" overflow="visible">
+            <path d="M 601 320 C 601 364.44305 601.09235 371.6983 595 418 C 577.41284 558.697 501.83203 666 339.99997 666 C 235.22083 666 163.26732 618.63367 126.99997 551 C 91.56026 485.49023 78.99997 415.55414 78.99997 320 C 78.99997 285.3333 80.99997 252.66666 84.99997 221.99998 C 102.823456 83.37282 179.19362 -22.000015 339.99997 -22.000015 C 443.87323 -22.000015 516.66675 25.207306 553 90.999985 C 588.6371 156.87462 601 224.636 601 320 Z M 481 522 C 490.3333 489.3333 495 426 495 332 C 495 233.33333 490 164.66667 480 126 C 462.70688 59.879227 414.84778 19 340 19 C 316.6667 19 292 24.666672 266 36 C 234 50.66667 212 81.33333 200 128 C 190 166 185 234 185 332 C 185 427.3333 190.33333 492.66666 201 528 C 219.66667 592.6667 266 625 340 625 C 414.6667 625 461.6667 590.6667 481 522 Z "/>
+        </symbol>
+        <symbol id="g30" overflow="visible">
+            <path d="M 360 666 C 314 624 248.66667 603 164 603 L 143 603 L 143 551 L 164 551 C 214.66667 551 261 559.6667 303 577 L 303 89 C 303 77.66667 301.6667 70 299 66 C 293.6667 56 261.6667 51 203.00002 51 L 150.00002 51 L 150.00002 0 C 188.66669 2.6666718 256 4 352 4 C 448 4 515.3333 2.6666718 554 0 L 554 51 L 501 51 C 442.3333 51 410 56 404 66 C 402 70 401 77.66667 401 89 L 401 632 C 401 666.3756 396.6876 666 360 666 Z "/>
+        </symbol>
+        <symbol id="g31" overflow="visible">
+            <path d="M 152 424 C 187.79085 424 214 450.20844 214 486 C 214 521.3333 196.33333 542 161 548 C 191.66667 592.6667 239.66667 615 305 615 C 399.6441 615 476 556.103 476 464 C 476 400.6667 432 331.6667 344 257 L 104 52 C 96 45.33333 91.66667 39.33333 91 34 L 91 0 L 556 0 L 590 199 L 540 199 C 531.3333 145 522.3333 114.66667 513 108 C 507.6667 104.66667 473.33334 103 410 103 L 229 103 C 358.38892 198.3889 385.88855 216.63466 469.00003 276 C 509.00003 305.3333 537.3334 332.3333 554.00006 357 C 577.3334 391.6667 589.00006 427.6667 589.00006 465 C 589.00006 531.6667 560.3334 583 503.00006 619 C 454.33337 650.3333 395.00006 666 325.00006 666 C 266.33337 666 214.33337 651.3333 169.00005 622 C 117.000046 588.6667 91.000046 544 91.000046 488 C 91.000046 450.47626 120.78989 424 152.00005 424 Z "/>
+        </symbol>
+        <symbol id="g32" overflow="visible">
+            <path d="M 432 433 L 329 433 L 348 510 C 353.34375 529.23755 366 584.683 366 587 C 366 613 352.6667 626 326 626 C 300 626 282.6667 612.6667 274 586 L 236 433 L 122 433 C 95.81311 433 84 424.9225 84 402 C 84 384.28607 97.214584 381 119 381 L 223 381 L 166 154 C 158 119.33333 154 97.66667 154 89 C 154 27.275406 213.08467 -11 278 -11 C 334.6667 -11 382.6667 12.666672 422 60 C 456 100.66667 473 129.33333 473 146 C 473 158 465 164 449 164 C 437 164 428 157.66667 422 145 C 400.60022 94.31633 344.90387 30 282 30 C 257.3333 30 244.99998 46.33333 244.99998 79 C 244.99998 89 245.99998 98 247.99998 106 L 316 381 L 429 381 C 454.3333 381 467 391.6667 467 413 C 467 430.10046 454.024 433 432 433 Z "/>
+        </symbol>
+        <symbol id="g33" overflow="visible">
+            <path d="M 694 276 L 84 276 C 64 276 56 263.3333 56 249.99998 C 56 236.66666 64 223.99998 84 223.99998 L 694 223.99998 C 714 223.99998 722 236.66666 722 249.99998 C 722 261.5432 714 275.99997 694 275.99997 Z "/>
+        </symbol>
+    </defs>
+    <defs id="clip-path"/>
+</svg>

--- a/packages/preview/quill/0.4.0/docs/images/qft.svg
+++ b/packages/preview/quill/0.4.0/docs/images/qft.svg
@@ -1,0 +1,1240 @@
+<svg class="typst-doc" viewBox="0 0 585.9021311111111 124.87574999999998" width="585.9021311111111" height="124.87574999999998" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(-0 -0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0.87867963 0.87867963 C 1.4412888 0.31607053 2.2043505 0 3 0 L 582.90216 0 C 584.55896 0.00000000000000032750764 585.90216 1.3431457 585.90216 3 L 585.90216 121.87575 C 585.90216 123.53261 584.55896 124.87575 582.90216 124.87575 L 3 124.87575 C 1.3431457 124.87575 0.000000000000000082243954 123.53261 0.00000000000000018369701 121.87575 L 0.000000000000007462737 3 C 0.000000000000007511457 2.2043505 0.31607053 1.4412888 0.87867963 0.87867963 Z "/>
+        </g>
+        <g transform="translate(6 6)">
+            <g class="typst-group">
+                <g transform="matrix(1.3 0 0 1.3 0 0)">
+                    <g transform="translate(27.73635 3.4000000000000012)">
+                        <g class="typst-group">
+                            <g transform="matrix(0.85 0 0 0.85 0 0)">
+                                <g transform="translate(5.09 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 21.635 0 "/>
+                                </g>
+                                <g transform="translate(35.269999999999996 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18.0665 0 "/>
+                                </g>
+                                <g transform="translate(63.403000000000006 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.185 0 "/>
+                                </g>
+                                <g transform="translate(87.773 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 23.2605 0 "/>
+                                </g>
+                                <g transform="translate(126.294 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18.546 0 "/>
+                                </g>
+                                <g transform="translate(155.38599999999997 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 220.64 0 "/>
+                                </g>
+                                <g transform="translate(376.02599999999995 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.545 0 "/>
+                                </g>
+                                <g transform="translate(5.09 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 21.635 0 "/>
+                                </g>
+                                <g transform="translate(53.3365 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 -19.83 "/>
+                                </g>
+                                <g transform="translate(26.724999999999998 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 26.6115 0 "/>
+                                </g>
+                                <g transform="translate(55.6365 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 23.9515 0 "/>
+                                </g>
+                                <g transform="translate(87.773 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 57.067 0 "/>
+                                </g>
+                                <g transform="translate(144.83999999999997 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 27.091 0 "/>
+                                </g>
+                                <g transform="translate(180.47599999999994 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.185 0 "/>
+                                </g>
+                                <g transform="translate(204.84599999999998 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 23.2605 0 "/>
+                                </g>
+                                <g transform="translate(243.367 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 23.2605 0 "/>
+                                </g>
+                                <g transform="translate(281.8879999999999 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.185 0 "/>
+                                </g>
+                                <g transform="translate(306.258 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 69.768 0 "/>
+                                </g>
+                                <g transform="translate(376.02599999999995 27.244999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.545 0 "/>
+                                </g>
+                                <g transform="translate(5.09 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 74.498 0 "/>
+                                </g>
+                                <g transform="translate(111.0335 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 -59.49 "/>
+                                </g>
+                                <g transform="translate(79.588 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 31.4455 0 "/>
+                                </g>
+                                <g transform="translate(113.3335 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 83.3275 0 "/>
+                                </g>
+                                <g transform="translate(228.10649999999998 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 -39.66 "/>
+                                </g>
+                                <g transform="translate(196.66099999999997 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 31.4455 0 "/>
+                                </g>
+                                <g transform="translate(230.4065 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 36.221 0 "/>
+                                </g>
+                                <g transform="translate(266.62749999999994 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 31.4455 0 "/>
+                                </g>
+                                <g transform="translate(306.258 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.545 0 "/>
+                                </g>
+                                <g transform="translate(331.348 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18.0665 0 "/>
+                                </g>
+                                <g transform="translate(359.481 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.545 0 "/>
+                                </g>
+                                <g transform="translate(376.02599999999995 66.905)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.545 0 "/>
+                                </g>
+                                <g transform="translate(5.09 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 105.9435 0 "/>
+                                </g>
+                                <g transform="translate(144.83999999999997 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 -79.32 "/>
+                                </g>
+                                <g transform="translate(111.0335 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 33.8065 0 "/>
+                                </g>
+                                <g transform="translate(147.14 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 80.9665 0 "/>
+                                </g>
+                                <g transform="translate(266.62749999999994 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 -59.49 "/>
+                                </g>
+                                <g transform="translate(228.10649999999998 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 38.521 0 "/>
+                                </g>
+                                <g transform="translate(268.92749999999995 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1455 0 "/>
+                                </g>
+                                <g transform="translate(306.258 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.545 0 "/>
+                                </g>
+                                <g transform="translate(349.4145 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 -19.83 "/>
+                                </g>
+                                <g transform="translate(322.803 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 26.6115 0 "/>
+                                </g>
+                                <g transform="translate(351.7145 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.3115 0 "/>
+                                </g>
+                                <g transform="translate(384.57099999999997 86.73499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 8 0 "/>
+                                </g>
+                                <g transform="translate(5.09 16.415)"/>
+                                <g transform="translate(-18.243000000000002 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(10.9 8.652)"/>
+                                            <g transform="translate(10.9 13.299999999999999)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.443000000000001 3.33)"/>
+                                            <g transform="translate(15.443000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(19.333000000000002 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(18.18 -0.0000000000000008881784197001252)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(22.18 3.999999999999999)"/>
+                                <g transform="translate(22.18 3.999999999999999)"/>
+                                <g transform="translate(22.18 10.829999999999998)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g4" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(31.269999999999996 10.829999999999998)"/>
+                                <g transform="translate(43.269999999999996 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 20.133 14.83 L 20.133 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.59 8.652000000000001)"/>
+                                            <g transform="translate(11.59 13.3)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(16.133000000000003 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(71.40299999999999 2.884999999999999)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(75.40299999999999 6.884999999999999)"/>
+                                <g transform="translate(75.40299999999999 6.884999999999999)"/>
+                                <g transform="translate(75.40299999999999 7.944999999999999)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g7" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(75.40299999999999 7.944999999999999)"/>
+                                <g transform="translate(95.77300000000001 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 30.521 14.83 L 30.521 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.59 8.652000000000001)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 1.5610000000000004)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(4.942 2.7370000000000005)"/>
+                                                        <g transform="translate(4.942 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(10.388 0)"/>
+                                                        <g transform="translate(10.388 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(26.520999999999997 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(134.29399999999998 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 21.092 14.83 L 21.092 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.59 10.213000000000001)"/>
+                                            <g transform="translate(11.59 13.3)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.092 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(392.5709999999999 16.415)"/>
+                                <g transform="translate(392.5709999999999 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 2.5519999999999996)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g10" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.892222222222223 5)"/>
+                                            <g transform="translate(17.892222222222223 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g11" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.894444444444446 2.5519999999999996)"/>
+                                            <g transform="translate(27.894444444444446 6.41)"/>
+                                            <g transform="translate(27.894444444444446 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g12" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(32.55444444444444 2.5519999999999996)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(3.9829999999999997 1.6310000000000007)"/>
+                                                        <g transform="translate(3.9829999999999997 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g13" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(8.687 0.007000000000000561)"/>
+                                                        <g transform="translate(8.687 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g14" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(11.515 0)"/>
+                                                        <g transform="translate(11.515 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(15.498000000000001 3.8430000000000004)"/>
+                                                        <g transform="translate(15.498000000000001 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(21.182000000000002 3.0470000000000006)"/>
+                                                        <g transform="translate(21.182000000000002 6.377000000000001)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g18" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(24.979000000000003 3.9060000000000006)"/>
+                                                        <g transform="translate(24.979000000000003 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g7" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(30.838 0.007000000000000561)"/>
+                                                        <g transform="translate(30.838 0.007000000000000561)"/>
+                                                        <g transform="translate(30.838 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(34.149 4.167000000000001)"/>
+                                                        <g transform="translate(34.149 6.377000000000001)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g19" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(72.06044444444444 3.33)"/>
+                                            <g transform="translate(72.06044444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(74.84044444444444 4.17)"/>
+                                            <g transform="translate(74.84044444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g20" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(79.84044444444444 3.33)"/>
+                                            <g transform="translate(79.84044444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(83.73044444444444 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(5.09 36.245)"/>
+                                <g transform="translate(-18.243000000000002 19.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(10.9 8.652)"/>
+                                            <g transform="translate(10.9 13.299999999999999)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(15.443000000000001 3.33)"/>
+                                            <g transform="translate(15.443000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(19.333000000000002 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(51.036500000000004 24.944999999999997)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(71.40299999999999 22.714999999999996)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(75.40299999999999 26.714999999999996)"/>
+                                <g transform="translate(75.40299999999999 26.714999999999996)"/>
+                                <g transform="translate(75.40299999999999 27.775)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g7" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(75.40299999999999 27.775)"/>
+                                <g transform="translate(163.38599999999997 19.83)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(167.38599999999997 23.83)"/>
+                                <g transform="translate(167.38599999999997 23.83)"/>
+                                <g transform="translate(167.38599999999997 30.659999999999997)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g4" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(176.47599999999997 30.659999999999997)"/>
+                                <g transform="translate(188.47599999999997 22.714999999999996)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(192.47599999999997 26.714999999999996)"/>
+                                <g transform="translate(192.47599999999997 26.714999999999996)"/>
+                                <g transform="translate(192.47599999999997 27.775)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g7" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(192.47599999999997 27.775)"/>
+                                <g transform="translate(212.84599999999998 19.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 30.521 14.83 L 30.521 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.59 8.652000000000001)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 1.5610000000000004)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(4.942 2.7370000000000005)"/>
+                                                        <g transform="translate(4.942 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(10.388 0)"/>
+                                                        <g transform="translate(10.388 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(26.520999999999997 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(251.36699999999993 19.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 30.521 14.83 L 30.521 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.59 8.652000000000001)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 1.5610000000000004)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(4.942 2.7370000000000005)"/>
+                                                        <g transform="translate(4.942 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(10.388 0)"/>
+                                                        <g transform="translate(10.388 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(26.520999999999997 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(289.888 22.714999999999996)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(293.888 26.714999999999996)"/>
+                                <g transform="translate(293.888 26.714999999999996)"/>
+                                <g transform="translate(293.888 27.775)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g7" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(293.888 27.775)"/>
+                                <g transform="translate(392.5709999999999 36.245)"/>
+                                <g transform="translate(392.5709999999999 19.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 2.5519999999999996)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g10" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.892222222222223 5)"/>
+                                            <g transform="translate(17.892222222222223 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g11" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.894444444444446 2.5519999999999996)"/>
+                                            <g transform="translate(27.894444444444446 6.41)"/>
+                                            <g transform="translate(27.894444444444446 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g12" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(32.55444444444444 2.5519999999999996)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(3.9829999999999997 1.6310000000000007)"/>
+                                                        <g transform="translate(3.9829999999999997 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g13" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(8.687 0.007000000000000561)"/>
+                                                        <g transform="translate(8.687 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g14" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(11.515 0)"/>
+                                                        <g transform="translate(11.515 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(15.498000000000001 3.8430000000000004)"/>
+                                                        <g transform="translate(15.498000000000001 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(21.182000000000002 3.0470000000000006)"/>
+                                                        <g transform="translate(21.182000000000002 6.377000000000001)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g21" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(24.979000000000003 3.9060000000000006)"/>
+                                                        <g transform="translate(24.979000000000003 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g7" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(30.838 0.007000000000000561)"/>
+                                                        <g transform="translate(30.838 0.007000000000000561)"/>
+                                                        <g transform="translate(30.838 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(34.149 4.167000000000001)"/>
+                                                        <g transform="translate(34.149 6.377000000000001)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g19" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(72.06044444444444 3.33)"/>
+                                            <g transform="translate(72.06044444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(74.84044444444444 4.17)"/>
+                                            <g transform="translate(74.84044444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g20" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(79.84044444444444 3.33)"/>
+                                            <g transform="translate(79.84044444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(83.73044444444444 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(0 39.66)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 14.83 L 10.18 14.83 L 10.18 0 Z "/>
+                                </g>
+                                <g transform="translate(4 43.66)"/>
+                                <g transform="translate(4 44.669999999999995)"/>
+                                <g transform="translate(4 50.489999999999995)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g22" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(6.18 50.489999999999995)"/>
+                                <g transform="translate(48.2465 39.66)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 14.83 L 10.18 14.83 L 10.18 0 Z "/>
+                                </g>
+                                <g transform="translate(52.2465 43.66)"/>
+                                <g transform="translate(52.2465 44.669999999999995)"/>
+                                <g transform="translate(52.2465 50.489999999999995)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g22" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(54.4265 50.489999999999995)"/>
+                                <g transform="translate(5.09 75.905)"/>
+                                <g transform="translate(-28.631000000000004 59.49)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(10.9 8.652)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 1.5610000000000004)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(4.942 2.7370000000000005)"/>
+                                                        <g transform="translate(4.942 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(10.388 0)"/>
+                                                        <g transform="translate(10.388 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(25.831 3.33)"/>
+                                            <g transform="translate(25.831 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(29.721 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(108.7335 64.605)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(225.80649999999997 64.605)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(289.888 62.375)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(293.888 66.375)"/>
+                                <g transform="translate(293.888 66.375)"/>
+                                <g transform="translate(293.888 67.435)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g7" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(293.888 67.435)"/>
+                                <g transform="translate(314.258 59.49)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(318.258 63.49)"/>
+                                <g transform="translate(318.258 63.49)"/>
+                                <g transform="translate(318.258 70.32000000000001)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g4" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(327.34799999999996 70.32000000000001)"/>
+                                <g transform="translate(339.34799999999996 59.49)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 20.133 14.83 L 20.133 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.59 8.652000000000001)"/>
+                                            <g transform="translate(11.59 13.3)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(16.133000000000003 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(392.5709999999999 75.905)"/>
+                                <g transform="translate(392.5709999999999 59.49)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 2.5519999999999996)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g10" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.892222222222223 5)"/>
+                                            <g transform="translate(17.892222222222223 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g11" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.894444444444446 2.5519999999999996)"/>
+                                            <g transform="translate(27.894444444444446 6.41)"/>
+                                            <g transform="translate(27.894444444444446 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g12" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(32.55444444444444 2.5519999999999996)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(3.9829999999999997 1.6310000000000007)"/>
+                                                        <g transform="translate(3.9829999999999997 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g13" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(8.687 0.007000000000000561)"/>
+                                                        <g transform="translate(8.687 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g14" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(11.515 0)"/>
+                                                        <g transform="translate(11.515 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(15.498000000000001 3.8430000000000004)"/>
+                                                        <g transform="translate(15.498000000000001 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(21.182000000000002 3.0470000000000006)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)"/>
+                                                                    <g transform="translate(0 1.12)"/>
+                                                                    <g transform="translate(0 3.33)">
+                                                                        <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                            <use xlink:href="#g19" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(4.405 1.95)"/>
+                                                                    <g transform="translate(4.405 3.33)">
+                                                                        <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                            <use xlink:href="#g23" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(8.295 0)"/>
+                                                                    <g transform="translate(8.295 3.33)">
+                                                                        <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                            <use xlink:href="#g18" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(33.274 0.007000000000000561)"/>
+                                                        <g transform="translate(33.274 0.007000000000000561)"/>
+                                                        <g transform="translate(33.274 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(36.585 4.167000000000001)"/>
+                                                        <g transform="translate(36.585 6.377000000000001)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g19" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(74.49644444444445 3.33)"/>
+                                            <g transform="translate(74.49644444444445 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(77.27644444444445 4.17)"/>
+                                            <g transform="translate(77.27644444444445 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g20" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(82.27644444444445 3.33)"/>
+                                            <g transform="translate(82.27644444444445 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(86.16644444444445 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(5.09 95.73499999999999)"/>
+                                <g transform="translate(-19.202 79.31999999999998)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 4.22)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(10.9 10.213000000000001)"/>
+                                            <g transform="translate(10.9 13.299999999999999)">
+                                                <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                    <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(16.402 3.33)"/>
+                                            <g transform="translate(16.402 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(20.292 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(142.53999999999996 84.43499999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(264.32749999999993 84.43499999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(289.888 82.20499999999998)">
+                                    <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 9.06 L 16.37 9.06 L 16.37 0 Z "/>
+                                </g>
+                                <g transform="translate(293.888 86.20499999999998)"/>
+                                <g transform="translate(293.888 86.20499999999998)"/>
+                                <g transform="translate(293.888 87.26499999999999)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g7" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(293.888 87.26499999999999)"/>
+                                <g transform="translate(347.11449999999996 84.43499999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(367.48099999999994 79.31999999999998)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(371.48099999999994 83.31999999999998)"/>
+                                <g transform="translate(371.48099999999994 83.31999999999998)"/>
+                                <g transform="translate(371.48099999999994 90.14999999999998)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g4" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(380.5709999999999 90.14999999999998)"/>
+                                <g transform="translate(392.5709999999999 95.73499999999999)"/>
+                                <g transform="translate(392.5709999999999 79.31999999999998)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 2.5519999999999996)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 4.17)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g10" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(11.780000000000001 3.33)"/>
+                                            <g transform="translate(11.780000000000001 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.892222222222223 5)"/>
+                                            <g transform="translate(17.892222222222223 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g11" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.894444444444446 2.5519999999999996)"/>
+                                            <g transform="translate(27.894444444444446 6.41)"/>
+                                            <g transform="translate(27.894444444444446 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g12" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(32.55444444444444 2.5519999999999996)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 0)"/>
+                                                        <g transform="translate(0 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(3.9829999999999997 1.6310000000000007)"/>
+                                                        <g transform="translate(3.9829999999999997 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g13" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(8.687 0.007000000000000561)"/>
+                                                        <g transform="translate(8.687 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g14" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(11.515 0)"/>
+                                                        <g transform="translate(11.515 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g15" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(15.498000000000001 3.8430000000000004)"/>
+                                                        <g transform="translate(15.498000000000001 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g16" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 0.007000000000000561)"/>
+                                                        <g transform="translate(17.871000000000002 4.648000000000001)">
+                                                            <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                <use xlink:href="#g17" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(21.182000000000002 4.167000000000001)"/>
+                                                        <g transform="translate(21.182000000000002 6.377000000000001)">
+                                                            <g class="typst-text" transform="scale(0.005 -0.005)">
+                                                                <use xlink:href="#g19" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(59.093444444444444 3.33)"/>
+                                            <g transform="translate(59.093444444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(61.873444444444445 4.17)"/>
+                                            <g transform="translate(61.873444444444445 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g20" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(66.87344444444444 3.33)"/>
+                                            <g transform="translate(66.87344444444444 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g3" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(70.76344444444445 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0 0)"/>
+    </g>
+    <defs id="glyph">
+        <symbol id="g0" overflow="visible">
+            <path d="M 139 -250 C 152.33333 -250 159 -242 159 -226 L 159 726 C 159 742 152.33333 750 139 750 C 125.66667 750 119 742 119 726 L 119 -226 C 119 -242 125.66667 -250 139 -250 Z "/>
+        </symbol>
+        <symbol id="g1" overflow="visible">
+            <path d="M 397 621 C 397 647.6667 383.3333 661 356 661 C 328.36603 661 300 632.63525 300 605 C 300 578.3333 313.3333 565 340 565 C 368.44824 565 397 592.8285 397 621 Z M 267 444 C 214.06895 444 169.27605 403.5279 147 369 C 120.33333 326.3333 107 299 107 287 C 107 278.3333 112 274 122 274 C 126.66667 274 130.33333 274.6667 133 276 C 137.66667 284 141.33333 290.6667 144 296 C 176 374.6667 216 414 264 414 C 282 414 291 400.3333 291 373 C 291 357.6667 288.6667 341 284 323 L 192 -46 C 177.82411 -103.8849 137.73953 -175 75 -175 C 65.66667 -175 56.66667 -173.66667 48 -171 C 72.66667 -161 85 -143.33333 85 -118 C 85 -92 71.33333 -79 44 -79 C 12.235291 -79 -13 -108.338684 -13 -140 C -13 -183.69493 29.783295 -205 77 -205 C 120.33333 -205 160.33333 -190 197 -160 C 231.66667 -130.66667 254.33333 -94.33333 265 -51 L 356 311 C 359.3333 324.3333 361 337 361 349 C 361 404.18274 321.87784 444 267 444 Z "/>
+        </symbol>
+        <symbol id="g2" overflow="visible">
+            <path d="M 303 664 C 260.3333 622 195.66666 601 108.999985 601 L 108.999985 557 C 167.66666 557 214.99998 565.6667 250.99998 583 L 250.99998 85 C 250.99998 72.33333 249.66666 64 246.99998 60 C 241.66666 48.66667 211.66666 43 156.99998 43 L 115.999985 43 L 115.999985 0 L 294 4 L 473 0 L 473 43 L 432 43 C 377.3333 43 347 48.66667 341 60 C 339 64 338 72.33333 338 85 L 338 632 C 338 658.7067 334.47937 664 303 664 Z "/>
+        </symbol>
+        <symbol id="g3" overflow="visible">
+            <path d="M 278 242 C 278.6667 244 279 246.66667 279 250 C 279 253.33333 278.6667 256 278 258 L 98 735 C 94 745 86.66667 750 76 750 C 60.66667 750 53 742 53 726 C 53 722.6667 53.33333 720 54 718 L 231 250 L 54 -217 C 53.33333 -219 53 -222 53 -226 C 53 -242 60.66667 -250 76 -250 C 86.66667 -250 94 -245 98 -235 Z "/>
+        </symbol>
+        <symbol id="g4" overflow="visible">
+            <path d="M 881 668 C 881 678 875 683 863 683 L 736 680 L 609 683 C 593.0144 683 586 673.90576 586 659 C 586 651.6667 588.6667 647.3334 594 646.00006 C 604 644.66675 611.6667 644.00006 617 644.00006 C 647.6667 642.66675 665.5 641.50006 670.5 640.50006 C 675.5 639.50006 678 636.3334 678 631.00006 C 677.3333 628.3334 676 622.3334 674 613.00006 L 615 375.00006 L 321 375.00006 L 379 602.00006 C 384.3333 623.3334 393.3333 636.3334 406 641.00006 C 412.6667 643.00006 430 644.00006 458 644.00006 C 484.81168 644.00006 496 643.9177 496 668 C 496 678 490 683 478 683 L 351 680 L 223 683 C 207.01442 683 200 673.90576 200 659 C 200 651.6667 203 647.3334 209 646.00006 C 219 644.66675 226.66667 644.00006 232 644.00006 C 262.6667 642.66675 280.5 641.50006 285.5 640.50006 C 290.5 639.50006 293 636.3334 293 631.00006 C 293 629.00006 291.6667 623.00006 289 613.00006 L 156 82.00006 C 150.66667 60.00006 140.66667 46.666733 126 42.00006 C 119.33333 40.00006 100.66667 39.00006 70 39.00006 C 47.81862 39.00006 39 36.95552 39 15.000061 C 39 5.000061 45 0.000061035156 57 0.000061035156 L 183 3.000061 L 246 2.000061 C 256.65405 2.000061 299.017 0.000061035156 310 0.000061035156 C 326.3851 0.000061035156 334 8.337875 334 24.000061 C 334 34.00006 323.3333 39.00006 302 39.00006 C 262 39.00006 242 43.33339 242 52.00006 C 242 52.00006 243 54.666733 245 68.00006 L 312 336.00006 L 605 336.00006 L 538 68.00006 C 534.6667 52.666733 523 43.33339 503 40.00006 C 498.3333 39.33339 481.3333 39.00006 452 39.00006 C 433.3333 39.00006 424 31.000061 424 15.000061 C 424 5.000061 430 0.000061035156 442 0.000061035156 L 568 3.000061 L 631 2.000061 C 641.50757 2.000061 683.33905 0.000061035156 696 0.000061035156 C 712.38513 0.000061035156 720 8.337875 720 24.000061 C 720 34.00006 709.3333 39.00006 688 39.00006 C 647.3333 39.00006 627 43.33339 627 52.00006 C 627 52.00006 628 54.666733 630 68.00006 L 764 602.00006 C 769.3333 623.3334 778.3333 636.3334 791 641.00006 C 797 643.00006 814.3333 644.00006 843 644.00006 C 868.9501 644.00006 881 644.29517 881 668 Z "/>
+        </symbol>
+        <symbol id="g5" overflow="visible">
+            <path d="M 739 531 C 739 581.6667 713.3333 621 662 649 C 620.6667 671.6667 572.3334 683 517.00006 683 L 235.00006 683 C 211.50154 683 202.00006 682.31824 202.00006 659 C 202.00006 651.6667 205.00006 647.3334 211.00006 646.00006 C 221.00006 644.66675 228.66673 644.00006 234.00006 644.00006 C 264.00006 642.66675 281.50006 641.50006 286.50006 640.50006 C 291.50006 639.50006 294.00006 636.3334 294.00006 631.00006 C 294.00006 629.00006 292.66675 623.00006 290.00006 613.00006 L 158.00006 82.00006 C 152.66673 60.00006 142.66673 46.33339 128.00006 41.00006 C 121.33339 39.00006 102.66673 38.00006 72.00006 38.00006 C 49.8291 38.00006 41.00006 36.96599 41.00006 15.000061 C 41.00006 4.3333893 47.00006 -0.6666107 59.00006 0.000061035156 L 183.00006 3.000061 L 309.00006 0.000061035156 C 325.08606 -1.23732 333.00006 8.266876 333.00006 23.000061 C 333.00006 33.00006 322.33337 38.00006 301.00006 38.00006 C 261.00006 38.00006 241.00006 42.666733 241.00006 52.00006 C 241.00006 52.00006 242.00006 54.00006 244.00006 68.00006 L 308.00006 327.00006 L 423.00006 327.00006 C 492.33337 327.00006 527.00006 298.33337 527.00006 241.00005 C 527.00006 232.33337 522.3334 210.00005 513.00006 174.00005 C 502.33337 132.00005 497.00006 103.66672 497.00006 89.000046 C 497.00006 13.430557 556.2065 -21.999954 632.00006 -21.999954 C 660.00006 -21.999954 687.50006 -9.333282 714.50006 16.000046 C 741.50006 41.333374 755.00006 68.000046 755.00006 96.000046 C 755.00006 106.000046 749.66675 111.000046 739.00006 111.000046 C 731.66675 111.000046 726.3334 105.66672 723.00006 95.000046 C 712.3334 63.666718 698.8334 41.333374 682.50006 28.000046 C 666.16675 14.666718 650.66675 8.000046 636.00006 8.000046 C 612.66675 8.000046 601.00006 26.666718 601.00006 64.000046 C 601.00006 88.000046 604.3334 125.333374 611.00006 176.00005 C 613.66675 196.66672 615.00006 212.33337 615.00006 223.00005 C 615.00006 276.33337 587.00006 315.00006 531.00006 339.00006 C 624.63245 362.40814 739.0001 429.13394 739.0001 531.00006 Z M 609.0001 616.00006 C 629.0001 603.3334 639.0001 581.3334 639.0001 550.00006 C 639.0001 530.00006 634.6668 506.66675 626.0001 480.00006 C 598.6668 398.00006 530.6668 357.00006 422.00012 357.00006 L 316.00012 357.00006 L 379.00012 610.00006 C 384.33344 630.66675 392.33344 641.66675 403.00012 643.00006 C 407.6668 643.66675 427.6668 644.00006 463.00012 644.00006 C 527.9275 644.00006 566.235 642.4138 609.0001 616.00006 Z "/>
+        </symbol>
+        <symbol id="g6" overflow="visible">
+            <path d="M 119 424 C 150.79085 424 175 448.20844 175 480 C 175 516 156.33333 534.6667 119 536 C 141.3666 583.0876 190.544 621 256 621 C 344.1449 621 402 555.2719 402 467 C 402 419 384.6667 372.6667 350 328 C 332.6667 305.3333 319.6667 289.3333 311 280 L 74 45 C 60.69464 33.357803 63 29.960907 63 0 L 475 0 L 506 188 L 464 188 C 456.6667 134.66667 448.6667 104.33333 440 97 C 435.3333 93.66667 403.66666 92 345 92 L 175 92 C 241.66667 151.33333 304.3333 204.33333 363 251 C 407.6667 286.3333 440 317.3333 460 344 C 490 382.6667 505 423.6667 505 467 C 505 529 480.6667 578 432 614 C 388.6667 647.3333 335 664 271 664 C 216.33333 664 168.66667 648 128 616 C 84.66667 581.3333 63 537 63 483 C 63 448.5313 88.20494 424 119 424 Z "/>
+        </symbol>
+        <symbol id="g7" overflow="visible">
+            <path d="M 751 53 C 751 82.61751 724.8598 106 695 106 C 664.3368 106 638 83.12465 638 53 C 638 22.871582 664.3305 0 695 0 C 725.4052 0 751 22.515701 751 53 Z M 475 53 C 475 82.61751 448.8598 106 419 106 C 388.2974 106 363 83.13408 363 53 C 363 22.862122 388.2914 0 419 0 C 449.4052 0 475 22.515701 475 53 Z M 200 53 C 200 83.12842 173.66951 106 143 106 C 113.143845 106 87 82.61595 87 53 C 87 23.382492 113.14021 0 143 0 C 173.37909 0 200 22.515701 200 53 Z "/>
+        </symbol>
+        <symbol id="g8" overflow="visible">
+            <path d="M 164 441 C 131.33333 441 104.33333 422.6667 83 386 C 69 361.3333 58.33333 334.66666 51 306 C 48.33333 295.3333 47 289 47 287 C 47 275.6667 54 270 68 270 C 87.22215 270 88.48686 280.56262 93 302 C 110.33333 371.3333 133.33333 406 162 406 C 180.66667 406 190 391 190 361 C 190 350.3333 184.66667 323.66666 174 281 L 121 67 C 114.33333 40.33333 111 26.333328 111 25 C 111 1.6666718 123.66667 -10 149 -10 C 167.66667 -10 181.66667 -2 191 14 C 194.33333 20 200.33333 40.66667 209 76 L 230 164 C 242 210.66667 249 237 251 243 C 259 269 271.3333 293.6667 288 317 C 330 376.3333 378.3333 406 433 406 C 469 406 487 384.3333 487 341 C 487 302.3333 467.6667 232.99998 429 132.99998 C 419 106.999985 414 88.66666 414 77.999985 C 414 24.379578 458.3088 -10.000015 512 -10.000015 C 559.3333 -10.000015 596.6666 13.999985 623.99994 61.999985 C 646.6666 102.66666 657.99994 129.99998 657.99994 143.99998 C 657.99994 155.33331 651.33325 160.99998 637.99994 160.99998 C 631.33325 160.33331 624.33325 154.99998 616.99994 144.99998 C 616.33325 143.66666 615.99994 142.33331 615.99994 140.99998 C 592.6666 63.666656 558.99994 24.999985 514.99994 24.999985 C 500.99994 24.999985 493.99994 35.333313 493.99994 55.999985 C 493.99994 69.999985 501.66663 95.999985 516.99994 133.99998 C 551.6666 223.33331 568.99994 287 568.99994 325 C 568.99994 371 553.33325 402.6667 521.99994 420 C 496.66663 434 468.33328 441 436.99994 441 C 371.66663 441 316.99994 413 272.99994 357 C 264.1241 406.45102 220.8838 441 163.99994 441 Z "/>
+        </symbol>
+        <symbol id="g9" overflow="visible">
+            <path d="M 696 273 L 82 273 C 62 273 56 263.3333 56 249.99998 C 56 236.66666 62 226.99998 82 226.99998 L 696 226.99998 C 716 226.99998 722 236.66666 722 249.99998 C 722 261.5432 716 272.99997 696 272.99997 Z "/>
+        </symbol>
+        <symbol id="g10" overflow="visible">
+            <path d="M 249 -22 C 389.6667 -22 460 92 460 320 C 460 473.3333 428.3333 575 365 625 C 329.6667 652.3333 291.33334 666 250.00002 666 C 109.33334 666 39.000015 550.6667 39.000015 320 C 39.000015 136.38824 87.780106 -22 249.00002 -22 Z M 361 524 C 367.6667 489.3333 371 425.3333 371 332 C 371 240 367.3333 172 360 128 C 347.3333 48 310.3333 8 248.99998 8 C 225.66666 8 203.33331 16.666672 181.99998 34 C 155.33331 56.66667 138.66666 104 131.99998 176 C 129.33331 200.66667 127.999985 252.66667 127.999985 332 C 127.999985 419.3333 130.66666 479.66666 135.99998 513 C 144.66666 567.6667 162.99998 602.6667 190.99998 618 C 212.99998 630 232.33331 636 248.99998 636 C 313.54602 636 349.9783 582.78235 361 524 Z "/>
+        </symbol>
+        <symbol id="g11" overflow="visible">
+            <path d="M 698 274 L 413 274 L 413 559 C 413 575 405 583 389 583 C 373 583 365 575 365 559 L 365 274 L 80 274 C 64 274 56 266 56 250 C 56 234 64 226 80 226 L 365 226 L 365 -59 C 365 -75 373 -83 389 -83 C 405 -83 413 -75 413 -59 L 413 226 L 698 226 C 714 226 722 234 722 250 C 722 263.22876 711.2291 274 698 274 Z "/>
+        </symbol>
+        <symbol id="g12" overflow="visible">
+            <path d="M 124 129 C 124 153 129 185.66667 139 227 L 188 227 C 252.66667 227 303 234.66667 339 250 C 372.3333 264 394.3333 283.6667 405 309 C 411.6667 326.3333 415 341.66666 415 355 C 415 410.4651 362.5758 442 307 442 C 268.3333 442 229.33331 432 189.99998 412 C 112.89758 372.28058 45.999985 281.27246 45.999985 171.00002 C 45.999985 68.982574 105.111206 -10.999985 203.99998 -10.999985 C 256.66666 -10.999985 303.66666 1.666687 345 27.000015 C 379 47.666687 404 68.66669 420 90.000015 C 426.6667 99.33334 430 105.66669 430 109.000015 C 430 120.33334 424.6667 126.000015 414 126.000015 C 409.3333 126.000015 404 122.000015 398 114.000015 C 364.6667 70.000015 324.33334 42.000015 277 30.000015 C 246.33333 22.000015 222.66667 18.000015 206 18.000015 C 148.81468 18.000015 124 71.94667 124 129.00002 Z M 375 355 C 375 289 310.6667 256 182.00002 256 L 147.00002 256 C 165.66669 322 194.00002 365.6667 232.00002 387 C 262 404.3333 287 413 307 413 C 343.44305 413 375 391.37445 375 355 Z "/>
+        </symbol>
+        <symbol id="g13" overflow="visible">
+            <path d="M 448 -10 C 473.0196 -10 498 12.927185 498 38 C 498 43.33333 495.3333 51.33333 490 62 C 466 106.66667 454 163.66667 454 233 C 454 270.3333 458.3333 311.3333 467 356 L 587 356 C 625 356 644 370.3333 644 399 C 644 420.3333 628.6667 431 598 431 L 226 431 C 186 431 147.33333 414 110 380 C 96.66667 367.3333 82.5 351 67.5 331 C 52.5 311 45 298.3333 45 293 C 45 282.3333 52 277 66 277 C 74 277 81 281 87 289 C 119 333.6667 162.33333 356 217 356 L 272 356 C 250.66667 281.3333 209.33333 180.66666 148 53.999985 C 144.66667 47.333313 142.33333 43.333313 141 41.999985 C 139 33.333313 138 27.666656 138 24.999985 C 138 1.6666565 150.66667 -10.000015 176 -10.000015 C 198 -10.000015 216.33333 7.9999847 231 43.999985 C 234.33333 52.666656 242 79.999985 254 125.999985 L 314 356 L 424 356 C 400 261.3333 388 187.33331 388 133.99998 C 388 75.143295 403.05408 -10.000015 448 -10.000015 Z "/>
+        </symbol>
+        <symbol id="g14" overflow="visible">
+            <path d="M 325 621 C 325 644.84314 305.81763 663 282 663 C 252.21732 663 223 634.504 223 605 C 223 581.15686 242.18237 563 266 563 C 295.78268 563 325 591.496 325 621 Z M 192 444 C 145.33333 444 108.33333 420 81 372 C 58.33333 332 47 304 47 288 C 47 277.3333 53.66667 272 67 272 C 77.66667 272 85 278 89 290 C 111.66667 368.6667 145 408 189 408 C 203 408 210 397.6667 210 377 C 210 364.3333 200 332 180 280 L 118 121 C 112 105 109 90.66667 109 78 C 109 25.759903 153.66695 -10 206 -10 C 252.66667 -10 289.3333 14.333328 316 63 C 338.6667 103 350 130.33333 350 145 C 350 156.33333 343.3333 162 330 162 C 324 161.33333 317.3333 156 310 146 C 308.6667 144.66667 308 143.33333 308 142 C 285.3333 64.66667 252.33331 26 208.99998 26 C 194.99998 26 187.99998 36 187.99998 56 C 187.99998 71.33333 193.33331 92 203.99998 118 L 283 323 C 287 333.6667 289 344.6667 289 356 C 289 408.2401 244.33305 444 192 444 Z "/>
+        </symbol>
+        <symbol id="g15" overflow="visible">
+            <path d="M 516 319 C 516 431.6667 496.3333 517.6667 457 577 C 425.03815 626.7184 361.22156 664 283.99997 664 C 251.99997 664 223.3333 658.6667 197.99997 648 C 88.364426 601.92126 51.99997 473.60583 51.99997 319 C 51.99997 285 53.66664 252.66667 56.99997 222 C 74.10147 90.88843 135.18726 -20 283.99997 -20 C 315.99997 -20 344.66663 -14.666672 369.99994 -4 C 480.04086 40.65428 515.99994 166.36996 515.99994 319 Z M 401.99994 541 C 413.33325 504.3333 418.99994 434.66666 418.99994 332 C 418.99994 234 414.66663 164.66667 405.99994 124 C 393.7713 65.302475 352.35263 16 283.99994 16 C 258.66663 16 234.33328 24.333328 210.99995 41 C 180.33328 63.66667 160.99995 109.33333 152.99995 178 C 150.33328 200.66667 148.99995 252 148.99995 332 C 148.99995 429.3333 153.99995 496 163.99995 532 C 181.33328 596 221.33328 628 283.99994 628 C 343.72092 628 387.55536 589.1486 401.99994 541 Z "/>
+        </symbol>
+        <symbol id="g16" overflow="visible">
+            <path d="M 227 57 C 227 88.738556 201.76553 115 170 115 C 138.26144 115 112 89.76553 112 58 C 112 26.261444 137.23447 0 169 0 C 200.73856 0 227 25.234467 227 57 Z "/>
+        </symbol>
+        <symbol id="g17" overflow="visible">
+            <path d="M 439 621 C 439 644.84314 419.81763 663 396 663 C 367.05884 663 337 633.9686 337 605 C 337 581.15686 356.18237 563 380 563 C 409.78268 563 439 591.496 439 621 Z M 294 443 C 237.70914 443 188.78397 405.75232 163 371 C 133 328.3333 118 300.3333 118 287 C 118 276.3333 124.66667 271 138 271 C 148 271 156 277.6667 162 291 C 172.66667 315 185.66667 336.3333 201 355 C 229.66667 389.6667 259.6667 407 291 407 C 310.3333 407 320 392.3333 320 363 C 320 351 319 341.3333 317 334 L 223 -45 C 208.85378 -101.584885 164.03938 -168 100 -168 C 91.33333 -168 83 -167 75 -165 C 93 -153.66667 102 -137.33333 102 -116 C 102 -88.66667 88 -75 60 -75 C 26.40738 -75 0 -104.16417 0 -138 C 0 -183.97922 50.330276 -204 101 -204 C 124.33333 -204 149 -199.66667 175 -191 C 237.43706 -170.18765 292.97687 -110.76306 309 -44 L 398 310 C 401.3333 323.3333 403 335.3333 403 346 C 403 404.43137 352.11957 443 294 443 Z "/>
+        </symbol>
+        <symbol id="g18" overflow="visible">
+            <path d="M 360 666 C 314 624 248.66667 603 164 603 L 143 603 L 143 551 L 164 551 C 214.66667 551 261 559.6667 303 577 L 303 89 C 303 77.66667 301.6667 70 299 66 C 293.6667 56 261.6667 51 203.00002 51 L 150.00002 51 L 150.00002 0 C 188.66669 2.6666718 256 4 352 4 C 448 4 515.3333 2.6666718 554 0 L 554 51 L 501 51 C 442.3333 51 410 56 404 66 C 402 70 401 77.66667 401 89 L 401 632 C 401 666.3756 396.6876 666 360 666 Z "/>
+        </symbol>
+        <symbol id="g19" overflow="visible">
+            <path d="M 530 442 C 459.3333 442 398 411.6667 346 351 C 338.78577 408.7138 280.86948 442 222 442 C 195.33333 442 171.33333 431.3333 150 410 C 128.66667 388.6667 111.66667 357.6667 99 317 C 95.66667 303.6667 93 293.33334 91 286 C 91 274 99.33333 268 116 268 C 130 268 138.66667 275.3333 142 290 C 161.33333 364 186.66667 401 218 401 C 242 401 254 385 254 353 C 254 345 248.66667 319.6667 238 277 L 217 188 L 194 101 C 182.66667 57.66667 177 33 177 27 C 177 1.6666718 190.66667 -11 218 -11 C 241.33333 -11 258.3333 0.66667175 269 24 L 288 101 C 303.3333 165.66667 315 211.66667 323 239 C 336.3333 265.6667 356.3333 295.33334 383 328 C 422.3333 376.6667 469.3333 401 524 401 C 567.3333 401 589 378.6667 589 334 C 589 297.3333 567.6667 226.66666 525 121.999985 C 518.3333 105.33331 515 90.999985 515 78.999985 C 515 24.410004 569.93524 -11.000015 627 -11.000015 C 659.6667 -11.000015 689.3334 0.6666565 716.00006 23.999985 C 766.00006 66.66666 791.00006 106.999985 791.00006 144.99998 C 791.00006 156.99998 782.66675 162.99998 766.00006 162.99998 C 754.00006 162.99998 746.66675 159.66666 744.00006 152.99998 C 728.00006 109.66666 711.3334 78.999985 694.00006 60.999985 C 674.00006 40.333313 653.00006 29.999985 631.00006 29.999985 C 613.66675 29.999985 605.00006 41.333313 605.00006 63.999985 C 605.00006 77.999985 609.3334 94.66666 618.00006 113.999985 C 659.3334 212.66666 680.00006 281.66666 680.00006 321 C 680.00006 403.89136 616.9313 442 530 442 Z "/>
+        </symbol>
+        <symbol id="g20" overflow="visible">
+            <path d="M 269 666 C 228.33333 624 168.33333 603 89 603 L 89 564 C 141 564 183.66667 572 217 588 L 217 82 C 217 64 212.5 52.33333 203.5 47 C 194.5 41.66667 170 39 130 39 L 95 39 L 95 0 C 120.33333 2 174.33333 3 257 3 C 339.6667 3 393.6667 2 419 0 L 419 39 L 384 39 C 342.6667 39 317.83334 41.66667 309.5 47 C 301.1667 52.33333 297 64 297 82 L 297 636 C 297 659.56604 295.16443 666 269 666 Z "/>
+        </symbol>
+        <symbol id="g21" overflow="visible">
+            <path d="M 152 424 C 187.79085 424 214 450.20844 214 486 C 214 521.3333 196.33333 542 161 548 C 191.66667 592.6667 239.66667 615 305 615 C 399.6441 615 476 556.103 476 464 C 476 400.6667 432 331.6667 344 257 L 104 52 C 96 45.33333 91.66667 39.33333 91 34 L 91 0 L 556 0 L 590 199 L 540 199 C 531.3333 145 522.3333 114.66667 513 108 C 507.6667 104.66667 473.33334 103 410 103 L 229 103 C 358.38892 198.3889 385.88855 216.63466 469.00003 276 C 509.00003 305.3333 537.3334 332.3333 554.00006 357 C 577.3334 391.6667 589.00006 427.6667 589.00006 465 C 589.00006 531.6667 560.3334 583 503.00006 619 C 454.33337 650.3333 395.00006 666 325.00006 666 C 266.33337 666 214.33337 651.3333 169.00005 622 C 117.000046 588.6667 91.000046 544 91.000046 488 C 91.000046 450.47626 120.78989 424 152.00005 424 Z "/>
+        </symbol>
+        <symbol id="g22" overflow="visible">
+            <path d="M 162 526 C 162 555.85614 138.61595 582 109 582 C 79.38249 582 56 555.8598 56 526 C 56 495.33676 78.87535 469 109 469 C 139.48366 469 162 495.6199 162 526 Z M 162 250 C 162 279.85614 138.61595 306 109 306 C 78.86212 306 56 280.7086 56 250 C 56 219.2974 78.86592 194 109 194 C 139.48366 194 162 219.59386 162 250 Z M 162 -26 C 162 4.6632385 139.12465 31 109 31 C 78.87158 31 56 4.66951 56 -26 C 56 -55.856155 79.38405 -82 109 -82 C 139.48366 -82 162 -56.406143 162 -26 Z "/>
+        </symbol>
+        <symbol id="g23" overflow="visible">
+            <path d="M 694 276 L 84 276 C 64 276 56 263.3333 56 249.99998 C 56 236.66666 64 223.99998 84 223.99998 L 694 223.99998 C 714 223.99998 722 236.66666 722 249.99998 C 722 261.5432 714 275.99997 694 275.99997 Z "/>
+        </symbol>
+    </defs>
+    <defs id="clip-path"/>
+</svg>

--- a/packages/preview/quill/0.4.0/docs/images/teleportation.svg
+++ b/packages/preview/quill/0.4.0/docs/images/teleportation.svg
@@ -1,0 +1,330 @@
+<svg class="typst-doc" viewBox="0 0 252.68849999999998 111.437" width="252.68849999999998" height="111.437" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(-0 -0)">
+            <path class="typst-shape" fill="#ffffff" d="M 0.87867963 0.87867963 C 1.4412888 0.31607053 2.2043505 0 3 0 L 249.6885 0 C 251.34535 0.00000000000000032750764 252.6885 1.3431457 252.6885 3 L 252.6885 108.437 C 252.6885 110.09386 251.34535 111.437 249.6885 111.437 L 3 111.437 C 1.3431457 111.437 0.000000000000000082243954 110.09386 0.00000000000000018369701 108.437 L 0.000000000000006639851 3 C 0.0000000000000066885707 2.2043505 0.31607053 1.4412888 0.87867963 0.87867963 Z "/>
+        </g>
+        <g transform="translate(6 6)">
+            <g class="typst-group">
+                <g transform="matrix(1.3 0 0 1.3 0 0)">
+                    <g transform="translate(40.91 4.000000000000001)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(16.3 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                </g>
+                                <g transform="translate(0 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.3 0 "/>
+                                </g>
+                                <g transform="translate(18.6 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 22.545 0 "/>
+                                </g>
+                                <g transform="translate(49.69 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.395 0 "/>
+                                </g>
+                                <g transform="translate(98.23499999999999 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 53.66 "/>
+                                </g>
+                                <g transform="translate(70.085 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 28.15 0 "/>
+                                </g>
+                                <g transform="translate(100.53499999999998 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 28.5775 0 "/>
+                                </g>
+                                <g transform="translate(0 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 16.3 0 "/>
+                                </g>
+                                <g transform="translate(16.3 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 24.845 0 "/>
+                                </g>
+                                <g transform="translate(70.085 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 26.83 "/>
+                                </g>
+                                <g transform="translate(41.144999999999996 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 28.94 0 "/>
+                                </g>
+                                <g transform="translate(72.38499999999999 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 25.85 0 "/>
+                                </g>
+                                <g transform="translate(98.23499999999999 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 30.8775 0 "/>
+                                </g>
+                                <g transform="translate(0 61.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 41.145 0 "/>
+                                </g>
+                                <g transform="translate(41.144999999999996 61.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 28.94 0 "/>
+                                </g>
+                                <g transform="translate(78.47999999999999 61.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 19.755 0 "/>
+                                </g>
+                                <g transform="translate(105.98999999999998 61.07499999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 23.1225 0 "/>
+                                </g>
+                                <g transform="translate(0 16.415)"/>
+                                <g transform="translate(-21.3 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 3.8900000000000006)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(13.41 3.33)"/>
+                                            <g transform="translate(13.41 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.3 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(14 5.114999999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(32.599999999999994 -0.0000000000000008881784197001252)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 17.09 14.83 L 17.09 0 Z "/>
+                                </g>
+                                <g transform="translate(36.599999999999994 3.999999999999999)"/>
+                                <g transform="translate(36.599999999999994 3.999999999999999)"/>
+                                <g transform="translate(36.599999999999994 10.829999999999998)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g3" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(45.68999999999999 10.829999999999998)"/>
+                                <g transform="translate(95.93499999999999 5.114999999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(117.98999999999998 -0.0000000000000008881784197001252)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 22.245 14.83 L 22.245 0 Z "/>
+                                </g>
+                                <g transform="translate(121.98999999999998 3.999999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 7.513 C 0 7.513 1.4245 2.732 7.1225 2.732 C 12.8205 2.732 14.245 7.513 14.245 7.513 "/>
+                                </g>
+                                <g transform="translate(129.11249999999998 12.195999999999998)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 5.698 -6.147 "/>
+                                </g>
+                                <g transform="translate(121.98999999999998 3.999999999999999)">
+                                    <path class="typst-shape" fill="#000000" d="M 15.403605 -0.73803514 C 15.403605 -0.73803514 11.793697 1.0973295 11.793697 1.0973295 C 11.793697 1.0973295 13.847302 3.0006704 13.847302 3.0006704 C 13.847302 3.0006704 15.403605 -0.73803514 15.403605 -0.73803514 Z "/>
+                                </g>
+                                <g transform="translate(-36.91 34.245)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(27.89 -2.5)"/>
+                                            <g transform="translate(27.89 -2.5)"/>
+                                            <g transform="translate(27.89 -2.5)"/>
+                                            <g transform="translate(27.89 21.82999999999999)"/>
+                                            <g transform="translate(27.89 29.32999999999999)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g4" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.89 17.632499999999993)"/>
+                                            <g transform="translate(27.89 25.112499999999994)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.89 5.914999999999996)"/>
+                                            <g transform="translate(27.89 20.914999999999996)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g6" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.89 1.7174999999999976)"/>
+                                            <g transform="translate(27.89 9.197499999999998)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g5" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.89 -2.5)"/>
+                                            <g transform="translate(27.89 5)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g7" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(27.89 29.32999999999999)"/>
+                                            <g transform="translate(0 5.999999999999996)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(4 4)"/>
+                                                        <g transform="translate(4 3.33)"/>
+                                                        <g transform="translate(4 3.33)"/>
+                                                        <g transform="translate(4 10.83)">
+                                                            <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                                <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(6.78 3.7700000000000005)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(0 0)"/>
+                                                                    <g transform="translate(0 0)"/>
+                                                                    <g transform="translate(0 7.06)">
+                                                                        <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                                            <use xlink:href="#g8" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(5.659999999999999 4.867999999999999)"/>
+                                                                    <g transform="translate(5.659999999999999 4.867999999999999)"/>
+                                                                    <g transform="translate(5.659999999999999 9.53)">
+                                                                        <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                            <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(9.16 4.867999999999999)"/>
+                                                                    <g transform="translate(9.16 9.53)">
+                                                                        <g class="typst-text" transform="scale(0.007 -0.007)">
+                                                                            <use xlink:href="#g9" x="0" fill="#000000"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(20 3.33)"/>
+                                                        <g transform="translate(20 10.83)">
+                                                            <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                                <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(23.89 10.83)"/>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(12 29.944999999999997)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 4.3 C 0 1.9273288 1.9273288 0 4.3 0 C 6.6726713 0 8.6 1.9273288 8.6 4.3 C 8.6 6.6726713 6.6726713 8.6 4.3 8.6 C 1.9273288 8.6 0 6.6726713 0 4.3 "/>
+                                </g>
+                                <g transform="translate(16.3 38.544999999999995)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0.0000000000000005265981 -8.6 "/>
+                                </g>
+                                <g transform="translate(12 34.245)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 8.6 0 "/>
+                                </g>
+                                <g transform="translate(67.785 31.944999999999997)">
+                                    <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                </g>
+                                <g transform="translate(117.98999999999998 26.83)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 22.245 14.83 L 22.245 0 Z "/>
+                                </g>
+                                <g transform="translate(121.98999999999998 30.83)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 7.513 C 0 7.513 1.4245 2.732 7.1225 2.732 C 12.8205 2.732 14.245 7.513 14.245 7.513 "/>
+                                </g>
+                                <g transform="translate(129.11249999999998 39.025999999999996)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 5.698 -6.147 "/>
+                                </g>
+                                <g transform="translate(121.98999999999998 30.83)">
+                                    <path class="typst-shape" fill="#000000" d="M 15.403605 -0.73803514 C 15.403605 -0.73803514 11.793697 1.0973295 11.793697 1.0973295 C 11.793697 1.0973295 13.847302 3.0006704 13.847302 3.0006704 C 13.847302 3.0006704 15.403605 -0.73803514 15.403605 -0.73803514 Z "/>
+                                </g>
+                                <g transform="translate(61.69 53.65999999999999)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 16.79 14.83 L 16.79 0 Z "/>
+                                </g>
+                                <g transform="translate(65.69 57.65999999999999)"/>
+                                <g transform="translate(65.69 57.65999999999999)"/>
+                                <g transform="translate(65.69 64.49)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g10" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(74.47999999999999 64.49)"/>
+                                <g transform="translate(90.47999999999999 53.65999999999999)">
+                                    <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 15.51 14.83 L 15.51 0 Z "/>
+                                </g>
+                                <g transform="translate(94.47999999999999 57.65999999999999)"/>
+                                <g transform="translate(94.47999999999999 57.65999999999999)"/>
+                                <g transform="translate(94.47999999999999 64.49)">
+                                    <g class="typst-text" transform="scale(0.01 -0.01)">
+                                        <use xlink:href="#g11" x="0" fill="#000000"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(101.99 64.49)"/>
+                                <g transform="translate(118.46249999999998 53.65999999999999)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" d="M 0 0 L 0 14.83 L 21.3 14.83 L 21.3 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 3.33)"/>
+                                            <g transform="translate(4 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g0" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(6.78 3.8900000000000006)"/>
+                                            <g transform="translate(6.78 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g1" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(13.41 3.33)"/>
+                                            <g transform="translate(13.41 10.83)">
+                                                <g class="typst-text" transform="scale(0.01 -0.01)">
+                                                    <use xlink:href="#g2" x="0" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(17.3 10.83)"/>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(0 0)"/>
+    </g>
+    <defs id="glyph">
+        <symbol id="g0" overflow="visible">
+            <path d="M 139 -250 C 152.33333 -250 159 -242 159 -226 L 159 726 C 159 742 152.33333 750 139 750 C 125.66667 750 119 742 119 726 L 119 -226 C 119 -242 125.66667 -250 139 -250 Z "/>
+        </symbol>
+        <symbol id="g1" overflow="visible">
+            <path d="M 534 393 C 534 383.6667 539.3333 373.6667 550 363 C 573.3333 341 585 314 585 282 C 585 253.33333 575.6667 221.66667 557 187 C 521.6667 119.66667 476.33334 71.66667 421 43 C 387.6667 26.333328 354.6667 17.666672 322 17 L 484 663 C 486 671.6667 487 677 487 679 C 487 689 481.6667 694 471 694 C 466.3333 694 462.66666 693 460 691 C 456 683 453.6667 676.3333 453 671 L 290 19 C 219.33333 28.333328 184 64 184 126 C 184 153.33333 201.66667 214.33333 237 309 C 244.33333 329 248 345.6667 248 359 C 248 408.5749 212.90883 444 163 444 C 118.33333 444 83.66667 419 59 369 C 39 329 29 302 29 288 C 29 278.6667 34.33333 274 45 274 C 58.389786 274 59.966278 279.882 64 294 C 87.33333 374 119.33333 414 160 414 C 174 414 181 405 181 387 C 181 371 173.66667 343 159 303 C 127 218.33333 111 162 111 134 C 111 46.66667 168 -1.3333282 282 -10 C 274 -45.33333 267 -74 261 -96 C 245.66667 -152.66667 238 -184.66667 238 -192 C 240.70691 -200.12073 241.86992 -205 255 -205 L 265 -201 C 271 -185 275.6667 -170.33333 279 -157 L 315 -13 C 397 -11.666672 469 24.333328 531 95 C 563.6667 131.66667 588 171.66667 604 215 C 624.6667 270.3333 635 322.3333 635 371 C 635 419.6667 619.3333 444 588 444 C 562.25916 444 534 418.5208 534 393 Z "/>
+        </symbol>
+        <symbol id="g2" overflow="visible">
+            <path d="M 278 242 C 278.6667 244 279 246.66667 279 250 C 279 253.33333 278.6667 256 278 258 L 98 735 C 94 745 86.66667 750 76 750 C 60.66667 750 53 742 53 726 C 53 722.6667 53.33333 720 54 718 L 231 250 L 54 -217 C 53.33333 -219 53 -222 53 -226 C 53 -242 60.66667 -250 76 -250 C 86.66667 -250 94 -245 98 -235 Z "/>
+        </symbol>
+        <symbol id="g3" overflow="visible">
+            <path d="M 881 668 C 881 678 875 683 863 683 L 736 680 L 609 683 C 593.0144 683 586 673.90576 586 659 C 586 651.6667 588.6667 647.3334 594 646.00006 C 604 644.66675 611.6667 644.00006 617 644.00006 C 647.6667 642.66675 665.5 641.50006 670.5 640.50006 C 675.5 639.50006 678 636.3334 678 631.00006 C 677.3333 628.3334 676 622.3334 674 613.00006 L 615 375.00006 L 321 375.00006 L 379 602.00006 C 384.3333 623.3334 393.3333 636.3334 406 641.00006 C 412.6667 643.00006 430 644.00006 458 644.00006 C 484.81168 644.00006 496 643.9177 496 668 C 496 678 490 683 478 683 L 351 680 L 223 683 C 207.01442 683 200 673.90576 200 659 C 200 651.6667 203 647.3334 209 646.00006 C 219 644.66675 226.66667 644.00006 232 644.00006 C 262.6667 642.66675 280.5 641.50006 285.5 640.50006 C 290.5 639.50006 293 636.3334 293 631.00006 C 293 629.00006 291.6667 623.00006 289 613.00006 L 156 82.00006 C 150.66667 60.00006 140.66667 46.666733 126 42.00006 C 119.33333 40.00006 100.66667 39.00006 70 39.00006 C 47.81862 39.00006 39 36.95552 39 15.000061 C 39 5.000061 45 0.000061035156 57 0.000061035156 L 183 3.000061 L 246 2.000061 C 256.65405 2.000061 299.017 0.000061035156 310 0.000061035156 C 326.3851 0.000061035156 334 8.337875 334 24.000061 C 334 34.00006 323.3333 39.00006 302 39.00006 C 262 39.00006 242 43.33339 242 52.00006 C 242 52.00006 243 54.666733 245 68.00006 L 312 336.00006 L 605 336.00006 L 538 68.00006 C 534.6667 52.666733 523 43.33339 503 40.00006 C 498.3333 39.33339 481.3333 39.00006 452 39.00006 C 433.3333 39.00006 424 31.000061 424 15.000061 C 424 5.000061 430 0.000061035156 442 0.000061035156 L 568 3.000061 L 631 2.000061 C 641.50757 2.000061 683.33905 0.000061035156 696 0.000061035156 C 712.38513 0.000061035156 720 8.337875 720 24.000061 C 720 34.00006 709.3333 39.00006 688 39.00006 C 647.3333 39.00006 627 43.33339 627 52.00006 C 627 52.00006 628 54.666733 630 68.00006 L 764 602.00006 C 769.3333 623.3334 778.3333 636.3334 791 641.00006 C 797 643.00006 814.3333 644.00006 843 644.00006 C 868.9501 644.00006 881 644.29517 881 668 Z "/>
+        </symbol>
+        <symbol id="g4" overflow="visible">
+            <path d="M 723 0 C 742.333 0 752 10 752 30 C 752 43.333008 745.667 52.333008 733 57 C 671 79.66699 617.5 122 572.5 184 C 527.5 246 505 309.667 505 375 L 505 750 L 397 750 L 397 375 C 397 296.333 431.333 220 500 146 C 560.667 79.33301 631.667 31.333008 713 2 C 717 0.6669922 720.333 0 723 0 Z "/>
+        </symbol>
+        <symbol id="g5" overflow="visible">
+            <path d="M 397 0 L 505 0 L 505 748 L 397 748 Z "/>
+        </symbol>
+        <symbol id="g6" overflow="visible">
+            <path d="M 250 750 C 368.3203 814.23047 505 959.06934 505 1123 L 505 1500 L 397 1500 L 397 1123 C 397 1052.333 375.667 983.667 333 917 C 288.333 847.667 233.66699 801.333 169 778 C 156.33301 773.333 150 764 150 750 C 150 736 156.33301 726.667 169 722 C 233.66699 698.667 288.333 652.333 333 583 C 375.667 516.333 397 447.667 397 377 L 397 0 L 505 0 L 505 377 C 505 541.1094 368.49707 685.67285 250 750 Z "/>
+        </symbol>
+        <symbol id="g7" overflow="visible">
+            <path d="M 733 693 C 745.667 697.667 752 706.667 752 720 C 752 740 742.333 750 723 750 C 720.333 750 717 749.333 713 748 C 631.667 718.667 560.667 670.667 500 604 C 431.333 530 397 453.667 397 375 L 397 0 L 505 0 L 505 375 C 505 440.333 527.5 504 572.5 566 C 617.5 628 671 670.333 733 693 Z "/>
+        </symbol>
+        <symbol id="g8" overflow="visible">
+            <path d="M 427 706 C 297.66193 706 212.16486 552.6595 181.99998 432 L 29.999985 -178 C 29.999985 -188.66667 34.666656 -194 43.999985 -194 L 48.999985 -194 C 56.333313 -194 60.666656 -190.66667 61.999985 -184 L 125.999985 74 C 147.99998 16 190.99998 -13 254.99998 -13 C 317 -13 373.6667 6.3333282 425 45 C 496.3333 98.33333 532 166.66667 532 250 C 532 316.6667 509 366.6667 463 400 C 520.3333 435.3333 555.6666 480 568.99994 534 C 572.33325 547.3333 573.99994 559.6666 573.99994 570.99994 C 573.99994 654.1746 506.9745 705.99994 426.99994 705.99994 Z M 305.99994 398.99994 C 311.33325 401.66663 328.6666 402.99994 357.99994 402.99994 C 364.66663 402.99994 371.33328 402.33325 377.99994 400.99994 C 367.99994 398.99994 358.66663 397.99994 349.99994 397.99994 L 331.99994 397.99994 C 320.66663 397.99994 311.99994 398.33325 305.99994 398.99994 Z M 147.99994 137.99994 C 147.99994 153.99994 149.99994 169.99994 153.99994 185.99994 L 212.99994 425.99994 C 239.61249 533.6072 312.39642 674.99994 425.99994 674.99994 C 482.66663 674.99994 510.99994 646.33325 510.99994 588.99994 C 510.99994 574.99994 508.66663 558.6666 503.99994 539.99994 C 489.99994 483.99994 463.66663 444.33325 424.99994 420.99994 C 402.99994 428.99994 380.99994 432.99994 358.99994 432.99994 C 314.98804 432.99994 269.99994 431.65063 269.99994 395.99994 C 269.99994 388.66663 272.66663 382.99994 277.99994 378.99994 C 286.66663 371.66663 310.33328 367.99994 348.99994 367.99994 C 374.33325 367.99994 398.6666 371.99994 421.99994 379.99994 C 449.33325 357.99994 462.99994 323.99994 462.99994 277.99994 C 462.99994 252.66661 458.99994 224.33327 450.99994 192.99994 C 428.1538 102.81784 359.57156 16.999939 255.99994 16.999939 C 187.87589 16.999939 147.99994 68.29884 147.99994 137.99994 Z "/>
+        </symbol>
+        <symbol id="g9" overflow="visible">
+            <path d="M 249 -22 C 389.6667 -22 460 92 460 320 C 460 473.3333 428.3333 575 365 625 C 329.6667 652.3333 291.33334 666 250.00002 666 C 109.33334 666 39.000015 550.6667 39.000015 320 C 39.000015 136.38824 87.780106 -22 249.00002 -22 Z M 361 524 C 367.6667 489.3333 371 425.3333 371 332 C 371 240 367.3333 172 360 128 C 347.3333 48 310.3333 8 248.99998 8 C 225.66666 8 203.33331 16.666672 181.99998 34 C 155.33331 56.66667 138.66666 104 131.99998 176 C 129.33331 200.66667 127.999985 252.66667 127.999985 332 C 127.999985 419.3333 130.66666 479.66666 135.99998 513 C 144.66666 567.6667 162.99998 602.6667 190.99998 618 C 212.99998 630 232.33331 636 248.99998 636 C 313.54602 636 349.9783 582.78235 361 524 Z "/>
+        </symbol>
+        <symbol id="g10" overflow="visible">
+            <path d="M 834 683 C 816.7029 683 758.4906 680 740.99994 680 C 721.0337 680 650.9867 683 630.99994 683 C 615.6666 683 607.99994 675 607.99994 659 C 607.99994 650.3333 613.33325 645.3333 623.99994 644 C 647.99994 641.3333 659.99994 632.6666 659.99994 617.99994 C 659.99994 608.6666 653.99994 597.6666 641.99994 584.99994 L 485.99994 416.99994 C 457.35492 484.68826 428.54102 552.2077 399.99994 619.99994 C 400.66663 621.99994 402.33328 623.99994 404.99994 625.99994 C 414.33325 635.99994 430.99994 641.99994 454.99994 643.99994 C 470.99994 645.99994 478.99994 653.6666 478.99994 666.99994 C 478.99994 677.6666 472.66663 682.99994 459.99994 682.99994 C 436.35214 682.99994 358.66986 679.99994 334.99994 679.99994 C 314.3369 679.99994 244.85382 682.99994 223.99992 682.99994 C 209.33325 682.99994 201.99992 674.99994 201.99992 658.99994 C 201.99992 648.99994 210.99992 643.99994 228.99992 643.99994 C 273.6189 643.99994 288.06006 644.1862 299.9999 614.99994 L 415.9999 341.99994 L 207.99991 118.99994 C 204.66658 115.66661 200.66658 112.33327 195.99991 108.99994 C 155.33324 65.66661 107.66658 42.333267 52.99991 38.99994 C 35.66658 37.66661 26.999908 29.333267 26.999908 13.999939 C 29.855377 5.4335327 30.851135 -0.000061035156 43.99991 -0.000061035156 C 61.296997 -0.000061035156 119.50926 2.999939 136.99991 2.999939 C 157.66292 2.999939 227.14601 -0.000061035156 247.99991 -0.000061035156 C 262.66656 -0.000061035156 269.99988 7.999939 269.99988 23.999939 C 269.99988 32.66661 264.66656 37.66661 253.9999 38.99994 C 229.9999 40.99994 217.9999 49.66661 217.9999 64.99994 C 217.9999 74.99994 226.66656 88.99994 243.9999 106.99994 C 306.44952 172.88364 368.6181 239.04842 429.9999 305.99994 C 463.87915 224.87918 498.68613 144.68616 531.9999 62.99994 C 531.3332 60.99994 529.6665 58.66661 526.9998 55.99994 C 518.3331 47.333267 501.99982 41.66661 477.99982 38.99994 C 462.6665 36.99994 454.99982 29.333267 454.99982 15.999939 C 454.99982 5.333267 461.33313 -0.000061035156 473.99982 -0.000061035156 L 598.9998 2.999939 C 619.85626 2.999939 690.4416 -0.000061035156 707.9998 -0.000061035156 C 723.3331 -0.000061035156 730.9998 7.6666107 730.9998 22.999939 C 730.9998 32.99994 723.6665 38.333267 708.9998 38.99994 C 677.6665 38.99994 658.3331 40.833267 650.9998 44.49994 C 643.6665 48.16661 635.9998 59.99994 627.9998 79.99994 L 500.99982 382.99994 C 568.9998 454.99994 619.6665 509.33325 652.9998 545.99994 C 676.9998 571.33325 693.3331 587.6666 701.9998 594.99994 C 738.6665 625.6666 779.6665 641.99994 824.9998 643.99994 C 845.55194 645.08167 850.9998 650.02124 850.9998 668.99994 C 848.14435 677.56635 847.14856 682.99994 833.99976 682.99994 Z "/>
+        </symbol>
+        <symbol id="g11" overflow="visible">
+            <path d="M 720 653 C 722 662.3333 723 668 723 670 C 723 678.6667 717.6667 683 707 683 L 277 683 C 252.23427 683 249.33888 680.2844 243 660 L 189 483 C 187 477.6667 185.66667 472.33334 185 467 C 187.81866 458.544 189.75928 453 201 453 C 206.33333 453 212 457 218 465 C 239.33333 530.3333 267.5 576.5 302.5 603.5 C 337.5 630.5 389 644 457 644 L 609 644 L 62 33 L 58 13 C 58 4.3333282 63.66667 0 75 0 L 516 0 C 541.6827 0 544.5381 2.3218842 551 23 L 621 242 C 622.491 246.10028 625 252.62823 625 257 C 625 267 619.3333 272 608 272 C 600.6667 272 594 262.6667 588 244.00002 C 566 176.00002 538.6667 126.000015 506 94.000015 C 470.6667 59.333344 413 42.000015 333 42.000015 L 173 42.000015 Z "/>
+        </symbol>
+    </defs>
+    <defs id="clip-path"/>
+</svg>

--- a/packages/preview/quill/0.4.0/src/arrow.typ
+++ b/packages/preview/quill/0.4.0/src/arrow.typ
@@ -1,0 +1,24 @@
+
+#let draw-arrow(start, end, length: 5pt, width: 2.5pt, stroke: 1pt + black, arrow-color: black) = {
+  place(line(start: start, end: end, stroke: stroke))
+  let dir = (end.at(0) - start.at(0), end.at(1) - start.at(1))
+  dir = dir.map(x => float(repr(x).slice(0,-2)))
+  // let angle = calc.atan2(dir.at(0), dir.at(1))
+  
+  let len = calc.sqrt(dir.map(x => x*x).sum())
+  dir = dir.map(x => x/len)
+  let normal = (-dir.at(1), dir.at(0))
+
+  let arrow-start = end
+  let arrow-end = (end.at(0) + length*dir.at(0), end.at(1) + length*dir.at(1))
+  let w = width/2
+  let v1 = (arrow-start.at(0) - w*normal.at(0), arrow-start.at(1) - w*normal.at(1))
+  let v2 = (arrow-start.at(0) + w*normal.at(0), arrow-start.at(1) + w*normal.at(1))
+  path(arrow-end, v1, v2, closed: true, fill: arrow-color)
+}
+
+#let test-arrow() = {
+  draw-arrow((0pt, 0pt), (20pt, 10pt), stroke: .1pt)
+}
+
+

--- a/packages/preview/quill/0.4.0/src/decorations.typ
+++ b/packages/preview/quill/0.4.0/src/decorations.typ
@@ -1,0 +1,205 @@
+#import "gates.typ": *
+
+
+// align: "left" (for rstick) or "right" (for lstick)
+// brace: auto, none, "{", "}", "|", "[", ...
+#let lrstick(content, n, align, brace, label, pad: 0pt, x: auto, y: auto) = gate(
+  content, 
+  x: x, 
+  y: y,
+  draw-function: draw-functions.draw-lrstick, 
+  size-hint: layout.lrstick-size-hint,
+  box: false, 
+  floating: true,
+  multi: if n == 1 { none } else { 
+   (
+    target: none,
+    num-qubits: n, 
+    wire-count: 0, 
+    label: label,
+    size-all-wires: if n > 1 { none } else { false }
+  )},
+  data: (
+    brace: brace,
+    align: align,
+    pad: pad
+  ), 
+  label: label
+)
+
+
+
+
+/// Basic command for labelling a wire at the start. 
+/// - content (content): Label to display, e.g., `$|0〉$`.
+/// - n (content): How many wires the `lstick` should span. 
+/// - brace (auto, none, str): If `brace` is `auto`, then a default `{` brace
+///      is shown only if `n > 1`. A brace is always shown when 
+///      explicitly given, e.g., `"}"`, `"["` or `"|"`. No brace is shown for 
+///      `brace: none`
+/// - pad (length): Adds a padding between the label and the connected wire to the right. 
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+#let lstick(
+  content, 
+  n: 1, 
+  brace: auto, 
+  pad: 0pt,
+  label: none, 
+  x: auto,
+  y: auto
+) = lrstick(content, n, right, brace, label, pad: pad, x: x, y: y)
+
+
+/// Basic command for labelling a wire at the end. 
+/// - content (content): Label to display, e.g., `$|0〉$`.
+/// - n (content): How many wires the `rstick` should span. 
+/// - pad (length): Adds a padding between the label and the connected wire to the left. 
+/// - brace (auto, none, str): If `brace` is `auto`, then a default `}` brace
+///      is shown only if `n > 1`. A brace is always shown when 
+///      explicitly given, e.g., `"}"`, `"["` or `"|"`. No brace is shown for 
+///      `brace: none`. 
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+#let rstick(
+  content, 
+  n: 1, 
+  brace: auto, 
+  pad: 0pt, 
+  label: none, 
+  x: auto,
+  y: auto
+) = lrstick(content, n, left, brace, label, pad: pad, x: x, y: y)
+
+/// Create a midstick, i.e., a mid-circuit text. 
+/// - content (content): Label to display, e.g., `$|0〉$`.
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+#let midstick(
+  content,
+  fill: none,
+  label: none,
+  x: auto,
+  y: auto
+) = gate(content, draw-function: draw-functions.draw-unboxed-gate, label: label, fill: fill, x: x, y: y)
+
+
+
+/// Creates a symbol similar to `\qwbundle` on `quantikz`. Annotates a wire to 
+/// be a bundle of quantum or classical wires. 
+/// - label (int, content): 
+#let nwire(label, x: auto, y: auto) = gate([#label], draw-function: draw-functions.draw-nwire, box: false, x: x, y: y)
+
+
+
+/// Set current wire mode (0: none, 1 wire: quantum, 2 wires: classical, more  
+/// are possible) and optionally the stroke style. 
+///
+/// The wire style is reset for each row.
+///
+/// - wire-count (int): Number of wires to display. 
+/// - stroke (auto, none, stroke): When given, the stroke is applied to the wire. 
+///                Otherwise the current stroke is kept. 
+/// - wire-distance (length): Distance between wires. 
+#let setwire(wire-count, stroke: auto, wire-distance: auto) = (
+  qc-instr: "setwire",
+  wire-count: wire-count,
+  stroke: stroke,
+  wire-distance: wire-distance
+)
+
+/// Highlight a group of circuit elements by drawing a rectangular box around
+/// them. 
+/// 
+/// - wires (int): Number of wires to include.
+/// - steps (int): Number of columns to include.
+/// - x (auto, int): The starting column of the gategroup. 
+/// - y (auto, int): The starting wire of the gategroup. 
+/// - z (str): The gategroup can be placed `"below"` or `"above"` the circuit. 
+/// - padding (length, dictionary): Padding of rectangle. May be one length
+///     for all sides or a dictionary with the keys `left`, `right`, `top`, 
+///     `bottom` and `default`. Not all keys need to be specified. The value 
+///     for `default` is used for the omitted sides or `0pt` if no `default` 
+///     is given. 
+/// - stroke (stroke): Stroke for rectangle.
+/// - fill (color): Fill color for rectangle.
+/// - radius (length, dictionary): Corner radius for rectangle.
+/// - label (array, str, content, dictionary): One or more labels to add to the  
+///        group. See @@gate(). 
+#let gategroup(
+  wires, 
+  steps, 
+  x: auto, 
+  y: auto,
+  z: "below",
+  padding: 0pt, 
+  stroke: .7pt, 
+  fill: none,
+  radius: 0pt,
+  label: none
+) = (
+  qc-instr: "gategroup",
+  wires: wires,
+  steps: steps,
+  x: x, 
+  y: y,
+  z: z,
+  padding: process-args.process-padding-arg(padding),
+  style: (fill: fill, stroke: stroke, radius: radius),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+/// Slice the circuit vertically, showing a separation line between columns. 
+/// 
+/// - n (int): Number of wires to slice.
+/// - x (auto, int): The starting column of the slice. 
+/// - y (auto, int): The starting wire of the slice. 
+/// - z (str): The slice can be placed `"below"` or `"above"` the circuit. 
+/// - stroke (stroke): Line style for the slice. 
+/// - label (array, str, content, dictionary): One or more labels to add to the  
+///        slice. See @@gate(). 
+#let slice(
+  n: 0, 
+  x: auto, 
+  y: auto,
+  z: "below",
+  stroke: (paint: red, thickness: .7pt, dash: "dashed"),
+  label: none
+) = (
+  qc-instr: "slice",
+  wires: n,
+  x: x,
+  y: y,
+  z: z,
+  style: (stroke: stroke),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+/// Lower-level interface to the cell coordinates to create an arbitrary
+/// annotatation by passing a custom function.
+/// 
+/// This function is passed the coordinates of the specified cell rows 
+/// and columns. 
+/// 
+/// - columns (int, array): Column indices for which to obtain coordinates. 
+/// - rows (int, array): Row indices for which to obtain coordinates. 
+/// - callback (function): Function to call with the obtained coordinates. The
+///     signature should be with signature `(col-coords, row-coords) => {}`. 
+///     This function is expected to display the content to draw in absolute 
+///     coordinates within the circuit. 
+/// - z (str): The annotation can be placed `"below"` or `"above"` the circuit. 
+#let annotate(
+  columns,
+  rows,
+  callback,
+  z: "below",
+) = (
+  qc-instr: "annotate",
+  rows: rows,
+  x: none,
+  y: none,
+  z: z,
+  columns: columns,
+  callback: callback
+)
+
+

--- a/packages/preview/quill/0.4.0/src/draw-functions.typ
+++ b/packages/preview/quill/0.4.0/src/draw-functions.typ
@@ -1,0 +1,342 @@
+// INTERNAL GATE DRAW FUNCTIONS
+
+
+#import "utility.typ"
+#import "arrow.typ"
+#import "layout.typ"
+
+
+
+
+
+
+// Default gate draw function. Draws a box with global padding
+// and the gates content. Stroke and default fill are only applied if 
+// gate.box is true
+#let draw-boxed-gate(gate, draw-params) = align(center, box(
+  inset: draw-params.padding, 
+  width: gate.width,
+  radius: gate.radius,
+  stroke: if gate.box { draw-params.wire }, 
+  fill: utility.if-auto(gate.fill, if gate.box {draw-params.background}),
+  gate.content,
+))
+
+// Same but without displaying a box
+#let draw-unboxed-gate(gate, draw-params) = box(
+  inset: draw-params.padding, 
+  fill: utility.if-auto(gate.fill, draw-params.background),
+  gate.content
+)
+
+// Draw a gate spanning multiple wires
+#let draw-boxed-multigate(gate, draw-params) = {
+  let dy = draw-params.multi.wire-distance
+  let extent = gate.multi.extent
+  if extent == auto { extent = draw-params.x-gate-size.height / 2 }
+  
+  let style-params = (
+      width: gate.width,
+      stroke: draw-params.wire, 
+      radius: gate.radius,
+      fill: utility.if-auto(gate.fill, draw-params.background), 
+      inset: draw-params.padding, 
+  )
+  align(center + horizon, box(
+    ..style-params,
+    height: dy + 2 * extent,
+    gate.content
+  ))
+  
+  
+  let draw-inouts(inouts, alignment) = {
+    
+    if inouts != none and dy != 0pt {
+      let width = measure(line(length: gate.width), draw-params.styles).width
+      let y0 = -(dy + extent) - draw-params.center-y-coords.at(0)
+      let get-wire-y(qubit) = { draw-params.center-y-coords.at(qubit) + y0 }
+      
+      set text(size: .8em)
+      style(styles => {
+        for inout in inouts {
+          let size = measure(inout.label, styles)
+          let y = get-wire-y(inout.qubit)
+          let label-x = draw-params.padding
+          if "n" in inout and inout.n > 1 {
+            let y2 = get-wire-y(inout.qubit + inout.n - 1)
+            let brace = utility.create-brace(auto, alignment, y2 - y + draw-params.padding)
+            let brace-x = 0pt
+            let size = measure(brace, styles)
+            if alignment == right { brace-x += width - size.width }
+            
+            place(brace, dy: y - 0.5 * draw-params.padding, dx: brace-x)
+            label-x = size.width
+            y += 0.5 * (y2 - y)
+          }
+          place(dy: y - size.height / 2, align(
+            alignment, 
+            box(inout.label, width: width, inset: (x: label-x))
+          ))
+        }
+      })
+      
+    }
+  
+  }
+  draw-inouts(gate.multi.inputs, left)
+  draw-inouts(gate.multi.outputs, right)
+}
+
+#let draw-targ(item, draw-params) = {
+  let size = item.data.size
+  box({
+    circle(
+      radius: size, 
+      stroke: draw-params.wire, 
+      fill: utility.if-auto(item.fill, draw-params.background)
+    )
+    place(line(start: (size, 0pt), length: 2*size, angle: -90deg, stroke: draw-params.wire))
+    place(line(start: (0pt, -size), length: 2*size, stroke: draw-params.wire))
+  })
+}
+
+#let draw-ctrl(gate, draw-params) = {
+  let color = utility.if-auto(gate.fill, draw-params.color)
+  if "show-dot" in gate.data and not gate.data.show-dot { return none }
+  if gate.data.open {
+    let stroke = utility.if-auto(gate.fill, draw-params.wire)
+    box(circle(stroke: stroke, fill: draw-params.background, radius: gate.data.size))
+  } else {
+    box(circle(fill: color, radius: gate.data.size))
+  }
+}
+
+#let draw-swap(gate, draw-params) = {
+  box({
+    let d = gate.data.size
+    let stroke = draw-params.wire
+    box(width: d, height: d, {
+      place(line(start: (-0pt, -0pt), end: (d, d), stroke: stroke))
+      place(line(start: (d, 0pt), end: (0pt, d), stroke: stroke))
+    })
+  })
+}
+
+
+
+#let draw-meter(gate, draw-params) = {
+  let content = {
+    set align(top)
+    let stroke = draw-params.wire
+    let padding = draw-params.padding
+    let fill = utility.if-none(gate.fill, draw-params.background)
+    let height = draw-params.x-gate-size.height 
+    let width = 1.5 * height
+    height -= 2 * padding
+    width -= 2 * padding
+    box(
+      width: width, height: height, inset: 0pt, 
+      {
+        let center-x = width / 2
+        place(path((0%, 110%), ((50%, 40%), (-40%, 0pt)), (100%, 110%), stroke: stroke))
+        set align(left)
+        arrow.draw-arrow((center-x, height * 1.2), (width * .9, height*.3), length: 3.8pt, width: 2.8pt, stroke: stroke, arrow-color: draw-params.color)
+    })
+  }
+  gate.content = rect(content, inset: 0pt, stroke: none)
+  if gate.multi != none and gate.multi.num-qubits > 1 {
+    draw-boxed-multigate(gate, draw-params)
+  } else {
+    draw-boxed-gate(gate, draw-params)
+  }
+}
+
+
+#let draw-nwire(gate, draw-params) = {
+  set text(size: .7em)
+  let size = measure(gate.content, draw-params.styles)
+  let extent = 2.5pt + size.height
+  box(height: 2 * extent, { // box is solely for height hint
+    place(dx: 1pt, dy: 0pt, gate.content)
+    place(dy: extent, line(start: (0pt,-4pt), end: (-5pt,4pt), stroke: draw-params.wire))
+  })
+}
+
+
+
+#let draw-permutation-gate(gate, draw-params) = {
+  let dy = draw-params.multi.wire-distance
+  let width = gate.width
+  if dy == 0pt { return box(width: width, height: 4pt) }
+  
+  let separation = gate.data.separation
+  if separation == auto { separation = draw-params.background }
+  if type(separation) == color { separation += 3pt }
+  if type(separation) == length { separation += draw-params.background }
+  
+  box(
+    height: dy + 4pt,
+    inset: (y: 2pt),
+    fill: draw-params.background,
+    width: width, {
+      let qubits = gate.data.qubits
+      let y0 = draw-params.center-y-coords.at(gate.qubit)
+      let bend = gate.data.bend * width / 2
+      for from in range(qubits.len()) {
+        let to = qubits.at(from)
+        let y-from = draw-params.center-y-coords.at(from + gate.qubit) - y0
+        let y-to = draw-params.center-y-coords.at(to + gate.qubit) - y0
+        if separation != none {
+          place(path(((0pt,y-from), (-bend, 0pt)), ((width, y-to), (-bend, 0pt)), stroke: separation))
+        }
+        place(path(((-.1pt,y-from), (-bend, 0pt)), ((width+.1pt, y-to), (-bend, 0pt)), stroke: draw-params.wire)) 
+      }
+    }
+  )
+}
+
+// Draw an lstick (align: "right") or rstick (align: "left")
+#let draw-lrstick(gate, draw-params) = {
+
+  assert(gate.data.align in (left, right), message: "Only left and right are allowed")
+  let isleftstick = (gate.data.align == right)
+  let draw-brace = gate.data.brace != none
+    
+  let content = box(inset: draw-params.padding, gate.content)
+  let size = measure(content, draw-params.styles)
+  
+ 
+  let brace = none
+  
+  if draw-brace {
+    let brace-height
+    if gate.multi == none {
+      brace-height = 1em + 2 * draw-params.padding
+    } else {
+      brace-height = draw-params.multi.wire-distance + .5em
+    }
+    let brace-symbol = gate.data.brace
+    if brace-symbol == auto and gate.multi == none {
+      brace-symbol = none
+    }
+    brace = utility.create-brace(brace-symbol, if isleftstick {right}else{left}, brace-height)
+  }
+  
+  let brace-size = measure(brace, draw-params.styles)
+  let width = size.width + brace-size.width + gate.data.pad
+  let height = size.height
+  let brace-offset-y
+  let content-offset-y = 0pt
+  
+  if gate.multi == none {
+    brace-offset-y = size.height/2 - brace-size.height/2
+  } else {
+    let dy = draw-params.multi.wire-distance
+    // at layout stage:
+    if dy == 0pt { return box(width: 2 * width, height: 0pt, content) }
+    height = dy
+    content-offset-y = -size.height/2 + height/2
+    brace-offset-y = -.25em
+  }
+  
+  let brace-pos-x = if isleftstick { size.width } else { gate.data.pad }
+  let content-pos-x = if isleftstick { 0pt } else { width - size.width}
+
+  box(
+    width: width, 
+    height: height, 
+    {
+      place(brace, dy: brace-offset-y, dx: brace-pos-x)
+      place(content, dy: content-offset-y, dx: content-pos-x)
+    }
+  )
+}
+
+
+
+
+#let draw-gategroup(x1, x2, y1, y2, item, draw-params) = {
+  let p = item.padding
+  let (x1, x2, y1, y2) = (x1 - p.left, x2 + p.right, y1 - p.top, y2 + p.bottom)
+  let size = (width: x2 - x1, height: y2 - y1)
+  layout.place-with-labels(
+    dx: x1, dy: y1, 
+    labels: item.labels, 
+    size: size,
+    draw-params: draw-params, rect(
+      width: size.width, height: size.height,
+      stroke: item.style.stroke,
+      fill: item.style.fill,
+      radius: item.style.radius
+    )
+  )
+}
+
+#let draw-slice(x, y1, y2, item, draw-params) = layout.place-with-labels(
+  dx: x, dy: y1, 
+  size: (width: 0pt, height: y2 - y1),
+  labels: item.labels, 
+  draw-params: draw-params, 
+  line(angle: 90deg, length: y2 - y1, stroke: item.style.stroke)
+)
+
+
+
+#let draw-horizontal-wire(x1, x2, y, stroke, wire-count, wire-distance: 1pt) = {
+  if x1 == x2 { return }
+
+  let wire = line(start: (x1, y), end: (x2, y), stroke: stroke)
+  range(wire-count)
+    .map(i => (2*i - (wire-count - 1)) * wire-distance)
+    .map(dy => place(wire, dy: dy))
+    .join()
+}
+
+#let draw-vertical-wire(
+  y1, 
+  y2,
+  x,
+  stroke,
+  wire-count: 1,
+  wire-distance: 1pt,
+) = {
+  let height = y2 - y1
+
+  let wire = line(start: (0pt, 0pt), end: (0pt, height), stroke: stroke)
+  let wires = range(wire-count)
+    .map(i => 2 * i * wire-distance)
+    .map(dx => place(wire, dx: dx))
+
+  place(
+    dx: x - (wire-count - 1) * wire-distance,
+    dy: y1,
+    wires.join()
+  )
+}
+
+#let draw-vertical-wire-with-labels(
+  y1, 
+  y2,
+  x,
+  stroke,
+  wire-count: 1,
+  wire-distance: 1pt,
+  wire-labels: (),
+  draw-params: none,
+) = {
+  let height = y2 - y1
+  
+  let wire = line(start: (0pt, 0pt), end: (0pt, height), stroke: stroke)
+  let wires = range(wire-count)
+    .map(i => 2 * i * wire-distance)
+    .map(dx => place(wire, dx: dx))
+
+  layout.place-with-labels(
+    dx: x - (wire-count - 1) * wire-distance,
+    dy: y1,
+    labels: wire-labels,
+    draw-params: draw-params,
+    size: (width: 2 * (wire-count - 1) * wire-distance, height: height),
+    wires.join()
+  )
+}

--- a/packages/preview/quill/0.4.0/src/gates.typ
+++ b/packages/preview/quill/0.4.0/src/gates.typ
@@ -1,0 +1,362 @@
+#import "layout.typ"
+#import "process-args.typ"
+#import "draw-functions.typ"
+
+
+
+/// This is the basic command for creating gates. Use this to create a simple gate, e.g., `gate($X$)`. 
+/// For special gates, many other dedicated gate commands exist. 
+///
+/// Note, that most of the parameters listed here are mostly used for derived gate 
+/// functions and do not need to be touched in all but very few cases. 
+///
+/// //#example(`quill.quantum-circuit(1, quill.gate($H$), 1)`)
+///
+/// - content (content): What to show in the gate (may be none for special gates like @@ctrl() ).
+/// - x (auto, int): The column to put the gate in. 
+/// - y (auto, int): The row to put the gate in. 
+/// - fill (none, color): Gate background fill color.
+/// - radius (length, dictionary): Gate rectangle border radius. 
+///             Allows the same values as the builtin `rect()` function.
+/// - width (auto, length): The width of the gate can be specified manually with this property. 
+/// - box (boolean): Whether this is a boxed gate (determines whether the outgoing 
+///             wire will be drawn all through the gate (`box: false`) or not).
+/// - floating (boolean): Whether the content for this gate will be shown floating 
+///             (i.e. no width is reserved).
+/// - multi (dictionary): Information for multi-qubit and controlled gates (see @@mqgate() ).
+/// - size-hint (function): Size hint function. This function should return a dictionary
+///             containing the keys `width` and `height`. The result is used to determine 
+///             the gates position and cell sizes of the grid. 
+///             Signature: `(gate, draw-params) => {}`.
+/// - draw-function (function): Drawing function that produces the displayed content.
+///             Signature: `(gate, draw-params) => {}`.
+/// - label (array, str, content, dictionary): One or more labels to add to the gate.
+///             Usually, a label consists of a dictionary with entries for the keys 
+///             `content` (the label content), `pos` (2d alignment specifying the 
+///             position of the label) and optionally `dx` and/or `dy` (lengths, ratios 
+///             or relative lengths). If only a single label is to be added, a plain 
+///             content or string value can be passed which is then placed at the default
+///             position. 
+///
+/// - data (any): Optional additional gate data. This can for example be a dictionary
+///             storing extra information that may be used for instance in a custom
+///             `draw-function`.
+#let gate(
+  content,
+  x: auto,
+  y: auto,
+  fill: auto,
+  radius: 0pt,
+  width: auto,
+  box: true,
+  floating: false,
+  multi: none,
+  size-hint: layout.default-size-hint,
+  draw-function: draw-functions.draw-boxed-gate,
+  gate-type: "",
+  data: none,
+  label: none
+) = (
+  content: content, 
+  x: x, 
+  y: y,
+  fill: fill,
+  radius: radius,
+  width: width,
+  box: box,
+  floating: floating,
+  multi: multi,
+  size-hint: size-hint,
+  draw-function: draw-function,
+  gate-type: gate-type, 
+  data: data,
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+
+
+/// Basic command for creating multi-qubit or controlled gates. See also @@ctrl() and @@swap(). 
+///
+/// - content (content):
+/// - n (int): Number of wires the multi-qubit gate spans. 
+/// - x (auto, int): The column to put the gate in. 
+/// - y (auto, int): The row to put the gate in. 
+/// - target (none, int): If specified, a control wire is drawn from the gate up 
+///        or down this many wires counted from the wire this `mqgate()` is placed on. 
+/// - fill (none, color): Gate background fill color.
+/// - radius (length, dictionary): Gate rectangle border radius. 
+///        Allows the same values as the builtin `rect()` function.
+/// - width (auto, length): The width of the gate can be specified manually with this property. 
+/// - box (boolean): Whether this is a boxed gate (determines whether the 
+///        outgoing wire will be drawn all through the gate (`box: false`) or not).
+/// - wire-count (int): Wire count for control wires.
+/// - inputs (none, array): You can put labels inside the gate to label the input wires with 
+///        this argument. It accepts a list of labels, each of which has to be a dictionary
+///        with the keys `qubit` (denoting the qubit to label, starting at 0) and `content`
+///        (containing the label content). Optionally, providing a value for the key `n` allows
+///        for labelling multiple qubits spanning over `n` wires. These are then grouped by a 
+///        brace. 
+/// - outputs (none, array): Same as `inputs` but for gate outputs. 
+/// - extent (auto, length): How much to extent the gate beyond the first and 
+///        last wire, default is to make it align with an X gate (so [size of x gate] / 2). 
+/// - size-all-wires (none, boolean): A single-qubit gate affects the height of the row
+///        it is being put on. For multi-qubit gate there are different possible 
+///        behaviours:
+///          - Affect height on only the first and last wire (`false`)
+///          - Affect the height of all wires (`true`)
+///          - Affect the height on no wire (`none`)
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+/// - wire-label (array, str, content, dictionary): One or more labels to add to the 
+///        control wire. Works analogous to `labels` but with default positioning to the 
+///        right of the wire. 
+/// - data (any): Optional additional gate data. This can for example be a dictionary
+///        storing extra information that may be used for instance in a custom
+///        `draw-function`.
+#let mqgate(
+  content,
+  x: auto,
+  y: auto,
+  n: 1, 
+  target: none,
+  fill: auto, 
+  radius: 0pt,
+  width: auto,
+  box: true, 
+  wire-count: 1,
+  inputs: none,
+  outputs: none,
+  extent: auto, 
+  size-all-wires: false,
+  draw-function: draw-functions.draw-boxed-multigate, 
+  label: none,
+  wire-label: none,
+  data: none,
+) = gate(
+  content, 
+  x: x, 
+  y: y, 
+  fill: fill, box: box, 
+  width: width,
+  radius: radius,
+  draw-function: draw-function,
+  multi: (
+    target: target,
+    num-qubits: n, 
+    wire-count: wire-count, 
+    label: label,
+    extent: extent,
+    size-all-wires: size-all-wires,
+    inputs: inputs,
+    outputs: outputs,
+    wire-label: process-args.process-label-arg(wire-label, default-pos: right),
+  ),
+  label: label,
+  data: data,
+)
+
+
+
+// SPECIAL GATES
+
+/// Draw a meter box representing a measurement. 
+/// - target (none, int): If given, draw a control wire to the given target
+///                           qubit the specified number of wires up or down.
+/// - wire-count (int):   Wire count for the (optional) control wire. 
+/// - n (int):            Number of wires to span this meter across. 
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+#let meter(
+  target: none, 
+  n: 1,
+  x: auto,
+  y: auto,
+  wire-count: 2, 
+  label: none, 
+  fill: auto, 
+  radius: 0pt
+) = {
+  label = if label != none {(content: label, pos: top, dy: -0.5em)} else { () }
+  if target == none and n == 1 {
+    gate(none, x: x, y: y, fill: fill, radius: radius, draw-function: draw-functions.draw-meter, data: (meter-label: label), label: label)
+  } else {
+     mqgate(none, x: x, y: y, n: n, target: target, fill: fill, radius: radius, box: true, wire-count: wire-count, draw-function: draw-functions.draw-meter, data: (meter-label: label), label: label)
+  }
+}
+
+/// Create a visualized permutation gate which maps the qubits $q_k, q_(k+1), ... $ to  
+/// the qubits $q_(p(k)), q_(p(k+1)), ...$ when placed on the qubit $k$. The permutation 
+/// map is given by the `qubits` argument. Note, that qubit indices start with 0. 
+/// 
+/// *Example:*
+///
+///  `permute(1, 0)` when placed on the second wire swaps the second and third wire. 
+/// 
+///  `permute(2, 0, 1)` when placed on wire 0 maps $(0,1,2) arrow.bar (2,0,1)$.
+/// 
+/// Note also, that the wiring is not very sophisticated and will probably look best for 
+/// relatively simple permutations. Furthermore, it only works with quantum wires. 
+///  
+/// - ..qubits (array): Qubit permutation specification. 
+/// - width (length): Width of the permutation gate. 
+/// - bend (ratio): How much to bend the wires. With `0%`, the wires are straight. 
+/// - separation (auto, none, length, color, stroke): Overlapping wires are separated by drawing a thicker line below. With this option, this line can be customized in color or thickness. 
+#let permute(
+  ..qubits, 
+  width: 30pt, 
+  bend: 100%, 
+  separation: auto,
+  x: auto,
+  y: auto,
+) = {
+  if qubits.named().len() != 0 {
+    assert(false, message: "Unexpected named argument `" + qubits.named().keys().first() + "` in function `permute()`")
+  }
+  mqgate(none, n: qubits.pos().len(), width: width, draw-function: draw-functions.draw-permutation-gate, data: (qubits: qubits.pos(), extent: 2pt, separation: separation, bend: bend))
+}
+
+/// Create an invisible (phantom) gate for reserving space. If `content` 
+/// is provided, the `height` and `width` parameters are ignored and the gate 
+/// will take the size it would have if `gate(content)` was called. 
+///
+/// Instead specifying width and/or height will create a gate with exactly the
+/// given size (without padding).
+///
+/// - content (content): Content to measure for the phantom gate size. 
+/// - width (length): Width of the phantom gate (ignored if `content` is not `none`). 
+/// - height (length): Height of the phantom gate (ignored if `content` is not `none`). 
+#let phantom(content: none, width: 0pt, height: 0pt) = {
+  let thecontent = if content != none { box(hide(content)) } else { 
+    box(width: width, height: height) 
+  }
+  gate(thecontent, box: false, fill: none)
+}
+
+/// Target element for controlled-X operations (#sym.plus.circle). 
+/// - fill (none, color, auto): Fill color for the target circle. If set 
+///        to `auto`, the target is filled with the circuits background color.
+/// - size (length): Size of the target symbol. 
+#let targ(
+  fill: none,
+  size: 4.3pt,
+  label: none, 
+  x: auto,
+  y: auto,
+) = gate(
+  none, 
+  x: x, 
+  y: y, 
+  box: false, 
+  draw-function: draw-functions.draw-targ, 
+  fill: if fill == true {auto} else if fill == false {none} else {fill}, 
+  data: (size: size), 
+  label: label
+)
+
+/// Target element for controlled-Z operations (#sym.bullet). 
+///
+/// - open (boolean): Whether to draw an open dot. 
+/// - fill (none, color): Fill color for the circle or stroke color if
+///        `open: true`. 
+/// - size (length): Size of the control circle. 
+// #let ctrl(open: false, fill: none, size: 2.3pt) = gate(none, draw-function: draw-ctrl, fill: fill, size: size, box: false, open: open)
+
+/// Target element for #smallcaps("swap") operations (#sym.times) without vertical wire). 
+/// - size (length): Size of the target symbol. 
+#let targX(size: 7pt, label: none, x: auto, y: auto) = gate(none, x: x, y: y, box: false, draw-function: draw-functions.draw-swap, data: (size: size), label: label)
+
+/// Create a phase gate shown as a point on the wire together with a label. 
+///
+/// - label (content): Angle value to display. 
+/// - open (boolean): Whether to draw an open dot. 
+/// - fill (none, color): Fill color for the circle or stroke color if
+///        `open: true`. 
+/// - size (length): Size of the circle. 
+#let phase(
+  label,
+  open: false,
+  fill: auto,
+  size: 2.3pt,
+  x: auto,
+  y: auto
+) = gate(
+  none, 
+  x: x, 
+  y: y,
+  box: false,
+  draw-function: (gate, draw-params) => box(
+    inset: (x: .6em), 
+    draw-functions.draw-ctrl(gate, draw-params)
+  ),
+  fill: fill,
+  data: (open: open, size: size),
+  label: process-args.process-label-arg(label, default-pos: top + right, default-dx: -.5em)
+)
+
+
+
+/// Creates a #smallcaps("swap") operation with another qubit. 
+/// 
+/// - n (int): How many wires up or down the target wire lives. 
+/// - size (length): Size of the target symbol. 
+/// - wire-label (array, str, content, dictionary): One or more labels 
+///        to add to the control wire. See @@mqgate(). 
+#let swap(
+  n, 
+  wire-count: 1, 
+  size: 7pt, 
+  label: none, 
+  wire-label: none,
+  x: auto,
+  y: auto
+) = mqgate(
+  none,
+  x: x, 
+  y: y,
+  target: n,
+  box: false,
+  draw-function: draw-functions.draw-swap,
+  wire-count: wire-count,
+  data: (size: size),
+  label: label,
+  wire-label: wire-label
+)
+
+
+
+/// Creates a control with a vertical wire to another qubit. 
+/// 
+/// - n (int): How many wires up or down the target wire lives. 
+/// - wire-count (int): Wire count for the control wire.  
+/// - open (boolean): Whether to draw an open dot. 
+/// - fill (none, color): Fill color for the circle or stroke color if
+///        `open: true`. 
+/// - size (length): Size of the control circle. 
+/// - show-dot (boolean): Whether to show the control dot. Set this to 
+///        false to obtain a vertical wire with no dots at all. 
+/// - wire-label (array, str, content, dictionary): One or more labels 
+///        to add to the control wire. See @@mqgate(). 
+#let ctrl(
+  n,
+  wire-count: 1,
+  open: false,
+  fill: auto,
+  size: 2.3pt,
+  show-dot: true,
+  label: none,
+  wire-label: none,
+  x: auto,
+  y: auto
+) = mqgate(
+  none,
+  x: x, 
+  y: y,
+  target: n,
+  box: false,
+  draw-function: draw-functions.draw-ctrl,
+  wire-count: wire-count,
+  fill: fill,
+  data: (open: open, size: size, show-dot: show-dot),
+  label: label,
+  wire-label: wire-label
+)

--- a/packages/preview/quill/0.4.0/src/layout.typ
+++ b/packages/preview/quill/0.4.0/src/layout.typ
@@ -1,0 +1,190 @@
+#import "length-helpers.typ": *
+
+/// Update bounds to contain the given rectangle
+/// - bounds (array): Current bound coordinates x0, y0, x1, y1
+/// - rect (array): Bounds rectangle x0, y0, x1, y1
+#let update-bounds(bounds, rect, em) = (
+  calc.min(bounds.at(0), convert-em-length(rect.at(0), em)), 
+  calc.min(bounds.at(1), convert-em-length(rect.at(1), em)),
+  calc.max(bounds.at(2), convert-em-length(rect.at(2), em)),
+  calc.max(bounds.at(3), convert-em-length(rect.at(3), em)),
+)
+
+#let offset-bounds(bounds, offset) = (
+  bounds.at(0) + offset.at(0),
+  bounds.at(1) + offset.at(1),
+  bounds.at(2) + offset.at(0),
+  bounds.at(3) + offset.at(1),
+)
+
+#let make-bounds(x0: 0pt, y0: 0pt, width: 0pt, height: 0pt, x1: none, y1: none, em) = (
+  convert-em-length(x0, em),
+  convert-em-length(y0, em),
+  convert-em-length(if x1 != none { x1 } else { x0 + width }, em),
+  convert-em-length(if y1 != none { y1 } else { y0 + height }, em),
+)
+
+
+/// Take an alignment or 2d alignment and return a 2d alignment with the possibly 
+/// unspecified axis set to a default value. 
+#let make-2d-alignment(alignment, default-vertical: horizon, default-horizontal: center) = {
+  if type(alignment) == "2d alignment" { return alignment }
+  let axis = alignment.axis()
+  if axis == none { return alignment }
+  if alignment.axis() == "horizontal" { return alignment + default-vertical }
+  if alignment.axis() == "vertical" { return alignment + default-horizontal }
+}
+
+
+#let make-2d-alignment-factor(alignment) = {
+  let alignment = make-2d-alignment(alignment)
+  let x = 0
+  let y = 0
+  if alignment.x == left { x = -1 }
+  else if alignment.x == right { x = 1 }
+  if alignment.y == top { y = -1 }
+  else if alignment.y == bottom { y = 1 }
+  return (x, y)
+}
+
+
+
+
+#let default-size-hint(item, draw-params) = {
+  let content = (item.draw-function)(item, draw-params)
+  let hint = measure(content, draw-params.styles)
+  hint.offset = auto
+  return hint
+}
+
+
+
+
+
+#let lrstick-size-hint(item, draw-params) = {
+  let content = (item.draw-function)(item, draw-params)
+  let hint = measure(content, draw-params.styles)
+  let dx = 0pt
+  if item.data.align == right { dx = hint.width } 
+  hint.offset = (x: dx, y: auto)
+  return hint
+}
+
+
+
+
+
+/// Place some content along with optional labels while computing bounds. 
+/// 
+/// Returns a pair of the placed content and a bounds array. 
+///
+/// - content (content): The content to place. 
+/// - dx (length): Horizontal displacement.
+/// - dy (length): Vertical displacement.
+/// - size (auto, dictionary): For computing bounds, the size of the placed content
+///           is needed. If `auto` is passed, this function computes the size itself
+///           but if it is already known it can be passed through this parameter. 
+/// - labels (array): An array of labels which in turn are dictionaries that must 
+///           specify values for the keys `content` (content), `pos` (strictly 2d 
+///           alignment), `dx` and `dy` (both length, ratio or relative length).
+/// - draw-params (dictionary): Drawing parameters. Must contain a styles object at 
+///           the key `styles` and an absolute length at the key `em`. 
+/// -> pair
+#let place-with-labels(
+  content, 
+  dx: 0pt, 
+  dy: 0pt,
+  size: auto,
+  labels: (),
+  draw-params: none,
+) = {
+  if size == auto { size = measure(content, draw-params.styles) }
+  let bounds = make-bounds(
+    x0: dx, y0: dy, width: size.width, height: size.height, draw-params.em
+  )
+  if labels.len() == 0 {
+    return (place(content, dx: dx, dy: dy), bounds)    
+  }
+  
+  let placed-labels = place(dx: dx, dy: dy, 
+    box({
+      for label in labels {
+        let label-size = measure(label.content, draw-params.styles)
+        let ldx = get-length(label.dx, size.width)
+        let ldy = get-length(label.dy, size.height)
+        
+        if label.pos.x == left { ldx -= label-size.width }
+        else if label.pos.x == center { ldx += 0.5 * (size.width - label-size.width) }
+        else if label.pos.x == right { ldx += size.width }
+        if label.pos.y == top { ldy -= label-size.height }
+        else if label.pos.y == horizon { ldy += 0.5 * (size.height - label-size.height) }
+        else if label.pos.y == bottom { ldy += size.height }
+        
+        
+        let placed-label = place(label.content, dx: ldx, dy: ldy)
+        let label-bounds = make-bounds(
+          x0: ldx + dx, y0: ldy + dy, 
+          width: label-size.width, height: label-size.height, 
+          draw-params.em
+        )
+        bounds = update-bounds(bounds, label-bounds, draw-params.em)
+        placed-label
+      }
+    })
+  )
+  return (place(content, dx: dx, dy: dy) + placed-labels, bounds)
+}
+
+
+
+
+// From a list of row heights or col widths, compute the respective
+// cell center coordinates, e.g., (3pt, 3pt, 4pt) -> (1.5pt, 4.5pt, 8pt)
+#let compute-center-coords(cell-lengths, gutter) = {
+  let center-coords = ()
+  let tmpx = 0pt
+  gutter.insert(0, 0pt)
+  // assert.eq(cell-lengths.len(), gutter.len())
+  for (cell-length, gutter) in cell-lengths.zip(gutter) {
+    center-coords.push(tmpx + cell-length / 2 + gutter)
+    tmpx += cell-length + gutter
+  }
+  return center-coords
+} 
+
+
+// Given a list of n center coordinates and n cell sizes along one axis (x or y), retrieve the coordinates for a single cell or a list of cells given by index. 
+// If a cell index is out of bounds, the outer last coordinate is returned
+// center-coords: List of center coordinates for each index
+// cell-sizes: List of cell sizes for each index
+// cells: Indices of cell for which to retrieve coordinates
+// These may also be floats. In this case, the integer part determines the cell index and the fractional part a percentage of the cell width. e.g., passing 2.5 would return the center coordinate of the cell
+#let get-cell-coords(center-coords, cell-sizes, cells) = {
+  let last = center-coords.at(-1) + cell-sizes.at(-1) / 2
+  let get(x) = { 
+    let integral = calc.floor(x)
+    let fractional = x - integral
+    let cell-width = cell-sizes.at(integral, default: 0pt)
+    return center-coords.at(integral, default: last) + cell-width * (fractional - 0.5)
+  }
+  if type(cells) in ("integer", "float") { get(cells)  }
+  else if type(cells) == "array" { cells.map(x => get(x)) }
+  else { panic("Unsupported coordinate type") }
+}
+
+#let get-cell-coords1(center-coords, cell-sizes, cells) = {
+  let last = center-coords.at(-1) + cell-sizes.at(-1) / 2
+  let get(x) = { 
+    let integral = calc.floor(x)
+    let fractional = x - integral
+    let cell-width = cell-sizes.at(integral, default: 0pt)
+    let c1 = center-coords.at(integral, default: last)
+    let c2 = center-coords.at(integral + 1, default: last)
+    return c1 + (c2 - c1) * (fractional)
+  }
+  if type(cells) in ("integer", "float") { get(cells)  }
+  else if type(cells) == "array" { cells.map(x => get(x)) }
+  else { panic("Unsupported coordinate type") }
+}
+
+#let std-scale = scale

--- a/packages/preview/quill/0.4.0/src/length-helpers.typ
+++ b/packages/preview/quill/0.4.0/src/length-helpers.typ
@@ -1,0 +1,13 @@
+
+
+#let convert-em-length(length, em) = {
+  if length.em == 0pt { return length }
+  if type(length.em) == "float" { return length.abs + length.em * em }
+  return length.abs + length.em / 1em * em
+}
+
+#let get-length(length, container-length) = {
+  if type(length) == "length" { return length }
+  if type(length) == "ratio" { return length * container-length}
+  if type(length) == "relative length" { return length.length + length.ratio * container-length}
+}

--- a/packages/preview/quill/0.4.0/src/process-args.typ
+++ b/packages/preview/quill/0.4.0/src/process-args.typ
@@ -1,0 +1,56 @@
+// This file contains helper functions to process and normalize special 
+// arguments to functions, especially where multiple formats and types 
+// are allowed.
+
+#import "layout.typ"
+
+
+#let process-padding-arg(padding) = {
+  let type = type(padding)
+  if type == "length" { 
+    return (left: padding, top: padding, right: padding, bottom: padding)
+  }
+  if type == "dictionary" {
+    let rest = padding.at("rest", default: 0pt)
+    let x = padding.at("x", default: rest)
+    let y = padding.at("y", default: rest)
+    return (
+      left: padding.at("left", default: x), 
+      right: padding.at("right", default: x), 
+      top: padding.at("top", default: y), 
+      bottom: padding.at("bottom", default: y), 
+    )
+  }
+  assert(false, message: "Unsupported type \"" + type + "\" as argument for padding")
+}
+
+
+/// Process the label argument to `gate`. Allowed input formats are none, array of dictionaries
+/// or a single dictionary/string/content (for just one label). 
+/// 
+/// Each dictionary needs to contain the key content and may optionally have values 
+/// for the  keys `pos` (specifying a 1d or 2d alignment) and `dx` as well as `dy`
+#let process-label-arg(
+  labels, 
+  default-pos: right,
+  default-dx: .4em, 
+  default-dy: .4em
+) = {
+  if labels == none {  return () }
+  let type = type(labels)
+  if type == "dictionary" { labels = (labels,) } 
+  else if type in ("content", "string") { labels = ((content: labels),) } 
+  else if type == "dictionary" { labels = ((content: labels),) } 
+  let processed-labels = ()
+  for label in labels {
+    let alignment = layout.make-2d-alignment(label.at("pos", default: default-pos))
+    let (x, y) = layout.make-2d-alignment-factor(alignment)
+    processed-labels.push((
+      content: label.content,
+      pos: alignment,
+      dx: label.at("dx", default: default-dx * x),
+      dy: label.at("dy", default: default-dy * y)
+    ))
+  }
+  processed-labels
+}

--- a/packages/preview/quill/0.4.0/src/quantum-circuit.typ
+++ b/packages/preview/quill/0.4.0/src/quantum-circuit.typ
@@ -1,0 +1,526 @@
+#import "utility.typ"
+#import "verifications.typ"
+#import "length-helpers.typ"
+#import "decorations.typ": *
+
+#let signum(x) = if x >= 0. { 1. } else { -1. }
+
+
+
+/// Create a quantum circuit diagram. Children may be
+/// - gates created by one of the many gate commands (@@gate(), 
+///   @@mqgate(), @@meter(), ...),
+/// - `[\ ]` for creating a new wire/row,
+/// - commands like @@setwire(), @@slice() or @@gategroup(),
+/// - integers for creating cells filled with the current wire setting,
+/// - lengths for creating space between rows or columns,
+/// - plain content or strings to be placed on the wire, and
+/// - @@lstick(), @@midstick() or @@rstick() for placement next to the wire.
+///
+///
+/// - wire (stroke): Style for drawing the circuit wires. This can take anything 
+///            that is valid for the stroke of the builtin `line()` function. 
+/// - row-spacing (length): Spacing between rows.
+/// - column-spacing (length): Spacing between columns.
+/// - min-row-height (length): Minimum height of a row (e.g., when no 
+///             gates are given).
+/// - min-column-width (length): Minimum width of a column.
+/// - gate-padding (length): General padding setting including the inset for 
+///            gate boxes and the distance of @@lstick() and co. to the wire. 
+/// - equal-row-heights (boolean): If true, then all rows will have the same 
+///            height and the wires will have equal distances orienting on the
+///            highest row. 
+/// - color (color): Foreground color, default for strokes, text, controls
+///            etc. If you want to have dark-themed circuits, set this to white  
+///            for instance and update `wire` and `fill` accordingly.           
+/// - fill (color): Default fill color for gates. 
+/// - font-size (length): Default font size for text in the circuit. 
+/// - scale (ratio): Total scale factor applied to the entire 
+///            circuit without changing proportions
+/// - baseline (length, content, str): Set the baseline for the circuit. If a 
+///            content or a string is given, the baseline will be adjusted auto-
+///            matically to align with the center of it. One useful application is 
+///            `"="` so the circuit aligns with the equals symbol. 
+/// - circuit-padding (dictionary): Padding for the circuit (e.g., to accommodate 
+///            for annotations) in form of a dictionary with possible keys 
+///            `left`, `right`, `top` and `bottom`. Not all of those need to be 
+///            specified. 
+///
+///            This setting basically just changes the size of the bounding box 
+///            for the circuit and can be used to increase it when labels or 
+///            annotations extend beyond the actual circuit. 
+/// - fill-wires (boolean): Whether to automatically fill up all wires until the end. 
+/// - ..children (any): Items, gates and circuit commands (see description). 
+#let quantum-circuit(
+  wire: .7pt + black,     
+  row-spacing: 12pt,
+  column-spacing: 12pt,
+  min-row-height: 10pt, 
+  min-column-width: 0pt, 
+  gate-padding: .4em, 
+  equal-row-heights: false, 
+  color: black,
+  fill: white,
+  font-size: 10pt,
+  scale: 100%,
+  baseline: 0pt,
+  circuit-padding: .4em,
+  fill-wires: true,
+  ..children
+) = { 
+  if children.pos().len() == 0 { return }
+  if children.named().len() > 0 { 
+    panic("Unexpected named argument '" + children.named().keys().at(0) + "' for quantum-circuit()")
+  }
+  set text(color, size: font-size)
+  set math.equation(numbering: none)
+
+  style(styles => {
+  
+  // Parameter object to pass to draw-function containing current style info
+  let draw-params = (
+    wire: wire,
+    padding: measure(line(length: gate-padding), styles).width,
+    background: fill,
+    color: color,
+    styles: styles,
+    x-gate-size: none,
+    multi: (wire-distance: 0pt),
+    em: measure(line(length: 1em), styles).width
+  )
+
+  draw-params.x-gate-size = layout.default-size-hint(gate($X$), draw-params)
+  
+  let items = children.pos().map( x => {
+    if type(x) in ("content", "string") and x != [\ ] { return gate(x) }
+    return x
+  })
+  
+  /////////// First part: Layout (and spacing)   ///////////
+  
+  let column-spacing = length-helpers.convert-em-length(column-spacing, draw-params.em)
+  let row-spacing = length-helpers.convert-em-length(row-spacing, draw-params.em)
+  let min-row-height = length-helpers.convert-em-length(min-row-height, draw-params.em)
+  let min-column-width = length-helpers.convert-em-length(min-column-width, draw-params.em)
+  
+  // All these arrays are gonna be filled up in the loop over `items`
+  let matrix = ((),)
+  let row-gutter = (0pt,)
+  let single-qubit-gates = ()
+  let multi-qubit-gates = ()
+  let meta-instructions = ()
+
+  let auto-cell = (empty: true, size: (width: 0pt, height: 0pt), gutter: 0pt)
+
+  let default-wire-style = (
+    count: 1,
+    distance: 1pt, 
+    stroke: wire
+  )
+  let wire-style = default-wire-style
+  let wire-instructions = ()
+
+  let (row, col) = (0, 0)
+  let prev-col = 0
+  let wire-ended = false
+
+  for item in items {
+    if item == [\ ] {
+      if fill-wires {
+        wire-instructions.push((row, prev-col, -1))
+      }
+      row += 1; col = 0; prev-col = 0
+
+      if row >= matrix.len() {
+        matrix.push(())
+        row-gutter.push(0pt)
+      }
+      wire-style = default-wire-style
+      wire-instructions.push(wire-style)
+      wire-ended = true
+    } else if utility.is-circuit-meta-instruction(item) { 
+      if item.qc-instr == "setwire" {
+        wire-style.count = item.wire-count
+
+        wire-style.distance = utility.if-auto(item.wire-distance, wire-style.distance)
+        wire-style.stroke = utility.if-auto(utility.update-stroke(wire-style.stroke, item.stroke), wire-style.stroke)
+        wire-instructions.push(wire-style)
+      } else {
+        // Visual meta instructions are handled later
+        let (x, y) = (item.x, item.y)
+        if x == auto { x = col }
+        if y == auto { y = row }
+        meta-instructions.push((x: x, y: y, item: item))
+      }
+    } else if utility.is-circuit-drawable(item) {
+      let gate = item
+      let (x, y) = (gate.x, gate.y)
+      if x == auto { 
+        x = col 
+        if y == auto {
+          if col != prev-col {
+            wire-instructions.push((row, prev-col, col))
+          }
+          prev-col = col 
+          col += 1
+        }
+      }
+      if y == auto { y = row }
+
+      if y >= matrix.len() { matrix += ((),) * (y - matrix.len() + 1) }
+      if x >= matrix.at(y).len() {
+        matrix.at(y) += (auto-cell,) * (x - matrix.at(y).len() + 1)
+      }
+
+      assert(matrix.at(y).at(x).empty, message: "Attempted to place a second gate at column " + str(x) + ", row " + str(y))
+
+      let size-hint = utility.get-size-hint(item, draw-params)
+      let gate-size = size-hint
+      if item.floating { size-hint.width = 0pt } // floating items don't take width in the layout
+
+      matrix.at(y).at(x) = (
+        size: size-hint,
+        gutter: 0pt,
+        box: item.box,
+        empty: gate.data == "placeholder"
+      )
+      let gate-info = (
+        gate: gate,
+        size: gate-size,
+        x: x,
+        y: y
+      )
+      if gate.multi != none { multi-qubit-gates.push(gate-info) } 
+      else { single-qubit-gates.push(gate-info) }
+      wire-ended = false
+    } else if type(item) == int {
+      wire-instructions.push((row, prev-col, col + item - 1))
+      col += item
+      prev-col = col - 1
+      if col >= matrix.at(row).len() {
+        matrix.at(row) += (auto-cell,) * (col - matrix.at(row).len())
+      }
+      wire-ended = false
+    } else if type(item) == length {
+      if wire-ended {
+        row-gutter.at(row - 1) = calc.max(row-gutter.at(row - 1), item)
+      } else if col > 0 {
+        matrix.at(row).at(col - 1).gutter = calc.max(matrix.at(row).at(col - 1).gutter, item)
+      }
+    }
+  }
+
+  // finish up matrix
+  let num-rows = matrix.len()
+  let num-cols = calc.max(0, ..matrix.map(array.len))
+  if num-rows == 0 or num-cols == 0 { return none }
+
+  
+  for i in range(num-rows) {
+    matrix.at(i) += (auto-cell,) * (num-cols - matrix.at(i).len())
+  }
+  row-gutter += (0pt,) * (matrix.len() - row-gutter.len())
+
+  if fill-wires {
+    wire-instructions.push((row, prev-col, -1)) // fill current wire
+    wire-instructions += range(row + 1, num-rows).map(row => (row, 0, -1)) // we may not have visited all wires due to manual placement. Fill all remaining wires. 
+  }
+
+  let vertical-wires = ()
+  // Treat multi-qubit gates (and controlled gates)
+  // - extract and store all necessary vertical control wires
+  // - Apply same size-hints to all cells that a mqgate spans (without the control wire). 
+  for gate in multi-qubit-gates {
+    let (x, y) = gate
+    let size = matrix.at(y).at(x).size
+    let multi = gate.gate.multi
+    
+    if multi.target != none and multi.target != 0 {
+      verifications.verify-controlled-gate(gate.gate, x, y, num-rows, num-cols)
+
+      let diff = if multi.target > 0 {multi.num-qubits - 1} else {0}
+      vertical-wires.push((
+        x: x, 
+        y: y + diff, 
+        target: multi.target - diff, 
+        wire-style: (count: multi.wire-count),
+        labels: multi.wire-label
+      ))
+    }
+    let nq = multi.num-qubits
+    if nq == 1 { continue }
+
+    verifications.verify-mqgate(gate.gate, x, y, num-rows, num-cols)
+
+    for qubit in range(y, y + nq) {
+      matrix.at(qubit).at(x).size.width = size.width
+    }
+    let start = y
+    if multi.size-all-wires != none {
+      if not multi.size-all-wires {
+        start = calc.max(0, y + nq - 1)
+      }
+      for qubit in range(start, y + nq) {
+        matrix.at(qubit).at(x).size = size
+      }
+    }
+  }
+
+
+  let row-heights = matrix.map(row => 
+    calc.max(min-row-height, ..row.map(item => item.size.height)) + row-spacing
+  )
+  if equal-row-heights {
+    let max-row-height = calc.max(..row-heights)
+    row-heights = (max-row-height,) * row-heights.len()
+  }
+
+  let col-widths = range(num-cols).map(j => 
+    calc.max(min-column-width, ..range(num-rows).map(i => {
+        matrix.at(i).at(j).size.width
+    })) + column-spacing 
+  )
+
+  let col-gutter = range(num-cols).map(j => 
+    calc.max(0pt, ..range(num-rows).map(i => {
+        matrix.at(i).at(j).gutter
+    }))
+  )
+
+  let center-x-coords = layout.compute-center-coords(col-widths, col-gutter).map(x => x - 0.5 * column-spacing)
+  let center-y-coords = layout.compute-center-coords(row-heights, row-gutter).map(x => x - 0.5 * row-spacing)
+  draw-params.center-y-coords = center-y-coords
+  
+  let circuit-width = col-widths.sum() + col-gutter.slice(0, -1).sum(default: 0pt) - column-spacing
+  let circuit-height = row-heights.sum() + row-gutter.sum() - row-spacing
+
+
+
+  /////////// Second part: Generation ///////////
+  
+  let bounds = (0pt, 0pt, circuit-width, circuit-height)
+  
+  let circuit = block(
+    width: circuit-width, height: circuit-height, {
+    set align(top + left) // quantum-circuit could be called in a scope where these have been changed which would mess up everything
+
+    let layer-below-circuit
+    let layer-above-circuit
+    for (item, x, y) in meta-instructions {
+      let (content, decoration-bounds) = (none, none)
+      if item.qc-instr == "gategroup" {
+        verifications.verify-gategroup(item, x, y, num-rows, num-cols)
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, y + item.wires - 1e-9))
+        let (dx1, dx2) = layout.get-cell-coords(center-x-coords, col-widths, (x, x + item.steps - 1e-9))
+        (content, decoration-bounds) = draw-functions.draw-gategroup(dx1, dx2, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "slice" {
+        verifications.verify-slice(item, x, y, num-rows, num-cols)
+        let end = if item.wires == 0 { row-heights.len() } else { y + item.wires }
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, end))
+        let dx = layout.get-cell-coords(center-x-coords, col-widths, x)
+        (content, decoration-bounds) = draw-functions.draw-slice(dx, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "annotate" {
+        let rows = layout.get-cell-coords(center-y-coords, row-heights, item.rows)
+        let cols = layout.get-cell-coords(center-x-coords, col-widths, item.columns)
+        let annotation = (item.callback)(cols, rows)
+        verifications.verify-annotation-content(annotation)
+        if type(annotation) == "dictionary" {
+          (content, decoration-bounds) = layout.place-with-labels(
+            annotation.content,
+            dx: annotation.at("dx", default: 0pt),
+            dy: annotation.at("dy", default: 0pt),
+            draw-params: draw-params
+          )
+        } else if type(annotation) in ("content", "string") {
+          layer-below-circuit += place(annotation)
+        } 
+      }
+      if decoration-bounds != none {
+        bounds = layout.update-bounds(bounds, decoration-bounds, draw-params.em)
+      }
+      if item.at("z", default: "below") == "below" { layer-below-circuit += content  }
+      else { layer-above-circuit += content  }
+    }
+
+    layer-below-circuit
+
+
+    let get-gate-pos(x, y, size-hint) = {
+      let dx = center-x-coords.at(x)
+      let dy = center-y-coords.at(y)
+      let (width, height) = size-hint
+      let offset = size-hint.at("offset", default: auto)
+
+      if offset == auto { return (dx - width / 2, dy - height / 2) } 
+
+      assert(type(offset) == "dictionary", message: "Unexpected type `" + type(offset) + "` for parameter `offset`") 
+      
+      let offset-x = offset.at("x", default: auto)
+      let offset-y = offset.at("y", default: auto)
+      if offset-x == auto { dx -= width / 2}
+      else if type(offset-x) == "length" { dx -= offset-x }
+      if offset-y == auto { dy -= height / 2}
+      else if type(offset-y) == "length" { dy -= offset-y }
+      return (dx, dy)
+    }
+
+
+    let get-anchor-width(x, y) = {
+      if x == num-cols { return 0pt }
+      let el = matrix.at(y).at(x)
+      if "box" in el and not el.box { return 0pt }
+      return el.size.width
+    }
+
+    let get-anchor-height(x, y) = {
+      let el = matrix.at(y).at(x)
+      if "box" in el and not el.box { return 0pt }
+      return el.size.height
+    }
+
+
+    let wire-style = default-wire-style
+    for wire-piece in wire-instructions {
+      if type(wire-piece) == dictionary {
+        wire-style = wire-piece
+      } else {
+        if wire-style.count == 0 { continue }
+        let (row, start-x, end-x) = wire-piece
+        if end-x == -1 {
+          end-x = num-cols - 1
+        }
+        if start-x == end-x { continue }
+
+        let draw-subwire(x1, x2) = {
+          let dx1 = center-x-coords.at(x1)
+          let dx2 = center-x-coords.at(x2, default: circuit-width)
+          let dy = center-y-coords.at(row)
+          dx1 += get-anchor-width(x1, row) / 2
+          dx2 -= get-anchor-width(x2, row) / 2
+          draw-functions.draw-horizontal-wire(dx1, dx2, dy, wire-style.stroke, wire-style.count, wire-distance: wire-style.distance)
+        }
+        // Draw wire pieces and take care not to draw through gates. 
+        for x in range(start-x + 1, end-x) {
+          let anchor-width = get-anchor-width(x, row)
+          if anchor-width == 0pt { continue } // no gate or `box: false` gate. 
+          draw-subwire(start-x, x)
+          start-x = x
+        }
+        draw-subwire(start-x, end-x)
+      }
+    }
+    
+    for (x, y, target, wire-style, labels) in vertical-wires {
+      let dx = center-x-coords.at(x)
+      let (dy1, dy2) = (center-y-coords.at(y), center-y-coords.at(y + target))
+      dy1 += get-anchor-height(x, y) / 2 * signum(target)
+      dy2 -= get-anchor-height(x, y + target) / 2 * signum(target)
+      
+      if labels.len() == 0 {
+        draw-functions.draw-vertical-wire(
+          dy1, dy2, dx, 
+          wire, wire-count: wire-style.count,
+        )
+      } else {
+        let (result, gate-bounds) = draw-functions.draw-vertical-wire-with-labels(
+          dy1, dy2, dx, 
+          wire, wire-count: wire-style.count,
+          wire-labels: labels,
+          draw-params: draw-params
+        )
+        result
+        bounds = layout.update-bounds(bounds, gate-bounds, draw-params.em)
+      }
+    }
+    
+    
+    for gate-info in single-qubit-gates {
+      let (gate, size, x, y) = gate-info
+      let (dx, dy) = get-gate-pos(x, y, size)
+      let content = utility.get-content(gate, draw-params)
+
+      let (result, gate-bounds) = layout.place-with-labels(
+        content, 
+        size: size,
+        dx: dx, dy: dy, 
+        labels: gate.labels, draw-params: draw-params
+      )
+      bounds = layout.update-bounds(bounds, gate-bounds, draw-params.em)
+      result
+    }
+    
+    for gate-info in multi-qubit-gates {
+      let (gate, size, x, y) = gate-info
+      let draw-params = draw-params
+      gate.qubit = y
+      if gate.multi.num-qubits > 1 {
+        let dy1 = center-y-coords.at(y + gate.multi.num-qubits - 1)
+        let dy2 = center-y-coords.at(y)
+        draw-params.multi.wire-distance = dy1 - dy2
+      }
+      
+      // lsticks need their offset to be updated again (but don't update the height!)
+      let content = utility.get-content(gate, draw-params)
+      let new-size = utility.get-size-hint(gate, draw-params)
+      size.offset = new-size.offset
+      size.width = new-size.width
+
+      let (dx, dy) = get-gate-pos(x, y, size)
+      let (result, gate-bounds) = layout.place-with-labels(
+        content, 
+        size: if gate.multi != none and gate.multi.num-qubits > 1 {auto} else {size},
+        dx: dx, dy: dy, 
+        labels: gate.labels, draw-params: draw-params
+      )
+      bounds = layout.update-bounds(bounds, gate-bounds, draw-params.em)
+      result
+    }
+
+    layer-above-circuit
+
+    // show matrix
+    // for (i, row) in matrix.enumerate() {
+    //   for (j, entry) in row.enumerate() {
+    //     let (dx, dy) = (center-x-coords.at(j), center-y-coords.at(i))
+    //     place(
+    //       dx: dx - entry.size.width / 2, dy: dy - entry.size.height / 2, 
+    //       box(stroke: green, width: entry.size.width, height: entry.size.height)
+    //     )
+    //   }
+    // }
+  
+  }) // end circuit = block(..., {
+    
+  let scale = scale
+  if circuit-padding != none {
+    let circuit-padding = process-args.process-padding-arg(circuit-padding)
+    bounds.at(0) -= circuit-padding.left
+    bounds.at(1) -= circuit-padding.top
+    bounds.at(2) += circuit-padding.right
+    bounds.at(3) += circuit-padding.bottom
+  }
+  let final-height = scale * (bounds.at(3) - bounds.at(1))
+  let final-width = scale * (bounds.at(2) - bounds.at(0))
+  
+  let thebaseline = baseline
+  if type(thebaseline) in ("content", "string") {
+    thebaseline = height/2 - measure(thebaseline, styles).height/2
+  }
+  if type(thebaseline) == "fraction" {
+    thebaseline = 100% - layout.get-cell-coords1(center-y-coords, row-heights, thebaseline / 1fr) + bounds.at(1)
+  }
+  box(baseline: thebaseline,
+    width: final-width,
+    height: final-height, 
+    // stroke: 1pt + gray,
+    align(left + top, move(dy: -scale * bounds.at(1), dx: -scale * bounds.at(0), 
+      layout.std-scale(
+        x: scale, 
+        y: scale, 
+        origin: left + top, 
+        circuit
+    )))
+  )
+  
+})
+}

--- a/packages/preview/quill/0.4.0/src/quill.typ
+++ b/packages/preview/quill/0.4.0/src/quill.typ
@@ -1,0 +1,20 @@
+#import "utility.typ"
+#import "decorations.typ": lstick, rstick, midstick, nwire, annotate, slice, setwire, gategroup
+#import "gates.typ": gate, mqgate, ctrl, swap, targ, meter, phantom, permute, phase, targX
+#import "quantum-circuit.typ": quantum-circuit
+#import "tequila.typ"
+
+
+#let help(..args) = {
+  import "@preview/tidy:0.3.0"
+
+  let namespace = (
+    ".": (
+      read.with("/src/quantum-circuit.typ"), 
+      read.with("/src/gates.typ"),
+      read.with("/src/decorations.typ"),
+    ),
+    "gates": read.with("/src/gates.typ"),
+  )
+  tidy.generate-help(namespace: namespace, package-name: "quill")(..args)
+}

--- a/packages/preview/quill/0.4.0/src/tequila-impl.typ
+++ b/packages/preview/quill/0.4.0/src/tequila-impl.typ
@@ -1,0 +1,216 @@
+#import "gates.typ"
+
+#let bgate(qubit, constructor, nq: 1, end: none, ..args) = ((
+  qubit: qubit,
+  n: nq,
+  end: end,
+  constructor: constructor,
+  args: args
+),)
+
+#let generate-single-qubit-gate(qubit, constructor: gates.gate, ..args) = {
+  if qubit.named().len() != 0 {
+    assert(false, message: "Unexpected argument `" + qubit.named().pairs().first().first() + "`")
+  }
+  qubit = qubit.pos()
+  if qubit.len() == 1 { qubit = qubit.first() }
+  if type(qubit) == int { return bgate(qubit, constructor, ..args) }
+  qubit.map(qubit => bgate(qubit, constructor, ..args))
+}
+
+#let generate-two-qubit-gate(control, target, start, end) = {
+  if type(control) == int and type(target) == int { 
+    return bgate(control, start, nq: target - control + 1, end: end, target - control) 
+  }
+  let gates = ()
+  if type(control) == int { control = (control,) }
+  if type(target) == int { target = (target,) }
+
+  for i in range(calc.max(control.len(), target.len())) {
+    let c = control.at(i, default: control.last())
+    let t = target.at(i, default: target.last())
+    assert.ne(t, c, message: "Target and control qubit cannot be the same")
+    gates.push(bgate(c, start, nq: t - c + 1, end: end, t - c) )
+
+  }
+  gates
+}
+
+
+#let gate(qubit, ..args) = bgate(qubit, gates.gate, ..args)
+
+#let mqgate(qubit, n: 1, ..args) = {
+  bgate(qubit, nq: n, gates.mqgate, ..args.pos(), ..args.named() + (n: n))
+}
+
+#let barrier() = bgate(0, barrier)
+
+#let x(..qubit) = generate-single-qubit-gate(qubit, $X$)
+#let y(..qubit) = generate-single-qubit-gate(qubit, $Y$)
+#let z(..qubit) = generate-single-qubit-gate(qubit, $Z$)
+
+#let h(..qubit) = generate-single-qubit-gate(qubit, $H$)
+#let s(..qubit) = generate-single-qubit-gate(qubit, $S$)
+#let sdg(..qubit) = generate-single-qubit-gate(qubit, $S^dagger$)
+#let sx(..qubit) = generate-single-qubit-gate(qubit, $sqrt(X)$)
+#let sxdg(..qubit) = generate-single-qubit-gate(qubit, $sqrt(X)^dagger$)
+#let t(..qubit) = generate-single-qubit-gate(qubit, $T$)
+#let tdg(..qubit) = generate-single-qubit-gate(qubit, $T^dagger$)
+#let p(theta, ..qubit) = generate-single-qubit-gate(qubit, $P (#theta)$)
+
+#let rx(theta, ..qubit) = generate-single-qubit-gate(qubit, $R_x (#theta)$)
+#let ry(theta, ..qubit) = generate-single-qubit-gate(qubit, $R_y (#theta)$)
+#let rz(theta, ..qubit) = generate-single-qubit-gate(qubit, $R_z (#theta)$)
+
+#let u(theta, phi, lambda, ..qubit) = generate-single-qubit-gate(
+  qubit, $U (#theta, #phi, #lambda)$
+)
+
+#let meter(..qubit) = generate-single-qubit-gate(qubit, constructor: gates.meter)
+
+
+#let cx(control, target) = generate-two-qubit-gate(
+  control, target, gates.ctrl, gates.targ
+)
+#let cz(control, target) = generate-two-qubit-gate(
+  control, target, gates.ctrl, gates.ctrl.with(0)
+)
+#let swap(control, target) = generate-two-qubit-gate(
+  control, target, gates.swap, gates.swap.with(0)
+)
+
+
+#let ca(control, target, content) = generate-two-qubit-gate(
+  control, target, gates.ctrl, gates.gate.with(content)
+)
+
+
+/// Constructs a circuit from operation instructions. 
+/// 
+/// - n (auto, int): Number of qubits. Can be inferred automatically. 
+/// - x (int): Determines at which column the subcircuit will be put in the circuit. 
+/// - y (int): Determines at which row the subcircuit will be put in the circuit. 
+/// - append-wire (boolean): If set to `true`, the a last column of outgoing wires will be added. 
+/// - ..children (any): Sequence of instructions. 
+#let build(
+  n: auto, 
+  x: 1, 
+  y: 0,
+  append-wire: true,
+  ..children
+) = {
+  let operations = children.pos().flatten()
+  let num-qubits = n
+  if num-qubits == auto {
+    num-qubits = calc.max(..operations.map(x => x.qubit + calc.max(0, x.n - 1))) + 1
+  }
+  let tracks = ((),) * num-qubits
+  
+  for op in operations {
+    let start = op.qubit
+    // if start < 0 { start = num-qubits + start }
+    let end = start + op.n - 1
+    assert(start >= 0 and start < num-qubits, message: "The qubit `" + str(start) + "` is out of range. Leave `n` at `auto` if you want to automatically resize the circuit. ")
+    assert(end >= 0 and end < num-qubits, message: "The qubit `" + str(end) + "` is out of range. Leave `n` at `auto` if you want to automatically resize the circuit. ")
+    let (q1, q2) = (start, end).sorted()
+    if op.constructor == barrier {
+      (q1, q2) = (0, num-qubits - 1)
+    }
+    let max-track-len = calc.max(..tracks.slice(q1, q2 + 1).map(array.len))
+    for q in range(q1, q2 + 1) {
+      let dif = max-track-len - tracks.at(q).len()
+      if op.constructor != barrier and q not in (q1, q2) {
+         dif += 1
+      }
+      tracks.at(q) += (1,) * dif
+    }
+    if op.constructor != barrier {
+      tracks.at(start).push((op.constructor)(..op.args, x: x + tracks.at(start).len(), y: y + start))
+      if op.end != none {
+        tracks.at(end).push((op.end)(x: x + tracks.at(end).len(), y: y + end))
+      }
+    }
+  }
+  
+  let max-track-len = calc.max(..tracks.map(array.len)) + 1
+  for q in range(tracks.len()) {
+    tracks.at(q) += (1,) * (max-track-len - tracks.at(q).len())
+  }
+  
+  let num-cols = x + calc.max(..tracks.map(array.len)) - 2
+  if append-wire { num-cols += 1 }
+  let placeholder = gates.gate(
+    none, 
+    x: num-cols, y: y + num-qubits - 1, 
+    data: "placeholder", box: false, floating: true, 
+    size-hint: (it, i) => (width: 0pt, height: 0pt)
+  )
+
+  (placeholder,) + tracks.flatten().filter(x => type(x) != int) 
+}
+
+
+
+/// Constructs a graph state preparation circuit. 
+/// 
+/// - n (auto, int): Number of qubits. Can be inferred automatically. 
+/// - x (int): Determines at which column the subcircuit will be put in the circuit. 
+/// - y (int): Determines at which row the subcircuit will be put in the circuit. 
+/// - invert (boolean): If set to `true`, the circuit will be inverted, i.e., a circuit for
+///     "uncomputing" the corresponding graph state. 
+/// ..edges (array): 
+#let graph-state(
+  n: auto,
+  x: 1,
+  y: 0,
+  invert: false,
+  ..edges
+) = {
+  edges = edges.pos()
+  let max-qubit = 0
+  for edge in edges {
+    assert(type(edge) == array, message: "Edges need to be pairs of vertices")
+    assert(edge.len() == 2, message: "Every edge needs to have exactly two vertices")
+    max-qubit = calc.max(max-qubit, ..edge)
+  }
+  let num-qubits = max-qubit + 1
+  if n != auto {
+    num-qubits = n
+    assert(n > max-qubit, message: "")
+  }
+  let gates = (
+    h(range(num-qubits)),
+    barrier(),
+    edges.map(edge => cz(..edge))
+  )
+  if invert {
+    gates = gates.rev()
+  }
+  build(
+    x: x, y: y, 
+    ..gates
+  )
+}
+
+
+/// Template for the quantum fourier transform (QFT). 
+/// - n (auto, int): Number of qubits. 
+/// - x (int): Determines at which column the QFT routine will be placed in the circuit. 
+/// - y (int): Determines at which row the QFT routine will be placed in the circuit. 
+#let qft(
+  n, 
+  x: 1, 
+  y: 0
+) = {
+  let gates = ()
+  for i in range(n - 1) {
+    gates.push(h(i))
+    for j in range(2, n - i + 1) {
+      gates.push(ca(i + j - 1, i, $R_#j$))
+      gates.push(p(i + j - 1))
+    }
+    gates.push(barrier())
+  }
+  gates.push(h(n - 1))
+  build(n: n, x: x, y: y, ..gates)
+}

--- a/packages/preview/quill/0.4.0/src/tequila.typ
+++ b/packages/preview/quill/0.4.0/src/tequila.typ
@@ -1,0 +1,1 @@
+#import "tequila-impl.typ": build, h, gate, mqgate, x, y, z, cx, cz, s, sdg, sx, sxdg, t, tdg, p, rx, ry, rz, u, barrier, swap, meter, graph-state, qft

--- a/packages/preview/quill/0.4.0/src/utility.typ
+++ b/packages/preview/quill/0.4.0/src/utility.typ
@@ -1,0 +1,56 @@
+
+#let if-none(a, b) = { if a != none { a } else { b } }
+#let if-auto(a, b) = { if a != auto { a } else { b } }
+#let is-gate(item) = { type(item) == "dictionary" and "gate-type" in item }
+#let is-circuit-drawable(item) = { is-gate(item) or type(item) in ("string", "content") }
+#let is-circuit-meta-instruction(item) = { type(item) == "dictionary" and "qc-instr" in item }
+
+
+
+// Get content from a gate or plain content item
+#let get-content(item, draw-params) = {
+  if is-gate(item) { 
+    if item.draw-function != none {
+      return (item.draw-function)(item, draw-params)
+    }
+  } else { return item }
+}
+
+// Get size hint for a gate or plain content item
+#let get-size-hint(item, draw-params) = {
+  if is-gate(item) { 
+    return (item.size-hint)(item, draw-params) 
+  } 
+  measure(item, draw-params.styles)
+}
+
+
+// Creates a sized brace with given length. 
+// `brace` can be auto, defaulting to "{" if alignment is right
+// and "}" if alignment is left. Other possible values are 
+// "[", "]", "|", "{", and "}".
+#let create-brace(brace, alignment, length) = {
+  if brace == auto {
+    brace = if alignment == right {"{"} else {"}"} 
+  }
+  return $ lr(#brace, size: length) $
+}
+
+/// Updates the first stroke with the second, i.e., returns the second stroke but all 
+/// fields that are auto are inherited from the first stroke. 
+/// If the second stroke is none, returns none. 
+#let update-stroke(stroke1, stroke2) = {
+  let if-not-auto(a, b) = if b == auto {a} else {b}
+  if stroke2 == none { return none }
+  if stroke2 == auto { return stroke1 }
+  if stroke1 == none { stroke1 = stroke() }
+  let s1 = stroke(stroke1)
+  let s2 = stroke(stroke2)
+  let paint = if-not-auto(s1.paint, s2.paint)
+  let thickness = if-not-auto(s1.thickness, s2.thickness)
+  let cap = if-not-auto(s1.cap, s2.cap)
+  let join = if-not-auto(s1.join, s2.join)
+  let dash = if-not-auto(s1.dash, s2.dash)
+  let miter-limit = if-not-auto(s1.miter-limit, s2.miter-limit)
+  return stroke(paint: paint, thickness: thickness, cap: cap, join: join, dash: dash, miter-limit: miter-limit)
+}

--- a/packages/preview/quill/0.4.0/src/verifications.typ
+++ b/packages/preview/quill/0.4.0/src/verifications.typ
@@ -1,0 +1,81 @@
+#let plural-s(n) = if n == 1 { "" } else { "s" }
+
+#let verify-controlled-gate(gate, x, y, circuit-rows, circuit-cols) = {
+  let multi = gate.multi
+  if y + multi.target >= circuit-rows or y + multi.target < 0 {
+    assert(false, message: 
+      "A controlled gate starting at qubit " + str(y) + 
+      " with relative target " + str(multi.target) + 
+      " exceeds the circuit which has only " + str(circuit-rows) + 
+      " qubit" + plural-s(circuit-rows)
+    )
+  }
+}
+
+
+#let verify-mqgate(gate, x, y, circuit-rows, circuit-cols) = {
+  let nq = gate.multi.num-qubits
+  if y + nq - 1 >= circuit-rows {
+    assert(false, message: 
+      "A " + str(nq) + "-qubit gate starting at qubit " + 
+      str(y) + " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubits"
+    )
+  }
+}
+
+#let verify-slice(slice, x, y, circuit-rows, circuit-cols) = {
+  if slice.wires < 0 {
+    assert(false, message: "`slice`: The number of wires needs to be > 0 (is " + str(slice.wires) + ")")
+  }
+  if y + slice.wires > circuit-rows {
+    assert(false, message: 
+      "A `slice` starting at qubit " + str(y) + 
+      " spanning " + str(slice.wires) + 
+      " qubit" + plural-s(slice.wires) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubit" + plural-s(circuit-rows)
+    )
+  }
+}
+
+
+#let verify-gategroup(gategroup, x, y, circuit-rows, circuit-cols) = {
+  if gategroup.wires <= 0 {
+    assert(false, message: "`gategroup`: The number of wires needs to be > 0 (is " + str(gategroup.wires) + ")")
+  }
+  if gategroup.steps <= 0 {
+    assert(false, message: "`gategroup`: The number of steps needs to be > 0 (is " + str(gategroup.steps) + ")")
+  }
+  if y + gategroup.wires > circuit-rows {
+    assert(false, message: 
+      "A `gategroup` at qubit " + str(y) + 
+      " spanning " + str(gategroup.wires) + 
+      " qubit" + plural-s(gategroup.wires) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubit" + plural-s(circuit-rows)
+    )
+  }
+  if x + gategroup.steps > circuit-cols {
+    assert(false, message: 
+      "A `gategroup` at column " + str(x) + 
+      " spanning " + str(gategroup.steps) + 
+      " column" + plural-s(gategroup.steps) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-cols) + " column" + plural-s(circuit-cols)
+    )
+  }
+}
+
+#let verify-annotation-content(annotation-content) = {
+  let content-type = type(annotation-content)
+  assert(content-type in ("content", "string", "dictionary"), message: "`annotate`: Unsupported callback return type `" + str(content-type) + "` (can be `dictionary` or `content`")
+
+  if content-type == "dictionary" {
+    assert("content" in annotation-content, message: "`annotate`: Missing field `content` in annotation. If the callback returns a dictionary, it must contain the key `content` and may specify coordinates with `dx` and `dy`.")
+    if "z" in annotation-content {
+      let z = annotation-content.z
+      assert(z in ("below", "above"), message: "`annotate`: The parameter `z` can take the values `\"above\"` and `\"below\"`")
+    }
+  }
+}

--- a/packages/preview/quill/0.4.0/typst.toml
+++ b/packages/preview/quill/0.4.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quill"
+version = "0.4.0"
+entrypoint = "src/quill.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Effortlessly create quantum circuit diagrams."
+
+homepage = "https://github.com/Mc-Zen/quill"
+keywords = ["quantum circuit diagram", "quantikz", "qcircuit"]
+categories = ["visualization"]
+disciplines = ["physics", "computer-science"]
+exclude = ["/docs/*"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] an update for a package

With this release, an alternative way of specifying quantum circuits is introduced. Similar to Qiskit (the well-known quantum computing framework written in Python), a circuit can now also be constructed by successively entering instructions. The circuit is then layed out automatically. This gives less control about the precise positioning of gates but allows for faster construction and also composition of sub-circuits. Moreoever, it is now easy to create templates for generic types of circuits. 

For this, the submodule *Tequila* has been added to **Quill**. Tequila also features two built-in templates: `tq.graph-state()` and `tq.qft()`. 

```typ
#import "@preview/quill:0.4.0": *
#import tequila as tq

#quantum-circuit(
  ..tq.graph-state((0, 1), (1, 2)),
  ..tq.build(y: 3, 
      tq.p($pi$, 0), 
      tq.cx(0, (1, 2)), 
    ),
  ..tq.graph-state(x: 6, y: 2, invert: true, (0, 1), (0, 2)),
  gategroup(x: 1, 3, 3),
  gategroup(x: 1, y: 3, 3, 3),
  gategroup(x: 6, y: 2, 3, 3),
  slice(x: 5)
)
```
![image](https://github.com/user-attachments/assets/70b967b5-dc0f-4773-a0a1-adf2ae424100)
