### PR TITLE
weave:0.1.0 and weave:0.2.0

### DIFF
--- a/packages/preview/weave/0.1.0/LICENSE
+++ b/packages/preview/weave/0.1.0/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Jason Daniel Pieck
+Copyright (c) 2024 Léana 江
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/preview/weave/0.1.0/typst.toml
+++ b/packages/preview/weave/0.1.0/typst.toml
@@ -7,4 +7,4 @@ license = "MIT"
 description = "A helper library for chaining lambda abstractions"
 categories = ["scripting"]
 keywords = ["functional", "composition", "pipe"]
-exclude = ["README", "LICENSE", ".gitignore", "tests/*"]
+exclude = [".gitignore", "tests/*"]

--- a/packages/preview/weave/0.1.0/typst.toml
+++ b/packages/preview/weave/0.1.0/typst.toml
@@ -7,3 +7,4 @@ license = "MIT"
 description = "A helper library for chaining lambda abstractions"
 categories = ["scripting"]
 keywords = ["functional", "composition", "pipe"]
+exclude = ["README", "LICENSE", ".gitignore", "tests/*"]

--- a/packages/preview/weave/0.2.0/.gitignore
+++ b/packages/preview/weave/0.2.0/.gitignore
@@ -1,0 +1,2 @@
+lib.pdf
+tests/tests.pdf

--- a/packages/preview/weave/0.2.0/LICENSE
+++ b/packages/preview/weave/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Léana 江
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/weave/0.2.0/README.md
+++ b/packages/preview/weave/0.2.0/README.md
@@ -1,0 +1,71 @@
+# weave
+A helper library for chaining lambda abstractions, imitating the `|>` or `.` operator in some
+functional languages.
+
+The function `compose` is the `pipe` function in the mathematical order.
+Functions suffixed with underscore are flipped version.
+
+# Changelog
+- 0.2.0 Redesigned interface to work with typst's `with` keyword.
+- 0.1.0 Initial release
+
+## Basic usage
+To chain functions into one single function, you can write:
+```typ
+#let add8 = pipe_((
+  x => x + 5, // first add 5
+  x => x + 3, // then add 3
+))
+```
+
+And then apply this to a value, for example.
+```typ
+#let result = add8(10)
+```
+
+This can be particularly useful when you need to destructure lists, as it allows creating binds that
+are scoped by a lambda expression.
+```typ
+#let two_and_one = pipe(
+  (1, 2),
+  (
+    ((a, b)) => (a, b, -1), // becomes a list of length three
+    ((a, b, _)) => (b, a), // discard the third element and swap
+  ),
+)
+```
+
+It can also improve readability with nested applications to a content value.
+```typ
+#compose_((
+  text.with(blue),
+  emph,
+  strong,
+  underline,
+  strike,
+))[This is a very long content with a lot of words]
+// Is equivalent to
+#text(blue,
+  emph(
+    strong(
+      underline(
+        strike[This is a very long content with a lot of words]
+      )
+    )
+  )
+)
+```
+
+You can also use it for show rules.
+```typ
+#show link: pipe_.with((
+  emph,
+  text.with(fill: blue),
+  underline,
+))
+
+// Is equivalent to (note the order)
+#show link: underline
+#show link: text.with(fill: blue)
+#show link: emph
+```

--- a/packages/preview/weave/0.2.0/README.md
+++ b/packages/preview/weave/0.2.0/README.md
@@ -1,41 +1,17 @@
 # weave
-A helper library for chaining lambda abstractions, imitating the `|>` or `.` operator in some
-functional languages.
+A helper library for chaining lambda abstractions, imitating the `|>` or `.`
+operator in some functional languages.
 
 The function `compose` is the `pipe` function in the mathematical order.
-Functions suffixed with underscore are flipped version.
+Functions suffixed with underscore have their arguments flipped.
 
-# Changelog
+## Changelog
 - 0.2.0 Redesigned interface to work with typst's `with` keyword.
 - 0.1.0 Initial release
 
 ## Basic usage
-To chain functions into one single function, you can write:
-```typ
-#let add8 = pipe_((
-  x => x + 5, // first add 5
-  x => x + 3, // then add 3
-))
-```
-
-And then apply this to a value, for example.
-```typ
-#let result = add8(10)
-```
-
-This can be particularly useful when you need to destructure lists, as it allows creating binds that
-are scoped by a lambda expression.
-```typ
-#let two_and_one = pipe(
-  (1, 2),
-  (
-    ((a, b)) => (a, b, -1), // becomes a list of length three
-    ((a, b, _)) => (b, a), // discard the third element and swap
-  ),
-)
-```
-
-It can also improve readability with nested applications to a content value.
+It can help improve readability with nested applications to a content value, or
+make the diff cleaner.
 ```typ
 #compose_((
   text.with(blue),
@@ -45,7 +21,8 @@ It can also improve readability with nested applications to a content value.
   strike,
 ))[This is a very long content with a lot of words]
 // Is equivalent to
-#text(blue,
+#text(
+  blue,
   emph(
     strong(
       underline(
@@ -56,16 +33,28 @@ It can also improve readability with nested applications to a content value.
 )
 ```
 
-You can also use it for show rules.
+You can use it for show rules just like the example above.
 ```typ
-#show link: pipe_.with((
-  emph,
+#show link: compose_.with((
   text.with(fill: blue),
+  emph,
   underline,
 ))
-
-// Is equivalent to (note the order)
-#show link: underline
+// These two are equivalent
 #show link: text.with(fill: blue)
 #show link: emph
+#show link: underline
 ```
+
+This can also be useful when you need to destructure lists, as it allows creating binds that
+are scoped by each lambda expression.
+```typ
+#let two_and_one = pipe(
+  (1, 2),
+  (
+    ((a, b)) => (a, b, -1), // becomes a list of length three
+    ((a, b, _)) => (b, a), // discard the third element and swap
+  ),
+)
+```
+

--- a/packages/preview/weave/0.2.0/lib.typ
+++ b/packages/preview/weave/0.2.0/lib.typ
@@ -17,7 +17,7 @@
   ((x, f) => f(x)),
 )
 
-/// Compose a list of transformation from right to left into a single function.
+/// Compose a list of transformation from right to left, apply them to a value
 /// This is the flipped version of its counterpart without `_` suffix
 #let compose_(transformations, input) = transformations.rev().fold(
   input,

--- a/packages/preview/weave/0.2.0/lib.typ
+++ b/packages/preview/weave/0.2.0/lib.typ
@@ -1,0 +1,25 @@
+/// Given a value, transform it using the list of functions
+#let pipe(input, transformations) = transformations.fold(
+  input,
+  ((x, f) => f(x)),
+)
+
+/// Given a list of transformations, apply them to a value
+/// This is the flipped version of its counterpart without `_` suffix
+#let pipe_(transformations, input) = transformations.fold(
+  input,
+  ((x, f) => f(x)),
+)
+
+/// Apply a list of transformations from right to left to a value
+#let compose(input, transformations) = transformations.rev().fold(
+  input,
+  ((x, f) => f(x)),
+)
+
+/// Compose a list of transformation from right to left into a single function.
+/// This is the flipped version of its counterpart without `_` suffix
+#let compose_(transformations, input) = transformations.rev().fold(
+  input,
+  ((x, f) => f(x)),
+)

--- a/packages/preview/weave/0.2.0/tests/README.md
+++ b/packages/preview/weave/0.2.0/tests/README.md
@@ -1,0 +1,5 @@
+Run
+```bash
+typst compile tests.typ --root ..
+```
+to test the package

--- a/packages/preview/weave/0.2.0/tests/tests.typ
+++ b/packages/preview/weave/0.2.0/tests/tests.typ
@@ -1,0 +1,48 @@
+#import "../lib.typ": *
+
+#pipe(
+  5,
+  (
+    x => x + 1,
+    x => x + 2,
+    x => assert(x == 8),
+  ),
+)
+
+#compose(
+  "y",
+  (
+    c => assert(c == "xyz"),
+    c => c + "z",
+    c => "x" + c,
+  ),
+)
+
+#let pipeline = pipe_.with((
+  c => c + "c",
+  c => "a" + c,
+))
+#assert(pipeline("b") == "abc")
+
+#let composed = compose_.with((
+  c => "a" + c,
+  c => c + "c",
+))
+#assert(composed("b") == "abc")
+
+#assert(
+  compose_((
+    emph,
+    strong,
+    underline,
+    strike,
+  ))[This is a very long content with a lot of words]
+ ==
+  emph(
+    strong(
+      underline(
+        strike[This is a very long content with a lot of words]
+      )
+    )
+  )
+)

--- a/packages/preview/weave/0.2.0/typst.toml
+++ b/packages/preview/weave/0.2.0/typst.toml
@@ -1,0 +1,9 @@
+[package]
+name = "weave"
+version = "0.2.0"
+entrypoint = "lib.typ"
+authors = ["Léana 江 <@leana8959>"]
+license = "MIT"
+description = "A helper library for chaining lambda abstractions"
+categories = ["scripting"]
+keywords = ["functional", "composition", "pipe"]

--- a/packages/preview/weave/0.2.0/typst.toml
+++ b/packages/preview/weave/0.2.0/typst.toml
@@ -7,4 +7,4 @@ license = "MIT"
 description = "A helper library for chaining lambda abstractions"
 categories = ["scripting"]
 keywords = ["functional", "composition", "pipe"]
-exclude = ["README", "LICENSE", ".gitignore", "tests/*"]
+exclude = [".gitignore", "tests/*"]

--- a/packages/preview/weave/0.2.0/typst.toml
+++ b/packages/preview/weave/0.2.0/typst.toml
@@ -7,3 +7,4 @@ license = "MIT"
 description = "A helper library for chaining lambda abstractions"
 categories = ["scripting"]
 keywords = ["functional", "composition", "pipe"]
+exclude = ["README", "LICENSE", ".gitignore", "tests/*"]


### PR DESCRIPTION

I am submitting
- [x] a new package
- [x] an update for a package

Description:
Rewrote library functions to work with `.with()` application, making the library more versatile. Is a breaking change.

PS: I also corrected my name in the license. I simply copied someone else's license and didn't pay attention to that last time.
