### PR TITLE
Add guidelines for the `description` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ version = "0.1.0"
 entrypoint = "lib.typ"
 authors = ["The Typst Project Developers"]
 license = "MIT"
-description = "An example package."
+description = "Calculate elementary arithemtics with functions"
 ```
 
 Required by the compiler:
@@ -79,7 +79,7 @@ version = "0.1.0"
 entrypoint = "lib.typ"
 authors = ["Typst GmbH <https://typst.app>"]
 license = "MIT-0"
-description = "An IEEE-style paper template to publish at conferences and journals for Electrical Engineering, Computer Science, and Computer Engineering"
+description = "IEEE-style paper to publish at conferences and journals"
 
 [template]
 path = "template"
@@ -172,6 +172,30 @@ are detailed below:
 
   If you are an author of an original template not affiliated with any
   organization, only the standard package naming guidelines apply to you.
+
+- **Description:** Write simple, easily-understandable and succinct
+	descriptions.
+	- Keep it short. Try to maximise the content:length ratio and weigh your words
+		thoughtfully. No more than 100 characters, preferably much less.
+	- Avoid the word ‘Typst’, which is redundant unless your package or template
+		actually has to do with Typst itself or its ecosystem (like in the case of
+		[Mantys](https://typst.app/universe/package/mantys/) or
+		[t4t](https://typst.app/universe/package/t4t)).
+	- Don’t terminate your description with a full stop.
+	- Avoid the words ‘package’ for packages and ‘template’ for templates;
+		instead:
+		- Packages allow the user to *do* things; use the imperative mood. For
+			example, `Draw Venn diagrams` is better than `A package for drawing Venn
+			diagrams`.
+		- Templates allow the user to write certain *types* of documents; clearly
+			indicate the type of document your template allows. For example, `Master’s
+			thesis at the Unseen University` is better than `A template for writing a
+			master’s thesis at the Unseen University`. Omit the indefinite article at
+			the beginning of the description for conciseness.
+	- Bilingual descriptions are welcome. If you wish to describe your package in a
+		language other then English, format the description like so: `ENGLISH |
+		ADDITIONAL-LANGUAGE` (with a vertical line as a boundary marker). Character
+		limit is doubled.
 
 - **Functionality:** Packages should conceivably be useful to other users and
   should expose their capabilities in a reasonable fashion.


### PR DESCRIPTION
The `description` field is defined as follows:

> * `description`: A short description of the package. Double-check this for grammar and spelling mistakes as it will appear in the [package list](https://typst.app/universe/search/).

A quick glance on the said package list reveals some inconsistencies. In order to help Typst Universe communicate professionalism and consistency even better, I suggest formulating guidelines that unify the way descriptions look. These should not be hard-set rules but guiding principles that cultivate better ways for package- and template authors to explain what their contributions are for. Practically, I think this should be done in three places:
- First, the [submission guidelines](README.md#submission-guidelines) section of the readme. This pull request offers a preliminary draft for such guidelines.
- Secondly, warnings by the [Typst package check](https://github.com/apps/typst-package-check) bot if something is automatically detected.
- Lastly, if the contributor doesn’t change the description and the individual case justifies that, human feedback is the last resort…. IIUC, @elegaanz is our friendly Universologist 😉. If you all think this is a good idea but it’s too much of a hassle, I don’t mind proposing polite suggestions to reword descriptions whenever pull requests are in if needed.

I don’t think contacting past contributors is a good idea, but when new versions of existing packages and templates are submitted in case that’s needed it’s possible to ask the contributors if they want to reword the description.

I took the liberty of changing the `description` field of the package [`example`](https://typst.app/universe/package/example) and the template [`charged-ieee`](https://typst.app/universe/package/charged-ieee) in the readme (but not in the actual packages) because this is just a draft.

What follows is some points I think worth considering, in the order of proposed guidelines in the pull request. My thoughts are written after the horizontal line in each subsection **(tl;dr: I think succinct, minimalist, short and sweet descriptions are the best — less is more)**. The rewording suggestions within each subsection tackle the point in question individually; some descriptions can be changed with respect to more than one point, but I wanted to keep it focused. The choice of packages and templates that serve as examples in the tables below is arbitrary and not done to criticise specific cases; I just copied and pasted the first packages I found that demonstrate the point under discussion 🙂

## Long descriptions

Some descriptions are extremely long; for example:

| Name | Description |
|-|-|
| `pintorita` | Package to draw Sequence Diagrams, Entity Relationship Diagrams, Component Diagrams, Activity Diagrams, Mind Maps, Gantt Diagrams, and DOT Diagrams based on Pintora which is heavily influenced by mermaid.js and plantuml.|
| `flyingcircus` | For creating homebrew documents with the same fancy style as the Flying Circus book? Provides simple commands to generate a whole aircraft stat page, vehicle, or even ship. |

---

Long descriptions are not doing the reader any favour in being *over* descriptive. I think there should be a hard limit of 100 characters at most; maybe even less (see [this](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes), where the limit is of 70–75 characters). At any rate package/template authors should be encouraged to maximise the content:length ratio; most packages and templates can and should have descriptions which are 50 characters or less, consisting of well-chosen words.

The above can be reworded as:

| Name | Description |
|-|-|
| `pintorita` | Draw diagrams with a Pintora-like syntax |
| `flyingcircus` | Documents in the style of the Flying Circus book |

## Explicit reference to Typst

Some packages and templates have an explicit reference to Typst; for example:

| Name | Description | With ‘Typst’? |
|-|-|-|
| `cades` | Generate QR codes in typst. | yes |
| `bookletic` | Create beautiful booklets with ease. | no |
| `letter-pro` | DIN 5008 letter template for Typst. | yes |
| `minimal-cv` | A clean and customizable CV template | no |

---

Context is king. There is no reason for this redundant information, as Typst Universe contains… well… packages and templates for Typst. There is reason for such an reference in the description of the package or template in their Git repositories, but this is completely unrelated: descriptions there and here don’t have to be identical, since here we have context that’s absent there.

The above can be reworded as:

| Name | Description |
|-|-|
| `cades` | Generate QR codes. |
| `letter-pro` | DIN 5008 letter template. |

## Full stop.

Some packages and templates terminate the field with a full stop while some do not; for example:

| Name | Description | With a full stop? |
|-|-|-|
| `umbra` | Basic shadows for Typst | no |
| `suiji` | A high efficient random number generator in Typst. | yes |

In fact, the readme itself is not consistent:

```toml
⋮
description = "An example package."
⋮
description = "An IEEE-style paper template to publish at conferences and journals for Electrical Engineering, Computer Science, and Computer Engineering"
⋮
```

---

I think terminal full stops are unnecessary and should be avoided. They create visual clutter, and the description field is not running text. As the packages are already delimited typographically, full stops don’t have a delimiting function either. Compare the following grocery list:

- Fruits.
- Vegetables.
- Tahini.

with this one:

- Fruits
- Vegetables
- Tahini

The latter is much more readable.

## ‘(A) package/template (for/to)’

Some packages and templates have the words ‘package’ or ‘template’, respectively, in the description; for example:

| Name | Description | Type | With ‘paper’ or ‘template’? |
|-|-|-|-|
| `game-theoryst` | A package for typesetting games in Typst. | package | yes |
| `curryst` | Typeset trees of inference rules. | package | no |
| `casual-szu-report` | A template for SZU course reports. | template | yes |
| `basic-resume` | A simple, standard resume, designed to work well with ATS. | template | no |

---

I think having these words is redundant, and it’s better to communicate directly what the package does or what the template is for, without stating they are a package or a template in the description text:

- The fact they are either is obvious from the context of them being listed in Typst Universe.
- The distinction between the two should be communicated structurally and visually, not with an explicit word (‘package’ or ‘template’) that contributes little to the content. See the next subsection for how they are differentiated linguistically in the proposed guidelines.

The above can be reworded as:

| Name | Description |
|-|-|
| `game-theoryst` | Typeset games in Typst. |
| `casual-szu-report` | SZU course reports. |

This is closely related to the next subsection (both make the same guideline in the pull request).

## Linguistic form

The corpus of package descriptions demonstrates uneven situation with regard to syntactic structures; for example:

| Name | Description | Form |
|-|-|-|
| `wordometer` | Word counts and document statistics. | standalone nouns |
| `polylux` | Presentation slides creation with Typst | deverbal nouns |
| `blinky` | Typesets paper titles in bibliographies as hyperlinks. | present-tense verb |
| `scrutinize` | A library for building exams, tests, etc. with Typst | noun with adjunct |
| `pyrunner` | Run python code in typst. | imperative verb |

Templates tend to use nominal forms more often.

---

I think we should treat packages and templates differently here. While I said above that using the words ‘package’ and ‘template’ should be avoided as they contribute little, I do think different linguistic forms suit each of the two better.

With packages — which allow the user to *do* things in their document — adopting the Linux kernel [guidelines](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes) and using the imperative mood seems most suitable. For example, the above can be reworded as:

| Name | Description |
|-|-|
| `wordometer` | Obtain word counts and other document statistics. |
| `polylux` | Create presentation slides with Typst |
| `blinky` | Typeset paper titles in bibliographies as hyperlinks. |
| `scrutinize` | Build exams, tests, etc. with Typst |

With templates — which provides the user with ready-made moulds for documents of different types — I think that standalone noun phrases that describe the *type* of document provided by the template are the most suitable. Examples of this form include:

| Name | Description | Type of document |
|-|-|-|
| `classy-german-invoice` | Minimalistic invoice for germany based freelancers | invoice |
| `fh-joanneum-iit-thesis` | BA or MA thesis at FH JOANNEUM | thesis |
| `knowledge-key` | A compact cheat-sheet | cheat-sheet |

This way, the following

| Name | Description | Form |
|-|-|-|
| `invoice-maker` | Generate beautiful invoices from a simple data record. | imperative verb |
| `g-exam` | Create exams with student information, grade chart, score control, questions, and sub-questions. | imperative verb |
| `wonderous-book` | A fiction book template with running headers and serif tyography | noun (‘template’) with adjuncts |
| `meppp` | Template for modern physics experiment reports at the Physics School of PKU. | noun (‘template’) with adjunct |

can be reworded as

| Name | Description |
|-|-|
| `invoice-maker` | Beautiful invoices generated from a simple data record. |
| `g-exam` | Exams with student information, grade chart, score control, questions, and sub-questions. |
| `wonderous-book` | Fiction book with running headers and serif tyography |
| `meppp` | Modern physics experiment reports at the Physics School of PKU. |

## Languages other than English

Some descriptions are in languages other than English; for example:

| Name | Description |
|-|-|
| `cumcm-muban` | 为高教社杯全国大学生数学建模竞赛设计的 Typst 模板 |
| `minerva-report-fcfm` | Template de artículos, informes y tareas para la Facultad de Ciencias Físicas y Matemáticas (FCFM). |
| `roremu` | 日本語のダミーテキスト生成（Lorem Ipsum） |

---

Linguistic diversity is great, and some packages and templates are indeed language-specific. I think it’s best if Typst Universe supports multilingual entries, and the user can choose their preferred language(s). If there is no plan to do so in the near future, maybe it’s possible to have a temporary workaround: bilingual descriptions are welcome with a certain structure (say `ENGLISH | ADDITIONAL-LANGUAGE`).

With this structure `roremu`’s description can be reworded as:
| Name | Description |
|-|-|
| `roremu` | Blind text (Lorem ipsum) generator for Japanese \| 日本語のダミーテキスト生成（Lorem Ipsum） |

Character-limit restrictions should be doubled, of course.

## Spelling and standard language

This is already covered by the definition of the `description` field, cited above. I don’t want to point out individual examples, but there are many which demonstrate non-standard features which are fine in other, more colloquial contexts but make Typst Universe look less professional than it could be. Capitalisation is an issue, and I also spotted some typos and other non-standard features. IMHO dealing with this should be done tactfully, since power structures are involved and we want to cultivate a diverse and welcoming community, but when done well this can improve Typst Universe without doing any harm.

## Conclusion

Typst itself is meticulous, and its evident much thought has been given to making it elegant, consistent, cohesive and coherent. In contrast, Typst Universe — being a repository of user-generated content — is a mixed bag. I hope what I propose here will be accepted, at least in part, and consequentially benefit the common ‘marketplace’ of our growing community 🙂