### PR TITLE
README fix for tiaoma:0.2.0 and tiamoa:0.2.1

### DIFF
--- a/packages/preview/tiaoma/0.2.0/README.md
+++ b/packages/preview/tiaoma/0.2.0/README.md
@@ -19,20 +19,22 @@
 
 Please refer to [manual](./manual.pdf) for more details.
 
-## Comparison
 
-There are multiple barcode/qrcode libraries for typst such as
+## Alternatives
 
-1. https://github.com/jneug/typst-codetastic
-2. https://github.com/Midbin/cades
+There are other barcode/qrcode packages for typst such as:
+- https://github.com/jneug/typst-codetastic
+- https://github.com/Midbin/cades
 
-Here is a comparison of them.
+Packages differ in provided customization options for generated barcodes. This package is limited by zint functionality, which focuses more on coverage than customization (e.g. inserting graphics into QR codes). Patching upstream zint code is (currently) outside of the scope of this package - if it doesn't provide functionality you need, check the rest of the typst ecosystem to see if it's available elsewhere or request it [upstream](https://github.com/zint/zint) and [notify us](https://github.com/Enter-tainer/zint-wasi/issues) when it's been merged.
 
-Pros of this package:
+### Pros
 
-1. Support more barcode types
-2. Might be faster because the zint is written in C and compiled to wasm. These libraries are written in typst and javascript.
+1. Support for far greater number of barcode types (all provided by zint library)
+2. Should be faster as is uses a WASM plugin which bundles zint code which is written in C; others are written in pure typst or javascript.
 
-Cons of this package:
+### Cons
 
-1. Doesn't provide enough customization options although it can be improved in the future. 
+1. While most if not all of zint functionality is covered, it's hard to guarantee there's no overlooked functionality.
+2. This package uses typst plugin system and has a WASM backend written in Rust which makes is less welcoming for new contributors.
+

--- a/packages/preview/tiaoma/0.2.1/README.md
+++ b/packages/preview/tiaoma/0.2.1/README.md
@@ -86,20 +86,22 @@
 
 Please refer to [manual](./manual.pdf) for more details.
 
-## Comparison
 
-There are multiple barcode/qrcode libraries for typst such as
+## Alternatives
 
-1. https://github.com/jneug/typst-codetastic
-2. https://github.com/Midbin/cades
+There are other barcode/qrcode packages for typst such as:
+- https://github.com/jneug/typst-codetastic
+- https://github.com/Midbin/cades
 
-Here is a comparison of them.
+Packages differ in provided customization options for generated barcodes. This package is limited by zint functionality, which focuses more on coverage than customization (e.g. inserting graphics into QR codes). Patching upstream zint code is (currently) outside of the scope of this package - if it doesn't provide functionality you need, check the rest of the typst ecosystem to see if it's available elsewhere or request it [upstream](https://github.com/zint/zint) and [notify us](https://github.com/Enter-tainer/zint-wasi/issues) when it's been merged.
 
-Pros of this package:
+### Pros
 
-1. Support more barcode types
-2. Might be faster because the zint is written in C and compiled to wasm. These libraries are written in typst and javascript.
+1. Support for far greater number of barcode types (all provided by zint library)
+2. Should be faster as is uses a WASM plugin which bundles zint code which is written in C; others are written in pure typst or javascript.
 
-Cons of this package:
+### Cons
 
-1. Doesn't provide enough customization options although it can be improved in the future. 
+1. While most if not all of zint functionality is covered, it's hard to guarantee there's no overlooked functionality.
+2. This package uses typst plugin system and has a WASM backend written in Rust which makes is less welcoming for new contributors.
+


### PR DESCRIPTION
Alternatives section was outdated, the new section contains a bit more details on how tiaoma differs from alternatives and reflects the state of the package better.

Sorry for sending a request in email form :grimacing:, forgot this is the proper channel for updates.