### PR TITLE
Fix for quill:0.4.0 

### DIFF
--- a/packages/preview/quill/0.4.0/README.md
+++ b/packages/preview/quill/0.4.0/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="Quill" src="docs/images/logo.svg" style="max-width: 100%; width: 300pt">
+  <img alt="Quill" src="docs/images/logo.svg">
 </div>
 
 <div align="center">

--- a/packages/preview/quill/0.4.0/docs/images/logo.svg
+++ b/packages/preview/quill/0.4.0/docs/images/logo.svg
@@ -1,173 +1,235 @@
-<svg class="typst-doc" viewBox="0 0 239.6381640625 61.412031228417966" width="239.6381640625" height="61.412031228417966" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+<svg class="typst-doc" viewBox="0 0 301.92961328125 76.83564059694336" width="301.92961328125pt" height="76.83564059694336pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
     <g>
         <g transform="translate(1 1)">
-            <path class="typst-shape" fill="#ffffff" d="M 0.87867963 0.87867963 C 1.4412888 0.31607053 2.2043505 0 3 0 L 234.63817 0 C 236.29501 0.00000000000000032750764 237.63817 1.3431457 237.63817 3 L 237.63817 56.412033 C 237.63817 58.068886 236.29501 59.412033 234.63817 59.412033 L 3 59.412033 C 1.3431457 59.412033 0.000000000000000082243954 58.068886 0.00000000000000018369701 56.412033 L 0.0000000000000034542406 3 C 0.0000000000000035029602 2.2043505 0.31607053 1.4412888 0.87867963 0.87867963 Z "/>
+            <path class="typst-shape" fill="#ffffff" d="M 0 3 C 0 1.3431457 1.3431457 0 3 0 L 296.92963 0 C 298.58646 0 299.92963 1.3431457 299.92963 3 L 299.92963 71.83564 C 299.92963 73.49249 298.58646 74.83564 296.92963 74.83564 L 3 74.83564 C 1.3431457 74.83564 0 73.49249 0 71.83564 Z "/>
         </g>
-        <g transform="translate(41.3 12.5)">
+        <g transform="translate(16 5)">
             <g class="typst-group">
                 <g>
-                    <g transform="translate(9 -3.5)">
-                        <path class="typst-shape" fill="#cce3f7" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 3" d="M 0 0 L 0 43.412033 L 120.09316 43.412033 L 120.09316 0 Z "/>
-                    </g>
-                    <g transform="translate(0 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
-                    </g>
-                    <g transform="translate(66.7931640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
-                    </g>
-                    <g transform="translate(46.4931640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.3 0 "/>
-                    </g>
-                    <g transform="translate(69.0931640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
-                    </g>
-                    <g transform="translate(87.0931640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 33 0 "/>
-                    </g>
-                    <g transform="translate(148.2156640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
-                    </g>
-                    <g transform="translate(150.2156640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
-                    </g>
-                    <g transform="translate(120.0931640625 7.414999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1225 0 "/>
-                    </g>
-                    <g transform="translate(0 28.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
-                    </g>
-                    <g transform="translate(0 30.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
-                    </g>
-                    <g transform="translate(66.7931640625 29.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 0 "/>
-                    </g>
-                    <g transform="translate(32.24658203125 28.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 34.54658 0 "/>
-                    </g>
-                    <g transform="translate(32.24658203125 30.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 34.54658 0 "/>
-                    </g>
-                    <g transform="translate(69.0931640625 28.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
-                    </g>
-                    <g transform="translate(69.0931640625 30.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
-                    </g>
-                    <g transform="translate(87.0931640625 29.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.9" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="0.9 4" d="M 0 0 L 33 0 "/>
-                    </g>
-                    <g transform="translate(149.2156640625 29.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 0 "/>
-                    </g>
-                    <g transform="translate(120.0931640625 28.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1225 0 "/>
-                    </g>
-                    <g transform="translate(120.0931640625 30.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 29.1225 0 "/>
-                    </g>
-                    <g transform="translate(151.5156640625 28.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 26.8225 0 "/>
-                    </g>
-                    <g transform="translate(151.5156640625 30.121015625)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 26.8225 0 "/>
-                    </g>
-                    <g transform="translate(0 0)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 94.29317 26.962812 C 94.29317 26.962812 95.79317 13.683 115.79317 -1.317 "/>
-                    </g>
-                    <g transform="translate(0 0)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 95.79317 13.683 115.79317 -1.317 "/>
-                    </g>
-                    <g transform="translate(0 0)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 98.79317 13.683 115.79317 -1.317 "/>
-                    </g>
-                    <g transform="translate(0 0)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 101.79317 17.683 115.79317 -1.317 "/>
-                    </g>
-                    <g transform="translate(0 16.415)"/>
-                    <g transform="translate(-21.3 -0.0000000000000008881784197001252)">
+                    <g transform="translate(32.89 9.75)">
                         <g class="typst-group">
-                            <g>
-                                <g transform="translate(4 4)"/>
-                                <g transform="translate(4 3.33)"/>
-                                <g transform="translate(4 3.33)"/>
-                                <g transform="translate(4 10.83)">
-                                    <g class="typst-text" transform="scale(0.01 -0.01)">
-                                        <use xlink:href="#g0" x="0" fill="#000000"/>
+                            <g transform="matrix(1.3 0 0 1.3 0 0)">
+                                <g transform="translate(9 -3.5)">
+                                    <path class="typst-shape" fill="#cce3f7" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 3" d="M 0 0 L 0 43.412033 L 120.09316 43.412033 L 120.09316 0 Z "/>
+                                </g>
+                                <g transform="translate(0 0)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(0 0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 94.29317 26.962812 C 94.29317 26.962812 95.79317 13.683 115.79317 -1.317 "/>
+                                            </g>
+                                            <g transform="translate(0 0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 95.79317 13.683 115.79317 -1.317 "/>
+                                            </g>
+                                            <g transform="translate(0 0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 98.79317 13.683 115.79317 -1.317 "/>
+                                            </g>
+                                            <g transform="translate(0 0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 97.30316 18.478868 C 97.30316 18.478868 101.79317 17.683 115.79317 -1.317 "/>
+                                            </g>
+                                        </g>
                                     </g>
                                 </g>
-                                <g transform="translate(6.78 3.8900000000000006)"/>
-                                <g transform="translate(6.78 10.83)">
-                                    <g class="typst-text" transform="scale(0.01 -0.01)">
-                                        <use xlink:href="#g1" x="0" fill="#000000"/>
+                                <g transform="translate(0 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
+                                </g>
+                                <g transform="translate(46.4931640625 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.3 0 "/>
+                                </g>
+                                <g transform="translate(66.7931640625 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.3 0 "/>
+                                </g>
+                                <g transform="translate(87.0931640625 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 33 0 "/>
+                                </g>
+                                <g transform="translate(120.0931640625 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
+                                </g>
+                                <g transform="translate(160.3381640625 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 18 0 "/>
+                                </g>
+                                <g transform="translate(0 28.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
+                                </g>
+                                <g transform="translate(0 30.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.246582 0 "/>
+                                </g>
+                                <g transform="translate(32.24658203125 28.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 34.54658 0 "/>
+                                </g>
+                                <g transform="translate(32.24658203125 30.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 34.54658 0 "/>
+                                </g>
+                                <g transform="translate(66.7931640625 28.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.3 0 "/>
+                                </g>
+                                <g transform="translate(66.7931640625 30.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 20.3 0 "/>
+                                </g>
+                                <g transform="translate(87.0931640625 29.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.9" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="0.9 4" d="M 0 0 L 33 0 "/>
+                                </g>
+                                <g transform="translate(120.0931640625 28.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="" d="M 0 0 L 29.1225 0 "/>
+                                </g>
+                                <g transform="translate(120.0931640625 30.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="" d="M 0 0 L 29.1225 0 "/>
+                                </g>
+                                <g transform="translate(149.2156640625 28.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="" d="M 0 0 L 29.1225 0 "/>
+                                </g>
+                                <g transform="translate(149.2156640625 30.121015625)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="" d="M 0 0 L 29.1225 0 "/>
+                                </g>
+                                <g transform="translate(66.7931640625 7.414999999999999)">
+                                    <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 21.706017 "/>
+                                </g>
+                                <g transform="translate(148.2156640625 14.829999999999998)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(0 0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.291016 "/>
+                                            </g>
+                                            <g transform="translate(2 0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.291016 "/>
+                                            </g>
+                                        </g>
                                     </g>
                                 </g>
-                                <g transform="translate(13.41 3.33)"/>
-                                <g transform="translate(13.41 10.83)">
-                                    <g class="typst-text" transform="scale(0.01 -0.01)">
-                                        <use xlink:href="#g2" x="0" fill="#000000"/>
+                                <g transform="translate(-21.3 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(0 0)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(4 10.83)">
+                                                            <g class="typst-text" transform="scale(1, -1)">
+                                                                <use xlink:href="#g1F84C94809B9E42FAA37887E8E852A3" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(6.78 10.83)">
+                                                            <g class="typst-text" transform="scale(1, -1)">
+                                                                <use xlink:href="#g89E1C176250D12809C327F63D14F058F" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                        <g transform="translate(13.41 10.83)">
+                                                            <g class="typst-text" transform="scale(1, -1)">
+                                                                <use xlink:href="#g2B14CA96C90686CE36BA412E7895F92" x="0" fill="#000000"/>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
                                     </g>
                                 </g>
-                                <g transform="translate(17.3 10.83)"/>
+                                <g transform="translate(18 0.12398437499999915)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" d="M 0 1.7 C 0 0.7611159 0.7611159 0 1.7 0 L 26.793163 0 C 27.732048 0 28.493164 0.7611159 28.493164 1.7 L 28.493164 12.882031 C 28.493164 13.820915 27.732048 14.582031 26.793163 14.582031 L 1.7 14.582031 C 0.7611159 14.582031 0 13.820915 0 12.882031 Z "/>
+                                            </g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 1.7 0 L 26.793163 0 C 27.732048 0 28.493164 0.7611159 28.493164 1.7 L 28.493164 12.882031 C 28.493164 13.820915 27.732048 14.582031 26.793163 14.582031 L 1.7 14.582031 C 0.7611159 14.582031 0 13.820915 0 12.882031 L 0 1.7 C 0 0.7611159 0.7611159 0 1.7 0 "/>
+                                            </g>
+                                            <g transform="translate(4 10.58203125)">
+                                                <g class="typst-text" transform="scale(1, -1)">
+                                                    <use xlink:href="#g14D4AA785267A7FA1644CD5B2D974E24" x="0" fill="#000000"/>
+                                                    <use xlink:href="#gB0F2AA1A9CAA553FE61159D02F23E96E" x="12.509765625" fill="#000000"/>
+                                                    <use xlink:href="#g2C91D7AF258EE4D069822C45054344A4" x="15.2197265625" fill="#000000"/>
+                                                    <use xlink:href="#g2C91D7AF258EE4D069822C45054344A4" x="17.8564453125" fill="#000000"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(24.9482421875 21.83)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)">
+                                                <g class="typst-group">
+                                                    <g/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(64.4931640625 5.114999999999999)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(138.0931640625 -0.0000000000000008881784197001252)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 22.245 14.83 L 22.245 0 Z "/>
+                                            </g>
+                                            <g transform="translate(4 4)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(0 0)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 7.513 C 0 7.513 1.4245 2.732 7.1225 2.732 C 12.8205 2.732 14.245 7.513 14.245 7.513 "/>
+                                                        </g>
+                                                        <g transform="translate(7.1225000000000005 8.196)">
+                                                            <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 5.698 -6.147 "/>
+                                                        </g>
+                                                        <g transform="translate(0 0)">
+                                                            <path class="typst-shape" fill="#000000" d="M 15.403605 -0.73803514 C 15.403605 -0.73803514 11.793697 1.0973295 11.793697 1.0973295 C 11.793697 1.0973295 13.847302 3.0006704 13.847302 3.0006704 C 13.847302 3.0006704 15.403605 -0.73803514 15.403605 -0.73803514 Z "/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(64.4931640625 26.821015624999998)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(146.91566406249999 26.821015624999998)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(-0 -0)">
+                                                <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
                             </g>
                         </g>
-                    </g>
-                    <g transform="translate(18 0.12398437499999915)">
-                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0.58578646 0.58578646 C 0.9608592 0.21071368 1.4695671 0 2 0 L 26.493164 0 C 27.597734 0.00000000000000017746116 28.493164 0.8954305 28.493164 2 L 28.493164 12.582031 C 28.493164 13.686601 27.597734 14.582031 26.493164 14.582031 L 2 14.582031 C 0.8954305 14.582031 0.000000000000000054829306 13.686601 0.00000000000000012246469 12.582031 L 0.00000000000000077042723 2 C 0.00000000000000080290687 1.4695671 0.21071368 0.9608592 0.58578646 0.58578646 Z "/>
-                    </g>
-                    <g transform="translate(22 10.706015625)">
-                        <g class="typst-text" transform="scale(0.0048828125 -0.0048828125)">
-                            <use xlink:href="#g3" x="0" fill="#000000"/>
-                            <use xlink:href="#g4" x="2562" fill="#000000"/>
-                            <use xlink:href="#g5" x="3117" fill="#000000"/>
-                            <use xlink:href="#g5" x="3657" fill="#000000"/>
-                        </g>
-                    </g>
-                    <g transform="translate(64.4931640625 5.114999999999999)">
-                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
-                    </g>
-                    <g transform="translate(138.0931640625 -0.0000000000000008881784197001252)">
-                        <path class="typst-shape" fill="#ffffff" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 14.83 L 22.245 14.83 L 22.245 0 Z "/>
-                    </g>
-                    <g transform="translate(142.0931640625 3.999999999999999)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 7.513 C 0 7.513 1.4245 2.732 7.1225 2.732 C 12.8205 2.732 14.245 7.513 14.245 7.513 "/>
-                    </g>
-                    <g transform="translate(149.2156640625 12.195999999999998)">
-                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.6" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 5.698 -6.147 "/>
-                    </g>
-                    <g transform="translate(142.0931640625 3.999999999999999)">
-                        <path class="typst-shape" fill="#000000" d="M 15.403605 -0.73803514 C 15.403605 -0.73803514 11.793697 1.0973295 11.793697 1.0973295 C 11.793697 1.0973295 13.847302 3.0006704 13.847302 3.0006704 C 13.847302 3.0006704 15.403605 -0.73803514 15.403605 -0.73803514 Z "/>
-                    </g>
-                    <g transform="translate(64.4931640625 26.821015624999998)">
-                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
-                    </g>
-                    <g transform="translate(146.91566406249999 26.821015624999998)">
-                        <path class="typst-shape" fill="#000000" d="M 0 2.3 C 0 1.0308968 1.0308968 0 2.3 0 C 3.5691032 0 4.6 1.0308968 4.6 2.3 C 4.6 3.5691032 3.5691032 4.6 2.3 4.6 C 1.0308968 4.6 0 3.5691032 0 2.3 "/>
                     </g>
                 </g>
             </g>
         </g>
-        <g transform="translate(0 0)"/>
     </g>
     <defs id="glyph">
-        <symbol id="g0" overflow="visible">
-            <path d="M 139 -250 C 152.33333 -250 159 -242 159 -226 L 159 726 C 159 742 152.33333 750 139 750 C 125.66667 750 119 742 119 726 L 119 -226 C 119 -242 125.66667 -250 139 -250 Z "/>
+        <symbol id="g1F84C94809B9E42FAA37887E8E852A3" overflow="visible">
+            <path d="M 1.39 -2.5 C 1.52 -2.5 1.5899999 -2.4199998 1.5899999 -2.26 L 1.5899999 7.2599998 C 1.5899999 7.4199996 1.52 7.5 1.39 7.5 C 1.26 7.5 1.1899999 7.4199996 1.1899999 7.2599998 L 1.1899999 -2.26 C 1.1899999 -2.4199998 1.26 -2.5 1.39 -2.5 Z "/>
         </symbol>
-        <symbol id="g1" overflow="visible">
-            <path d="M 534 393 C 534 383.6667 539.3333 373.6667 550 363 C 573.3333 341 585 314 585 282 C 585 253.33333 575.6667 221.66667 557 187 C 521.6667 119.66667 476.33334 71.66667 421 43 C 387.6667 26.333328 354.6667 17.666672 322 17 L 484 663 C 486 671.6667 487 677 487 679 C 487 689 481.6667 694 471 694 C 466.3333 694 462.66666 693 460 691 C 456 683 453.6667 676.3333 453 671 L 290 19 C 219.33333 28.333328 184 64 184 126 C 184 153.33333 201.66667 214.33333 237 309 C 244.33333 329 248 345.6667 248 359 C 248 408.5749 212.90883 444 163 444 C 118.33333 444 83.66667 419 59 369 C 39 329 29 302 29 288 C 29 278.6667 34.33333 274 45 274 C 58.389786 274 59.966278 279.882 64 294 C 87.33333 374 119.33333 414 160 414 C 174 414 181 405 181 387 C 181 371 173.66667 343 159 303 C 127 218.33333 111 162 111 134 C 111 46.66667 168 -1.3333282 282 -10 C 274 -45.33333 267 -74 261 -96 C 245.66667 -152.66667 238 -184.66667 238 -192 C 240.70691 -200.12073 241.86992 -205 255 -205 L 265 -201 C 271 -185 275.6667 -170.33333 279 -157 L 315 -13 C 397 -11.666672 469 24.333328 531 95 C 563.6667 131.66667 588 171.66667 604 215 C 624.6667 270.3333 635 322.3333 635 371 C 635 419.6667 619.3333 444 588 444 C 562.25916 444 534 418.5208 534 393 Z "/>
+        <symbol id="g89E1C176250D12809C327F63D14F058F" overflow="visible">
+            <path d="M 5.3399997 3.9299998 C 5.3399997 3.84 5.39 3.74 5.5 3.6299999 C 5.73 3.4099998 5.85 3.1399999 5.85 2.82 C 5.85 2.53 5.7599998 2.22 5.5699997 1.87 C 5.22 1.1999999 4.7599998 0.71999997 4.21 0.42999998 C 3.8799999 0.26 3.55 0.17999999 3.22 0.17 L 4.8399997 6.6299996 C 4.8599997 6.72 4.87 6.77 4.87 6.79 C 4.87 6.89 4.8199997 6.94 4.71 6.94 C 4.66 6.94 4.63 6.93 4.6 6.91 C 4.56 6.83 4.54 6.7599998 4.5299997 6.71 L 2.8999999 0.19 C 2.19 0.28 1.8399999 0.64 1.8399999 1.26 C 1.8399999 1.53 2.02 2.1399999 2.37 3.09 C 2.44 3.29 2.48 3.46 2.48 3.59 C 2.48 4.0899997 2.1299999 4.44 1.63 4.44 C 1.18 4.44 0.84 4.19 0.59 3.6899998 C 0.39 3.29 0.29 3.02 0.29 2.8799999 C 0.29 2.79 0.34 2.74 0.45 2.74 C 0.58 2.74 0.59999996 2.8 0.64 2.9399998 C 0.87 3.74 1.1899999 4.14 1.5999999 4.14 C 1.74 4.14 1.81 4.0499997 1.81 3.87 C 1.81 3.7099998 1.74 3.4299998 1.5899999 3.03 C 1.27 2.18 1.11 1.62 1.11 1.3399999 C 1.11 0.47 1.68 -0.01 2.82 -0.099999994 C 2.74 -0.45 2.6699998 -0.74 2.61 -0.96 C 2.46 -1.53 2.3799999 -1.8499999 2.3799999 -1.92 C 2.4099998 -2 2.4199998 -2.05 2.55 -2.05 L 2.6499999 -2.01 C 2.71 -1.8499999 2.76 -1.6999999 2.79 -1.5699999 L 3.1499999 -0.13 C 3.97 -0.12 4.69 0.24 5.31 0.95 C 5.64 1.3199999 5.8799996 1.7199999 6.04 2.1499999 C 6.25 2.7 6.35 3.22 6.35 3.7099998 C 6.35 4.2 6.19 4.44 5.8799996 4.44 C 5.62 4.44 5.3399997 4.19 5.3399997 3.9299998 Z "/>
         </symbol>
-        <symbol id="g2" overflow="visible">
-            <path d="M 278 242 C 278.6667 244 279 246.66667 279 250 C 279 253.33333 278.6667 256 278 258 L 98 735 C 94 745 86.66667 750 76 750 C 60.66667 750 53 742 53 726 C 53 722.6667 53.33333 720 54 718 L 231 250 L 54 -217 C 53.33333 -219 53 -222 53 -226 C 53 -242 60.66667 -250 76 -250 C 86.66667 -250 94 -245 98 -235 Z "/>
+        <symbol id="g2B14CA96C90686CE36BA412E7895F92" overflow="visible">
+            <path d="M 2.78 2.4199998 C 2.79 2.44 2.79 2.47 2.79 2.5 C 2.79 2.53 2.79 2.56 2.78 2.58 L 0.97999996 7.35 C 0.94 7.45 0.87 7.5 0.76 7.5 C 0.61 7.5 0.53 7.4199996 0.53 7.2599998 C 0.53 7.23 0.53 7.2 0.53999996 7.18 L 2.31 2.5 L 0.53999996 -2.1699998 C 0.53 -2.19 0.53 -2.22 0.53 -2.26 C 0.53 -2.4199998 0.61 -2.5 0.76 -2.5 C 0.87 -2.5 0.94 -2.45 0.97999996 -2.35 Z "/>
         </symbol>
-        <symbol id="g3" overflow="visible">
-            <path d="M 1171 -250 Q 1316 -307 1409.5 -328.5 Q 1503 -350 1616 -350 Q 1696 -350 1807.5 -317.5 Q 1919 -285 2017 -229 L 2052 -266 Q 1954 -356 1808.5 -409.5 Q 1663 -463 1503 -463 Q 1257 -463 1030 -369 Q 837 -291 734 -261 Q 631 -231 528 -231 Q 481 -231 428 -273 Q 396 -310 365 -354 L 283 -313 Q 377 -184 520 -80 Q 570 -43 625 -15 Q 387 16 231.5 191.5 Q 76 367 76 635 Q 76 942 246 1145 Q 416 1348 705 1348 Q 990 1348 1177 1165.5 Q 1364 983 1364 674 Q 1364 418 1237 238 Q 1089 28 827 -12 Q 706 -45 580 -135 Q 570 -142 560 -150 Q 592 -146 623 -145 Q 903 -146 1171 -250 Z M 678 1274 Q 510 1274 391 1122.5 Q 272 971 272 670 Q 272 387 415.5 220 Q 559 53 758 53 Q 938 53 1052.5 210 Q 1167 367 1167 635 Q 1167 934 1028 1104 Q 889 1274 678 1274 Z M 1921 -20 Q 1780 -20 1718.5 58.5 Q 1657 137 1657 258 L 1657 651 Q 1657 747 1631.5 778 Q 1606 809 1530 815 Q 1520 823 1520 847.5 Q 1520 872 1530 883 Q 1669 879 1739 879 Q 1790 879 1810 883 Q 1826 883 1827 870 Q 1819 720 1819 659 L 1819 287 Q 1819 166 1869 121 Q 1919 76 1982 76 Q 2072 76 2187 174 Q 2220 203 2220 254 L 2220 649 Q 2220 747 2195.5 779 Q 2171 811 2093 815 Q 2085 823 2085 847.5 Q 2085 872 2093 883 Q 2232 879 2302 879 Q 2353 879 2374 883 Q 2390 883 2390 870 Q 2382 720 2382 659 L 2382 266 Q 2382 186 2409.5 155.5 Q 2437 125 2531 117 Q 2539 107 2539.5 88.5 Q 2540 70 2531 61 Q 2367 43 2290 -20 Q 2272 -28 2251 -20 Q 2233 50 2228 100 Q 2226 110 2216 109.5 Q 2206 109 2198 102 Q 2048 -20 1921 -20 Z "/>
+        <symbol id="g14D4AA785267A7FA1644CD5B2D974E24" overflow="visible">
+            <path d="M 5.7177734 -1.2207031 Q 6.4257813 -1.4990234 6.882324 -1.6040039 Q 7.338867 -1.7089844 7.890625 -1.7089844 Q 8.28125 -1.7089844 8.825684 -1.550293 Q 9.370117 -1.3916016 9.848633 -1.1181641 L 10.019531 -1.2988281 Q 9.541016 -1.7382813 8.830566 -1.9995117 Q 8.120117 -2.2607422 7.338867 -2.2607422 Q 6.1376953 -2.2607422 5.029297 -1.8017578 Q 4.086914 -1.4208984 3.5839844 -1.2744141 Q 3.0810547 -1.1279297 2.578125 -1.1279297 Q 2.3486328 -1.1279297 2.0898438 -1.3330078 Q 1.9335938 -1.5136719 1.7822266 -1.7285156 L 1.3818359 -1.5283203 Q 1.8408203 -0.8984375 2.5390625 -0.390625 Q 2.7832031 -0.20996094 3.0517578 -0.07324219 Q 1.8896484 0.078125 1.1303711 0.9350586 Q 0.37109375 1.7919922 0.37109375 3.100586 Q 0.37109375 4.5996094 1.2011719 5.5908203 Q 2.03125 6.5820313 3.4423828 6.5820313 Q 4.8339844 6.5820313 5.7470703 5.690918 Q 6.6601563 4.7998047 6.6601563 3.2910156 Q 6.6601563 2.0410156 6.040039 1.1621094 Q 5.317383 0.13671875 4.038086 -0.05859375 Q 3.4472656 -0.21972656 2.8320313 -0.6591797 Q 2.7832031 -0.6933594 2.734375 -0.7324219 Q 2.890625 -0.7128906 3.0419922 -0.7080078 Q 4.4091797 -0.7128906 5.7177734 -1.2207031 Z M 3.3105469 6.220703 Q 2.4902344 6.220703 1.9091797 5.480957 Q 1.328125 4.741211 1.328125 3.2714844 Q 1.328125 1.8896484 2.0288086 1.0742188 Q 2.7294922 0.25878906 3.7011719 0.25878906 Q 4.580078 0.25878906 5.13916 1.0253906 Q 5.698242 1.7919922 5.698242 3.100586 Q 5.698242 4.560547 5.0195313 5.390625 Q 4.3408203 6.220703 3.3105469 6.220703 Z M 9.379883 -0.09765625 Q 8.691406 -0.09765625 8.391113 0.28564453 Q 8.09082 0.6689453 8.09082 1.2597656 L 8.09082 3.178711 Q 8.09082 3.647461 7.9663086 3.7988281 Q 7.841797 3.9501953 7.470703 3.9794922 Q 7.421875 4.0185547 7.421875 4.1381836 Q 7.421875 4.2578125 7.470703 4.3115234 Q 8.149414 4.291992 8.491211 4.291992 Q 8.740234 4.291992 8.837891 4.3115234 Q 8.916016 4.3115234 8.920898 4.248047 Q 8.881836 3.515625 8.881836 3.2177734 L 8.881836 1.4013672 Q 8.881836 0.8105469 9.125977 0.5908203 Q 9.370117 0.37109375 9.677734 0.37109375 Q 10.1171875 0.37109375 10.678711 0.8496094 Q 10.839844 0.99121094 10.839844 1.2402344 L 10.839844 3.1689453 Q 10.839844 3.647461 10.720215 3.803711 Q 10.600586 3.959961 10.219727 3.9794922 Q 10.180664 4.0185547 10.180664 4.1381836 Q 10.180664 4.2578125 10.219727 4.3115234 Q 10.8984375 4.291992 11.240234 4.291992 Q 11.489258 4.291992 11.591797 4.3115234 Q 11.669922 4.3115234 11.669922 4.248047 Q 11.630859 3.515625 11.630859 3.2177734 L 11.630859 1.2988281 Q 11.630859 0.9082031 11.765137 0.75927734 Q 11.899414 0.61035156 12.358398 0.57128906 Q 12.397461 0.52246094 12.399902 0.4321289 Q 12.402344 0.34179688 12.358398 0.29785156 Q 11.557617 0.20996094 11.181641 -0.09765625 Q 11.09375 -0.13671875 10.991211 -0.09765625 Q 10.90332 0.24414063 10.878906 0.48828125 Q 10.869141 0.5371094 10.8203125 0.53466797 Q 10.771484 0.53222656 10.732422 0.49804688 Q 10 -0.09765625 9.379883 -0.09765625 Z "/>
         </symbol>
-        <symbol id="g4" overflow="visible">
-            <path d="M 184 1227 Q 184 1264 219 1294.5 Q 254 1325 291 1325 Q 330 1325 359.5 1291 Q 389 1257 389 1219 Q 389 1184 356.5 1152 Q 324 1120 283 1120 Q 246 1120 215 1154 Q 184 1188 184 1227 Z M 371 250 Q 371 127 395.5 98.5 Q 420 70 518 63 Q 528 53 528 28.5 Q 528 4 518 -4 Q 383 0 291 0 Q 197 0 61 -4 Q 53 4 53 28.5 Q 53 53 61 63 Q 159 71 184 99 Q 209 127 209 250 L 209 649 Q 209 735 185.5 757.5 Q 162 780 76 788 Q 64 823 72 846 Q 262 871 352 905 Q 379 905 379 891 Q 371 760 371 658 L 371 250 Z "/>
+        <symbol id="gB0F2AA1A9CAA553FE61159D02F23E96E" overflow="visible">
+            <path d="M 0.8984375 5.991211 Q 0.8984375 6.171875 1.0693359 6.320801 Q 1.2402344 6.4697266 1.4208984 6.4697266 Q 1.6113281 6.4697266 1.7553711 6.303711 Q 1.8994141 6.1376953 1.8994141 5.9521484 Q 1.8994141 5.78125 1.7407227 5.625 Q 1.5820313 5.46875 1.3818359 5.46875 Q 1.2011719 5.46875 1.0498047 5.6347656 Q 0.8984375 5.8007813 0.8984375 5.991211 Z M 1.8115234 1.2207031 Q 1.8115234 0.6201172 1.9311523 0.48095703 Q 2.0507813 0.34179688 2.5292969 0.3076172 Q 2.578125 0.25878906 2.578125 0.13916016 Q 2.578125 0.01953125 2.5292969 -0.01953125 Q 1.8701172 0 1.4208984 0 Q 0.96191406 0 0.29785156 -0.01953125 Q 0.25878906 0.01953125 0.25878906 0.13916016 Q 0.25878906 0.25878906 0.29785156 0.3076172 Q 0.7763672 0.3466797 0.8984375 0.48339844 Q 1.0205078 0.6201172 1.0205078 1.2207031 L 1.0205078 3.1689453 Q 1.0205078 3.5888672 0.9057617 3.6987305 Q 0.7910156 3.8085938 0.37109375 3.8476563 Q 0.3125 4.0185547 0.3515625 4.1308594 Q 1.2792969 4.2529297 1.71875 4.4189453 Q 1.8505859 4.4189453 1.8505859 4.350586 Q 1.8115234 3.7109375 1.8115234 3.2128906 L 1.8115234 1.2207031 Z "/>
         </symbol>
-        <symbol id="g5" overflow="visible">
-            <path d="M 195 250 L 195 1145 Q 195 1258 174.5 1282.5 Q 154 1307 63 1313 Q 40 1336 51 1374 Q 233 1388 338 1430 Q 365 1430 365 1409 Q 357 1327 356 1194 L 356 250 Q 356 127 382 97.5 Q 408 68 504 63 Q 512 53 512 28.5 Q 512 4 504 -4 Q 369 0 276 0 Q 190 0 47 -4 Q 37 4 37 28.5 Q 37 53 47 63 Q 143 67 169 97 Q 195 127 195 250 Z "/>
+        <symbol id="g2C91D7AF258EE4D069822C45054344A4" overflow="visible">
+            <path d="M 0.95214844 1.2207031 L 0.95214844 5.5908203 Q 0.95214844 6.142578 0.8520508 6.262207 Q 0.7519531 6.381836 0.3076172 6.411133 Q 0.1953125 6.5234375 0.24902344 6.7089844 Q 1.1376953 6.7773438 1.6503906 6.982422 Q 1.7822266 6.982422 1.7822266 6.879883 Q 1.7431641 6.479492 1.7382813 5.830078 L 1.7382813 1.2207031 Q 1.7382813 0.6201172 1.8652344 0.47607422 Q 1.9921875 0.33203125 2.4609375 0.3076172 Q 2.5 0.25878906 2.5 0.13916016 Q 2.5 0.01953125 2.4609375 -0.01953125 Q 1.8017578 0 1.3476563 0 Q 0.9277344 0 0.22949219 -0.01953125 Q 0.18066406 0.01953125 0.18066406 0.13916016 Q 0.18066406 0.25878906 0.22949219 0.3076172 Q 0.6982422 0.32714844 0.8251953 0.4736328 Q 0.95214844 0.6201172 0.95214844 1.2207031 Z "/>
         </symbol>
     </defs>
-    <defs id="clip-path"/>
 </svg>

--- a/packages/preview/quill/0.4.0/typst.toml
+++ b/packages/preview/quill/0.4.0/typst.toml
@@ -6,7 +6,7 @@ authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
 license = "MIT"
 description = "Effortlessly create quantum circuit diagrams."
 
-homepage = "https://github.com/Mc-Zen/quill"
+repository = "https://github.com/Mc-Zen/quill"
 keywords = ["quantum circuit diagram", "quantikz", "qcircuit"]
 categories = ["visualization"]
 disciplines = ["physics", "computer-science"]


### PR DESCRIPTION
Re-adds repository field to typst.toml in place of `homepage`. Also increases logo size which is displayed smaller in the Typst Universe due to different Markdown HTML support. 