### PR TITLE
quill:0.5.0

### DIFF
--- a/packages/preview/quill/0.5.0/LICENSE
+++ b/packages/preview/quill/0.5.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/quill/0.5.0/README.md
+++ b/packages/preview/quill/0.5.0/README.md
@@ -118,7 +118,7 @@ The following example demonstrates how to compose multiple subcircuits.
 
 ## Examples
 
-Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview). The code for these examples can be found in the [example folder](./examples/) or in the [user guide][guide]. 
+Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview). The code for these examples can be found in the [example folder](https://github.com/Mc-Zen/quill/tree/v0.5.0/examples) or in the [user guide][guide]. 
 
 <div align="center">
   
@@ -139,10 +139,10 @@ Some show-off examples, loosely replicating figures from [Quantum Computation an
 
 ## Contribution
 
-If you spot an issue or have a suggestion, you are invited to [post it](https://github.com/Mc-Zen/quill/issues) or to contribute. In [architecture.md](docs/architecture.md), you can also find a description of the algorithm that forms the base of `quantum-circuit()`. 
+If you spot an issue or have a suggestion, you are invited to [post it](https://github.com/Mc-Zen/quill/issues) or to contribute. In [architecture.md](https://github.com/Mc-Zen/quill/tree/v0.5.0/docs/architecture.md), you can also find a description of the algorithm that forms the base of `quantum-circuit()`. 
 
 ## Tests
-This package uses [typst-test](https://github.com/tingerrr/typst-test/) for running [tests](tests/). 
+This package uses [typst-test](https://github.com/tingerrr/typst-test/) for running [tests](https://github.com/Mc-Zen/quill/tree/v0.5.0/tests/). 
 
 
 ## Changelog

--- a/packages/preview/quill/0.5.0/README.md
+++ b/packages/preview/quill/0.5.0/README.md
@@ -1,6 +1,9 @@
 <div align="center">
-  <img alt="Quill" src="docs/images/logo.svg">
+
+  ![Quill logo](https://github.com/user-attachments/assets/bf6bfe99-6667-41b0-9b45-13c73ed18590)
+
 </div>
+
 
 <div align="center">
 
@@ -40,9 +43,11 @@ The function `quantum-circuit()` takes any number of positional gates and works 
   )
 }
 ```
-<h3 align="center">
-  <img alt="Bell Circuit" src="docs/images/bell.svg">
-</h3>
+<div align="center">
+  
+  ![Bell circuit](https://github.com/user-attachments/assets/53d0c581-ab62-44e3-abf5-5497993d7aba)
+  
+</div>
 
 Plain quantum gates — such as a Hadamard gate — can be written with the shorthand notation `$H$` instead of the more lengthy `gate($H$)`. The latter offers more options, however. 
 
@@ -52,9 +57,11 @@ Refer to the [user guide][guide] for a full documentation of this package. You c
 
 Instead of listing every featured gate (as is done in the [user guide][guide]), this gallery quickly showcases a large selection of possible gates and decorations that can be added to any quantum circuit. 
 
-<h3 align="center">
-  <img alt="Gallery" src="docs/images/gallery.svg" />
-</h3>
+<div align="center">
+
+  ![Gallery](https://github.com/user-attachments/assets/29987e5b-c373-4cd6-86a0-58e27d778fb1)
+  
+</div>
 
 
 ## Tequila
@@ -103,7 +110,9 @@ The following example demonstrates how to compose multiple subcircuits.
 )
 ```
 <div align="center">
-  <img alt="Gallery" src="docs/images/composition.svg" />
+
+  ![composition](https://github.com/user-attachments/assets/41c8d60a-1a5e-4d0b-a7f4-82756423f5a8)
+
 </div>
 
 
@@ -111,15 +120,21 @@ The following example demonstrates how to compose multiple subcircuits.
 
 Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview). The code for these examples can be found in the [example folder](./examples/) or in the [user guide][guide]. 
 
-<h3 align="center">
-  <img alt="Quantum teleportation circuit" src="docs/images/teleportation.svg">
-</h3>
-<h3 align="center">
-  <img alt="Quantum circuit for phase estimation" src="docs/images/phase-estimation.svg">
-</h3>
-<h3 align="center">
-  <img alt="Quantum fourier transformation circuit" src="docs/images/qft.svg">
-</h3>
+<div align="center">
+  
+  ![Quantum teleportation circuit](https://github.com/user-attachments/assets/f38abeb9-fc2f-4be4-9592-7932e07af764)
+  
+</div>
+<div align="center">
+
+  ![Quantum circuit for phase estimation](https://github.com/user-attachments/assets/6e947f71-67dc-4522-936e-6d9b795a1bba)
+
+</div>
+<div align="center">
+
+  ![Quantum fourier transformation circuit](https://github.com/user-attachments/assets/3fc92cd0-915e-4c5e-893d-63dac6f83ade)
+
+</div>
 
 
 ## Contribution

--- a/packages/preview/quill/0.5.0/README.md
+++ b/packages/preview/quill/0.5.0/README.md
@@ -1,0 +1,195 @@
+<div align="center">
+  <img alt="Quill" src="docs/images/logo.svg">
+</div>
+
+<div align="center">
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fquill%2Fv0.5.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/quill)
+[![Test Status](https://github.com/Mc-Zen/quill/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/quill/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/quill/blob/main/LICENSE)
+[![User Manual](https://img.shields.io/badge/manual-.pdf-purple)][guide]
+
+</div>
+
+
+**Quill** is a package for creating quantum circuit diagrams in [Typst](https://typst.app/). 
+
+
+_Note, that this package is in beta and may still be undergoing breaking changes. As new features like data types and scoped functions will be added to Typst, this package will be adapted to profit from the new paradigms._
+
+_Meanwhile, we suggest importing everything from the package in a local scope to avoid polluting the global namespace (see example below)._
+
+- [**Usage**](#basic-usage) _quick introduction_
+- [**Cheat sheet**](#cheat-sheet) _gallery for quickly viewing all kinds of gates_
+- [**Tequila**](#tequila) _building (sub-)circuits in a way similar to QASM or Qiskit_
+- [**Examples**](#examples)
+- [**Changelog**](#changelog)
+
+
+## Basic usage
+
+The function `quantum-circuit()` takes any number of positional gates and works somewhat similarly to the built-int Typst functions `table()` or `grid()`. A variety of different gate and instruction commands are available for adding elements and integers can be used to produce any number of empty cells (filled with the current wire style). A new wire is started by adding a `[\ ]` item. 
+
+```typ
+#{
+  import "@preview/quill:0.5.0": *
+
+  quantum-circuit(
+    lstick($|0〉$), $H$, ctrl(1), rstick($(|00〉+|11〉)/√2$, n: 2), [\ ],
+    lstick($|0〉$), 1, targ(), 1
+  )
+}
+```
+<h3 align="center">
+  <img alt="Bell Circuit" src="docs/images/bell.svg">
+</h3>
+
+Plain quantum gates — such as a Hadamard gate — can be written with the shorthand notation `$H$` instead of the more lengthy `gate($H$)`. The latter offers more options, however. 
+
+Refer to the [user guide][guide] for a full documentation of this package. You can also look up the documentation of any function by calling the help module, e.g., `help("gate")` in order to print the signature and description of the `gate` command, just where you are currently typing (powered by [tidy][tidy]). 
+
+## Cheat Sheet
+
+Instead of listing every featured gate (as is done in the [user guide][guide]), this gallery quickly showcases a large selection of possible gates and decorations that can be added to any quantum circuit. 
+
+<h3 align="center">
+  <img alt="Gallery" src="docs/images/gallery.svg" />
+</h3>
+
+
+## Tequila
+
+_Tequila_ is a submodule that adds a completely different way of building circuits. 
+
+```typ
+#import "@preview/quill:0.5.0" as quill: tequila as tq
+
+#quill.quantum-circuit(
+  ..tq.build(
+    tq.h(0),
+    tq.cx(0, 1),
+    tq.cx(0, 2),
+  ),
+  quill.gategroup(x: 2, y: 0, 3, 2)
+)
+```
+This is similar to how _QASM_ and _Qiskit_ work: gates are successively applied to the circuit which is then layed out automatically by packing gates as tightly as possible. We start by calling the `tq.build()` function and filling it with quantum operations. This returns a collection of gates which we expand into the circuit with the `..` syntax. 
+Now, we still have the option to add annotations, groups, slices, or even more gates via manual placement. 
+
+The syntax works analog to Qiskit. Available gates are `x`, `y`, `z`, `h`, `s`, `sdg`, `sx`, `sxdg`, `t`, `tdg`, `p`, `rx`, `ry`, `rz`, `u`, `cx`, `cz`, and `swap`. With `barrier`, an invisible barrier can be inserted to prevent gates on different qubits to be packed tightly. Finally, with `tq.gate` and `tq.mqgate`, a generic gate can be created. These two accept the same styling arguments as the normal `gate` (or `mqgate`).
+
+Also like Qiskit, all qubit arguments support ranges, e.g., `tq.h(range(5))` adds a Hadamard gate on the first five qubits and `tq.cx((0, 1), (1, 2))` adds two CX gates: one from qubit 0 to 1 and one from qubit 1 to 2. 
+
+With Tequila, it is easy to build templates for quantum circuits and to compose circuits of various building blocks. For this purpose, `tq.build()` and the built-in templates all feature optional `x` and `y` arguments to allow placing a subcircuit at an arbitrary position of the circuit. 
+As an example, Tequila provides a `tq.graph-state()` template for quickly drawing graph state preparation circuits. 
+
+The following example demonstrates how to compose multiple subcircuits. 
+
+
+```typ
+#import tequila as tq
+
+#quantum-circuit(
+  ..tq.graph-state((0, 1), (1, 2)),
+  ..tq.build(y: 3, 
+      tq.p($pi$, 0), 
+      tq.cx(0, (1, 2)), 
+    ),
+  ..tq.graph-state(x: 6, y: 2, invert: true, (0, 1), (0, 2)),
+  gategroup(x: 1, 3, 3),
+  gategroup(x: 1, y: 3, 3, 3),
+  gategroup(x: 6, y: 2, 3, 3),
+  slice(x: 5)
+)
+```
+<div align="center">
+  <img alt="Gallery" src="docs/images/composition.svg" />
+</div>
+
+
+## Examples
+
+Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview). The code for these examples can be found in the [example folder](./examples/) or in the [user guide][guide]. 
+
+<h3 align="center">
+  <img alt="Quantum teleportation circuit" src="docs/images/teleportation.svg">
+</h3>
+<h3 align="center">
+  <img alt="Quantum circuit for phase estimation" src="docs/images/phase-estimation.svg">
+</h3>
+<h3 align="center">
+  <img alt="Quantum fourier transformation circuit" src="docs/images/qft.svg">
+</h3>
+
+
+## Contribution
+
+If you spot an issue or have a suggestion, you are invited to [post it](https://github.com/Mc-Zen/quill/issues) or to contribute. In [architecture.md](docs/architecture.md), you can also find a description of the algorithm that forms the base of `quantum-circuit()`. 
+
+## Tests
+This package uses [typst-test](https://github.com/tingerrr/typst-test/) for running [tests](tests/). 
+
+
+## Changelog
+### v0.5.0
+- Added support for multi-controlled gates with Tequila. 
+- Switched to using `context` instead of the now deprecated `style()` for measurement. 
+Note: Starting with this version, Typst 0.11.0 or higher is required. 
+
+### v0.4.0
+- Alternative model for creating and composing circuits: [Tequila](#tequila). 
+
+### v0.3.0
+- New features
+  - Enable manual placement of gates, `gate($X$, x: 3, y: 1)`, similar to built-in `table()` in addition to automatic placement. This works for most elements, not only gates. 
+  - Add parameter `pad` to `lstick()` and `rstick()`. 
+  - Add parameter `fill-wires` to `quantum-circuit()`. All wires are filled unto the end (determined by the longest wire) by default (breaking change ⚠️). This behavior can be reverted by setting `fill-wires: false`. 
+  - `gategroup()` `slice()` and `annotate()` can now be placed above or below the circuit with `z: "above"` and `z: "below"`.
+  - `help()` command for quickly displaying the documentation of a given function, e.g., `help("gate")`. Powered by [tidy][tidy]. 
+- Improvements:
+  - Complete rework of circuit layout implementation
+    - allows transparent gates since wires are not drawn through gates anymore. The default fill is now `auto` and using `none` sets the background to transparent. 
+    - `midstick` is now transparent by default. 
+  - `setwire()` can now be used to override only partial wire settings, such as wire color `setwire(1, stroke: blue)`, width `setwire(1, stroke: 1pt)` or wire distance, all separately. Before, some settings were reset. 
+- Fixes:
+  - Fixed `lstick`/`rstick` when equation numbering is turned on. 
+- Removed:
+  - The already deprecated `scale-factor` (use `scale` instead)
+
+### v0.2.1
+- Improvements:
+  - Add `fill` parameter to `midstick()`. 
+  - Add `bend` parameter to `permute()`. 
+  - Add `separation` parameter to `permute()`. 
+- Fixes:
+  - With Typst 0.11.0, `scale()` now takes into account outer alignment. This broke the positioning of centered/right-aligned circuits, e.g., ones put into a `figure()`. 
+  - Change wires to be drawn all through `ctrl()`, making it consistent to `swap()` and `targ()`. 
+
+
+### v0.2.0
+- New features:
+  - Add arbitrary labels to any `gate` (also derived gates such as `meter`, `ctrl`, ...), `gategroup` or `slice` that can be anchored to any of the nine 2d alignments. 
+  - Add optional gate inputs and outputs for multi-qubit gates (see gallery).
+  - Implicit gates (breaking change ⚠️): a content item automatically becomes a gate, so you can just type `$H$` instead of `gate($H$)` (of course, the `gate()` function is still important in order to use the many available options). 
+- Other breaking changes ⚠️: 
+  - `slice()` has no `dx` and `dy` parameters anymore. Instead, labels are handled through `label` exactly as in `gate()`. Also the `wires` parameter is replaced with `n` for consistency with other multi-qubit gates. 
+  - Swap order of row and column parameters in `annotate()` to make it consistent with built-in Typst functions. 
+- Improvements: 
+  - Improve layout (allow row/column spacing and min lengths to be specified in em-lengths).
+  - Automatic bounds computation, even for labels. 
+  - Improve meter (allow multi-qubit gate meters and respect global (per-circuit) gate padding).d
+- Fixes:
+  - `lstick`/`rstick` braces broke with Typst 0.7.0.
+  - `lstick`/`rstick` bounds.
+- Documentation
+  - Add section on creating custom gates. 
+  - Add section on using labels. 
+  - Explain usage of `slice()` and `gategroup()`.
+
+### v0.1.0
+
+Initial Release
+
+
+[guide]: https://github.com/Mc-Zen/quill/releases/download/v0.5.0/quill-guide.pdf
+[tidy]: https://github.com/Mc-Zen/tidy

--- a/packages/preview/quill/0.5.0/src/arrow.typ
+++ b/packages/preview/quill/0.5.0/src/arrow.typ
@@ -1,0 +1,24 @@
+
+#let draw-arrow(start, end, length: 5pt, width: 2.5pt, stroke: 1pt + black, arrow-color: black) = {
+  place(line(start: start, end: end, stroke: stroke))
+  let dir = (end.at(0) - start.at(0), end.at(1) - start.at(1))
+  dir = dir.map(x => float(repr(x).slice(0,-2)))
+  // let angle = calc.atan2(dir.at(0), dir.at(1))
+  
+  let len = calc.sqrt(dir.map(x => x*x).sum())
+  dir = dir.map(x => x/len)
+  let normal = (-dir.at(1), dir.at(0))
+
+  let arrow-start = end
+  let arrow-end = (end.at(0) + length*dir.at(0), end.at(1) + length*dir.at(1))
+  let w = width/2
+  let v1 = (arrow-start.at(0) - w*normal.at(0), arrow-start.at(1) - w*normal.at(1))
+  let v2 = (arrow-start.at(0) + w*normal.at(0), arrow-start.at(1) + w*normal.at(1))
+  path(arrow-end, v1, v2, closed: true, fill: arrow-color)
+}
+
+#let test-arrow() = {
+  draw-arrow((0pt, 0pt), (20pt, 10pt), stroke: .1pt)
+}
+
+

--- a/packages/preview/quill/0.5.0/src/decorations.typ
+++ b/packages/preview/quill/0.5.0/src/decorations.typ
@@ -1,0 +1,213 @@
+#import "gates.typ": *
+
+
+// align: "left" (for rstick) or "right" (for lstick)
+// brace: auto, none, "{", "}", "|", "[", ...
+#let lrstick(content, n, align, brace, label, pad: 0pt, x: auto, y: auto) = gate(
+  content, 
+  x: x, 
+  y: y,
+  draw-function: draw-functions.draw-lrstick, 
+  size-hint: layout.lrstick-size-hint,
+  box: false, 
+  floating: true,
+  multi: if n == 1 { none } else { 
+   (
+    target: none,
+    num-qubits: n, 
+    wire-count: 0, 
+    label: label,
+    size-all-wires: if n > 1 { none } else { false }
+  )},
+  data: (
+    brace: brace,
+    align: align,
+    pad: pad
+  ), 
+  label: label
+)
+
+
+
+
+/// Basic command for labelling a wire at the start. 
+/// - content (content): Label to display, e.g., `$|0〉$`.
+/// - n (content): How many wires the `lstick` should span. 
+/// - brace (auto, none, str): If `brace` is `auto`, then a default `{` brace
+///      is shown only if `n > 1`. A brace is always shown when 
+///      explicitly given, e.g., `"}"`, `"["` or `"|"`. No brace is shown for 
+///      `brace: none`
+/// - pad (length): Adds a padding between the label and the connected wire to the right. 
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+#let lstick(
+  content, 
+  n: 1, 
+  brace: auto, 
+  pad: 0pt,
+  label: none, 
+  x: auto,
+  y: auto
+) = lrstick(content, n, right, brace, label, pad: pad, x: x, y: y)
+
+
+/// Basic command for labelling a wire at the end. 
+/// - content (content): Label to display, e.g., `$|0〉$`.
+/// - n (content): How many wires the `rstick` should span. 
+/// - pad (length): Adds a padding between the label and the connected wire to the left. 
+/// - brace (auto, none, str): If `brace` is `auto`, then a default `}` brace
+///      is shown only if `n > 1`. A brace is always shown when 
+///      explicitly given, e.g., `"}"`, `"["` or `"|"`. No brace is shown for 
+///      `brace: none`. 
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+#let rstick(
+  content, 
+  n: 1, 
+  brace: auto, 
+  pad: 0pt, 
+  label: none, 
+  x: auto,
+  y: auto
+) = lrstick(content, n, left, brace, label, pad: pad, x: x, y: y)
+
+/// Create a midstick, i.e., a mid-circuit text. 
+/// - content (content): Label to display, e.g., `$|0〉$`.
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+#let midstick(
+  content,
+  n: 1,
+  fill: none,
+  label: none,
+  x: auto,
+  y: auto
+) = {
+  if n == 1 { 
+    gate(content, draw-function: draw-functions.draw-unboxed-gate, label: label, fill: fill, x: x, y: y) 
+  } else {
+    mqgate(content, n: n, draw-function: draw-functions.draw-boxed-multigate, label: label, fill: fill, x: x, y: y, stroke: none) 
+  }
+}
+
+
+
+
+/// Creates a symbol similar to `\qwbundle` on `quantikz`. Annotates a wire to 
+/// be a bundle of quantum or classical wires. 
+/// - label (int, content): 
+#let nwire(label, x: auto, y: auto) = gate([#label], draw-function: draw-functions.draw-nwire, box: false, x: x, y: y)
+
+
+
+/// Set current wire mode (0: none, 1 wire: quantum, 2 wires: classical, more  
+/// are possible) and optionally the stroke style. 
+///
+/// The wire style is reset for each row.
+///
+/// - wire-count (int): Number of wires to display. 
+/// - stroke (auto, none, stroke): When given, the stroke is applied to the wire. 
+///                Otherwise the current stroke is kept. 
+/// - wire-distance (length): Distance between wires. 
+#let setwire(wire-count, stroke: auto, wire-distance: auto) = (
+  qc-instr: "setwire",
+  wire-count: wire-count,
+  stroke: stroke,
+  wire-distance: wire-distance
+)
+
+/// Highlight a group of circuit elements by drawing a rectangular box around
+/// them. 
+/// 
+/// - wires (int): Number of wires to include.
+/// - steps (int): Number of columns to include.
+/// - x (auto, int): The starting column of the gategroup. 
+/// - y (auto, int): The starting wire of the gategroup. 
+/// - z (str): The gategroup can be placed `"below"` or `"above"` the circuit. 
+/// - padding (length, dictionary): Padding of rectangle. May be one length
+///     for all sides or a dictionary with the keys `left`, `right`, `top`, 
+///     `bottom` and `default`. Not all keys need to be specified. The value 
+///     for `default` is used for the omitted sides or `0pt` if no `default` 
+///     is given. 
+/// - stroke (stroke): Stroke for rectangle.
+/// - fill (color): Fill color for rectangle.
+/// - radius (length, dictionary): Corner radius for rectangle.
+/// - label (array, str, content, dictionary): One or more labels to add to the  
+///        group. See @@gate(). 
+#let gategroup(
+  wires, 
+  steps, 
+  x: auto, 
+  y: auto,
+  z: "below",
+  padding: 0pt, 
+  stroke: .7pt, 
+  fill: none,
+  radius: 0pt,
+  label: none
+) = (
+  qc-instr: "gategroup",
+  wires: wires,
+  steps: steps,
+  x: x, 
+  y: y,
+  z: z,
+  padding: process-args.process-padding-arg(padding),
+  style: (fill: fill, stroke: stroke, radius: radius),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+/// Slice the circuit vertically, showing a separation line between columns. 
+/// 
+/// - n (int): Number of wires to slice.
+/// - x (auto, int): The starting column of the slice. 
+/// - y (auto, int): The starting wire of the slice. 
+/// - z (str): The slice can be placed `"below"` or `"above"` the circuit. 
+/// - stroke (stroke): Line style for the slice. 
+/// - label (array, str, content, dictionary): One or more labels to add to the  
+///        slice. See @@gate(). 
+#let slice(
+  n: 0, 
+  x: auto, 
+  y: auto,
+  z: "below",
+  stroke: (paint: red, thickness: .7pt, dash: "dashed"),
+  label: none
+) = (
+  qc-instr: "slice",
+  wires: n,
+  x: x,
+  y: y,
+  z: z,
+  style: (stroke: stroke),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+/// Lower-level interface to the cell coordinates to create an arbitrary
+/// annotatation by passing a custom function.
+/// 
+/// This function is passed the coordinates of the specified cell rows 
+/// and columns. 
+/// 
+/// - columns (int, array): Column indices for which to obtain coordinates. 
+/// - rows (int, array): Row indices for which to obtain coordinates. 
+/// - callback (function): Function to call with the obtained coordinates. The
+///     signature should be with signature `(col-coords, row-coords) => {}`. 
+///     This function is expected to display the content to draw in absolute 
+///     coordinates within the circuit. 
+/// - z (str): The annotation can be placed `"below"` or `"above"` the circuit. 
+#let annotate(
+  columns,
+  rows,
+  callback,
+  z: "below",
+) = (
+  qc-instr: "annotate",
+  rows: rows,
+  x: none,
+  y: none,
+  z: z,
+  columns: columns,
+  callback: callback
+)
+
+

--- a/packages/preview/quill/0.5.0/src/draw-functions.typ
+++ b/packages/preview/quill/0.5.0/src/draw-functions.typ
@@ -1,0 +1,338 @@
+// INTERNAL GATE DRAW FUNCTIONS
+
+
+#import "utility.typ"
+#import "arrow.typ"
+#import "layout.typ"
+
+
+
+
+
+
+// Default gate draw function. Draws a box with global padding
+// and the gates content. Stroke and default fill are only applied if 
+// gate.box is true
+#let draw-boxed-gate(gate, draw-params) = align(center, box(
+  inset: draw-params.padding, 
+  width: gate.width,
+  radius: gate.radius,
+  stroke: if gate.box { draw-params.wire }, 
+  fill: utility.if-auto(gate.fill, if gate.box {draw-params.background}),
+  gate.content,
+))
+
+// Same but without displaying a box
+#let draw-unboxed-gate(gate, draw-params) = box(
+  inset: draw-params.padding, 
+  fill: utility.if-auto(gate.fill, draw-params.background),
+  gate.content
+)
+
+// Draw a gate spanning multiple wires
+#let draw-boxed-multigate(gate, draw-params) = {
+  let dy = draw-params.multi.wire-distance
+  let extent = gate.multi.extent
+  if extent == auto { extent = draw-params.x-gate-size.height / 2 }
+  
+  let style-params = (
+      width: gate.width,
+      stroke: utility.if-auto(gate.stroke, draw-params.wire), 
+      radius: gate.radius,
+      fill: utility.if-auto(gate.fill, draw-params.background), 
+      inset: draw-params.padding, 
+  )
+  align(center + horizon, box(
+    ..style-params,
+    height: dy + 2 * extent,
+    gate.content
+  ))
+  
+  
+  let draw-inouts(inouts, alignment) = {
+    
+    if inouts != none and dy != 0pt {
+      let width = measure(line(length: gate.width)).width
+      let y0 = -(dy + extent) - draw-params.center-y-coords.at(0)
+      let get-wire-y(qubit) = { draw-params.center-y-coords.at(qubit) + y0 }
+      
+      set text(size: .8em)
+      context {
+        for inout in inouts {
+          let size = measure(inout.label)
+          let y = get-wire-y(inout.qubit)
+          let label-x = draw-params.padding
+          if "n" in inout and inout.n > 1 {
+            let y2 = get-wire-y(inout.qubit + inout.n - 1)
+            let brace = utility.create-brace(auto, alignment, y2 - y + draw-params.padding)
+            let brace-x = 0pt
+            let size = measure(brace)
+            if alignment == right { brace-x += width - size.width }
+            
+            place(brace, dy: y - 0.5 * draw-params.padding, dx: brace-x)
+            label-x = size.width
+            y += 0.5 * (y2 - y)
+          }
+          place(dy: y - size.height / 2, align(
+            alignment, 
+            box(inout.label, width: width, inset: (x: label-x))
+          ))
+        }
+      }
+      
+    }
+  
+  }
+  draw-inouts(gate.multi.inputs, left)
+  draw-inouts(gate.multi.outputs, right)
+}
+
+#let draw-targ(item, draw-params) = {
+  let size = item.data.size
+  box({
+    circle(
+      radius: size, 
+      stroke: draw-params.wire, 
+      fill: utility.if-auto(item.fill, draw-params.background)
+    )
+    place(line(start: (size, 0pt), length: 2*size, angle: -90deg, stroke: draw-params.wire))
+    place(line(start: (0pt, -size), length: 2*size, stroke: draw-params.wire))
+  })
+}
+
+#let draw-ctrl(gate, draw-params) = {
+  let color = utility.if-auto(gate.fill, draw-params.color)
+  if "show-dot" in gate.data and not gate.data.show-dot { return none }
+  if gate.data.open {
+    let stroke = utility.if-auto(gate.fill, draw-params.wire)
+    box(circle(stroke: stroke, fill: draw-params.background, radius: gate.data.size))
+  } else {
+    box(circle(fill: color, radius: gate.data.size))
+  }
+}
+
+#let draw-swap(gate, draw-params) = {
+  box({
+    let d = gate.data.size
+    let stroke = draw-params.wire
+    box(width: d, height: d, {
+      place(line(start: (-0pt, -0pt), end: (d, d), stroke: stroke))
+      place(line(start: (d, 0pt), end: (0pt, d), stroke: stroke))
+    })
+  })
+}
+
+
+
+#let draw-meter(gate, draw-params) = {
+  let content = {
+    set align(top)
+    let stroke = draw-params.wire
+    let padding = draw-params.padding
+    let fill = utility.if-none(gate.fill, draw-params.background)
+    let height = draw-params.x-gate-size.height 
+    let width = 1.5 * height
+    height -= 2 * padding
+    width -= 2 * padding
+    box(
+      width: width, height: height, inset: 0pt, 
+      {
+        let center-x = width / 2
+        place(path((0%, 110%), ((50%, 40%), (-40%, 0pt)), (100%, 110%), stroke: stroke))
+        set align(left)
+        arrow.draw-arrow((center-x, height * 1.2), (width * .9, height*.3), length: 3.8pt, width: 2.8pt, stroke: stroke, arrow-color: draw-params.color)
+    })
+  }
+  gate.content = rect(content, inset: 0pt, stroke: none)
+  if gate.multi != none and gate.multi.num-qubits > 1 {
+    draw-boxed-multigate(gate, draw-params)
+  } else {
+    draw-boxed-gate(gate, draw-params)
+  }
+}
+
+
+#let draw-nwire(gate, draw-params) = {
+  set text(size: .7em)
+  let size = measure(gate.content)
+  let extent = 2.5pt + size.height
+  box(height: 2 * extent, { // box is solely for height hint
+    place(dx: 1pt, dy: 0pt, gate.content)
+    place(dy: extent, line(start: (0pt,-4pt), end: (-5pt,4pt), stroke: draw-params.wire))
+  })
+}
+
+
+
+#let draw-permutation-gate(gate, draw-params) = {
+  let dy = draw-params.multi.wire-distance
+  let width = gate.width
+  if dy == 0pt { return box(width: width, height: 4pt) }
+  
+  let separation = gate.data.separation
+  if separation == auto { separation = draw-params.background }
+  if type(separation) == color { separation += 3pt }
+  if type(separation) == length { separation += draw-params.background }
+  
+  box(
+    height: dy + 4pt,
+    inset: (y: 2pt),
+    fill: draw-params.background,
+    width: width, {
+      let qubits = gate.data.qubits
+      let y0 = draw-params.center-y-coords.at(gate.qubit)
+      let bend = gate.data.bend * width / 2
+      for from in range(qubits.len()) {
+        let to = qubits.at(from)
+        let y-from = draw-params.center-y-coords.at(from + gate.qubit) - y0
+        let y-to = draw-params.center-y-coords.at(to + gate.qubit) - y0
+        if separation != none {
+          place(path(((0pt,y-from), (-bend, 0pt)), ((width, y-to), (-bend, 0pt)), stroke: separation))
+        }
+        place(path(((-.1pt,y-from), (-bend, 0pt)), ((width+.1pt, y-to), (-bend, 0pt)), stroke: draw-params.wire)) 
+      }
+    }
+  )
+}
+
+// Draw an lstick (align: "right") or rstick (align: "left")
+#let draw-lrstick(gate, draw-params) = {
+
+  assert(gate.data.align in (left, right), message: "`lstick`/`rstick`: Only left and right are allowed for parameter align")
+    
+  let content = box(inset: draw-params.padding, gate.content)
+  let size = measure(content)
+  let brace = none
+  
+  if gate.data.brace != none {
+    let brace-height
+    if gate.multi == none {
+      brace-height = 1em + 2 * draw-params.padding
+    } else {
+      brace-height = draw-params.multi.wire-distance + .5em
+    }
+    let brace-symbol = gate.data.brace
+    if brace-symbol == auto and gate.multi == none {
+      brace-symbol = none
+    }
+    brace = utility.create-brace(brace-symbol, gate.data.align, brace-height)
+  }
+  
+  let brace-size = measure(brace)
+  let width = size.width + brace-size.width + gate.data.pad
+  let height = size.height
+  let brace-offset-y
+  let content-offset-y = 0pt
+  
+  if gate.multi == none {
+    brace-offset-y = size.height / 2 - brace-size.height / 2
+  } else {
+    let dy = draw-params.multi.wire-distance
+    // at first (layout) stage:
+    if dy == 0pt { return box(width: 2 * width, height: 0pt, content) }
+    height = dy
+    content-offset-y = -size.height / 2 + height / 2
+    brace-offset-y = -.25em
+  }
+  
+  let brace-pos-x = if gate.data.align == right { size.width } else { gate.data.pad }
+  let content-pos-x = if gate.data.align == right { 0pt } else { width - size.width }
+
+  box(
+    width: width, 
+    height: height, 
+    {
+      place(brace, dy: brace-offset-y, dx: brace-pos-x)
+      place(content, dy: content-offset-y, dx: content-pos-x)
+    }
+  )
+}
+
+
+
+
+#let draw-gategroup(x1, x2, y1, y2, item, draw-params) = {
+  let p = item.padding
+  let (x1, x2, y1, y2) = (x1 - p.left, x2 + p.right, y1 - p.top, y2 + p.bottom)
+  let size = (width: x2 - x1, height: y2 - y1)
+  layout.place-with-labels(
+    dx: x1, dy: y1, 
+    labels: item.labels, 
+    size: size,
+    draw-params: draw-params, rect(
+      width: size.width, height: size.height,
+      stroke: item.style.stroke,
+      fill: item.style.fill,
+      radius: item.style.radius
+    )
+  )
+}
+
+#let draw-slice(x, y1, y2, item, draw-params) = layout.place-with-labels(
+  dx: x, dy: y1, 
+  size: (width: 0pt, height: y2 - y1),
+  labels: item.labels, 
+  draw-params: draw-params, 
+  line(angle: 90deg, length: y2 - y1, stroke: item.style.stroke)
+)
+
+
+
+#let draw-horizontal-wire(x1, x2, y, stroke, wire-count, wire-distance: 1pt) = {
+  if x1 == x2 { return }
+
+  let wire = line(start: (x1, y), end: (x2, y), stroke: stroke)
+  range(wire-count)
+    .map(i => (2*i - (wire-count - 1)) * wire-distance)
+    .map(dy => place(wire, dy: dy))
+    .join()
+}
+
+#let draw-vertical-wire(
+  y1, 
+  y2,
+  x,
+  stroke,
+  wire-count: 1,
+  wire-distance: 1pt,
+) = {
+  let height = y2 - y1
+
+  let wire = line(start: (0pt, 0pt), end: (0pt, height), stroke: stroke)
+  let wires = range(wire-count)
+    .map(i => 2 * i * wire-distance)
+    .map(dx => place(wire, dx: dx))
+
+  place(
+    dx: x - (wire-count - 1) * wire-distance,
+    dy: y1,
+    wires.join()
+  )
+}
+
+#let draw-vertical-wire-with-labels(
+  y1, 
+  y2,
+  x,
+  stroke,
+  wire-count: 1,
+  wire-distance: 1pt,
+  wire-labels: (),
+  draw-params: none,
+) = {
+  let height = y2 - y1
+  
+  let wire = line(start: (0pt, 0pt), end: (0pt, height), stroke: stroke)
+  let wires = range(wire-count)
+    .map(i => 2 * i * wire-distance)
+    .map(dx => place(wire, dx: dx))
+
+  layout.place-with-labels(
+    dx: x - (wire-count - 1) * wire-distance,
+    dy: y1,
+    labels: wire-labels,
+    draw-params: draw-params,
+    size: (width: 2 * (wire-count - 1) * wire-distance, height: height),
+    wires.join()
+  )
+}

--- a/packages/preview/quill/0.5.0/src/gates.typ
+++ b/packages/preview/quill/0.5.0/src/gates.typ
@@ -1,0 +1,367 @@
+#import "layout.typ"
+#import "process-args.typ"
+#import "draw-functions.typ"
+
+
+
+/// This is the basic command for creating gates. Use this to create a simple gate, e.g., `gate($X$)`. 
+/// For special gates, many other dedicated gate commands exist. 
+///
+/// Note, that most of the parameters listed here are mostly used for derived gate 
+/// functions and do not need to be touched in all but very few cases. 
+///
+/// //#example(`quill.quantum-circuit(1, quill.gate($H$), 1)`)
+///
+/// - content (content): What to show in the gate (may be none for special gates like @@ctrl() ).
+/// - x (auto, int): The column to put the gate in. 
+/// - y (auto, int): The row to put the gate in. 
+/// - fill (none, color): Gate background fill color.
+/// - radius (length, dictionary): Gate rectangle border radius. 
+///             Allows the same values as the builtin `rect()` function.
+/// - width (auto, length): The width of the gate can be specified manually with this property. 
+/// - box (boolean): Whether this is a boxed gate (determines whether the outgoing 
+///             wire will be drawn all through the gate (`box: false`) or not).
+/// - floating (boolean): Whether the content for this gate will be shown floating 
+///             (i.e. no width is reserved).
+/// - multi (dictionary): Information for multi-qubit and controlled gates (see @@mqgate() ).
+/// - size-hint (function): Size hint function. This function should return a dictionary
+///             containing the keys `width` and `height`. The result is used to determine 
+///             the gates position and cell sizes of the grid. 
+///             Signature: `(gate, draw-params) => {}`.
+/// - draw-function (function): Drawing function that produces the displayed content.
+///             Signature: `(gate, draw-params) => {}`.
+/// - label (array, str, content, dictionary): One or more labels to add to the gate.
+///             Usually, a label consists of a dictionary with entries for the keys 
+///             `content` (the label content), `pos` (2d alignment specifying the 
+///             position of the label) and optionally `dx` and/or `dy` (lengths, ratios 
+///             or relative lengths). If only a single label is to be added, a plain 
+///             content or string value can be passed which is then placed at the default
+///             position. 
+///
+/// - data (any): Optional additional gate data. This can for example be a dictionary
+///             storing extra information that may be used for instance in a custom
+///             `draw-function`.
+#let gate(
+  content,
+  x: auto,
+  y: auto,
+  fill: auto,
+  stroke: auto,
+  radius: 0pt,
+  width: auto,
+  box: true,
+  floating: false,
+  multi: none,
+  size-hint: layout.default-size-hint,
+  draw-function: draw-functions.draw-boxed-gate,
+  gate-type: "",
+  data: none,
+  label: none
+) = (
+  content: content, 
+  x: x, 
+  y: y,
+  fill: fill,
+  stroke: stroke,
+  radius: radius,
+  width: width,
+  box: box,
+  floating: floating,
+  multi: multi,
+  size-hint: size-hint,
+  draw-function: draw-function,
+  gate-type: gate-type, 
+  data: data,
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+
+
+/// Basic command for creating multi-qubit or controlled gates. See also @@ctrl() and @@swap(). 
+///
+/// - content (content):
+/// - n (int): Number of wires the multi-qubit gate spans. 
+/// - x (auto, int): The column to put the gate in. 
+/// - y (auto, int): The row to put the gate in. 
+/// - target (none, int): If specified, a control wire is drawn from the gate up 
+///        or down this many wires counted from the wire this `mqgate()` is placed on. 
+/// - fill (none, color): Gate background fill color.
+/// - radius (length, dictionary): Gate rectangle border radius. 
+///        Allows the same values as the builtin `rect()` function.
+/// - width (auto, length): The width of the gate can be specified manually with this property. 
+/// - box (boolean): Whether this is a boxed gate (determines whether the 
+///        outgoing wire will be drawn all through the gate (`box: false`) or not).
+/// - wire-count (int): Wire count for control wires.
+/// - inputs (none, array): You can put labels inside the gate to label the input wires with 
+///        this argument. It accepts a list of labels, each of which has to be a dictionary
+///        with the keys `qubit` (denoting the qubit to label, starting at 0) and `content`
+///        (containing the label content). Optionally, providing a value for the key `n` allows
+///        for labelling multiple qubits spanning over `n` wires. These are then grouped by a 
+///        brace. 
+/// - outputs (none, array): Same as `inputs` but for gate outputs. 
+/// - extent (auto, length): How much to extent the gate beyond the first and 
+///        last wire, default is to make it align with an X gate (so [size of x gate] / 2). 
+/// - size-all-wires (none, boolean): A single-qubit gate affects the height of the row
+///        it is being put on. For multi-qubit gate there are different possible 
+///        behaviours:
+///          - Affect height on only the first and last wire (`false`)
+///          - Affect the height of all wires (`true`)
+///          - Affect the height on no wire (`none`)
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+/// - wire-label (array, str, content, dictionary): One or more labels to add to the 
+///        control wire. Works analogous to `labels` but with default positioning to the 
+///        right of the wire. 
+/// - data (any): Optional additional gate data. This can for example be a dictionary
+///        storing extra information that may be used for instance in a custom
+///        `draw-function`.
+#let mqgate(
+  content,
+  x: auto,
+  y: auto,
+  n: 1, 
+  target: none,
+  fill: auto, 
+  stroke: auto,
+  radius: 0pt,
+  width: auto,
+  box: true, 
+  wire-count: 1,
+  inputs: none,
+  outputs: none,
+  extent: auto, 
+  size-all-wires: false,
+  draw-function: draw-functions.draw-boxed-multigate, 
+  label: none,
+  wire-label: none,
+  data: none,
+) = gate(
+  content, 
+  x: x, 
+  y: y, 
+  fill: fill, 
+  stroke: stroke,
+  box: box, 
+  width: width,
+  radius: radius,
+  draw-function: draw-function,
+  multi: (
+    target: target,
+    num-qubits: n, 
+    wire-count: wire-count, 
+    label: label,
+    extent: extent,
+    size-all-wires: size-all-wires,
+    inputs: inputs,
+    outputs: outputs,
+    wire-label: process-args.process-label-arg(wire-label, default-pos: right),
+  ),
+  label: label,
+  data: data,
+)
+
+
+
+// SPECIAL GATES
+
+/// Draw a meter box representing a measurement. 
+/// - target (none, int): If given, draw a control wire to the given target
+///                           qubit the specified number of wires up or down.
+/// - wire-count (int):   Wire count for the (optional) control wire. 
+/// - n (int):            Number of wires to span this meter across. 
+/// - label (array, str, content, dictionary): One or more labels to add to the gate. 
+///        See @@gate(). 
+#let meter(
+  target: none, 
+  n: 1,
+  x: auto,
+  y: auto,
+  wire-count: 2, 
+  label: none, 
+  fill: auto, 
+  radius: 0pt
+) = {
+  label = if label != none {(content: label, pos: top, dy: -0.5em)} else { () }
+  if target == none and n == 1 {
+    gate(none, x: x, y: y, fill: fill, radius: radius, draw-function: draw-functions.draw-meter, data: (meter-label: label), label: label)
+  } else {
+     mqgate(none, x: x, y: y, n: n, target: target, fill: fill, radius: radius, box: true, wire-count: wire-count, draw-function: draw-functions.draw-meter, data: (meter-label: label), label: label)
+  }
+}
+
+/// Create a visualized permutation gate which maps the qubits $q_k, q_(k+1), ... $ to  
+/// the qubits $q_(p(k)), q_(p(k+1)), ...$ when placed on the qubit $k$. The permutation 
+/// map is given by the `qubits` argument. Note, that qubit indices start with 0. 
+/// 
+/// *Example:*
+///
+///  `permute(1, 0)` when placed on the second wire swaps the second and third wire. 
+/// 
+///  `permute(2, 0, 1)` when placed on wire 0 maps $(0,1,2) arrow.bar (2,0,1)$.
+/// 
+/// Note also, that the wiring is not very sophisticated and will probably look best for 
+/// relatively simple permutations. Furthermore, it only works with quantum wires. 
+///  
+/// - ..qubits (array): Qubit permutation specification. 
+/// - width (length): Width of the permutation gate. 
+/// - bend (ratio): How much to bend the wires. With `0%`, the wires are straight. 
+/// - separation (auto, none, length, color, stroke): Overlapping wires are separated by drawing a thicker line below. With this option, this line can be customized in color or thickness. 
+#let permute(
+  ..qubits, 
+  width: 30pt, 
+  bend: 100%, 
+  separation: auto,
+  x: auto,
+  y: auto,
+) = {
+  if qubits.named().len() != 0 {
+    assert(false, message: "Unexpected named argument `" + qubits.named().keys().first() + "` in function `permute()`")
+  }
+  mqgate(none, n: qubits.pos().len(), width: width, draw-function: draw-functions.draw-permutation-gate, data: (qubits: qubits.pos(), extent: 2pt, separation: separation, bend: bend))
+}
+
+/// Create an invisible (phantom) gate for reserving space. If `content` 
+/// is provided, the `height` and `width` parameters are ignored and the gate 
+/// will take the size it would have if `gate(content)` was called. 
+///
+/// Instead specifying width and/or height will create a gate with exactly the
+/// given size (without padding).
+///
+/// - content (content): Content to measure for the phantom gate size. 
+/// - width (length): Width of the phantom gate (ignored if `content` is not `none`). 
+/// - height (length): Height of the phantom gate (ignored if `content` is not `none`). 
+#let phantom(content: none, width: 0pt, height: 0pt) = {
+  let thecontent = if content != none { box(hide(content)) } else { 
+    box(width: width, height: height) 
+  }
+  gate(thecontent, box: false, fill: none)
+}
+
+/// Target element for controlled-X operations (#sym.plus.circle). 
+/// - fill (none, color, auto): Fill color for the target circle. If set 
+///        to `auto`, the target is filled with the circuits background color.
+/// - size (length): Size of the target symbol. 
+#let targ(
+  fill: none,
+  size: 4.3pt,
+  label: none, 
+  x: auto,
+  y: auto,
+) = gate(
+  none, 
+  x: x, 
+  y: y, 
+  box: false, 
+  draw-function: draw-functions.draw-targ, 
+  fill: if fill == true {auto} else if fill == false {none} else {fill}, 
+  data: (size: size), 
+  label: label
+)
+
+/// Target element for controlled-Z operations (#sym.bullet). 
+///
+/// - open (boolean): Whether to draw an open dot. 
+/// - fill (none, color): Fill color for the circle or stroke color if
+///        `open: true`. 
+/// - size (length): Size of the control circle. 
+// #let ctrl(open: false, fill: none, size: 2.3pt) = gate(none, draw-function: draw-ctrl, fill: fill, size: size, box: false, open: open)
+
+/// Target element for #smallcaps("swap") operations (#sym.times) without vertical wire). 
+/// - size (length): Size of the target symbol. 
+#let targX(size: 7pt, label: none, x: auto, y: auto) = gate(none, x: x, y: y, box: false, draw-function: draw-functions.draw-swap, data: (size: size), label: label)
+
+/// Create a phase gate shown as a point on the wire together with a label. 
+///
+/// - label (content): Angle value to display. 
+/// - open (boolean): Whether to draw an open dot. 
+/// - fill (none, color): Fill color for the circle or stroke color if
+///        `open: true`. 
+/// - size (length): Size of the circle. 
+#let phase(
+  label,
+  open: false,
+  fill: auto,
+  size: 2.3pt,
+  x: auto,
+  y: auto
+) = gate(
+  none, 
+  x: x, 
+  y: y,
+  box: false,
+  draw-function: (gate, draw-params) => box(
+    inset: (x: .6em), 
+    draw-functions.draw-ctrl(gate, draw-params)
+  ),
+  fill: fill,
+  data: (open: open, size: size),
+  label: process-args.process-label-arg(label, default-pos: top + right, default-dx: -.5em)
+)
+
+
+
+/// Creates a #smallcaps("swap") operation with another qubit. 
+/// 
+/// - n (int): How many wires up or down the target wire lives. 
+/// - size (length): Size of the target symbol. 
+/// - wire-label (array, str, content, dictionary): One or more labels 
+///        to add to the control wire. See @@mqgate(). 
+#let swap(
+  n, 
+  wire-count: 1, 
+  size: 7pt, 
+  label: none, 
+  wire-label: none,
+  x: auto,
+  y: auto
+) = mqgate(
+  none,
+  x: x, 
+  y: y,
+  target: n,
+  box: false,
+  draw-function: draw-functions.draw-swap,
+  wire-count: wire-count,
+  data: (size: size),
+  label: label,
+  wire-label: wire-label
+)
+
+
+
+/// Creates a control with a vertical wire to another qubit. 
+/// 
+/// - n (int): How many wires up or down the target wire lives. 
+/// - wire-count (int): Wire count for the control wire.  
+/// - open (boolean): Whether to draw an open dot. 
+/// - fill (none, color): Fill color for the circle or stroke color if
+///        `open: true`. 
+/// - size (length): Size of the control circle. 
+/// - show-dot (boolean): Whether to show the control dot. Set this to 
+///        false to obtain a vertical wire with no dots at all. 
+/// - wire-label (array, str, content, dictionary): One or more labels 
+///        to add to the control wire. See @@mqgate(). 
+#let ctrl(
+  n,
+  wire-count: 1,
+  open: false,
+  fill: auto,
+  size: 2.3pt,
+  show-dot: true,
+  label: none,
+  wire-label: none,
+  x: auto,
+  y: auto
+) = mqgate(
+  none,
+  x: x, 
+  y: y,
+  target: n,
+  box: false,
+  draw-function: draw-functions.draw-ctrl,
+  wire-count: wire-count,
+  fill: fill,
+  data: (open: open, size: size, show-dot: show-dot),
+  label: label,
+  wire-label: wire-label
+)

--- a/packages/preview/quill/0.5.0/src/layout.typ
+++ b/packages/preview/quill/0.5.0/src/layout.typ
@@ -1,0 +1,187 @@
+#import "length-helpers.typ": *
+
+/// Update bounds to contain the given rectangle
+/// - bounds (array): Current bound coordinates x0, y0, x1, y1
+/// - rect (array): Bounds rectangle x0, y0, x1, y1
+#let update-bounds(bounds, rect) = (
+  calc.min(bounds.at(0), rect.at(0).to-absolute()), 
+  calc.min(bounds.at(1), rect.at(1).to-absolute()),
+  calc.max(bounds.at(2), rect.at(2).to-absolute()),
+  calc.max(bounds.at(3), rect.at(3).to-absolute()),
+)
+
+#let offset-bounds(bounds, offset) = (
+  bounds.at(0) + offset.at(0),
+  bounds.at(1) + offset.at(1),
+  bounds.at(2) + offset.at(0),
+  bounds.at(3) + offset.at(1),
+)
+
+#let make-bounds(x0: 0pt, y0: 0pt, width: 0pt, height: 0pt, x1: none, y1: none) = (
+  x0.to-absolute(),
+  y0.to-absolute(),
+  (if x1 != none { x1 } else { x0 + width }).to-absolute(),
+  (if y1 != none { y1 } else { y0 + height }).to-absolute(),
+)
+
+
+/// Take an alignment or 2d alignment and return a 2d alignment with the possibly 
+/// unspecified axis set to a default value. 
+#let make-2d-alignment(alignment, default-vertical: horizon, default-horizontal: center) = {
+  let axis = alignment.axis()
+  if axis == none { return alignment }
+  if alignment.axis() == "horizontal" { return alignment + default-vertical }
+  if alignment.axis() == "vertical" { return alignment + default-horizontal }
+}
+
+
+#let make-2d-alignment-factor(alignment) = {
+  let alignment = make-2d-alignment(alignment)
+  let x = 0
+  let y = 0
+  if alignment.x == left { x = -1 }
+  else if alignment.x == right { x = 1 }
+  if alignment.y == top { y = -1 }
+  else if alignment.y == bottom { y = 1 }
+  return (x, y)
+}
+
+
+
+
+#let default-size-hint(item, draw-params) = {
+  let content = (item.draw-function)(item, draw-params)
+  let hint = measure(content)
+  hint.offset = auto
+  return hint
+}
+
+
+
+
+
+#let lrstick-size-hint(item, draw-params) = {
+  let content = (item.draw-function)(item, draw-params)
+  let hint = measure(content)
+  let dx = 0pt
+  if item.data.align == right { dx = hint.width } 
+  hint.offset = (x: dx, y: auto)
+  return hint
+}
+
+
+
+
+
+/// Place some content along with optional labels while computing bounds. 
+/// 
+/// Returns a pair of the placed content and a bounds array. 
+///
+/// - content (content): The content to place. 
+/// - dx (length): Horizontal displacement.
+/// - dy (length): Vertical displacement.
+/// - size (auto, dictionary): For computing bounds, the size of the placed content
+///           is needed. If `auto` is passed, this function computes the size itself
+///           but if it is already known it can be passed through this parameter. 
+/// - labels (array): An array of labels which in turn are dictionaries that must 
+///           specify values for the keys `content` (content), `pos` (strictly 2d 
+///           alignment), `dx` and `dy` (both length, ratio or relative length).
+/// - draw-params (dictionary): Drawing parameters. 
+/// -> pair
+#let place-with-labels(
+  content, 
+  dx: 0pt, 
+  dy: 0pt,
+  size: auto,
+  labels: (),
+  draw-params: none,
+) = {
+  if size == auto { size = measure(content) }
+  let bounds = make-bounds(
+    x0: dx, y0: dy, width: size.width, height: size.height
+  )
+  if labels.len() == 0 {
+    return (place(content, dx: dx, dy: dy), bounds)    
+  }
+  
+  let placed-labels = place(dx: dx, dy: dy, 
+    box({
+      for label in labels {
+        let label-size = measure(label.content)
+        let ldx = get-length(label.dx, size.width)
+        let ldy = get-length(label.dy, size.height)
+        
+        if label.pos.x == left { ldx -= label-size.width }
+        else if label.pos.x == center { ldx += 0.5 * (size.width - label-size.width) }
+        else if label.pos.x == right { ldx += size.width }
+        if label.pos.y == top { ldy -= label-size.height }
+        else if label.pos.y == horizon { ldy += 0.5 * (size.height - label-size.height) }
+        else if label.pos.y == bottom { ldy += size.height }
+        
+        
+        let placed-label = place(label.content, dx: ldx, dy: ldy)
+        let label-bounds = make-bounds(
+          x0: ldx + dx, y0: ldy + dy, 
+          width: label-size.width, height: label-size.height
+        )
+        bounds = update-bounds(bounds, label-bounds)
+        placed-label
+      }
+    })
+  )
+  return (place(content, dx: dx, dy: dy) + placed-labels, bounds)
+}
+
+
+
+
+// From a list of row heights or col widths, compute the respective
+// cell center coordinates, e.g., (3pt, 3pt, 4pt) -> (1.5pt, 4.5pt, 8pt)
+#let compute-center-coords(cell-lengths, gutter) = {
+  let center-coords = ()
+  let tmpx = 0pt
+  gutter.insert(0, 0pt)
+  // assert.eq(cell-lengths.len(), gutter.len())
+  for (cell-length, gutter) in cell-lengths.zip(gutter) {
+    center-coords.push(tmpx + cell-length / 2 + gutter)
+    tmpx += cell-length + gutter
+  }
+  return center-coords
+} 
+
+
+// Given a list of n center coordinates and n cell sizes along one axis (x or y), retrieve the coordinates for a single cell or a list of cells given by index. 
+// If a cell index is out of bounds, the outer last coordinate is returned
+// center-coords: List of center coordinates for each index
+// cell-sizes: List of cell sizes for each index
+// cells: Indices of cell for which to retrieve coordinates
+// These may also be floats. In this case, the integer part determines the cell index and the fractional part a percentage of the cell width. e.g., passing 2.5 would return the center coordinate of the cell
+#let get-cell-coords(center-coords, cell-sizes, cells) = {
+  let last = center-coords.at(-1) + cell-sizes.at(-1) / 2
+  let get(x) = { 
+    let integral = calc.floor(x)
+    let fractional = x - integral
+    let cell-width = cell-sizes.at(integral, default: 0pt)
+    return center-coords.at(integral, default: last) + cell-width * (fractional - 0.5)
+  }
+  if type(cells) in (int, float) { get(cells)  }
+  else if type(cells) == array { cells.map(x => get(x)) }
+  else { panic("Unsupported coordinate type") }
+}
+
+#let get-cell-coords1(center-coords, cell-sizes, cells) = {
+  let last = center-coords.at(-1) + cell-sizes.at(-1) / 2
+  let get(x) = { 
+    let integral = calc.floor(x)
+    let fractional = x - integral
+    let cell-width = cell-sizes.at(integral, default: 0pt)
+    let c1 = center-coords.at(integral, default: last)
+    let c2 = center-coords.at(integral + 1, default: last)
+    return c1 + (c2 - c1) * (fractional)
+  }
+  if type(cells) in (int, float) { get(cells)  }
+  else if type(cells) == array { cells.map(x => get(x)) }
+  else { panic("Unsupported coordinate type") }
+}
+
+#let std-scale = scale

--- a/packages/preview/quill/0.5.0/src/length-helpers.typ
+++ b/packages/preview/quill/0.5.0/src/length-helpers.typ
@@ -1,0 +1,7 @@
+
+
+#let get-length(len, container-length) = {
+  if type(len) == length { return len }
+  if type(len) == ratio { return len * container-length}
+  if type(len) == relative { return len.length + len.ratio * container-length}
+}

--- a/packages/preview/quill/0.5.0/src/process-args.typ
+++ b/packages/preview/quill/0.5.0/src/process-args.typ
@@ -1,0 +1,56 @@
+// This file contains helper functions to process and normalize special 
+// arguments to functions, especially where multiple formats and types 
+// are allowed.
+
+#import "layout.typ"
+
+
+#let process-padding-arg(padding) = {
+  let type = type(padding)
+  if type == length { 
+    return (left: padding, top: padding, right: padding, bottom: padding)
+  }
+  if type == dictionary {
+    let rest = padding.at("rest", default: 0pt)
+    let x = padding.at("x", default: rest)
+    let y = padding.at("y", default: rest)
+    return (
+      left: padding.at("left", default: x), 
+      right: padding.at("right", default: x), 
+      top: padding.at("top", default: y), 
+      bottom: padding.at("bottom", default: y), 
+    )
+  }
+  assert(false, message: "Unsupported type \"" + type + "\" as argument for padding")
+}
+
+
+/// Process the label argument to `gate`. Allowed input formats are none, array of dictionaries
+/// or a single dictionary/string/content (for just one label). 
+/// 
+/// Each dictionary needs to contain the key content and may optionally have values 
+/// for the  keys `pos` (specifying a 1d or 2d alignment) and `dx` as well as `dy`
+#let process-label-arg(
+  labels, 
+  default-pos: right,
+  default-dx: .4em, 
+  default-dy: .4em
+) = {
+  if labels == none {  return () }
+  let type = type(labels)
+  if type == dictionary { labels = (labels,) } 
+  else if type in (content, str) { labels = ((content: labels),) } 
+  else if type == dictionary { labels = ((content: labels),) } 
+  let processed-labels = ()
+  for label in labels {
+    let alignment = layout.make-2d-alignment(label.at("pos", default: default-pos))
+    let (x, y) = layout.make-2d-alignment-factor(alignment)
+    processed-labels.push((
+      content: label.content,
+      pos: alignment,
+      dx: label.at("dx", default: default-dx * x),
+      dy: label.at("dy", default: default-dy * y)
+    ))
+  }
+  processed-labels
+}

--- a/packages/preview/quill/0.5.0/src/quantum-circuit.typ
+++ b/packages/preview/quill/0.5.0/src/quantum-circuit.typ
@@ -1,0 +1,524 @@
+#import "utility.typ"
+#import "verifications.typ"
+#import "length-helpers.typ"
+#import "decorations.typ": *
+
+#let signum(x) = if x >= 0. { 1. } else { -1. }
+
+
+
+/// Create a quantum circuit diagram. Children may be
+/// - gates created by one of the many gate commands (@@gate(), 
+///   @@mqgate(), @@meter(), ...),
+/// - `[\ ]` for creating a new wire/row,
+/// - commands like @@setwire(), @@slice() or @@gategroup(),
+/// - integers for creating cells filled with the current wire setting,
+/// - lengths for creating space between rows or columns,
+/// - plain content or strings to be placed on the wire, and
+/// - @@lstick(), @@midstick() or @@rstick() for placement next to the wire.
+///
+///
+/// - wire (stroke): Style for drawing the circuit wires. This can take anything 
+///            that is valid for the stroke of the builtin `line()` function. 
+/// - row-spacing (length): Spacing between rows.
+/// - column-spacing (length): Spacing between columns.
+/// - min-row-height (length): Minimum height of a row (e.g., when no 
+///             gates are given).
+/// - min-column-width (length): Minimum width of a column.
+/// - gate-padding (length): General padding setting including the inset for 
+///            gate boxes and the distance of @@lstick() and co. to the wire. 
+/// - equal-row-heights (boolean): If true, then all rows will have the same 
+///            height and the wires will have equal distances orienting on the
+///            highest row. 
+/// - color (color): Foreground color, default for strokes, text, controls
+///            etc. If you want to have dark-themed circuits, set this to white  
+///            for instance and update `wire` and `fill` accordingly.           
+/// - fill (color): Default fill color for gates. 
+/// - font-size (length): Default font size for text in the circuit. 
+/// - scale (ratio): Total scale factor applied to the entire 
+///            circuit without changing proportions
+/// - baseline (length, content, str): Set the baseline for the circuit. If a 
+///            content or a string is given, the baseline will be adjusted auto-
+///            matically to align with the center of it. One useful application is 
+///            `"="` so the circuit aligns with the equals symbol. 
+/// - circuit-padding (dictionary): Padding for the circuit (e.g., to accommodate 
+///            for annotations) in form of a dictionary with possible keys 
+///            `left`, `right`, `top` and `bottom`. Not all of those need to be 
+///            specified. 
+///
+///            This setting basically just changes the size of the bounding box 
+///            for the circuit and can be used to increase it when labels or 
+///            annotations extend beyond the actual circuit. 
+/// - fill-wires (boolean): Whether to automatically fill up all wires until the end. 
+/// - ..children (any): Items, gates and circuit commands (see description). 
+#let quantum-circuit(
+  wire: .7pt + black,     
+  row-spacing: 12pt,
+  column-spacing: 12pt,
+  min-row-height: 10pt, 
+  min-column-width: 0pt, 
+  gate-padding: .4em, 
+  equal-row-heights: false, 
+  color: black,
+  fill: white,
+  font-size: 10pt,
+  scale: 100%,
+  baseline: 0pt,
+  circuit-padding: .4em,
+  fill-wires: true,
+  ..children
+) = { 
+  if children.pos().len() == 0 { return }
+  if children.named().len() > 0 { 
+    panic("Unexpected named argument '" + children.named().keys().at(0) + "' for quantum-circuit()")
+  }
+  set text(color, size: font-size)
+  set math.equation(numbering: none)
+
+  context {
+  
+  // Parameter object to pass to draw-function containing current style info
+  let draw-params = (
+    wire: wire,
+    padding: measure(line(length: gate-padding)).width,
+    background: fill,
+    color: color,
+    x-gate-size: none,
+    multi: (wire-distance: 0pt)
+  )
+
+  draw-params.x-gate-size = layout.default-size-hint(gate($X$), draw-params)
+  
+  let items = children.pos().map( x => {
+    if type(x) in (content, str) and x != [\ ] { return gate(x) }
+    return x
+  })
+  
+  /////////// First part: Layout (and spacing)   ///////////
+  
+  let column-spacing = column-spacing.to-absolute()
+  let row-spacing = row-spacing.to-absolute()
+  let min-row-height = min-row-height.to-absolute()
+  let min-column-width = min-column-width.to-absolute()
+  
+  // All these arrays are gonna be filled up in the loop over `items`
+  let matrix = ((),)
+  let row-gutter = (0pt,)
+  let single-qubit-gates = ()
+  let multi-qubit-gates = ()
+  let meta-instructions = ()
+
+  let auto-cell = (empty: true, size: (width: 0pt, height: 0pt), gutter: 0pt)
+
+  let default-wire-style = (
+    count: 1,
+    distance: 1pt, 
+    stroke: wire
+  )
+  let wire-style = default-wire-style
+  let wire-instructions = ()
+
+  let (row, col) = (0, 0)
+  let prev-col = 0
+  let wire-ended = false
+
+  for item in items {
+    if item == [\ ] {
+      if fill-wires {
+        wire-instructions.push((row, prev-col, -1))
+      }
+      row += 1; col = 0; prev-col = 0
+
+      if row >= matrix.len() {
+        matrix.push(())
+        row-gutter.push(0pt)
+      }
+      wire-style = default-wire-style
+      wire-instructions.push(wire-style)
+      wire-ended = true
+    } else if utility.is-circuit-meta-instruction(item) { 
+      if item.qc-instr == "setwire" {
+        wire-style.count = item.wire-count
+
+        wire-style.distance = utility.if-auto(item.wire-distance, wire-style.distance)
+        wire-style.stroke = utility.if-auto(utility.update-stroke(wire-style.stroke, item.stroke), wire-style.stroke)
+        wire-instructions.push(wire-style)
+      } else {
+        // Visual meta instructions are handled later
+        let (x, y) = (item.x, item.y)
+        if x == auto { x = col }
+        if y == auto { y = row }
+        meta-instructions.push((x: x, y: y, item: item))
+      }
+    } else if utility.is-circuit-drawable(item) {
+      let gate = item
+      let (x, y) = (gate.x, gate.y)
+      if x == auto { 
+        x = col 
+        if y == auto {
+          if col != prev-col {
+            wire-instructions.push((row, prev-col, col))
+          }
+          prev-col = col 
+          col += 1
+        }
+      }
+      if y == auto { y = row }
+
+      if y >= matrix.len() { matrix += ((),) * (y - matrix.len() + 1) }
+      if x >= matrix.at(y).len() {
+        matrix.at(y) += (auto-cell,) * (x - matrix.at(y).len() + 1)
+      }
+
+      assert(matrix.at(y).at(x).empty, message: "Attempted to place a second gate at column " + str(x) + ", row " + str(y))
+
+      let size-hint = utility.get-size-hint(item, draw-params)
+      let gate-size = size-hint
+      if item.floating { size-hint.width = 0pt } // floating items don't take width in the layout
+
+      matrix.at(y).at(x) = (
+        size: size-hint,
+        gutter: 0pt,
+        box: item.box,
+        empty: gate.data == "placeholder"
+      )
+      let gate-info = (
+        gate: gate,
+        size: gate-size,
+        x: x,
+        y: y
+      )
+      if gate.multi != none { multi-qubit-gates.push(gate-info) } 
+      else { single-qubit-gates.push(gate-info) }
+      wire-ended = false
+    } else if type(item) == int {
+      wire-instructions.push((row, prev-col, col + item - 1))
+      col += item
+      prev-col = col - 1
+      if col >= matrix.at(row).len() {
+        matrix.at(row) += (auto-cell,) * (col - matrix.at(row).len())
+      }
+      wire-ended = false
+    } else if type(item) == length {
+      if wire-ended {
+        row-gutter.at(row - 1) = calc.max(row-gutter.at(row - 1), item)
+      } else if col > 0 {
+        matrix.at(row).at(col - 1).gutter = calc.max(matrix.at(row).at(col - 1).gutter, item)
+      }
+    }
+  }
+
+  // finish up matrix
+  let num-rows = matrix.len()
+  let num-cols = calc.max(0, ..matrix.map(array.len))
+  if num-rows == 0 or num-cols == 0 { return none }
+
+  
+  for i in range(num-rows) {
+    matrix.at(i) += (auto-cell,) * (num-cols - matrix.at(i).len())
+  }
+  row-gutter += (0pt,) * (matrix.len() - row-gutter.len())
+
+  if fill-wires {
+    wire-instructions.push((row, prev-col, -1)) // fill current wire
+    wire-instructions += range(row + 1, num-rows).map(row => (row, 0, -1)) // we may not have visited all wires due to manual placement. Fill all remaining wires. 
+  }
+
+  let vertical-wires = ()
+  // Treat multi-qubit gates (and controlled gates)
+  // - extract and store all necessary vertical control wires
+  // - Apply same size-hints to all cells that a mqgate spans (without the control wire). 
+  for gate in multi-qubit-gates {
+    let (x, y) = gate
+    let size = matrix.at(y).at(x).size
+    let multi = gate.gate.multi
+    
+    if multi.target != none and multi.target != 0 {
+      verifications.verify-controlled-gate(gate.gate, x, y, num-rows, num-cols)
+
+      let diff = if multi.target > 0 {multi.num-qubits - 1} else {0}
+      vertical-wires.push((
+        x: x, 
+        y: y + diff, 
+        target: multi.target - diff, 
+        wire-style: (count: multi.wire-count),
+        labels: multi.wire-label
+      ))
+    }
+    let nq = multi.num-qubits
+    if nq == 1 { continue }
+
+    verifications.verify-mqgate(gate.gate, x, y, num-rows, num-cols)
+
+    for qubit in range(y, y + nq) {
+      matrix.at(qubit).at(x).size.width = size.width
+    }
+    let start = y
+    if multi.size-all-wires != none {
+      if not multi.size-all-wires {
+        start = calc.max(0, y + nq - 1)
+      }
+      for qubit in range(start, y + nq) {
+        matrix.at(qubit).at(x).size = size
+      }
+    }
+  }
+
+
+  let row-heights = matrix.map(row => 
+    calc.max(min-row-height, ..row.map(item => item.size.height)) + row-spacing
+  )
+  if equal-row-heights {
+    let max-row-height = calc.max(..row-heights)
+    row-heights = (max-row-height,) * row-heights.len()
+  }
+
+  let col-widths = range(num-cols).map(j => 
+    calc.max(min-column-width, ..range(num-rows).map(i => {
+        matrix.at(i).at(j).size.width
+    })) + column-spacing 
+  )
+
+  let col-gutter = range(num-cols).map(j => 
+    calc.max(0pt, ..range(num-rows).map(i => {
+        matrix.at(i).at(j).gutter
+    }))
+  )
+
+  let center-x-coords = layout.compute-center-coords(col-widths, col-gutter).map(x => x - 0.5 * column-spacing)
+  let center-y-coords = layout.compute-center-coords(row-heights, row-gutter).map(x => x - 0.5 * row-spacing)
+  draw-params.center-y-coords = center-y-coords
+  
+  let circuit-width = col-widths.sum() + col-gutter.slice(0, -1).sum(default: 0pt) - column-spacing
+  let circuit-height = row-heights.sum() + row-gutter.sum() - row-spacing
+
+
+
+  /////////// Second part: Generation ///////////
+  
+  let bounds = (0pt, 0pt, circuit-width, circuit-height)
+  
+  let circuit = block(
+    width: circuit-width, height: circuit-height, {
+    set align(top + left) // quantum-circuit could be called in a scope where these have been changed which would mess up everything
+
+    let layer-below-circuit
+    let layer-above-circuit
+    for (item, x, y) in meta-instructions {
+      let (the-content, decoration-bounds) = (none, none)
+      if item.qc-instr == "gategroup" {
+        verifications.verify-gategroup(item, x, y, num-rows, num-cols)
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, y + item.wires - 1e-9))
+        let (dx1, dx2) = layout.get-cell-coords(center-x-coords, col-widths, (x, x + item.steps - 1e-9))
+        (the-content, decoration-bounds) = draw-functions.draw-gategroup(dx1, dx2, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "slice" {
+        verifications.verify-slice(item, x, y, num-rows, num-cols)
+        let end = if item.wires == 0 { row-heights.len() } else { y + item.wires }
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, end))
+        let dx = layout.get-cell-coords(center-x-coords, col-widths, x)
+        (the-content, decoration-bounds) = draw-functions.draw-slice(dx, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "annotate" {
+        let rows = layout.get-cell-coords(center-y-coords, row-heights, item.rows)
+        let cols = layout.get-cell-coords(center-x-coords, col-widths, item.columns)
+        let annotation = (item.callback)(cols, rows)
+        verifications.verify-annotation-content(annotation)
+        if type(annotation) == dictionary {
+          (the-content, decoration-bounds) = layout.place-with-labels(
+            annotation.content,
+            dx: annotation.at("dx", default: 0pt),
+            dy: annotation.at("dy", default: 0pt),
+            draw-params: draw-params
+          )
+        } else if type(annotation) in (content, str) {
+          layer-below-circuit += place(annotation)
+        } 
+      }
+      if decoration-bounds != none {
+        bounds = layout.update-bounds(bounds, decoration-bounds)
+      }
+      if item.at("z", default: "below") == "below" { layer-below-circuit += the-content  }
+      else { layer-above-circuit += the-content  }
+    }
+
+    layer-below-circuit
+
+
+    let get-gate-pos(x, y, size-hint) = {
+      let dx = center-x-coords.at(x)
+      let dy = center-y-coords.at(y)
+      let (width, height) = size-hint
+      let offset = size-hint.at("offset", default: auto)
+
+      if offset == auto { return (dx - width / 2, dy - height / 2) } 
+
+      assert(type(offset) == dictionary, message: "Unexpected type `" + type(offset) + "` for parameter `offset`") 
+      
+      let offset-x = offset.at("x", default: auto)
+      let offset-y = offset.at("y", default: auto)
+      if offset-x == auto { dx -= width / 2}
+      else if type(offset-x) == length { dx -= offset-x }
+      if offset-y == auto { dy -= height / 2}
+      else if type(offset-y) == length { dy -= offset-y }
+      return (dx, dy)
+    }
+
+
+    let get-anchor-width(x, y) = {
+      if x == num-cols { return 0pt }
+      let el = matrix.at(y).at(x)
+      if "box" in el and not el.box { return 0pt }
+      return el.size.width
+    }
+
+    let get-anchor-height(x, y) = {
+      let el = matrix.at(y).at(x)
+      if "box" in el and not el.box { return 0pt }
+      return el.size.height
+    }
+
+
+    let wire-style = default-wire-style
+    for wire-piece in wire-instructions {
+      if type(wire-piece) == dictionary {
+        wire-style = wire-piece
+      } else {
+        if wire-style.count == 0 { continue }
+        let (row, start-x, end-x) = wire-piece
+        if end-x == -1 {
+          end-x = num-cols - 1
+        }
+        if start-x == end-x { continue }
+
+        let draw-subwire(x1, x2) = {
+          let dx1 = center-x-coords.at(x1)
+          let dx2 = center-x-coords.at(x2, default: circuit-width)
+          let dy = center-y-coords.at(row)
+          dx1 += get-anchor-width(x1, row) / 2
+          dx2 -= get-anchor-width(x2, row) / 2
+          draw-functions.draw-horizontal-wire(dx1, dx2, dy, wire-style.stroke, wire-style.count, wire-distance: wire-style.distance)
+        }
+        // Draw wire pieces and take care not to draw through gates. 
+        for x in range(start-x + 1, end-x) {
+          let anchor-width = get-anchor-width(x, row)
+          if anchor-width == 0pt { continue } // no gate or `box: false` gate. 
+          draw-subwire(start-x, x)
+          start-x = x
+        }
+        draw-subwire(start-x, end-x)
+      }
+    }
+    
+    for (x, y, target, wire-style, labels) in vertical-wires {
+      let dx = center-x-coords.at(x)
+      let (dy1, dy2) = (center-y-coords.at(y), center-y-coords.at(y + target))
+      dy1 += get-anchor-height(x, y) / 2 * signum(target)
+      dy2 -= get-anchor-height(x, y + target) / 2 * signum(target)
+      
+      if labels.len() == 0 {
+        draw-functions.draw-vertical-wire(
+          dy1, dy2, dx, 
+          wire, wire-count: wire-style.count,
+        )
+      } else {
+        let (result, gate-bounds) = draw-functions.draw-vertical-wire-with-labels(
+          dy1, dy2, dx, 
+          wire, wire-count: wire-style.count,
+          wire-labels: labels,
+          draw-params: draw-params
+        )
+        result
+        bounds = layout.update-bounds(bounds, gate-bounds)
+      }
+    }
+    
+    
+    for gate-info in single-qubit-gates {
+      let (gate, size, x, y) = gate-info
+      let (dx, dy) = get-gate-pos(x, y, size)
+      let content = utility.get-content(gate, draw-params)
+
+      let (result, gate-bounds) = layout.place-with-labels(
+        content, 
+        size: size,
+        dx: dx, dy: dy, 
+        labels: gate.labels, draw-params: draw-params
+      )
+      bounds = layout.update-bounds(bounds, gate-bounds)
+      result
+    }
+    
+    for gate-info in multi-qubit-gates {
+      let (gate, size, x, y) = gate-info
+      let draw-params = draw-params
+      gate.qubit = y
+      if gate.multi.num-qubits > 1 {
+        let dy1 = center-y-coords.at(y + gate.multi.num-qubits - 1)
+        let dy2 = center-y-coords.at(y)
+        draw-params.multi.wire-distance = dy1 - dy2
+      }
+      
+      // lsticks need their offset/width to be updated again (but don't update the height!)
+      let content = utility.get-content(gate, draw-params)
+      let new-size = utility.get-size-hint(gate, draw-params)
+      size.offset = new-size.offset
+      size.width = new-size.width
+
+      let (dx, dy) = get-gate-pos(x, y, size)
+      let (result, gate-bounds) = layout.place-with-labels(
+        content, 
+        size: if gate.multi != none and gate.multi.num-qubits > 1 {auto} else {size},
+        dx: dx, dy: dy, 
+        labels: gate.labels, draw-params: draw-params
+      )
+      bounds = layout.update-bounds(bounds, gate-bounds)
+      result
+    }
+
+    layer-above-circuit
+
+    // show matrix
+    // for (i, row) in matrix.enumerate() {
+    //   for (j, entry) in row.enumerate() {
+    //     let (dx, dy) = (center-x-coords.at(j), center-y-coords.at(i))
+    //     place(
+    //       dx: dx - entry.size.width / 2, dy: dy - entry.size.height / 2, 
+    //       box(stroke: green, width: entry.size.width, height: entry.size.height)
+    //     )
+    //   }
+    // }
+  
+  }) // end circuit = block(..., {
+    
+  let scale = scale
+  if circuit-padding != none {
+    let circuit-padding = process-args.process-padding-arg(circuit-padding)
+    bounds.at(0) -= circuit-padding.left
+    bounds.at(1) -= circuit-padding.top
+    bounds.at(2) += circuit-padding.right
+    bounds.at(3) += circuit-padding.bottom
+  }
+  let final-height = scale * (bounds.at(3) - bounds.at(1))
+  let final-width = scale * (bounds.at(2) - bounds.at(0))
+  
+  let thebaseline = baseline
+  if type(thebaseline) in (content, str) {
+    thebaseline = height/2 - measure(thebaseline).height/2
+  }
+  if type(thebaseline) == fraction {
+    thebaseline = 100% - layout.get-cell-coords1(center-y-coords, row-heights, thebaseline / 1fr) + bounds.at(1)
+  }
+  box(baseline: thebaseline,
+    width: final-width,
+    height: final-height, 
+    // stroke: 1pt + gray,
+    align(left + top, move(dy: -scale * bounds.at(1), dx: -scale * bounds.at(0), 
+      layout.std-scale(
+        x: scale, 
+        y: scale, 
+        origin: left + top, 
+        circuit
+    )))
+  )
+  
+}
+}

--- a/packages/preview/quill/0.5.0/src/quill.typ
+++ b/packages/preview/quill/0.5.0/src/quill.typ
@@ -1,0 +1,20 @@
+#import "utility.typ"
+#import "decorations.typ": lstick, rstick, midstick, nwire, annotate, slice, setwire, gategroup
+#import "gates.typ": gate, mqgate, ctrl, swap, targ, meter, phantom, permute, phase, targX, draw-functions
+#import "quantum-circuit.typ": quantum-circuit
+#import "tequila.typ"
+
+
+#let help(..args) = {
+  import "@preview/tidy:0.3.0"
+
+  let namespace = (
+    ".": (
+      read.with("/src/quantum-circuit.typ"), 
+      read.with("/src/gates.typ"),
+      read.with("/src/decorations.typ"),
+    ),
+    "gates": read.with("/src/gates.typ"),
+  )
+  tidy.generate-help(namespace: namespace, package-name: "quill")(..args)
+}

--- a/packages/preview/quill/0.5.0/src/tequila-impl.typ
+++ b/packages/preview/quill/0.5.0/src/tequila-impl.typ
@@ -1,0 +1,267 @@
+#import "gates.typ"
+
+#let bgate(qubit, constructor, nq: 1, supplements: (), ..args) = ((
+  qubit: qubit,
+  n: nq,
+  supplements: supplements,
+  constructor: constructor,
+  args: args
+),)
+
+#let generate-single-qubit-gate(qubit, constructor: gates.gate, ..args) = {
+  if qubit.named().len() != 0 {
+    assert(false, message: "Unexpected argument `" + qubit.named().pairs().first().first() + "`")
+  }
+  qubit = qubit.pos()
+  if qubit.len() == 1 { qubit = qubit.first() }
+  if type(qubit) == int { return bgate(qubit, constructor, ..args) }
+  qubit.map(qubit => bgate(qubit, constructor, ..args))
+}
+
+#let generate-two-qubit-gate(control, target, start, end) = {
+  if type(control) == int and type(target) == int { 
+    assert.ne(target, control, message: "Target and control qubit cannot be the same")
+    return bgate(
+      control,
+      start,
+      target - control,
+      nq: target - control + 1,
+      supplements: ((target, end),)
+    ) 
+  }
+  let gates = ()
+  if type(control) == int { control = (control,) }
+  if type(target) == int { target = (target,) }
+
+  for i in range(calc.max(control.len(), target.len())) {
+    let c = control.at(i, default: control.last())
+    let t = target.at(i, default: target.last())
+    assert.ne(t, c, message: "Target and control qubit cannot be the same")
+    gates.push(bgate(c, start, nq: t - c + 1, t - c, supplements: ((t, end),)))
+  }
+  gates
+}
+
+#let generate-multi-controlled-gate(controls, qubit, target) = {
+  let sort-ops(cs, q) = {
+    let k = cs.map(c => (c, gates.ctrl.with(0))) + ((q, target),)
+    k = k.sorted(key: x => x.first())
+    let n = k.last().at(0) - k.first().at(0)
+    if k.first().at(1) == gates.ctrl.with(0) { k.first().at(1) = gates.ctrl.with(n) }
+    else if k.last().at(1) == gates.ctrl.with(0) { k.at(2).at(1) = gates.ctrl.with(-n) }
+    return k
+  }
+  let gates = ()
+  controls = controls.map(c => if type(c) == int { (c,)} else { c })
+  if type(qubit) == int { qubit = (qubit,) }
+
+  for i in range(calc.max(qubit.len(), ..controls.map(array.len))) {
+    let q = qubit.at(i, default: qubit.last())
+    let cs = controls.map(c => c.at(i, default: c.last()))
+    assert((cs + (q,)).dedup().len() == cs.len() + 1, message: "Target and control qubits need to be all different (were " + str(q) + " and " + repr(cs) + ")")
+    let ops = sort-ops(cs, q)
+    gates.push(bgate(
+      ops.first().at(0), ops.first().at(1), 
+      nq: ops.last().at(0) - ops.first().at(0) + 1, 
+      supplements: ops.slice(1)
+    ))
+  }
+  gates
+}
+
+
+#let gate(qubit, ..args) = bgate(qubit, gates.gate, ..args)
+
+#let mqgate(qubit, n: 1, ..args) = {
+  bgate(qubit, nq: n, gates.mqgate, ..args.pos(), ..args.named() + (n: n))
+}
+
+#let barrier() = bgate(0, barrier)
+
+#let x(..qubit) = generate-single-qubit-gate(qubit, $X$)
+#let y(..qubit) = generate-single-qubit-gate(qubit, $Y$)
+#let z(..qubit) = generate-single-qubit-gate(qubit, $Z$)
+
+#let h(..qubit) = generate-single-qubit-gate(qubit, $H$)
+#let s(..qubit) = generate-single-qubit-gate(qubit, $S$)
+#let sdg(..qubit) = generate-single-qubit-gate(qubit, $S^dagger$)
+#let sx(..qubit) = generate-single-qubit-gate(qubit, $sqrt(X)$)
+#let sxdg(..qubit) = generate-single-qubit-gate(qubit, $sqrt(X)^dagger$)
+#let t(..qubit) = generate-single-qubit-gate(qubit, $T$)
+#let tdg(..qubit) = generate-single-qubit-gate(qubit, $T^dagger$)
+#let p(theta, ..qubit) = generate-single-qubit-gate(qubit, $P (#theta)$)
+
+#let rx(theta, ..qubit) = generate-single-qubit-gate(qubit, $R_x (#theta)$)
+#let ry(theta, ..qubit) = generate-single-qubit-gate(qubit, $R_y (#theta)$)
+#let rz(theta, ..qubit) = generate-single-qubit-gate(qubit, $R_z (#theta)$)
+
+#let u(theta, phi, lambda, ..qubit) = generate-single-qubit-gate(
+  qubit, $U (#theta, #phi, #lambda)$
+)
+
+#let meter(..qubit) = generate-single-qubit-gate(qubit, constructor: gates.meter)
+
+
+#let cx(control, target) = generate-two-qubit-gate(
+  control, target, gates.ctrl, gates.targ
+)
+#let cz(control, target) = generate-two-qubit-gate(
+  control, target, gates.ctrl, gates.ctrl.with(0)
+)
+#let swap(control, target) = generate-two-qubit-gate(
+  control, target, gates.swap, gates.swap.with(0)
+)
+#let ccx(control1, control2, target) = generate-multi-controlled-gate(
+  (control1, control2), target, gates.targ
+)
+#let cccx(control1, control2, control3, target) = generate-multi-controlled-gate(
+  (control1, control2, control3), target, gates.targ
+)
+#let ccz(control1, control2, target) = generate-multi-controlled-gate(
+  (control1, control2), target, gates.ctrl.with(0)
+)
+#let cca(control1, control2, target, content) = generate-multi-controlled-gate(
+  (control1, control2), target, gates.gate.with(content)
+)
+
+
+#let ca(control, target, content) = generate-two-qubit-gate(
+  control, target, gates.ctrl, gates.gate.with(content)
+)
+
+#let multi-controlled-gate(controls, qubit, target) = generate-multi-controlled-gate(
+  controls, qubit, target
+)
+
+
+/// Constructs a circuit from operation instructions. 
+/// 
+/// - n (auto, int): Number of qubits. Can be inferred automatically. 
+/// - x (int): Determines at which column the subcircuit will be put in the circuit. 
+/// - y (int): Determines at which row the subcircuit will be put in the circuit. 
+/// - append-wire (boolean): If set to `true`, the a last column of outgoing wires will be added. 
+/// - ..children (any): Sequence of instructions. 
+#let build(
+  n: auto, 
+  x: 1, 
+  y: 0,
+  append-wire: true,
+  ..children
+) = {
+  let operations = children.pos().flatten()
+  let num-qubits = n
+  if num-qubits == auto {
+    num-qubits = calc.max(..operations.map(x => x.qubit + calc.max(0, x.n - 1))) + 1
+  }
+  let tracks = ((),) * num-qubits
+  
+  for op in operations {
+    let start = op.qubit
+    // if start < 0 { start = num-qubits + start }
+    let end = start + op.n - 1
+    assert(start >= 0 and start < num-qubits, message: "The qubit `" + str(start) + "` is out of range. Leave `n` at `auto` if you want to automatically resize the circuit. ")
+    assert(end >= 0 and end < num-qubits, message: "The qubit `" + str(end) + "` is out of range. Leave `n` at `auto` if you want to automatically resize the circuit. ")
+    let (q1, q2) = (start, end).sorted()
+    if op.constructor == barrier {
+      (q1, q2) = (0, num-qubits - 1)
+    }
+    let max-track-len = calc.max(..tracks.slice(q1, q2 + 1).map(array.len))
+    let h = (q1, q2)
+    let h = (start,) + op.supplements.map(x => x.first())
+    for q in range(q1, q2 + 1) {
+      let dif = max-track-len - tracks.at(q).len()
+      if op.constructor != barrier and q not in h {
+         dif += 1
+      }
+      tracks.at(q) += (1,) * dif
+    }
+    if op.constructor != barrier {
+      tracks.at(start).push((op.constructor)(..op.args, x: x + tracks.at(start).len(), y: y + start))
+      for (qubit, supplement) in op.supplements {
+        tracks.at(qubit).push((supplement)(x: x + tracks.at(end).len(), y: y + qubit))
+      }
+    }
+  }
+  
+  let max-track-len = calc.max(..tracks.map(array.len)) + 1
+  for q in range(tracks.len()) {
+    tracks.at(q) += (1,) * (max-track-len - tracks.at(q).len())
+  }
+  
+  let num-cols = x + calc.max(..tracks.map(array.len)) - 2
+  if append-wire { num-cols += 1 }
+  let placeholder = gates.gate(
+    none, 
+    x: num-cols, y: y + num-qubits - 1, 
+    data: "placeholder", box: false, floating: true, 
+    size-hint: (it, i) => (width: 0pt, height: 0pt)
+  )
+
+  (placeholder,) + tracks.flatten().filter(x => type(x) != int) 
+}
+
+
+
+/// Constructs a graph state preparation circuit. 
+/// 
+/// - n (auto, int): Number of qubits. Can be inferred automatically. 
+/// - x (int): Determines at which column the subcircuit will be put in the circuit. 
+/// - y (int): Determines at which row the subcircuit will be put in the circuit. 
+/// - invert (boolean): If set to `true`, the circuit will be inverted, i.e., a circuit for
+///     "uncomputing" the corresponding graph state. 
+/// ..edges (array): 
+#let graph-state(
+  n: auto,
+  x: 1,
+  y: 0,
+  invert: false,
+  ..edges
+) = {
+  edges = edges.pos()
+  let max-qubit = 0
+  for edge in edges {
+    assert(type(edge) == array, message: "Edges need to be pairs of vertices")
+    assert(edge.len() == 2, message: "Every edge needs to have exactly two vertices")
+    max-qubit = calc.max(max-qubit, ..edge)
+  }
+  let num-qubits = max-qubit + 1
+  if n != auto {
+    num-qubits = n
+    assert(n > max-qubit, message: "")
+  }
+  let gates = (
+    h(range(num-qubits)),
+    barrier(),
+    edges.map(edge => cz(..edge))
+  )
+  if invert {
+    gates = gates.rev()
+  }
+  build(
+    x: x, y: y, 
+    ..gates
+  )
+}
+
+
+/// Template for the quantum fourier transform (QFT). 
+/// - n (auto, int): Number of qubits. 
+/// - x (int): Determines at which column the QFT routine will be placed in the circuit. 
+/// - y (int): Determines at which row the QFT routine will be placed in the circuit. 
+#let qft(
+  n, 
+  x: 1, 
+  y: 0
+) = {
+  let gates = ()
+  for i in range(n - 1) {
+    gates.push(h(i))
+    for j in range(2, n - i + 1) {
+      gates.push(ca(i + j - 1, i, $R_#j$))
+      gates.push(p(i + j - 1))
+    }
+    gates.push(barrier())
+  }
+  gates.push(h(n - 1))
+  build(n: n, x: x, y: y, ..gates)
+}

--- a/packages/preview/quill/0.5.0/src/tequila.typ
+++ b/packages/preview/quill/0.5.0/src/tequila.typ
@@ -1,0 +1,1 @@
+#import "tequila-impl.typ": build, h, gate, mqgate, x, y, z, cx, cz, s, sdg, sx, sxdg, t, tdg, p, rx, ry, rz, u, barrier, swap, meter, graph-state, qft, ccx, ccz, cca, cccx, multi-controlled-gate

--- a/packages/preview/quill/0.5.0/src/utility.typ
+++ b/packages/preview/quill/0.5.0/src/utility.typ
@@ -1,0 +1,56 @@
+
+#let if-none(a, b) = { if a != none { a } else { b } }
+#let if-auto(a, b) = { if a != auto { a } else { b } }
+#let is-gate(item) = { type(item) == dictionary and "gate-type" in item }
+#let is-circuit-drawable(item) = { is-gate(item) or type(item) in (str, content) }
+#let is-circuit-meta-instruction(item) = { type(item) == dictionary and "qc-instr" in item }
+
+
+
+// Get content from a gate or plain content item
+#let get-content(item, draw-params) = {
+  if is-gate(item) { 
+    if item.draw-function != none {
+      return (item.draw-function)(item, draw-params)
+    }
+  } else { return item }
+}
+
+// Get size hint for a gate or plain content item
+#let get-size-hint(item, draw-params) = {
+  if is-gate(item) { 
+    return (item.size-hint)(item, draw-params) 
+  } 
+  measure(item)
+}
+
+
+// Creates a sized brace with given length. 
+// `brace` can be auto, defaulting to "{" if alignment is right
+// and "}" if alignment is left. Other possible values are 
+// "[", "]", "|", "{", and "}".
+#let create-brace(brace, alignment, length) = {
+  if brace == auto {
+    brace = if alignment == right {"{"} else {"}"} 
+  }
+  return $ lr(#brace, size: length) $
+}
+
+/// Updates the first stroke with the second, i.e., returns the second stroke but all 
+/// fields that are auto are inherited from the first stroke. 
+/// If the second stroke is none, returns none. 
+#let update-stroke(stroke1, stroke2) = {
+  let if-not-auto(a, b) = if b == auto {a} else {b}
+  if stroke2 == none { return none }
+  if stroke2 == auto { return stroke1 }
+  if stroke1 == none { stroke1 = stroke() }
+  let s1 = stroke(stroke1)
+  let s2 = stroke(stroke2)
+  let paint = if-not-auto(s1.paint, s2.paint)
+  let thickness = if-not-auto(s1.thickness, s2.thickness)
+  let cap = if-not-auto(s1.cap, s2.cap)
+  let join = if-not-auto(s1.join, s2.join)
+  let dash = if-not-auto(s1.dash, s2.dash)
+  let miter-limit = if-not-auto(s1.miter-limit, s2.miter-limit)
+  return stroke(paint: paint, thickness: thickness, cap: cap, join: join, dash: dash, miter-limit: miter-limit)
+}

--- a/packages/preview/quill/0.5.0/src/verifications.typ
+++ b/packages/preview/quill/0.5.0/src/verifications.typ
@@ -1,0 +1,81 @@
+#let plural-s(n) = if n == 1 { "" } else { "s" }
+
+#let verify-controlled-gate(gate, x, y, circuit-rows, circuit-cols) = {
+  let multi = gate.multi
+  if y + multi.target >= circuit-rows or y + multi.target < 0 {
+    assert(false, message: 
+      "A controlled gate starting at qubit " + str(y) + 
+      " with relative target " + str(multi.target) + 
+      " exceeds the circuit which has only " + str(circuit-rows) + 
+      " qubit" + plural-s(circuit-rows)
+    )
+  }
+}
+
+
+#let verify-mqgate(gate, x, y, circuit-rows, circuit-cols) = {
+  let nq = gate.multi.num-qubits
+  if y + nq - 1 >= circuit-rows {
+    assert(false, message: 
+      "A " + str(nq) + "-qubit gate starting at qubit " + 
+      str(y) + " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubits"
+    )
+  }
+}
+
+#let verify-slice(slice, x, y, circuit-rows, circuit-cols) = {
+  if slice.wires < 0 {
+    assert(false, message: "`slice`: The number of wires needs to be > 0 (is " + str(slice.wires) + ")")
+  }
+  if y + slice.wires > circuit-rows {
+    assert(false, message: 
+      "A `slice` starting at qubit " + str(y) + 
+      " spanning " + str(slice.wires) + 
+      " qubit" + plural-s(slice.wires) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubit" + plural-s(circuit-rows)
+    )
+  }
+}
+
+
+#let verify-gategroup(gategroup, x, y, circuit-rows, circuit-cols) = {
+  if gategroup.wires <= 0 {
+    assert(false, message: "`gategroup`: The number of wires needs to be > 0 (is " + str(gategroup.wires) + ")")
+  }
+  if gategroup.steps <= 0 {
+    assert(false, message: "`gategroup`: The number of steps needs to be > 0 (is " + str(gategroup.steps) + ")")
+  }
+  if y + gategroup.wires > circuit-rows {
+    assert(false, message: 
+      "A `gategroup` at qubit " + str(y) + 
+      " spanning " + str(gategroup.wires) + 
+      " qubit" + plural-s(gategroup.wires) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubit" + plural-s(circuit-rows)
+    )
+  }
+  if x + gategroup.steps > circuit-cols {
+    assert(false, message: 
+      "A `gategroup` at column " + str(x) + 
+      " spanning " + str(gategroup.steps) + 
+      " column" + plural-s(gategroup.steps) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-cols) + " column" + plural-s(circuit-cols)
+    )
+  }
+}
+
+#let verify-annotation-content(annotation-content) = {
+  let content-type = type(annotation-content)
+  assert(content-type in (content, str, dictionary), message: "`annotate`: Unsupported callback return type `" + str(content-type) + "` (can be `dictionary` or `content`")
+
+  if content-type == dictionary {
+    assert("content" in annotation-content, message: "`annotate`: Missing field `content` in annotation. If the callback returns a dictionary, it must contain the key `content` and may specify coordinates with `dx` and `dy`.")
+    if "z" in annotation-content {
+      let z = annotation-content.z
+      assert(z in ("below", "above"), message: "`annotate`: The parameter `z` can take the values `\"above\"` and `\"below\"`")
+    }
+  }
+}

--- a/packages/preview/quill/0.5.0/typst.toml
+++ b/packages/preview/quill/0.5.0/typst.toml
@@ -1,0 +1,14 @@
+[package]
+name = "quill"
+version = "0.5.0"
+entrypoint = "src/quill.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Effortlessly create quantum circuit diagrams."
+compiler = "0.11.0"
+
+repository = "https://github.com/Mc-Zen/quill"
+keywords = ["quantum circuit diagram", "quantikz", "qcircuit"]
+categories = ["visualization"]
+disciplines = ["physics", "computer-science"]
+exclude = ["/docs/*"]


### PR DESCRIPTION

I am submitting
- [x] an update for a package

This release 
- adds support for multi-controlled gates with Tequila. 
- switches to using `context` instead of the now deprecated `style()` for measurement. 

Note: Starting with this version, Typst 0.11.0 or higher is required. 