### PR TITLE
Configuration fix for zero:0.1.0

### DIFF
--- a/packages/preview/zero/0.1.0/typst.toml
+++ b/packages/preview/zero/0.1.0/typst.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Advanced scientific number formatting."
 compiler = "0.11.0"
 
-homepage = "https://github.com/Mc-Zen/zero"
+repository = "https://github.com/Mc-Zen/zero"
 keywords = ["number", "table", "siunitx"]
 categories = ["visualization", "layout"]
 exclude = ["/docs/*", "/tests/*"]


### PR DESCRIPTION
Re-adds `repository` field to typst.toml in place of `homepage`.