### PR TITLE
Fix a typo in the bundler source code, and a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ The infrastructure around the package repository is licensed under the terms of
 the Apache-2.0 license. Packages in `packages/` are licensed under their
 respective license.
 
+[list]: https://typst.app/universe/search/
 [universe]: https://typst.app/universe/
 [categories]: https://github.com/typst/packages/blob/main/CATEGORIES.md
 [disciplines]: https://github.com/typst/packages/blob/main/DISCIPLINES.md

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -276,7 +276,7 @@ fn read_readme(dir_path: &Path) -> anyhow::Result<String> {
     fs::read_to_string(dir_path.join("README.md")).context("failed to read README.md")
 }
 
-/// Build a comrpessed archive for a directory.
+/// Build a compressed archive for a directory.
 fn build_archive(dir_path: &Path, manifest: &PackageManifest) -> anyhow::Result<Vec<u8>> {
     let mut buf = vec![];
     let compressed = flate2::write::GzEncoder::new(&mut buf, flate2::Compression::default());


### PR DESCRIPTION
This is a trivial PR. Please see the file changed.
