### PR TITLE
droplet:0.3.0

### DIFF
--- a/packages/preview/droplet/0.3.0/LICENSE
+++ b/packages/preview/droplet/0.3.0/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Eric Biedert
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/droplet/0.3.0/README.md
+++ b/packages/preview/droplet/0.3.0/README.md
@@ -1,0 +1,81 @@
+# droplet
+
+A package for creating dropped capitals.
+
+## Usage
+
+This package exports a single `dropcap` function that is used to create dropped capitals. The function takes one or two positional arguments, and several optional keyword arguments for customization:
+
+| Parameter        | Type                          | Description                                               | Default |
+|------------------|-------------------------------|-----------------------------------------------------------|---------|
+| `height`         | `integer`, `length`, `auto`   | The height of the dropped capital.                        | `2`     |
+| `justify`        | `boolean`, `auto`             | Whether the text should be justified.                     | `auto`  |
+| `gap`            | `length`                      | The space between the dropped capital and the text.       | `0pt`   |
+| `hanging-indent` | `length`                      | The indent of lines after the first.                      | `0pt`   |
+| `overhang`       | `length`, `relative`, `ratio` | How much the dropped capital should hang into the margin. | `0pt`   |
+| `depth`          | `integer`, `length`           | The space below the dropped capital.                      | `0pt`   |
+| `transform`      | `function`, `none`            | A function to be applied to the dropped capital.          | `none`  |
+| `..text-args`    |                               | How to style the `text` of the dropped capital.           |         |
+
+Some parameters allow values of different types for maximum flexibility:
+
+- If `height` is given as an integer, it is interpreted as a number of lines. If given as `auto`, the dropped capital will not be scaled and remain at its original size.
+- If `overhang` has a relative part, it is resolved relative to the width of the dropped capital.
+- If `depth` is given as an integer, it is interpreted as a number of lines.
+- The `transform` function takes the extracted or passed dropped capital and returns the content to be shown.
+
+If two positional arguments are given, the first is used as the dropped capital, and the second as the text. If only one argument is given, the dropped capital is automatically extracted from the text.
+
+### Extraction
+
+If no explicit dropped capital is passed, it is extracted automatically. For this to work, the package looks into the content making up the first paragraph and extracts the first letter of the first word. This letter is then split off from the rest of the text and used as the dropped capital. There are some special cases to consider:
+
+- If the first element of the paragraph is a `box`, the whole box is used as the dropped capital.
+- If the first element is a list or enum item, it is assumed that the literal meaning of the list or enum syntax was intended, and the number or bullet is used as the dropped capital.
+
+Affixes, such as punctuation, super- and subscripts, quotes, and spaces will also be detected and stay with the dropped capital.
+
+### Paragraph Splitting
+
+To wrap the text around the dropped capital, the paragraph is split into two parts: the part next to the dropped capital and the part after it. As Typst doesn't natively support wrapping text around an element, this package splits the paragraph at word boundaries and tries to fit as much in the first part as possible. This approach comes with some limitations:
+
+- The paragraph is split at word boundaries, which makes hyphenation across the split impossible.
+- Some elements cannot be properly split, such as containers, lists, and context expressions.
+- The approach uses a greedy algorithm, which might not always find the optimal split.
+- If the split happens at a block element, the spacing between the two parts might be off.
+
+To determine whether an elements fits into the first part, the position of top edge of the element is crucial. If the top edge is above the baseline of the dropped capital, the element is considered to be part of the first part. This means that elements with a large height will be part of the first part. This is done to avoid gaps between the two parts of the paragraph.
+
+### Styling
+
+In case you wish to style the dropped capital more than what is possible with the arguments of the `text` function, you can use a `transform` function. This function takes the extracted or passed dropped capital and returns the content to be shown. The function is provided with the context of the dropped capital.
+
+Note that when using `em` units, they are resolved relative to the font size of the dropped capital. When the dropped capital is scaled to fit the given `height` parameter, the font size is adjusted so that the _bounds_ of the transformed content match the given height. For that, the `top-edge` and `bottom-edge` parameters of `text-args` are set to `bounds` by default.
+
+## Example
+
+```typ
+#import "@preview/droplet:0.3.0": dropcap
+
+#set par(justify: true)
+
+#dropcap(
+  height: 3,
+  gap: 4pt,
+  hanging-indent: 1em,
+  overhang: 8pt,
+  font: "Curlz MT",
+)[
+  *Typst* is a new markup-based typesetting system that is designed to be as
+  _powerful_ as LaTeX while being _much easier_ to learn and use. Typst has:
+
+  - Built-in markup for the most common formatting tasks
+  - Flexible functions for everything else
+  - A tightly integrated scripting system
+  - Math typesetting, bibliography management, and more
+  - Fast compile times thanks to incremental compilation
+  - Friendly error messages in case something goes wrong
+]
+```
+
+![Result of example code.](assets/example.svg)

--- a/packages/preview/droplet/0.3.0/assets/example.svg
+++ b/packages/preview/droplet/0.3.0/assets/example.svg
@@ -1,0 +1,684 @@
+<svg class="typst-doc" viewBox="0 0 327.81102362204723 282.96799999999996" width="327.81102362204723pt" height="282.96799999999996pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <g>
+        <g transform="translate(0.5 0.5)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-0 -0)">
+                        <path class="typst-shape" fill="#ffffff" fill-rule="nonzero" d="M 0 3.5 C 0 1.5670034 1.5670034 0 3.5 0 L 323.31104 0 C 325.24402 0 326.81104 1.5670034 326.81104 3.5 L 326.81104 278.468 C 326.81104 280.401 325.24402 281.968 323.31104 281.968 L 3.5 281.968 C 1.5670034 281.968 0 280.401 0 278.468 Z "/>
+                    </g>
+                    <g transform="translate(-0 -0)">
+                        <path class="typst-shape" fill="none" stroke="#e6e6e6" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 3.5 0 L 323.31104 0 C 325.24402 0 326.81104 1.5670034 326.81104 3.5 L 326.81104 278.468 C 326.81104 280.401 325.24402 281.968 323.31104 281.968 L 3.5 281.968 C 1.5670034 281.968 0 280.401 0 278.468 L 0 3.5 C 0 1.5670034 1.5670034 0 3.5 0 "/>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(22 14)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-8 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 45.44037484586929)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g1BAC3AE01942301927DD19B9102A2BC9" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(23.495948212083846 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 9.212)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g265637C9307382B48DC9BDE1B287525A" x="0" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g37A3ACAD7D276BCAFA33F00B556DE78C" x="7.812000000000001" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g70533EB769C0E098F9AA53B64E6AFEE8" x="15.946000000000002" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gA5FC0CBE7FC3DD0E47B04F2814C04F45" x="21.924" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(26.936 9.212)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="4.59861256832723" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="8.39261256832723" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="18.45122513665446" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="29.44783770498169" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="37.03583770498169" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g147A4F8094A171354C3770BA2E8E0851" x="43.195837704981685" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="58.25245027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="69.31245027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="75.71045027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g943EEFA5114B464FF389239628F645F4" x="80.9184502733089" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g8374945ABC56B1CB80F6E92B63EFD1BA" x="88.08645027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="95.52045027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g62E1080388B5DBD637C6963B92460B41" x="102.78645027330892" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gF6ED3E3A4C7BDD0FB480DBED2709CF64" x="107.51845027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="114.42045027330892" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="120.81845027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="126.27845027330892" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="132.63445027330891" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="144.31706284163616" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="148.74106284163616" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="155.95106284163617" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="163.31506284163618" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="169.5730628416362" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="175.0330628416362" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="181.2910628416362" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="185.7150628416362" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="190.13906284163622" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="193.93306284163623" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="201.52106284163622" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="213.11967540996346" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="218.57967540996347" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="225.78967540996348" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g62E1080388B5DBD637C6963B92460B41" x="231.2496754099635" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(14 27.523999999999997)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="0" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="4.4239999999999995" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="10.681999999999999" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="27.338384426245423" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="31.762384426245422" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="39.29438442624542" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="45.692384426245425" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="55.712768852490846" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="59.50676885249084" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="70.56315327873627" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="77.64715327873627" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="83.90515327873626" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="89.36515327873627" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="93.15915327873627" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="100.15915327873627" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="107.74715327873626" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="114.10315327873626" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="126.78353770498168" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="131.2075377049817" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gF6ED3E3A4C7BDD0FB480DBED2709CF64" x="143.85992213122714" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="150.90192213122714" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="162.75630655747258" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="169.15430655747258" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(194.2106909837179 27.523999999999997)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g85BDD712C85B3D7E57093744806CCEE9" x="0" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gA15578292FAA67611F31F457DC97EF81" x="6.944" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g911D42E87675C61034F7A23E20BFF690" x="13.104" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g3A2F313727CD3350B0CFD3739DCF60C6" x="22.624000000000002" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g25F7A97075E390B81E06DD29CDF9FECF" x="28.238000000000003" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gEEFC3CE3163D3191E855D71C43BAE018" x="33.236000000000004" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g874F7DB99721F0FD04327E6823649975" x="37.632000000000005" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gCCD8A86A404CEDB1A7227180A29B8B9E" x="44.926" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(242.86069098371792 27.523999999999997)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="5.596384426245424" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="11.994384426245425" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(14 45.836)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g5E3B6DB72A626BEAD3D22ECB3CC2C4" x="0" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="7.392" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g81B043E4203D1DA3EF1B86C5164A7916" x="13.790000000000001" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="21.266000000000002" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g9179B2D2A9E200466DE2606DE51A4BDE" x="27.524" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g147A4F8094A171354C3770BA2E8E0851" x="39.85386791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="50.31186791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="57.84386791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="61.63786791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="65.33386791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gF6ED3E3A4C7BDD0FB480DBED2709CF64" x="74.68173583141811" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="81.72373583141811" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="87.9817358314181" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="91.7757358314181" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="99.3637358314181" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(123.45360374712716 45.836)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#gC051A57B8B21E8A5F22AD17806E736A9" x="0" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g874F7DB99721F0FD04327E6823649975" x="10.962" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gE81C33119EC92ECA818F9DC958FE0512" x="18.256" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g9FBAF428159CD209BE9BC892D5BE4A21" x="23.702" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g3A2F313727CD3350B0CFD3739DCF60C6" x="34.05786791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g4E7ED7F4D503F18CB9F87E4084765759" x="39.67186791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gC921DA4C2505E536B143666DAB5BB97D" x="46.47586791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gE24BC04FAC9B34AC1945A99047F7540D" x="51.41786791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g3A2F313727CD3350B0CFD3739DCF60C6" x="55.28186791570906" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g25F7A97075E390B81E06DD29CDF9FECF" x="60.89586791570906" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(189.34747166283623 45.836)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="3.089867915709057" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="7.513867915709056" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="17.659735831418114" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="21.355735831418116" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="27.613735831418115" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="34.011735831418115" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="39.21973583141811" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="49.89760374712717" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="56.295603747127174" fill="#000000" fill-rule="nonzero"/>
+                                        <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="63.883603747127175" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(22 78.14799999999998)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8374945ABC56B1CB80F6E92B63EFD1BA" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="7.434" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="12.894000000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE1DB41F6D9C511CA82E0B4ADC07DE267" x="19.012" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g81B043E4203D1DA3EF1B86C5164A7916" x="25.592" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="33.263999999999996" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="40.474" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="47.739999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="53.199999999999996" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="61.123999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="68.65599999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="75.05399999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD0DF5A8CDB09E39896B947740CC03A5E" x="80.51399999999998" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(22 94.948)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 9.212)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g584E4A5E8B2E44892DDE3A1C7F192E4E" x="0" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 9.212)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g6086AF707F869D2968A3D14EE379050A" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g8374945ABC56B1CB80F6E92B63EFD1BA" x="8.232" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="15.666" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="19.46" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="23.156000000000002" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g62E1080388B5DBD637C6963B92460B41" x="27.580000000000002" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="32.312000000000005" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="36.106" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="48.76460393700787" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="59.82460393700787" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="66.22260393700788" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g943EEFA5114B464FF389239628F645F4" x="71.43060393700787" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g8374945ABC56B1CB80F6E92B63EFD1BA" x="78.59860393700788" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="86.03260393700788" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE49CB035CF1BC9F0FC3F7067B630D8D5" x="98.36920787401576" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="102.70920787401576" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="109.76520787401576" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="120.04381181102363" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="124.46781181102364" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="131.99981181102365" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="143.32841574803152" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="154.38841574803152" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="161.44441574803153" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="166.90441574803154" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="176.3990196850394" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="182.3910196850394" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="189.4470196850394" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="200.5070196850394" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="211.5670196850394" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="218.62301968503942" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE49CB035CF1BC9F0FC3F7067B630D8D5" x="231.28162362204728" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="235.62162362204728" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="242.6776236220473" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="247.8856236220473" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="258.94562362204726" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="265.3436236220473" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g62E1080388B5DBD637C6963B92460B41" x="269.76762362204727" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 27.523999999999997)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="4.4239999999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="8.218" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="15.806000000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="26.306" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="30.73" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="37.128" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g943EEFA5114B464FF389239628F645F4" x="42.588" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="49.756" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 45.836)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g584E4A5E8B2E44892DDE3A1C7F192E4E" x="0" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 45.836)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g410AF3236A945D009F63FCA8D3C4D09F" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="6.957999999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="10.654" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gAFB665305D4754FAECAE9C74D0DCDD8D" x="16.814" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="23.674" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF6ED3E3A4C7BDD0FB480DBED2709CF64" x="27.468" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="34.37" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="38.065999999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE49CB035CF1BC9F0FC3F7067B630D8D5" x="47.824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g8374945ABC56B1CB80F6E92B63EFD1BA" x="52.164" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="59.598" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="67.18599999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="73.178" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="77.602" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="81.396" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="88.452" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="96.03999999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE49CB035CF1BC9F0FC3F7067B630D8D5" x="105" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="109.34" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="116.396" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="125.104" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g41F65FF5CDEFC395FC08320CDD4280E3" x="131.264" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="138.11" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="144.36800000000002" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="149.78600000000003" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="156.99600000000004" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="161.42000000000004" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="168.95200000000006" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="172.74600000000007" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="180.33400000000006" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="190.83400000000006" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="197.09200000000007" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="200.78800000000007" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="206.24800000000008" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 64.148)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g584E4A5E8B2E44892DDE3A1C7F192E4E" x="0" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 64.148)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#gCE992FDD00F82896D12588559411C0E3" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="13.229999999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="17.653999999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="21.447999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="28.447999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="35.98" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="40.403999999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="44.099999999999994" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="54.809999999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="58.60399999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="66.192" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="70.61599999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="76.87399999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="83.87399999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="89.08199999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="95.47999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="99.90399999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="106.25999999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="116.84399999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="122.30399999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="128.29599999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="133.50399999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="137.29799999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="144.56399999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="148.98799999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="152.78199999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="160.36999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="170.86999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="176.32999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="183.54" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="189" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="193.424" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="199.68200000000002" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 82.45999999999998)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g584E4A5E8B2E44892DDE3A1C7F192E4E" x="0" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 82.45999999999998)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g84EC738B8C4742CF902A4A9BE36FFAC5" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="11.746" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="18.144000000000002" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="22.568" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="39.13567454068241" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="43.55967454068241" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="50.76967454068241" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="58.13367454068241" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="64.3916745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="69.85167454068241" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="76.1096745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="80.5336745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="84.9576745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="88.7516745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="96.3396745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5BF4044AE3C1666C4DF98B6347561756" x="103.3396745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF6ED3E3A4C7BDD0FB480DBED2709CF64" x="115.4553490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="122.3573490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF6ED3E3A4C7BDD0FB480DBED2709CF64" x="126.1513490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="133.0533490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="136.74934908136478" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="140.5433490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="147.5993490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="154.5993490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="159.8073490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="166.2053490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="173.4713490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="181.0033490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="197.24902362204722" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="208.30902362204722" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="214.70702362204722" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="222.2950236220472" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="228.6930236220472" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="235.6930236220472" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="241.95102362204722" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="253.01102362204722" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="259.2690236220472" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="266.8570236220472" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5BF4044AE3C1666C4DF98B6347561756" x="271.2810236220472" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 100.77199999999999)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="6.398000000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="13.986" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="24.57" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="35.63" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="42.686" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="47.782" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 119.08399999999999)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g584E4A5E8B2E44892DDE3A1C7F192E4E" x="0" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 119.08399999999999)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g410AF3236A945D009F63FCA8D3C4D09F" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="6.789999999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="13.187999999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="18.648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="27.783270603674527" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="33.77527060367453" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="40.831270603674525" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="51.89127060367453" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="59.157270603674526" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="62.95127060367452" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="66.64727060367453" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="77.61654120734906" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="82.04054120734907" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="85.83454120734906" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="96.89454120734906" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="103.15254120734906" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="113.3238118110236" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="117.74781181102361" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="125.2798118110236" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="131.67781181102362" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g943EEFA5114B464FF389239628F645F4" x="139.2658118110236" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="146.43381181102362" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="156.60508241469816" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="161.02908241469817" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="172.7963530183727" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="176.59035301837272" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="184.17835301837272" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="190.1703530183727" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="195.2663530183727" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="201.52435301837272" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="212.58435301837272" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="218.84235301837273" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="226.43035301837273" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="230.85435301837273" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="237.25235301837273" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="245.65962362204726" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="251.65162362204725" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="258.70762362204727" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g62E1080388B5DBD637C6963B92460B41" x="269.76762362204727" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 137.396)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#gDC08E99E334A3F3C073A58E3F6EA9E5A" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="7.266" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="11.06" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="14.756" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="21.154" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="25.578" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="29.372" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="36.428" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(0 155.70799999999997)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g584E4A5E8B2E44892DDE3A1C7F192E4E" x="0" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 155.70799999999997)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g410AF3236A945D009F63FCA8D3C4D09F" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="6.789999999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="11.997999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="15.791999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="22.049999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g70290CF8D2D4763544A0F69644596675" x="29.637999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g926640D8B940E5DE31F42E464FE476CE" x="36.721999999999994" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD0417A6D802086877AC24BBA53182BA1" x="40.41799999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="51.05383727034119" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="57.311837270341194" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="62.51983727034119" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="67.61583727034119" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="74.67183727034119" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="83.30567454068238" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="94.36567454068238" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="100.62367454068237" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="106.08367454068238" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="111.54367454068239" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="117.94167454068238" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="124.94167454068238" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="131.1996745406824" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="140.0855118110236" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="143.8795118110236" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g86335E45CA2AED4A1909A1DE015CEE2B" x="154.8933490813648" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7E978C86F36CD586F6CAC7ED4046B3D8" x="160.88534908136478" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="167.28334908136478" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="172.74334908136478" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="182.42718635170598" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="187.887186351706" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gF3D78E78501FAC01B2F36E974C2BF074" x="194.943186351706" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="206.003186351706" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g189C5CFDD5D480E2901FE16D1E1EFDDC" x="212.26118635170602" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52AA783804DF8664DF2EF6EF41B2695C" x="216.68518635170602" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC0F2F63A6FD3BEEDAB48B98990735B48" x="224.21718635170603" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="228.01118635170604" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="235.59918635170604" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="246.02502362204723" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="253.02502362204723" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7066C9289A7FC07D0D387BA4B25B33D8" x="260.1790236220472" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g61D3EAF02DD9B6CC5405574B12D6BBAF" x="266.4370236220472" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(11.914 174.01999999999998)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g147A4F8094A171354C3770BA2E8E0851" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gCCC0E72C8F14AA9907A44072C330848C" x="10.458" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1645756238B1E9533FEDE0CA8FAF4667" x="15.554" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5B78D483D83797DE607A804E62A98151" x="22.61" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD14925D751EE471FE91EC7AFC9100DF" x="30.198" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <defs id="glyph">
+        <symbol id="g1BAC3AE01942301927DD19B9102A2BC9" overflow="visible">
+            <path d="M 19.668222 40.636356 Q 19.498669 40.918945 19.498669 41.229794 Q 19.498669 41.766712 19.964941 42.176468 Q 20.431213 42.586224 20.939875 42.586224 Q 21.900679 42.586224 22.66367 41.89388 Q 23.42666 41.201534 23.42666 40.52332 Q 23.42666 39.19515 22.253916 38.14957 Q 21.08117 37.10399 19.498669 37.10399 Q 17.803133 37.10399 16.573868 38.248474 Q 15.3446045 39.392963 15.3446045 40.975464 Q 15.3446045 42.529705 17.280342 43.98504 Q 19.21608 45.440376 21.928938 45.440376 Q 24.670055 45.440376 27.001417 43.829617 Q 29.33278 42.218857 29.33278 39.929882 Q 29.33278 36.28448 26.323202 34.433517 Q 23.313625 32.582558 15.3446045 31.706532 Q 15.570676 25.06568 15.570676 20.487732 Q 15.570676 14.553354 15.033756 1.5542417 Q 19.583447 1.5542417 22.40934 2.7128582 L 22.40934 0.932545 Q 18.42483 0.33910728 14.12947 0.22607152 Q 12.660006 0.16955364 10.003665 -0.39562517 L 10.003665 1.1586165 L 13.536033 1.384688 Q 13.536033 7.064735 12.631746 16.912975 Q 11.72746 26.761217 10.597102 31.084835 Q 7.0082173 30.350101 -0.05651788 29.64363 L 0.33910728 24.302689 L -1.1586165 24.133135 Q -1.3564291 29.163227 -1.9781258 31.819567 L -0.5086609 32.0739 L -0.2825894 30.915281 Q 7.4886193 31.593494 14.581614 32.865147 Q 21.674606 34.1368 24.175524 35.789948 Q 26.67644 37.443096 26.67644 40.52332 Q 26.67644 42.303635 25.362398 43.46225 Q 24.048359 44.620865 21.815903 44.620865 Q 20.2334 44.620865 18.820454 43.50464 Q 17.407507 42.38841 17.407507 40.975464 Q 17.407507 39.873363 18.12811 38.8843 Q 18.848713 37.895237 19.781258 37.895237 Q 20.79858 37.895237 21.392017 38.488678 Q 21.985455 39.082115 21.985455 39.929882 Q 21.985455 40.353767 21.674606 40.77765 Q 21.363758 41.201534 20.883356 41.201534 Q 20.459473 41.201534 19.668222 40.636356 Z "/>
+        </symbol>
+        <symbol id="g265637C9307382B48DC9BDE1B287525A" overflow="visible">
+            <path d="M 3.388 -2.352 C 3.6120002 -1.96 3.822 -1.4560001 3.99 -1.036 C 5.11 1.666 5.796 3.1780002 6.538 4.7460003 C 6.734 5.152 7.1540003 5.586 7.6720004 5.6280003 C 7.756 5.7120004 7.756 6.02 7.6720004 6.104 C 7.322 6.09 7.07 6.076 6.678 6.076 C 6.188 6.076 5.7120004 6.09 5.1940002 6.104 C 5.11 6.02 5.11 5.7120004 5.1940002 5.6280003 C 5.642 5.586 6.09 5.5160003 5.866 5.012 L 4.4240003 1.778 C 4.4240003 1.764 4.4240003 1.764 4.4100003 1.75 C 4.4100003 1.764 4.4100003 1.778 4.396 1.8060001 L 3.094 4.7320004 C 3.0800002 4.7460003 3.0800002 4.76 3.0800002 4.774 C 2.828 5.32 2.73 5.558 3.556 5.6280003 C 3.64 5.7120004 3.64 6.02 3.556 6.104 C 3.038 6.09 2.198 6.076 1.694 6.076 C 1.218 6.076 0.42000002 6.09 0.14 6.104 C 0.056 6.02 0.056 5.7120004 0.14 5.6280003 C 0.75600004 5.572 0.86800003 5.474 1.246 4.592 L 3.052 0.448 C 3.094 0.37800002 3.15 0.322 3.1920002 0.266 C 3.374 0.014 3.528 -0.19600001 3.444 -0.39200002 L 3.108 -1.1620001 C 2.926 -1.5960001 2.7580001 -1.848 2.3660002 -1.848 C 2.114 -1.848 2.072 -1.792 1.876 -1.792 C 1.3440001 -1.792 1.036 -2.1560001 1.036 -2.436 C 1.036 -2.618 1.0780001 -2.842 1.204 -2.996 C 1.33 -3.15 1.5680001 -3.2480001 1.75 -3.2480001 C 1.932 -3.2480001 2.352 -3.1920002 2.548 -3.108 C 2.842 -2.9680002 3.2340002 -2.632 3.388 -2.352 Z "/>
+        </symbol>
+        <symbol id="g37A3ACAD7D276BCAFA33F00B556DE78C" overflow="visible">
+            <path d="M 1.33 4.326 L 1.33 -1.5400001 C 1.33 -2.7020001 1.176 -2.73 0.322 -2.8000002 C 0.238 -2.884 0.238 -3.1920002 0.322 -3.276 C 0.91 -3.262 1.498 -3.2480001 2.24 -3.2480001 C 2.982 -3.2480001 3.556 -3.262 4.158 -3.276 C 4.242 -3.1920002 4.242 -2.884 4.158 -2.8000002 C 3.3040001 -2.7440002 3.15 -2.7020001 3.15 -1.5400001 L 3.15 0.098000005 C 3.4580002 -0.056 3.752 -0.14 4.0880003 -0.14 C 6.216 -0.14 7.602 1.26 7.602 3.318 C 7.602 4.102 7.308 4.9700003 6.762 5.5160003 C 6.2720003 6.006 5.572 6.216 4.8440003 6.216 C 4.438 6.216 3.6820002 5.7260003 3.1920002 5.2780004 L 3.108 5.2780004 C 3.0800002 5.67 3.038 5.978 3.038 5.978 C 3.0240002 6.1460004 2.9120002 6.216 2.716 6.216 C 2.198 6.076 1.358 5.88 0.39200002 5.754 C 0.36400002 5.67 0.39200002 5.3900003 0.42000002 5.306 C 1.19 5.236 1.33 5.124 1.33 4.326 Z M 3.15 0.91 L 3.15 4.494 C 3.15 4.578 3.15 4.6480002 3.15 4.7320004 C 3.556 5.096 4.0740004 5.2780004 4.396 5.2780004 C 4.9700003 5.2780004 5.642 4.578 5.642 2.94 C 5.642 1.764 5.222 0.448 4.004 0.448 C 3.8500001 0.448 3.5 0.532 3.15 0.91 Z "/>
+        </symbol>
+        <symbol id="g70533EB769C0E098F9AA53B64E6AFEE8" overflow="visible">
+            <path d="M 0.67200005 2.0440001 C 0.72800004 1.358 0.79800004 0.70000005 0.91 0.16800001 C 1.176 0.08400001 2.072 -0.14 2.8560002 -0.14 C 3.934 -0.14 5.2780004 0.448 5.2780004 1.666 C 5.2780004 2.142 5.1660004 2.52 4.8440003 2.8700001 C 4.452 3.318 3.864 3.6680002 3.22 3.9480002 C 2.66 4.1860003 2.464 4.6340003 2.464 5.04 C 2.464 5.362 2.73 5.6280003 3.1360002 5.6280003 C 3.6260002 5.6280003 4.102 5.1800003 4.452 4.326 C 4.704 4.284 4.8580003 4.2980003 4.998 4.396 C 4.998 4.9 4.9420004 5.432 4.816 5.88 C 4.368 6.076 4.018 6.216 3.2480001 6.216 C 2.506 6.216 1.8060001 5.9360003 1.358 5.4880004 C 1.036 5.1660004 0.882 4.774 0.882 4.396 C 0.882 3.976 1.0500001 3.64 1.316 3.3460002 C 1.75 2.8700001 2.52 2.38 2.94 2.184 C 3.5 1.932 3.654 1.4280001 3.654 1.092 C 3.654 0.644 3.206 0.40600002 2.828 0.40600002 C 2.198 0.40600002 1.526 1.0500001 1.232 2.072 C 1.008 2.114 0.896 2.1000001 0.67200005 2.0440001 Z "/>
+        </symbol>
+        <symbol id="gA5FC0CBE7FC3DD0E47B04F2814C04F45" overflow="visible">
+            <path d="M 0.882 6.076 C 0.68600005 6.076 0.476 6.02 0.294 5.866 L 0.294 5.46 C 0.294 5.3900003 0.308 5.3760004 0.36400002 5.3760004 L 1.274 5.3760004 C 1.246 3.9620001 1.232 2.17 1.232 1.47 C 1.232 0.98 1.358 0.504 1.6520001 0.252 C 1.9740001 -0.014 2.4780002 -0.14 2.8140001 -0.14 C 3.584 -0.14 4.438 0.252 4.718 0.644 C 4.718 0.81200004 4.6340003 0.896 4.466 1.036 C 4.284 0.896 3.934 0.84000003 3.6680002 0.84000003 C 3.3600001 0.84000003 3.052 1.0780001 3.052 1.778 C 3.052 2.4780002 3.038 3.976 3.038 5.3760004 L 4.452 5.3760004 C 4.592 5.3760004 4.788 5.432 4.788 5.558 L 4.788 5.992 C 4.788 6.0480003 4.7460003 6.076 4.676 6.076 L 3.038 6.076 L 3.052 6.552 C 3.0800002 7.4900002 3.122 8.134 3.122 8.134 C 3.122 8.218 3.0800002 8.26 3.01 8.26 C 2.9120002 8.26 2.394 8.106 2.17 8.008 C 1.932 7.9100003 1.526 7.826 1.4280001 7.7000003 C 1.33 7.5740004 1.274 7.196 1.274 6.076 Z "/>
+        </symbol>
+        <symbol id="gC0F2F63A6FD3BEEDAB48B98990735B48" overflow="visible">
+            <path d="M 2.5340002 1.7080001 L 2.5340002 4.494 C 2.5340002 5.1940002 2.5900002 6.09 2.5900002 6.09 C 2.5900002 6.1460004 2.52 6.188 2.408 6.188 C 2.016 6.0340004 1.4560001 5.908 0.49 5.782 C 0.462 5.698 0.49 5.474 0.518 5.3900003 C 1.288 5.32 1.4280001 5.236 1.4280001 4.438 L 1.4280001 1.7080001 C 1.4280001 0.546 1.274 0.504 0.42000002 0.43400002 C 0.33600003 0.35000002 0.33600003 0.056 0.42000002 -0.028 C 0.882 -0.014 1.4280001 0 1.988 0 C 2.548 0 3.0800002 -0.014 3.542 -0.028 C 3.6260002 0.056 3.6260002 0.35000002 3.542 0.43400002 C 2.6880002 0.49 2.5340002 0.546 2.5340002 1.7080001 Z M 1.26 8.386001 C 1.26 8.022 1.5960001 7.6580005 1.932 7.6580005 C 2.3240001 7.6580005 2.66 8.036 2.66 8.33 C 2.66 8.666 2.3660002 9.058001 1.988 9.058001 C 1.6520001 9.058001 1.26 8.722 1.26 8.386001 Z "/>
+        </symbol>
+        <symbol id="g61D3EAF02DD9B6CC5405574B12D6BBAF" overflow="visible">
+            <path d="M 0.67200005 1.932 C 0.72800004 1.246 0.77000004 0.588 0.77000004 0 C 0.91 0.028 1.0500001 0.042000003 1.12 0.042000003 C 1.218 0.042000003 1.302 0.042000003 1.4000001 0.014 C 1.778 -0.08400001 2.1560001 -0.14 2.674 -0.14 C 3.4580002 -0.14 4.9 0.238 4.9 1.6240001 C 4.9 2.576 4.214 3.1360002 3.262 3.486 C 2.4220002 3.808 1.8620001 4.018 1.8620001 4.788 C 1.8620001 5.362 2.3660002 5.684 2.842 5.684 C 3.15 5.684 3.9620001 5.572 4.144 4.382 C 4.228 4.2980003 4.5080004 4.3120003 4.592 4.396 C 4.6340003 4.9 4.662 5.418 4.676 5.88 C 4.242 5.9500003 3.5700002 6.1460004 2.842 6.1460004 C 1.8060001 6.1460004 0.86800003 5.474 0.86800003 4.578 C 0.86800003 3.556 1.33 3.122 2.408 2.674 C 3.5700002 2.198 3.8360002 1.904 3.8360002 1.302 C 3.8360002 0.616 3.164 0.322 2.6460001 0.322 C 2.1000001 0.322 1.792 0.504 1.6520001 0.658 C 1.3440001 0.98 1.19 1.5960001 1.1060001 1.9460001 C 1.0220001 2.03 0.75600004 2.016 0.67200005 1.932 Z "/>
+        </symbol>
+        <symbol id="g7E978C86F36CD586F6CAC7ED4046B3D8" overflow="visible">
+            <path d="M 4.102 0.67200005 C 4.1860003 0.238 4.34 -0.14 5.04 -0.14 C 5.572 -0.14 6.076 0.098000005 6.3700004 0.37800002 C 6.342 0.546 6.2860003 0.67200005 6.132 0.75600004 C 6.0340004 0.67200005 5.796 0.532 5.6140003 0.532 C 5.208 0.532 5.1940002 1.0780001 5.1940002 1.722 L 5.1940002 3.7800002 C 5.1940002 5.768 4.102 6.1460004 3.0800002 6.1460004 C 1.932 6.1460004 0.77000004 5.3900003 0.77000004 4.592 C 0.77000004 4.256 0.938 4.0880003 1.26 4.0880003 C 1.666 4.0880003 1.9180001 4.382 1.9180001 4.564 C 1.9180001 4.662 1.904 4.76 1.876 4.816 C 1.8620001 4.8580003 1.848 4.9420004 1.848 5.096 C 1.848 5.53 2.436 5.684 2.9680002 5.684 C 3.444 5.684 4.102 5.446 4.102 3.864 C 4.102 3.766 4.06 3.71 4.018 3.696 L 2.8140001 3.4020002 C 1.47 3.066 0.504 2.3240001 0.504 1.3720001 C 0.504 0.224 1.288 -0.14 2.2680001 -0.14 C 2.7580001 -0.14 3.1780002 -0.028 3.7940001 0.448 L 4.0740004 0.67200005 Z M 4.102 3.262 L 4.102 1.414 C 4.102 1.232 4.018 1.1340001 3.9060001 1.0500001 C 3.542 0.75600004 3.066 0.43400002 2.674 0.43400002 C 1.9740001 0.43400002 1.666 0.994 1.666 1.4280001 C 1.666 2.058 1.96 2.7020001 2.996 2.9680002 Z "/>
+        </symbol>
+        <symbol id="g5B78D483D83797DE607A804E62A98151" overflow="visible">
+            <path d="M 2.576 5.012 C 2.492 4.914 2.408 4.886 2.408 5.012 C 2.394 5.3900003 2.3660002 5.9360003 2.296 6.076 C 2.2680001 6.1460004 2.24 6.188 2.128 6.188 C 1.7360001 6.0340004 1.3720001 5.908 0.40600002 5.782 C 0.37800002 5.698 0.40600002 5.474 0.43400002 5.3900003 C 1.19 5.32 1.3440001 5.25 1.3440001 4.438 L 1.3440001 1.7080001 C 1.3440001 0.56 1.204 0.504 0.36400002 0.43400002 C 0.28 0.35000002 0.28 0.056 0.36400002 -0.028 C 0.78400004 -0.014 1.3440001 0 1.904 0 C 2.464 0 2.884 -0.014 3.3040001 -0.028 C 3.388 0.056 3.388 0.35000002 3.3040001 0.43400002 C 2.5900002 0.504 2.45 0.56 2.45 1.7080001 L 2.45 4.004 C 2.45 4.2980003 2.576 4.466 2.6880002 4.592 C 3.22 5.11 3.8500001 5.418 4.396 5.418 C 4.676 5.418 4.9700003 5.236 5.138 4.914 C 5.2780004 4.6340003 5.306 4.256 5.306 3.8360002 L 5.306 1.7080001 C 5.306 0.56 5.1660004 0.504 4.438 0.43400002 C 4.368 0.35000002 4.368 0.056 4.438 -0.028 C 4.8580003 -0.014 5.306 0 5.866 0 C 6.426 0 6.9300003 -0.014 7.3500004 -0.028 C 7.42 0.056 7.42 0.35000002 7.3500004 0.43400002 C 6.566 0.504 6.412 0.56 6.412 1.7080001 L 6.412 3.7940001 C 6.412 4.564 6.3560004 5.236 6.0340004 5.67 C 5.796 5.978 5.362 6.1460004 4.872 6.1460004 C 4.1860003 6.1460004 3.4020002 5.964 2.576 5.012 Z "/>
+        </symbol>
+        <symbol id="g7066C9289A7FC07D0D387BA4B25B33D8" overflow="visible">
+            <path d="M 5.4040003 1.302 C 4.886 0.77000004 4.48 0.546 3.6680002 0.546 C 3.164 0.546 2.576 0.84000003 2.142 1.554 C 1.8620001 2.016 1.694 2.66 1.694 3.4720001 L 5.418 3.444 C 5.586 3.444 5.684 3.528 5.684 3.6820002 C 5.684 4.8580003 5.264 6.118 3.318 6.118 C 2.1000001 6.118 0.518 4.9560003 0.518 2.828 C 0.518 2.0440001 0.71400005 1.288 1.176 0.75600004 C 1.6520001 0.19600001 2.3100002 -0.14 3.318 -0.14 C 4.382 -0.14 5.138 0.35000002 5.698 1.0780001 C 5.656 1.218 5.572 1.288 5.4040003 1.302 Z M 1.7360001 3.9480002 C 2.002 5.53 2.982 5.656 3.318 5.656 C 3.8500001 5.656 4.48 5.362 4.48 4.1860003 C 4.48 4.06 4.4240003 3.99 4.27 3.99 Z "/>
+        </symbol>
+        <symbol id="g147A4F8094A171354C3770BA2E8E0851" overflow="visible">
+            <path d="M 2.842 5.572 C 2.926 5.656 2.926 5.9500003 2.842 6.0340004 C 2.4220002 6.02 1.932 6.006 1.4280001 6.006 C 0.896 6.006 0.518 6.02 0.154 6.0340004 C 0.07 5.9500003 0.07 5.656 0.154 5.572 C 0.81200004 5.5020003 0.966 5.362 1.26 4.6340003 L 3.094 0.112 C 3.1780002 -0.08400001 3.2900002 -0.16800001 3.43 -0.16800001 C 3.556 -0.16800001 3.6680002 -0.08400001 3.766 0.14 L 5.1800003 3.584 L 6.622 0.112 C 6.7060003 -0.08400001 6.8180003 -0.16800001 6.958 -0.16800001 C 7.084 -0.16800001 7.196 -0.08400001 7.28 0.126 L 9.114 4.564 C 9.338 5.138 9.576 5.53 10.29 5.572 C 10.374001 5.656 10.374001 5.9500003 10.29 6.0340004 C 10.01 6.02 9.702001 6.006 9.282001 6.006 C 8.862 6.006 8.274 6.02 7.854 6.0340004 C 7.7700005 5.9500003 7.7700005 5.656 7.854 5.572 C 8.904 5.5160003 8.764 5.11 8.568 4.6200004 L 7.392 1.7080001 C 7.2520003 1.358 7.196 1.358 7.084 1.6520001 L 5.88 4.718 C 5.6140003 5.3760004 5.642 5.5160003 6.3840003 5.572 C 6.4680004 5.656 6.4680004 5.9500003 6.3840003 6.0340004 C 5.964 6.02 5.4040003 6.006 4.984 6.006 C 4.6340003 6.006 4.172 6.02 3.752 6.0340004 C 3.6680002 5.9500003 3.6680002 5.656 3.752 5.572 C 4.4100003 5.5160003 4.578 5.11 4.83 4.48 L 4.914 4.256 L 3.934 1.778 C 3.752 1.316 3.7240002 1.302 3.542 1.75 L 2.4220002 4.6340003 C 2.1560001 5.306 2.17 5.53 2.842 5.572 Z "/>
+        </symbol>
+        <symbol id="gF3D78E78501FAC01B2F36E974C2BF074" overflow="visible">
+            <path d="M 2.38 5.012 C 2.3660002 5.432 2.338 5.9360003 2.2680001 6.076 C 2.24 6.1460004 2.2120001 6.188 2.1000001 6.188 C 1.7080001 6.0340004 1.3440001 5.908 0.37800002 5.782 C 0.35000002 5.698 0.37800002 5.474 0.40600002 5.3900003 C 1.1620001 5.32 1.316 5.25 1.316 4.438 L 1.316 1.7080001 C 1.316 0.56 1.1340001 0.49 0.36400002 0.43400002 C 0.28 0.35000002 0.28 0.056 0.36400002 -0.028 C 0.78400004 -0.014 1.316 0 1.876 0 C 2.436 0 2.8700001 -0.014 3.2900002 -0.028 C 3.374 0.056 3.374 0.35000002 3.2900002 0.43400002 C 2.576 0.504 2.4220002 0.56 2.4220002 1.7080001 L 2.4220002 4.004 C 2.4220002 4.2980003 2.548 4.466 2.66 4.592 C 3.22 5.138 3.7380002 5.418 4.172 5.418 C 4.704 5.418 5.096 5.0820003 5.096 4.144 L 5.096 1.7080001 C 5.096 0.56 4.984 0.49 4.228 0.43400002 C 4.158 0.35000002 4.158 0.056 4.228 -0.028 C 4.578 -0.014 5.096 0 5.656 0 C 6.216 0 6.678 -0.014 7.0280004 -0.028 C 7.098 0.056 7.098 0.35000002 7.0280004 0.43400002 C 6.328 0.49 6.202 0.56 6.202 1.7080001 L 6.202 3.934 C 6.202 4.13 6.202 4.326 6.188 4.494 C 6.86 5.236 7.4900002 5.418 8.036 5.418 C 8.568 5.418 8.876 5.11 8.876 4.172 L 8.876 1.7080001 C 8.876 0.56 8.736 0.49 8.008 0.43400002 C 7.938 0.35000002 7.938 0.056 8.008 -0.028 C 8.358 -0.014 8.876 0 9.436 0 C 9.996 0 10.486 -0.014 10.878 -0.028 C 10.948 0.056 10.948 0.35000002 10.878 0.43400002 C 10.108001 0.49 9.982 0.56 9.982 1.7080001 L 9.982 3.92 C 9.982 5.1660004 9.772 6.1460004 8.54 6.1460004 C 7.826 6.1460004 6.958 5.88 6.23 5.11 C 6.188 5.0680003 6.104 4.998 6.076 5.124 C 5.9500003 5.698 5.4040003 6.1460004 4.676 6.1460004 C 3.864 6.1460004 3.1360002 5.67 2.548 5.012 C 2.4780002 4.9420004 2.394 4.8440003 2.38 5.012 Z "/>
+        </symbol>
+        <symbol id="gCCC0E72C8F14AA9907A44072C330848C" overflow="visible">
+            <path d="M 2.464 5.012 C 2.436 5.572 2.4220002 5.9360003 2.352 6.076 C 2.3240001 6.1460004 2.296 6.188 2.184 6.188 C 1.792 6.0340004 1.4280001 5.908 0.462 5.782 C 0.43400002 5.698 0.462 5.474 0.49 5.3900003 C 1.246 5.32 1.4000001 5.25 1.4000001 4.438 L 1.4000001 1.7080001 C 1.4000001 0.546 1.232 0.49 0.36400002 0.43400002 C 0.28 0.35000002 0.28 0.056 0.36400002 -0.028 C 0.85400003 -0.014 1.4000001 0 1.96 0 C 2.52 0 3.164 -0.014 3.654 -0.028 C 3.7380002 0.056 3.7380002 0.35000002 3.654 0.43400002 C 2.674 0.504 2.506 0.546 2.506 1.7080001 L 2.506 3.654 C 2.506 4.018 2.674 4.34 2.842 4.592 C 2.996 4.816 3.318 5.2780004 3.486 5.2780004 C 3.6120002 5.2780004 3.7380002 5.25 3.8500001 5.096 C 3.9480002 4.9560003 4.116 4.774 4.354 4.774 C 4.69 4.774 5.012 5.124 5.012 5.474 C 5.012 5.7400002 4.76 6.1460004 4.172 6.1460004 C 3.5140002 6.1460004 2.94 5.53 2.618 4.984 C 2.5340002 4.83 2.464 4.9420004 2.464 5.012 Z "/>
+        </symbol>
+        <symbol id="g943EEFA5114B464FF389239628F645F4" overflow="visible">
+            <path d="M 1.204 1.7080001 C 1.204 0.546 1.0500001 0.49 0.266 0.43400002 C 0.18200001 0.35000002 0.18200001 0.056 0.266 -0.028 C 0.72800004 -0.014 1.204 0 1.764 0 C 2.2540002 0 2.716 -0.014 3.038 -0.028 C 3.122 0.056 3.122 0.35000002 3.038 0.43400002 C 2.464 0.49 2.3100002 0.546 2.3100002 1.7080001 L 2.3100002 2.926 C 2.576 2.9120002 2.772 2.898 2.9120002 2.8560002 C 3.066 2.7440002 3.1920002 2.618 3.3600001 2.394 L 4.382 1.0220001 C 4.788 0.476 4.9560003 0.21000001 4.9700003 0.042000003 C 4.9700003 0 4.984 -0.028 5.026 -0.028 C 5.306 -0.014 5.6140003 0 5.894 0 C 6.328 0 6.762 -0.014 7.0420003 -0.028 C 7.1260004 0.056 7.1260004 0.35000002 7.0420003 0.43400002 C 6.566 0.49 6.216 0.546 5.8380003 1.0220001 L 3.99 3.3460002 C 3.934 3.4160001 3.8920002 3.4720001 3.8920002 3.542 C 3.8920002 3.598 3.8920002 3.6260002 3.9480002 3.6820002 L 5.1800003 4.9560003 C 5.6000004 5.4040003 6.09 5.5160003 6.65 5.572 C 6.734 5.656 6.734 5.9500003 6.65 6.0340004 C 6.328 6.02 5.9360003 6.006 5.432 6.006 C 4.9 6.006 4.382 6.02 4.06 6.0340004 C 3.976 5.9500003 3.976 5.656 4.06 5.572 C 4.8440003 5.5160003 4.5080004 5.026 4.382 4.8580003 C 4.06 4.452 3.6260002 3.976 3.262 3.71 C 2.954 3.486 2.576 3.318 2.3100002 3.276 L 2.3100002 8.162001 C 2.3100002 9.0720005 2.3660002 9.632 2.3660002 9.632 C 2.3660002 9.7300005 2.3100002 9.772 2.184 9.772 C 1.8340001 9.632 0.78400004 9.436 0.224 9.394 C 0.19600001 9.282001 0.224 9.058001 0.308 8.974 C 0.35000002 8.974 0.39200002 8.974 0.43400002 8.974 C 1.0500001 8.932 1.204 8.932 1.204 7.826 Z "/>
+        </symbol>
+        <symbol id="g8374945ABC56B1CB80F6E92B63EFD1BA" overflow="visible">
+            <path d="M 3.038 -0.14 C 3.584 -0.14 4.242 0.14 4.928 0.70000005 C 4.998 0.75600004 5.124 0.78400004 5.138 0.68600005 C 5.1800003 0.33600003 5.2920003 -0.14 5.2920003 -0.14 C 5.4040003 -0.18200001 5.474 -0.16800001 5.558 -0.14 C 5.866 0.112 6.3560004 0.322 7.21 0.42000002 C 7.294 0.504 7.294 0.71400005 7.21 0.79800004 C 6.314 0.86800003 6.188 1.1340001 6.188 1.82 L 6.188 4.5080004 C 6.188 4.928 6.244 5.9500003 6.244 5.9500003 C 6.244 5.992 6.202 6.0340004 6.132 6.0340004 C 6.0620003 6.02 5.852 6.006 5.642 6.006 C 5.1940002 6.006 4.69 6.02 4.214 6.0340004 C 4.13 5.9500003 4.13 5.656 4.214 5.572 C 4.9 5.53 5.0820003 5.362 5.0820003 4.438 L 5.0820003 1.7360001 C 5.0820003 1.47 5.0540004 1.358 4.8580003 1.19 C 4.34 0.74200004 3.808 0.518 3.4580002 0.518 C 3.038 0.518 2.338 0.71400005 2.338 1.96 L 2.338 4.5080004 C 2.338 4.928 2.394 5.9500003 2.394 5.9500003 C 2.394 5.992 2.352 6.0340004 2.282 6.0340004 C 2.2120001 6.02 2.002 6.006 1.792 6.006 C 1.3440001 6.006 0.84000003 6.02 0.36400002 6.0340004 C 0.28 5.9500003 0.28 5.656 0.36400002 5.572 C 1.036 5.5160003 1.232 5.362 1.232 4.452 L 1.232 1.764 C 1.232 0.79800004 1.6520001 -0.14 3.038 -0.14 Z "/>
+        </symbol>
+        <symbol id="gDC08E99E334A3F3C073A58E3F6EA9E5A" overflow="visible">
+            <path d="M 2.184 5.152 C 2.17 5.572 2.142 5.9360003 2.072 6.076 C 2.0440001 6.1460004 2.016 6.188 1.904 6.188 C 1.5120001 6.0340004 1.148 5.908 0.18200001 5.782 C 0.154 5.698 0.18200001 5.474 0.21000001 5.3900003 C 0.966 5.32 1.12 5.25 1.12 4.438 L 1.12 -1.5400001 C 1.12 -2.7020001 0.966 -2.772 0.112 -2.8140001 C 0.028 -2.898 0.028 -3.1920002 0.112 -3.276 C 0.602 -3.262 1.12 -3.2480001 1.6800001 -3.2480001 C 2.24 -3.2480001 2.9120002 -3.262 3.374 -3.276 C 3.4580002 -3.1920002 3.4580002 -2.898 3.374 -2.8140001 C 2.38 -2.7580001 2.226 -2.7020001 2.226 -1.5400001 L 2.226 -0.028 C 2.226 0.154 2.282 0.14 2.4220002 0.08400001 C 2.772 -0.056 3.1920002 -0.14 3.64 -0.14 C 4.4240003 -0.14 5.124 0.098000005 5.698 0.644 C 6.3560004 1.288 6.734 2.1560001 6.734 3.2900002 C 6.734 4.774 5.684 6.1460004 4.256 6.1460004 C 3.6120002 6.1460004 2.898 5.7260003 2.338 5.096 C 2.2540002 5.012 2.198 5.012 2.184 5.152 Z M 2.45 4.6340003 C 2.8140001 5.0820003 3.4580002 5.5020003 3.864 5.5020003 C 4.76 5.5020003 5.53 4.494 5.53 2.9120002 C 5.53 1.764 5.124 0.33600003 3.556 0.33600003 C 3.3040001 0.33600003 2.8140001 0.40600002 2.562 0.63 C 2.282 0.882 2.226 0.966 2.226 1.47 L 2.226 4.018 C 2.226 4.3120003 2.282 4.438 2.45 4.6340003 Z "/>
+        </symbol>
+        <symbol id="g62E1080388B5DBD637C6963B92460B41" overflow="visible">
+            <path d="M 3.7940001 3.122 C 3.976 3.122 4.172 3.5140002 4.172 3.6820002 C 4.172 3.822 4.116 3.9620001 3.976 3.9620001 L 0.91 3.9620001 C 0.74200004 3.9620001 0.56 3.64 0.56 3.388 C 0.56 3.2480001 0.644 3.122 0.77000004 3.122 Z "/>
+        </symbol>
+        <symbol id="gF6ED3E3A4C7BDD0FB480DBED2709CF64" overflow="visible">
+            <path d="M 2.338 5.5160003 C 2.2540002 5.432 2.198 5.46 2.198 5.586 L 2.198 8.162001 C 2.198 9.0720005 2.2540002 9.632 2.2540002 9.632 C 2.2540002 9.7300005 2.198 9.772 2.072 9.772 C 1.722 9.632 0.67200005 9.436 0.112 9.394 C 0.08400001 9.282001 0.112 9.058001 0.19600001 8.974 C 0.238 8.974 0.28 8.974 0.322 8.974 C 0.938 8.932 1.092 8.932 1.092 7.826 L 1.092 0.994 C 1.092 0.448 1.0780001 0.19600001 1.036 0 C 1.1060001 -0.112 1.176 -0.16800001 1.3440001 -0.16800001 C 1.4280001 -0.08400001 1.5680001 0.042000003 1.6800001 0.16800001 C 1.82 0.33600003 1.904 0.33600003 2.058 0.21000001 C 2.38 -0.056 2.8000002 -0.14 3.2900002 -0.14 C 4.718 -0.14 6.3840003 1.1620001 6.3840003 3.388 C 6.3840003 5.096 5.124 6.1460004 3.9060001 6.1460004 C 3.3040001 6.1460004 2.772 5.908 2.338 5.5160003 Z M 2.436 5.0820003 C 2.8000002 5.4040003 3.22 5.53 3.6260002 5.53 C 4.48 5.53 5.1800003 4.494 5.1800003 3.1360002 C 5.1800003 1.5400001 4.5360003 0.33600003 3.206 0.33600003 C 2.772 0.33600003 2.4780002 0.644 2.198 0.994 L 2.198 4.494 C 2.198 4.788 2.2540002 4.928 2.436 5.0820003 Z "/>
+        </symbol>
+        <symbol id="g70290CF8D2D4763544A0F69644596675" overflow="visible">
+            <path d="M 4.676 0.70000005 C 4.7460003 0.75600004 4.872 0.78400004 4.886 0.68600005 C 4.928 0.35000002 5.04 -0.14 5.04 -0.14 C 5.152 -0.18200001 5.222 -0.16800001 5.306 -0.14 C 5.6140003 0.112 6.104 0.322 6.958 0.42000002 C 7.0420003 0.504 7.0420003 0.71400005 6.958 0.79800004 C 6.0620003 0.86800003 5.9360003 1.1340001 5.9360003 1.82 L 5.9360003 8.162001 C 5.9360003 9.0720005 5.992 9.632 5.992 9.632 C 5.992 9.7300005 5.9360003 9.772 5.81 9.772 C 5.46 9.632 4.4100003 9.436 3.8500001 9.394 C 3.822 9.282001 3.8500001 9.058001 3.934 8.974 C 3.976 8.974 4.018 8.974 4.06 8.974 C 4.676 8.932 4.83 8.932 4.83 7.826 L 4.83 6.0340004 C 4.83 5.9360003 4.802 5.908 4.704 5.908 C 4.6480002 5.908 4.0740004 6.1460004 3.6120002 6.1460004 C 2.6880002 6.1460004 2.072 5.8380003 1.5120001 5.306 C 0.91 4.704 0.546 3.878 0.546 2.842 C 0.546 1.12 1.414 -0.14 2.926 -0.14 C 3.4720001 -0.14 3.99 0.14 4.676 0.70000005 Z M 4.83 1.7360001 C 4.83 1.47 4.802 1.358 4.606 1.19 C 4.0880003 0.74200004 3.64 0.518 3.2900002 0.518 C 2.5340002 0.518 1.75 1.3440001 1.75 3.094 C 1.75 4.102 1.9460001 4.662 2.1560001 4.9560003 C 2.5900002 5.6140003 3.1780002 5.656 3.4580002 5.656 C 3.9620001 5.656 4.3120003 5.474 4.592 5.152 C 4.788 4.928 4.83 4.83 4.83 4.396 Z "/>
+        </symbol>
+        <symbol id="g189C5CFDD5D480E2901FE16D1E1EFDDC" overflow="visible">
+            <path d="M 0.602 6.006 C 0.40600002 6.006 0.35000002 5.8380003 0.35000002 5.7260003 L 0.35000002 5.544 C 0.35000002 5.474 0.36400002 5.46 0.42000002 5.46 L 1.246 5.46 L 1.246 1.246 C 1.246 0.252 1.6800001 -0.14 2.3240001 -0.14 C 2.9680002 -0.14 3.6680002 0.16800001 4.214 0.78400004 C 4.1860003 0.924 4.102 1.008 3.9620001 1.0220001 C 3.598 0.74200004 3.1780002 0.63 2.8140001 0.63 C 2.436 0.63 2.352 1.0500001 2.352 1.9180001 L 2.352 5.46 L 3.808 5.46 C 3.9480002 5.46 4.144 5.5160003 4.144 5.642 L 4.144 5.9220004 C 4.144 5.978 4.102 6.006 4.032 6.006 L 2.352 6.006 L 2.352 6.552 C 2.352 7.4620004 2.408 8.022 2.408 8.022 C 2.408 8.106 2.3660002 8.148001 2.296 8.148001 C 2.24 8.148001 2.114 8.092 1.988 8.022 C 1.8340001 7.938 1.694 7.868 1.5120001 7.826 C 1.3440001 7.7700005 1.204 7.728 1.204 7.63 C 1.204 7.4620004 1.246 7.5600004 1.246 6.006 Z "/>
+        </symbol>
+        <symbol id="gD0417A6D802086877AC24BBA53182BA1" overflow="visible">
+            <path d="M 2.8560002 -2.24 C 3.0800002 -1.848 3.262 -1.4560001 3.43 -1.036 C 4.55 1.666 5.1800003 3.108 5.908 4.676 C 6.188 5.264 6.3840003 5.4880004 7.0420003 5.572 C 7.1260004 5.656 7.1260004 5.9500003 7.0420003 6.0340004 C 6.762 6.02 6.44 6.006 6.0480003 6.006 C 5.6280003 6.006 5.1940002 6.02 4.774 6.0340004 C 4.69 5.9500003 4.69 5.656 4.774 5.572 C 5.222 5.53 5.67 5.446 5.446 4.9420004 L 4.06 1.7360001 C 3.9620001 1.5120001 3.8360002 1.47 3.7240002 1.75 L 2.4780002 4.662 C 2.226 5.25 2.1560001 5.5160003 2.94 5.572 C 3.0240002 5.656 3.0240002 5.9500003 2.94 6.0340004 C 2.4220002 6.02 1.8620001 6.006 1.358 6.006 C 0.882 6.006 0.504 6.02 0.224 6.0340004 C 0.14 5.9500003 0.14 5.656 0.224 5.572 C 0.78400004 5.5020003 0.966 5.3760004 1.33 4.5220003 L 2.9120002 0.84000003 C 3.038 0.56 3.2480001 -0.08400001 3.108 -0.476 C 2.94 -0.938 2.772 -1.33 2.562 -1.764 C 2.408 -2.0440001 2.2120001 -2.17 1.8620001 -2.17 C 1.666 -2.17 1.61 -2.128 1.4560001 -2.128 C 1.0500001 -2.128 0.84000003 -2.548 0.84000003 -2.73 C 0.84000003 -3.0240002 1.12 -3.2480001 1.498 -3.2480001 C 1.792 -3.2480001 2.352 -3.1360002 2.8560002 -2.24 Z "/>
+        </symbol>
+        <symbol id="gD14925D751EE471FE91EC7AFC9100DF" overflow="visible">
+            <path d="M 6.216 5.418 C 6.4820004 5.418 6.734 5.67 6.734 5.9500003 C 6.734 6.244 6.4680004 6.4680004 6.09 6.4680004 C 5.7260003 6.4680004 5.0540004 6.23 4.69 5.754 C 4.5220003 5.866 4.06 6.1460004 3.2340002 6.1460004 C 1.988 6.1460004 0.84000003 5.306 0.84000003 4.018 C 0.84000003 3.262 1.176 2.828 1.5680001 2.45 C 1.176 2.114 0.952 1.5120001 0.952 1.036 C 0.952 0.532 1.232 0.14 1.5960001 -0.042000003 C 0.84000003 -0.49 0.448 -1.1340001 0.448 -1.7360001 C 0.448 -2.954 1.5960001 -3.332 2.674 -3.332 C 4.564 -3.332 6.6080003 -2.4220002 6.6080003 -0.91 C 6.6080003 -0.462 6.3980002 -0.112 5.992 0.224 C 5.446 0.67200005 4.466 0.68600005 3.9480002 0.68600005 C 3.696 0.68600005 3.3460002 0.658 3.01 0.616 C 2.8000002 0.602 2.66 0.588 2.5900002 0.588 C 2.184 0.588 1.694 0.78400004 1.694 1.386 C 1.694 1.666 1.778 1.96 1.9460001 2.198 C 2.282 2.002 2.674 1.904 3.22 1.904 C 4.452 1.904 5.586 2.674 5.586 4.046 C 5.586 4.704 5.3900003 5.0820003 4.984 5.5020003 C 5.0820003 5.642 5.362 5.8380003 5.544 5.8380003 C 5.642 5.8380003 5.7400002 5.796 5.8240004 5.67 C 5.88 5.558 6.0620003 5.418 6.216 5.418 Z M 1.848 -0.14 C 2.002 -0.18200001 2.226 -0.21000001 2.408 -0.21000001 C 2.842 -0.21000001 3.2340002 -0.16800001 3.43 -0.16800001 C 4.13 -0.16800001 4.718 -0.18200001 5.124 -0.40600002 C 5.67 -0.71400005 5.8380003 -0.91 5.8380003 -1.274 C 5.8380003 -2.282 4.354 -2.8140001 3.094 -2.8140001 C 2.5900002 -2.8140001 1.414 -2.408 1.414 -1.4560001 C 1.414 -0.98 1.442 -0.63 1.848 -0.14 Z M 4.466 3.9060001 C 4.466 2.604 3.808 2.338 3.2900002 2.338 C 2.114 2.338 1.988 3.332 1.988 4.228 C 1.988 5.208 2.338 5.7120004 3.108 5.7120004 C 3.99 5.7120004 4.466 5.0680003 4.466 3.9060001 Z "/>
+        </symbol>
+        <symbol id="g52AA783804DF8664DF2EF6EF41B2695C" overflow="visible">
+            <path d="M 2.338 4.004 C 2.338 4.2980003 2.464 4.466 2.576 4.592 C 3.108 5.11 3.822 5.418 4.368 5.418 C 4.6480002 5.418 4.9420004 5.236 5.11 4.914 C 5.25 4.6340003 5.2780004 4.256 5.2780004 3.8360002 L 5.2780004 1.7080001 C 5.2780004 0.56 5.138 0.504 4.4100003 0.43400002 C 4.34 0.35000002 4.34 0.056 4.4100003 -0.028 C 4.802 -0.014 5.2780004 0 5.8380003 0 C 6.3980002 0 6.86 -0.014 7.322 -0.028 C 7.392 0.056 7.392 0.35000002 7.322 0.43400002 C 6.538 0.504 6.3840003 0.56 6.3840003 1.7080001 L 6.3840003 3.7940001 C 6.3840003 4.564 6.328 5.25 6.006 5.67 C 5.768 5.978 5.334 6.1460004 4.8440003 6.1460004 C 4.158 6.1460004 3.318 5.964 2.464 5.012 C 2.464 4.998 2.45 4.998 2.436 4.984 C 2.394 4.928 2.3240001 4.8440003 2.3240001 5.012 L 2.338 8.162001 C 2.338 9.0720005 2.394 9.632 2.394 9.632 C 2.394 9.7300005 2.338 9.772 2.2120001 9.772 C 1.8620001 9.632 0.81200004 9.436 0.252 9.394 C 0.224 9.282001 0.252 9.058001 0.33600003 8.974 C 0.37800002 8.974 0.42000002 8.974 0.462 8.974 C 1.0780001 8.932 1.232 8.932 1.232 7.826 L 1.232 1.7080001 C 1.232 0.546 1.064 0.49 0.252 0.43400002 C 0.16800001 0.35000002 0.16800001 0.056 0.252 -0.028 C 0.71400005 -0.014 1.232 0 1.792 0 C 2.3240001 0 2.786 -0.014 3.1780002 -0.028 C 3.262 0.056 3.262 0.35000002 3.1780002 0.43400002 C 2.464 0.49 2.338 0.546 2.338 1.7080001 Z "/>
+        </symbol>
+        <symbol id="g1645756238B1E9533FEDE0CA8FAF4667" overflow="visible">
+            <path d="M 0.574 2.8700001 C 0.574 1.442 1.526 -0.14 3.5140002 -0.14 C 4.4100003 -0.14 5.096 0.18200001 5.572 0.644 C 6.202 1.26 6.4820004 2.142 6.4820004 2.996 C 6.4820004 4.452 5.684 6.1460004 3.542 6.1460004 C 2.618 6.1460004 1.8620001 5.768 1.3440001 5.1660004 C 0.84000003 4.564 0.574 3.752 0.574 2.8700001 Z M 3.332 5.656 C 4.5360003 5.656 5.2780004 4.564 5.2780004 2.548 C 5.2780004 0.78400004 4.368 0.35000002 3.71 0.35000002 C 2.2540002 0.35000002 1.778 2.114 1.778 3.1920002 C 1.778 4.4100003 2.072 5.656 3.332 5.656 Z "/>
+        </symbol>
+        <symbol id="g85BDD712C85B3D7E57093744806CCEE9" overflow="visible">
+            <path d="M 3.7240002 5.656 C 3.7800002 5.908 3.9060001 6.328 3.9060001 6.4960003 C 3.9060001 6.734 3.766 6.874 3.318 6.874 C 2.786 6.874 2.786 6.2580004 2.674 5.7260003 L 2.492 4.9 C 1.792 4.396 1.274 3.976 0.882 3.486 C 0.938 3.2900002 1.064 3.1920002 1.316 3.1920002 C 1.6240001 3.598 1.932 3.8500001 2.3240001 4.172 L 0.882 -2.2540002 C 0.79800004 -2.6460001 0.588 -2.8140001 0.14 -2.884 L -0.126 -2.926 C -0.19600001 -2.94 -0.266 -2.954 -0.266 -3.038 L -0.266 -3.3040001 L -0.238 -3.332 C -0.238 -3.332 0.71400005 -3.262 1.218 -3.262 C 1.764 -3.262 2.716 -3.2900002 2.716 -3.2900002 L 2.7440002 -3.262 L 2.7440002 -2.982 C 2.7440002 -2.9120002 2.716 -2.884 2.66 -2.8700001 L 2.394 -2.828 C 2.184 -2.8000002 1.82 -2.73 1.932 -2.2540002 L 2.548 0.322 C 2.7580001 0.098000005 3.164 -0.14 3.5700002 -0.14 C 4.564 -0.14 5.3760004 0.42000002 5.992 1.1620001 C 6.748 2.086 7.1260004 3.038 7.1260004 4.046 C 7.1260004 5.222 6.734 6.1460004 5.334 6.1460004 C 4.6200004 6.1460004 4.102 5.88 3.7240002 5.656 Z M 5.978 3.822 C 5.978 3.15 5.698 2.17 5.1660004 1.358 C 4.802 0.77000004 4.242 0.35000002 3.71 0.35000002 C 3.3460002 0.35000002 2.9680002 0.532 2.674 0.938 L 3.598 5.026 C 3.9480002 5.25 4.354 5.5020003 4.886 5.5020003 C 5.8380003 5.5020003 5.978 4.5080004 5.978 3.822 Z "/>
+        </symbol>
+        <symbol id="gA15578292FAA67611F31F457DC97EF81" overflow="visible">
+            <path d="M 1.092 2.2680001 C 1.092 1.526 1.274 -0.14 3.052 -0.14 C 3.5 -0.14 3.934 -0.08400001 4.34 0.126 C 5.558 0.74200004 6.51 2.226 6.51 3.878 C 6.51 4.886 6.2580004 6.1460004 4.5360003 6.1460004 C 2.198 6.1460004 1.092 3.9480002 1.092 2.2680001 Z M 2.2540002 2.38 C 2.2540002 3.64 2.8000002 5.684 4.284 5.684 C 4.704 5.684 4.928 5.46 5.138 5.0680003 C 5.306 4.718 5.348 4.2000003 5.348 3.7800002 C 5.348 3.22 5.264 2.016 4.7460003 1.232 C 4.354 0.63 3.7940001 0.37800002 3.262 0.37800002 C 2.8560002 0.37800002 2.2540002 0.91 2.2540002 2.38 Z "/>
+        </symbol>
+        <symbol id="g911D42E87675C61034F7A23E20BFF690" overflow="visible">
+            <path d="M 3.71 -0.16800001 C 3.822 -0.16800001 4.0740004 0.028 4.2980003 0.37800002 C 4.816 1.204 5.586 2.548 6.076 3.598 L 6.1600003 3.6120002 C 6.3560004 2.716 6.566 1.582 6.7060003 0.644 C 6.8040004 -0.028 6.9020004 -0.16800001 7.0280004 -0.16800001 C 7.196 -0.16800001 7.392 0 7.6720004 0.35000002 C 8.078 0.85400003 8.526 1.4840001 8.722 1.778 C 9.030001 2.198 9.52 3.066 9.912001 3.99 C 10.122001 4.48 10.29 4.984 10.29 5.4880004 C 10.29 5.88 10.108001 6.1460004 9.562 6.1460004 C 9.156 6.1460004 8.918 5.964 8.918 5.6280003 C 8.918 5.544 8.946 5.4040003 8.988 5.348 C 9.198 5.026 9.282001 4.7320004 9.282001 4.5080004 C 9.282001 3.878 8.918 2.8000002 8.386001 2.086 C 8.176001 1.792 7.952 1.5120001 7.756 1.316 L 7.6580005 1.3440001 C 7.532 2.072 7.3500004 3.01 7.168 3.766 C 7.0420003 4.2980003 6.9160004 4.774 6.8180003 5.012 C 6.5940003 5.012 6.3560004 4.9560003 6.132 4.8440003 C 5.544 3.5 4.6340003 1.8340001 4.3120003 1.33 L 4.27 1.3440001 L 3.7940001 4.326 C 3.584 5.6280003 3.43 6.1460004 2.9120002 6.1460004 C 2.45 6.1460004 1.638 5.32 1.148 4.578 C 1.176 4.438 1.288 4.34 1.442 4.326 C 1.8340001 4.704 2.1560001 4.998 2.4220002 4.998 C 2.562 4.998 2.632 4.76 2.7440002 4.144 L 3.332 0.72800004 C 3.4580002 0.028 3.584 -0.16800001 3.71 -0.16800001 Z "/>
+        </symbol>
+        <symbol id="g3A2F313727CD3350B0CFD3739DCF60C6" overflow="visible">
+            <path d="M 2.338 2.786 C 5.9360003 3.486 5.9360003 4.55 5.9360003 5.0820003 C 5.9360003 5.096 5.9360003 5.096 5.9360003 5.11 C 5.9360003 5.46 5.6140003 6.1460004 4.606 6.1460004 C 2.17 6.1460004 1.1620001 3.766 1.1620001 1.988 C 1.1620001 0.79800004 1.722 -0.14 2.884 -0.14 C 3.822 -0.14 4.676 0.35000002 5.5020003 1.414 C 5.432 1.5680001 5.348 1.638 5.1800003 1.638 C 4.382 0.82600003 4.06 0.70000005 3.388 0.70000005 C 2.7580001 0.70000005 2.3240001 1.036 2.3240001 2.3100002 C 2.3240001 2.38 2.3240001 2.674 2.338 2.786 Z M 4.9700003 5.1800003 C 4.9700003 3.92 3.5 3.4580002 2.436 3.318 C 2.926 5.306 3.696 5.7120004 4.284 5.7120004 C 4.788 5.7120004 4.9700003 5.586 4.9700003 5.1800003 Z "/>
+        </symbol>
+        <symbol id="g25F7A97075E390B81E06DD29CDF9FECF" overflow="visible">
+            <path d="M 3.094 3.99 L 3.206 4.48 C 3.332 5.026 3.4580002 5.5160003 3.4580002 5.754 C 3.4580002 5.964 3.332 6.104 3.15 6.104 C 2.7020001 6.104 2.128 6.006 1.47 5.9220004 C 1.3720001 5.81 1.4000001 5.656 1.4840001 5.53 L 2.0440001 5.4880004 C 2.2120001 5.474 2.296 5.348 2.296 5.208 C 2.296 5.0820003 2.296 4.886 2.198 4.494 L 1.4280001 1.008 C 1.358 0.71400005 1.246 0.462 1.246 0.238 C 1.246 0.014 1.3720001 -0.14 1.778 -0.14 C 2.2680001 -0.14 2.282 0.462 2.4220002 1.008 L 2.828 2.6460001 C 3.5 3.864 4.284 5.1660004 4.606 5.1660004 C 4.7460003 5.1660004 4.816 5.096 4.9 4.998 C 4.998 4.886 5.1800003 4.704 5.3760004 4.704 C 5.754 4.704 6.006 5.11 6.006 5.4880004 C 6.006 5.782 5.796 6.1460004 5.2780004 6.1460004 C 4.578 6.1460004 3.766 5.2780004 3.15 3.976 Z "/>
+        </symbol>
+        <symbol id="gEEFC3CE3163D3191E855D71C43BAE018" overflow="visible">
+            <path d="M 2.632 5.46 C 2.352 3.864 2.198 3.0240002 2.058 1.9740001 C 1.876 0.602 1.61 -1.6520001 1.1060001 -2.45 C 0.952 -2.6880002 0.67200005 -2.8700001 0.462 -2.8700001 C 0.266 -2.8700001 0.21000001 -2.772 0.126 -2.632 C 0 -2.45 -0.266 -2.184 -0.574 -2.184 C -0.966 -2.184 -1.092 -2.45 -1.092 -2.6880002 C -1.092 -2.996 -0.75600004 -3.332 0.19600001 -3.332 C 0.77000004 -3.332 1.386 -3.052 1.82 -2.45 C 2.2120001 -1.904 2.52 -0.84000003 3.066 1.82 C 3.2900002 2.9120002 3.5140002 4.046 3.7240002 5.222 L 3.766 5.46 L 5.0680003 5.46 C 5.1940002 5.46 5.4040003 5.5160003 5.432 5.6280003 C 5.432 5.6280003 5.5020003 5.9220004 5.5020003 5.9360003 C 5.5020003 5.978 5.474 6.006 5.4040003 6.006 L 3.864 6.006 L 4.018 6.8040004 C 4.116 7.3360004 4.27 7.8120003 4.438 8.190001 C 4.788 9.058001 5.362 9.31 5.6000004 9.31 C 5.9220004 9.31 6.076 9.240001 6.1460004 8.946 C 6.202 8.6380005 6.314 8.26 6.7900004 8.26 C 7.2240005 8.26 7.322 8.596001 7.322 8.736 C 7.322 9.2960005 6.7060003 9.772 5.7120004 9.772 C 5.32 9.772 4.466 9.562 3.878 8.876 C 3.388 8.302 3.0240002 7.2240005 2.772 6.006 L 1.848 5.964 C 1.582 5.9500003 1.4840001 5.8380003 1.4560001 5.7260003 C 1.442 5.684 1.4000001 5.5160003 1.4000001 5.4880004 C 1.4000001 5.46 1.442 5.46 1.4840001 5.46 Z "/>
+        </symbol>
+        <symbol id="g874F7DB99721F0FD04327E6823649975" overflow="visible">
+            <path d="M 7.084 4.928 C 7.1400003 5.1800003 7.2660003 5.6000004 7.2660003 5.768 C 7.2660003 6.006 7.1260004 6.1460004 6.678 6.1460004 C 6.1460004 6.1460004 6.1740003 5.53 6.0340004 4.998 L 5.6280003 3.4580002 C 4.592 1.694 3.9060001 0.70000005 3.206 0.70000005 C 2.954 0.70000005 2.786 0.84000003 2.786 1.218 C 2.786 1.442 2.8140001 1.7360001 2.9120002 2.114 L 3.5140002 4.396 C 3.6260002 4.8440003 3.808 5.418 3.808 5.684 C 3.808 5.9500003 3.7240002 6.1460004 3.3040001 6.1460004 C 2.632 6.1460004 1.8340001 5.67 1.19 4.8440003 C 1.232 4.718 1.316 4.606 1.5120001 4.606 C 1.876 5.026 2.338 5.306 2.4780002 5.306 C 2.576 5.306 2.618 5.236 2.618 5.0680003 C 2.618 4.9420004 2.5340002 4.6340003 2.436 4.27 L 1.82 1.9180001 C 1.722 1.554 1.6800001 1.246 1.6800001 0.98 C 1.6800001 0.18200001 2.128 -0.14 2.618 -0.14 C 3.71 -0.14 4.4100003 0.72800004 5.4040003 2.184 L 5.446 2.1560001 L 5.2920003 1.61 C 5.1660004 1.1620001 5.0540004 0.588 5.0540004 0.322 C 5.0540004 0.056 5.152 -0.14 5.572 -0.14 C 6.244 -0.14 6.874 0.33600003 7.518 1.1620001 C 7.4760003 1.288 7.392 1.4000001 7.196 1.4000001 C 6.8320003 0.98 6.426 0.70000005 6.2860003 0.70000005 C 6.188 0.70000005 6.1460004 0.77000004 6.1460004 0.938 C 6.1460004 1.064 6.216 1.3720001 6.3 1.7360001 Z "/>
+        </symbol>
+        <symbol id="gCCD8A86A404CEDB1A7227180A29B8B9E" overflow="visible">
+            <path d="M 4.004 8.162001 C 4.214 9.0720005 4.354 9.632 4.354 9.632 C 4.354 9.7300005 4.3120003 9.772 4.1860003 9.772 C 3.808 9.632 2.8000002 9.450001 2.226 9.408 L 2.184 9.0720005 C 2.184 9.030001 2.198 9.002 2.2540002 9.002 L 2.6880002 8.974 C 2.8700001 8.974 2.982 8.89 2.982 8.582001 C 2.982 8.428 2.954 8.190001 2.884 7.8820004 L 1.498 1.666 C 1.4000001 1.218 1.302 0.74200004 1.302 0.476 C 1.302 0.21000001 1.3720001 -0.14 1.8900001 -0.14 C 2.52 -0.14 3.2900002 0.224 3.92 1.274 C 3.864 1.414 3.7940001 1.5120001 3.6120002 1.5120001 C 3.1920002 1.008 2.7440002 0.70000005 2.576 0.70000005 C 2.464 0.70000005 2.408 0.78400004 2.408 0.896 C 2.408 1.008 2.45 1.218 2.576 1.778 Z "/>
+        </symbol>
+        <symbol id="g5E3B6DB72A626BEAD3D22ECB3CC2C4" overflow="visible">
+            <path d="M 2.086 0 L 5.0680003 0 C 5.446 0 6.734 -0.028 6.734 -0.028 C 6.874 0.67200005 7.0140004 1.582 7.098 2.3100002 C 6.958 2.38 6.8040004 2.408 6.636 2.38 C 6.3560004 1.3720001 5.8380003 0.546 4.354 0.546 L 3.4720001 0.546 C 2.926 0.546 2.674 0.81200004 2.674 1.526 L 2.674 7.322 C 2.674 8.484 2.9120002 8.554 3.8920002 8.596001 C 3.976 8.68 3.976 8.974 3.8920002 9.058001 C 3.262 9.044001 2.604 9.030001 2.072 9.030001 C 1.5680001 9.030001 0.91 9.044001 0.266 9.058001 C 0.18200001 8.974 0.18200001 8.68 0.266 8.596001 C 1.246 8.554 1.4840001 8.484 1.4840001 7.322 L 1.4840001 1.7080001 C 1.4840001 0.546 1.246 0.476 0.266 0.43400002 C 0.18200001 0.35000002 0.18200001 0.056 0.266 -0.028 C 0.81200004 -0.014 1.61 0 2.086 0 Z "/>
+        </symbol>
+        <symbol id="g81B043E4203D1DA3EF1B86C5164A7916" overflow="visible">
+            <path d="M 4.9 1.7080001 L 4.9 7.056 C 4.9 7.952 5.04 8.484 5.544 8.484 L 5.852 8.484 C 6.9020004 8.484 7.5600004 8.12 7.7980003 7.0420003 C 7.952 7.0420003 8.148001 7.056 8.274 7.112 C 8.176001 7.756 8.106 8.47 8.092 9.1 C 8.092 9.114 8.064 9.142 8.05 9.142 C 7.5740004 9.1 6.02 9.030001 4.914 9.030001 L 3.71 9.030001 C 2.632 9.030001 0.98 9.1 0.448 9.142 C 0.42000002 9.142 0.39200002 9.114 0.39200002 9.1 C 0.33600003 8.47 0.19600001 7.742 0.042000003 7.07 C 0.18200001 7.0140004 0.35000002 7 0.518 7 C 0.79800004 8.12 1.442 8.484 2.3660002 8.484 L 3.052 8.484 C 3.5700002 8.484 3.71 7.952 3.71 7.098 L 3.71 1.7080001 C 3.71 0.546 3.4720001 0.476 2.352 0.43400002 C 2.2680001 0.35000002 2.2680001 0.056 2.352 -0.028 C 3.038 -0.014 3.752 0 4.3120003 0 C 4.8440003 0 5.558 -0.014 6.2580004 -0.028 C 6.342 0.056 6.342 0.35000002 6.2580004 0.43400002 C 5.138 0.476 4.9 0.546 4.9 1.7080001 Z "/>
+        </symbol>
+        <symbol id="g9179B2D2A9E200466DE2606DE51A4BDE" overflow="visible">
+            <path d="M 7.532 1.4280001 L 5.3900003 4.368 C 5.25 4.55 5.1660004 4.69 5.1660004 4.83 C 5.1660004 4.9560003 5.1800003 5.0820003 5.306 5.25 L 7.2240005 7.728 C 7.714 8.358 8.148001 8.54 8.778 8.596001 C 8.862 8.68 8.862 8.974 8.778 9.058001 C 8.358 9.044001 7.84 9.030001 7.518 9.030001 C 7.196 9.030001 6.6080003 9.044001 6.0480003 9.058001 C 5.964 8.974 5.964 8.68 6.0480003 8.596001 C 6.664 8.554 6.9300003 8.47 6.5940003 8.008 L 4.872 5.558 C 4.788 5.446 4.704 5.3900003 4.6480002 5.3900003 C 4.606 5.3900003 4.55 5.446 4.48 5.544 L 2.94 7.84 C 2.5340002 8.400001 2.4780002 8.554 3.262 8.596001 C 3.3460002 8.68 3.3460002 8.974 3.262 9.058001 C 2.7440002 9.044001 2.226 9.030001 1.666 9.030001 C 1.12 9.030001 0.658 9.044001 0.238 9.058001 C 0.154 8.974 0.16800001 8.68 0.252 8.596001 C 0.84000003 8.554 1.1060001 8.484 1.6800001 7.6580005 L 3.6680002 4.816 C 3.7800002 4.6480002 3.864 4.5360003 3.864 4.396 C 3.864 4.3120003 3.808 4.1860003 3.7240002 4.0740004 L 1.6520001 1.302 C 1.176 0.658 0.72800004 0.49 0.098000005 0.43400002 C 0.014 0.35000002 0.014 0.056 0.098000005 -0.028 C 0.518 -0.014 1.036 0 1.358 0 C 1.6800001 0 2.2680001 -0.014 2.828 -0.028 C 2.9120002 0.056 2.9120002 0.35000002 2.828 0.43400002 C 2.2120001 0.476 1.9460001 0.546 2.282 1.0220001 L 4.13 3.6120002 C 4.214 3.7240002 4.2980003 3.808 4.34 3.808 C 4.396 3.808 4.452 3.766 4.5360003 3.654 L 6.2720003 1.19 C 6.664 0.63 6.7200003 0.476 5.9360003 0.43400002 C 5.852 0.35000002 5.852 0.056 5.9360003 -0.028 C 6.454 -0.014 6.972 0 7.532 0 C 8.078 0 8.54 -0.014 8.96 -0.028 C 9.044001 0.056 9.030001 0.35000002 8.946 0.43400002 C 8.358 0.476 8.12 0.616 7.532 1.4280001 Z "/>
+        </symbol>
+        <symbol id="g926640D8B940E5DE31F42E464FE476CE" overflow="visible">
+            <path d="M 1.33 1.7080001 C 1.33 0.546 1.176 0.476 0.322 0.43400002 C 0.238 0.35000002 0.238 0.056 0.322 -0.028 C 0.81200004 -0.014 1.33 0 1.8900001 0 C 2.45 0 2.982 -0.014 3.444 -0.028 C 3.528 0.056 3.528 0.35000002 3.444 0.43400002 C 2.5900002 0.476 2.436 0.546 2.436 1.7080001 L 2.436 8.162001 C 2.436 9.0720005 2.492 9.632 2.492 9.632 C 2.492 9.7300005 2.436 9.772 2.3100002 9.772 C 1.96 9.632 0.91 9.436 0.35000002 9.394 C 0.322 9.282001 0.35000002 9.058001 0.43400002 8.974 C 1.246 8.918 1.33 8.876 1.33 7.826 Z "/>
+        </symbol>
+        <symbol id="gC051A57B8B21E8A5F22AD17806E736A9" overflow="visible">
+            <path d="M 2.548 4.494 L 1.75 1.008 C 1.6800001 0.72800004 1.5680001 0.37800002 1.5680001 0.238 C 1.5680001 0.014 1.694 -0.14 2.142 -0.14 C 2.674 -0.14 2.6460001 0.476 2.786 1.008 L 3.3460002 3.262 C 4.438 4.8440003 5.222 5.306 5.67 5.306 C 5.9500003 5.306 6.0340004 5.208 6.0340004 4.788 C 6.0340004 4.6200004 6.02 4.284 5.9220004 3.8500001 L 5.25 1.008 C 5.1800003 0.72800004 5.0680003 0.37800002 5.0680003 0.238 C 5.0680003 0.014 5.1940002 -0.14 5.642 -0.14 C 6.1740003 -0.14 6.1600003 0.476 6.2860003 1.008 L 6.8180003 3.206 C 8.008 4.872 8.554 5.306 9.002 5.306 C 9.268001 5.306 9.408 5.208 9.408 4.788 C 9.408 4.6340003 9.394 4.228 9.282001 3.7940001 L 8.736 1.5960001 C 8.596001 1.0220001 8.484 0.448 8.484 0.322 C 8.484 0.042000003 8.736 -0.14 8.932 -0.14 C 9.758 -0.14 10.528 0.266 11.004001 1.414 C 10.976001 1.5400001 10.878 1.61 10.696 1.61 C 10.360001 1.0780001 9.968 0.70000005 9.716001 0.70000005 C 9.646 0.70000005 9.618 0.78400004 9.618 0.85400003 C 9.618 0.91 9.646 1.26 9.688001 1.414 L 10.346001 3.9060001 C 10.43 4.228 10.486 4.662 10.486 4.928 C 10.486 5.81 10.066 6.1460004 9.632 6.1460004 C 8.6380005 6.1460004 7.868 5.2920003 7.056 4.27 C 7.098 4.494 7.112 4.7460003 7.112 4.928 C 7.112 5.908 6.6920004 6.1460004 6.3 6.1460004 C 5.2920003 6.1460004 4.382 5.4040003 3.556 4.34 L 3.528 4.354 L 3.556 4.48 C 3.696 5.026 3.878 5.572 3.878 5.81 C 3.878 6.006 3.766 6.104 3.584 6.104 C 3.1360002 6.104 2.506 6.006 1.848 5.9220004 C 1.75 5.81 1.778 5.656 1.8620001 5.53 L 2.4220002 5.4880004 C 2.5900002 5.474 2.674 5.348 2.674 5.208 C 2.674 5.0820003 2.632 4.886 2.548 4.494 Z "/>
+        </symbol>
+        <symbol id="gE81C33119EC92ECA818F9DC958FE0512" overflow="visible">
+            <path d="M 2.926 -0.14 C 3.934 -0.14 4.8440003 0.588 5.5160003 1.526 C 5.474 1.666 5.334 1.764 5.208 1.764 C 4.662 1.148 4.102 0.68600005 3.3600001 0.68600005 C 3.122 0.68600005 2.8560002 0.74200004 2.66 1.008 C 2.45 1.274 2.3100002 1.554 2.3100002 2.394 C 2.3100002 4.48 3.2900002 5.7120004 4.368 5.7120004 C 4.564 5.7120004 4.9560003 5.642 4.9560003 5.1800003 C 4.9560003 5.096 4.928 4.984 4.886 4.914 C 4.8440003 4.8580003 4.816 4.704 4.816 4.6200004 C 4.816 4.396 4.9560003 4.172 5.1940002 4.172 C 5.572 4.172 5.9220004 4.452 5.9220004 4.802 C 5.9220004 5.348 5.88 6.1460004 4.354 6.1460004 C 3.7940001 6.1460004 2.898 5.782 2.3100002 5.1660004 C 1.6240001 4.4240003 1.1620001 3.3460002 1.1620001 2.086 C 1.1620001 1.6240001 1.26 0.994 1.582 0.532 C 1.876 0.126 2.352 -0.14 2.926 -0.14 Z "/>
+        </symbol>
+        <symbol id="g9FBAF428159CD209BE9BC892D5BE4A21" overflow="visible">
+            <path d="M 2.464 1.008 L 2.996 3.332 C 3.878 4.48 4.788 5.306 5.2920003 5.306 C 5.586 5.306 5.782 5.222 5.782 4.788 C 5.782 4.592 5.754 4.326 5.642 3.8500001 L 5.11 1.61 C 4.998 1.1620001 4.872 0.588 4.872 0.322 C 4.872 0.056 5.026 -0.14 5.446 -0.14 C 6.118 -0.14 6.748 0.33600003 7.392 1.1620001 C 7.3500004 1.288 7.2660003 1.4000001 7.07 1.4000001 C 6.7060003 0.98 6.3 0.70000005 6.1600003 0.70000005 C 6.0620003 0.70000005 6.02 0.77000004 6.02 0.938 C 6.02 1.064 6.09 1.3720001 6.1740003 1.7360001 L 6.7060003 3.9620001 C 6.8180003 4.452 6.888 4.774 6.888 5.026 C 6.888 5.866 6.51 6.1460004 5.964 6.1460004 C 5.236 6.1460004 4.5080004 5.852 3.22 4.368 L 4.0740004 8.162001 C 4.284 9.0720005 4.4240003 9.632 4.4240003 9.632 C 4.4240003 9.7300005 4.382 9.772 4.256 9.772 C 3.878 9.632 2.8700001 9.450001 2.296 9.408 L 2.2540002 9.0720005 C 2.2540002 9.030001 2.2680001 9.002 2.3240001 9.002 L 2.7580001 8.974 C 2.94 8.974 3.052 8.89 3.052 8.582001 C 3.052 8.428 3.0240002 8.190001 2.954 7.8820004 L 1.4280001 1.008 C 1.358 0.72800004 1.246 0.37800002 1.246 0.238 C 1.246 0.014 1.3720001 -0.14 1.82 -0.14 C 2.352 -0.14 2.338 0.476 2.464 1.008 Z "/>
+        </symbol>
+        <symbol id="g4E7ED7F4D503F18CB9F87E4084765759" overflow="visible">
+            <path d="M 5.7400002 6.0620003 C 5.362 6.104 5.1800003 6.1460004 4.6200004 6.1460004 C 3.122 6.1460004 1.092 3.9480002 1.092 1.75 C 1.092 0.966 1.274 -0.14 2.45 -0.14 C 3.1920002 -0.14 3.976 0.63 4.816 1.876 L 4.8440003 1.848 L 4.662 1.26 C 4.564 0.938 4.5220003 0.658 4.5220003 0.49 C 4.5220003 0.224 4.6200004 -0.14 5.096 -0.14 C 5.964 -0.14 6.524 0.42000002 6.888 1.218 C 6.8180003 1.3440001 6.748 1.442 6.566 1.442 C 6.188 0.924 5.9220004 0.70000005 5.782 0.70000005 C 5.7400002 0.70000005 5.6140003 0.72800004 5.6140003 0.896 C 5.6140003 1.0220001 5.698 1.414 5.754 1.6800001 L 6.7200003 6.0340004 C 6.622 6.0340004 6.538 6.0340004 6.44 6.0340004 C 6.188 6.02 5.9500003 6.006 5.7400002 6.0620003 Z M 5.04 3.066 C 4.354 1.8060001 3.276 0.63 2.828 0.63 C 2.352 0.63 2.2120001 1.19 2.2120001 1.9740001 C 2.2120001 3.4580002 3.374 5.7120004 4.662 5.7120004 C 4.9560003 5.7120004 5.264 5.6140003 5.53 5.446 C 5.53 5.446 5.3900003 3.9620001 5.04 3.066 Z "/>
+        </symbol>
+        <symbol id="gC921DA4C2505E536B143666DAB5BB97D" overflow="visible">
+            <path d="M 2.436 -0.14 L 2.6460001 -0.14 C 4.018 -0.14 4.8440003 0.616 4.8440003 1.6520001 C 4.8440003 2.3100002 4.466 2.954 3.1780002 3.808 C 2.7580001 4.0880003 2.618 4.34 2.618 4.69 C 2.618 5.1800003 2.898 5.684 3.5 5.684 C 3.8500001 5.684 4.0880003 5.572 4.13 5.2780004 C 4.172 4.9420004 4.4100003 4.55 4.774 4.55 C 5.1660004 4.55 5.2780004 4.802 5.2780004 5.026 C 5.2780004 5.53 4.55 6.1460004 3.6820002 6.1460004 C 2.464 6.1460004 1.722 5.25 1.722 4.396 C 1.722 3.8360002 2.03 3.2340002 2.94 2.618 C 3.6820002 2.114 3.7940001 1.6520001 3.7940001 1.358 C 3.7940001 0.588 3.2340002 0.322 2.604 0.322 C 2.24 0.322 2.0440001 0.39200002 2.002 0.70000005 C 1.96 1.0220001 1.764 1.442 1.3440001 1.442 C 0.938 1.442 0.82600003 1.1060001 0.82600003 0.952 C 0.82600003 0.43400002 1.47 -0.08400001 2.436 -0.14 Z "/>
+        </symbol>
+        <symbol id="gE24BC04FAC9B34AC1945A99047F7540D" overflow="visible">
+            <path d="M 3.43 4.48 C 3.556 5.026 3.7240002 5.572 3.7240002 5.81 C 3.7240002 6.006 3.6120002 6.104 3.43 6.104 C 2.982 6.104 2.352 6.006 1.694 5.9220004 C 1.5960001 5.81 1.6240001 5.656 1.7080001 5.53 L 2.2680001 5.4880004 C 2.436 5.474 2.52 5.348 2.52 5.208 C 2.52 5.0820003 2.492 4.886 2.394 4.494 L 1.7360001 1.61 C 1.638 1.1620001 1.498 0.588 1.498 0.322 C 1.498 0.056 1.6520001 -0.14 2.072 -0.14 C 2.7440002 -0.14 3.374 0.33600003 4.018 1.1620001 C 3.976 1.288 3.8920002 1.4000001 3.696 1.4000001 C 3.332 0.98 2.926 0.70000005 2.786 0.70000005 C 2.6880002 0.70000005 2.6460001 0.77000004 2.6460001 0.938 C 2.6460001 1.064 2.716 1.3720001 2.8000002 1.7360001 Z M 2.8140001 7.98 C 2.8140001 7.616 3.122 7.308 3.486 7.308 C 3.8500001 7.308 4.158 7.616 4.158 7.98 C 4.158 8.344 3.8500001 8.652 3.486 8.652 C 3.122 8.652 2.8140001 8.344 2.8140001 7.98 Z "/>
+        </symbol>
+        <symbol id="gE1DB41F6D9C511CA82E0B4ADC07DE267" overflow="visible">
+            <path d="M 0.79800004 0.602 C 0.79800004 0.19600001 1.1340001 -0.14 1.5400001 -0.14 C 1.9460001 -0.14 2.282 0.19600001 2.282 0.602 C 2.282 1.008 1.9460001 1.3440001 1.5400001 1.3440001 C 1.1340001 1.3440001 0.79800004 1.008 0.79800004 0.602 Z "/>
+        </symbol>
+        <symbol id="gD0DF5A8CDB09E39896B947740CC03A5E" overflow="visible">
+            <path d="M 0.98 0.84000003 C 0.98 0.43400002 1.316 0.098000005 1.722 0.098000005 C 2.128 0.098000005 2.464 0.43400002 2.464 0.84000003 C 2.464 1.246 2.128 1.582 1.722 1.582 C 1.316 1.582 0.98 1.246 0.98 0.84000003 Z M 0.98 5.012 C 0.98 4.606 1.316 4.27 1.722 4.27 C 2.128 4.27 2.464 4.606 2.464 5.012 C 2.464 5.418 2.128 5.754 1.722 5.754 C 1.316 5.754 0.98 5.418 0.98 5.012 Z "/>
+        </symbol>
+        <symbol id="g584E4A5E8B2E44892DDE3A1C7F192E4E" overflow="visible">
+            <path d="M 0.86800003 3.22 C 0.86800003 2.338 1.582 1.6240001 2.464 1.6240001 C 3.3460002 1.6240001 4.06 2.338 4.06 3.22 C 4.06 4.102 3.3460002 4.816 2.464 4.816 C 1.582 4.816 0.86800003 4.102 0.86800003 3.22 Z "/>
+        </symbol>
+        <symbol id="g6086AF707F869D2968A3D14EE379050A" overflow="visible">
+            <path d="M 2.072 9.030001 C 1.5680001 9.030001 0.81200004 9.044001 0.266 9.058001 C 0.18200001 8.974 0.18200001 8.68 0.266 8.596001 C 1.246 8.554 1.4840001 8.484 1.4840001 7.322 L 1.4840001 1.7080001 C 1.4840001 0.546 1.246 0.476 0.266 0.43400002 C 0.18200001 0.35000002 0.18200001 0.056 0.266 -0.028 C 0.81200004 -0.014 1.5680001 0 2.086 0 C 2.5900002 0 2.954 -0.028 4.13 -0.028 C 6.9160004 -0.028 7.6580005 1.3720001 7.6580005 2.576 C 7.6580005 3.92 6.7200003 4.69 5.5020003 5.04 L 5.5020003 5.0680003 C 6.202 5.418 6.8320003 6.1460004 6.8320003 6.9020004 C 6.8320003 7.84 6.426 9.058001 3.822 9.058001 C 3.332 9.058001 2.576 9.030001 2.072 9.030001 Z M 2.674 4.6480002 L 3.64 4.6480002 C 5.558 4.6480002 6.3560004 3.5700002 6.3560004 2.3100002 C 6.3560004 1.288 5.964 0.43400002 3.8360002 0.43400002 C 2.8560002 0.43400002 2.674 0.79800004 2.674 1.6520001 Z M 2.674 7.7000003 C 2.674 8.442 2.674 8.582001 3.8920002 8.582001 C 4.676 8.582001 5.698 8.162001 5.698 6.734 C 5.698 5.544 4.872 5.124 3.71 5.124 L 2.674 5.124 Z "/>
+        </symbol>
+        <symbol id="gE49CB035CF1BC9F0FC3F7067B630D8D5" overflow="visible">
+            <path d="M 2.45 1.7080001 L 2.45 5.46 L 3.752 5.46 C 3.878 5.46 4.0740004 5.5160003 4.0740004 5.642 L 4.0740004 5.9220004 C 4.0740004 5.978 4.032 6.006 3.9620001 6.006 L 2.45 6.006 L 2.45 6.8040004 C 2.45 8.96 3.094 9.2960005 3.556 9.2960005 C 3.976 9.2960005 4.2000003 9.128 4.396 8.6380005 C 4.5080004 8.386001 4.662 8.190001 4.9560003 8.190001 C 5.1940002 8.190001 5.53 8.484 5.53 8.764 C 5.53 9.002 5.3760004 9.254001 5.0820003 9.478001 C 4.718 9.7300005 4.354 9.772 3.822 9.772 C 2.6460001 9.772 1.3440001 8.75 1.3440001 6.566 L 1.3440001 6.006 L 0.63 6.006 C 0.37800002 6.006 0.308 5.8380003 0.308 5.7260003 L 0.308 5.544 C 0.308 5.474 0.322 5.46 0.37800002 5.46 L 1.3440001 5.46 L 1.3440001 1.7080001 C 1.3440001 0.546 1.12 0.49 0.36400002 0.43400002 C 0.28 0.35000002 0.28 0.056 0.36400002 -0.028 C 0.85400003 -0.014 1.3440001 0 1.904 0 C 2.464 0 3.1360002 -0.014 3.6260002 -0.028 C 3.71 0.056 3.71 0.35000002 3.6260002 0.43400002 C 2.5340002 0.49 2.45 0.546 2.45 1.7080001 Z "/>
+        </symbol>
+        <symbol id="g86335E45CA2AED4A1909A1DE015CEE2B" overflow="visible">
+            <path d="M 5.572 1.274 C 5.5160003 1.4000001 5.4040003 1.4560001 5.2780004 1.47 C 4.802 0.85400003 4.2000003 0.546 3.598 0.546 C 2.576 0.546 1.722 1.582 1.722 3.22 C 1.722 4.76 2.394 5.684 3.318 5.684 C 4.144 5.684 4.256 5.1940002 4.3120003 4.704 C 4.354 4.326 4.55 4.2000003 4.8440003 4.2000003 C 5.138 4.2000003 5.53 4.382 5.53 4.816 C 5.53 5.586 4.7320004 6.1460004 3.388 6.1460004 C 2.002 6.1460004 0.518 4.9 0.518 2.9120002 C 0.518 1.1060001 1.526 -0.14 3.2900002 -0.14 C 4.13 -0.14 4.872 0.126 5.572 1.274 Z "/>
+        </symbol>
+        <symbol id="g410AF3236A945D009F63FCA8D3C4D09F" overflow="visible">
+            <path d="M 3.9620001 4.5220003 C 5.152 4.5220003 5.1940002 4.2000003 5.236 3.5700002 C 5.32 3.486 5.6140003 3.486 5.698 3.5700002 C 5.684 3.92 5.67 4.326 5.67 4.802 C 5.67 5.2780004 5.684 5.642 5.698 6.006 C 5.6140003 6.09 5.32 6.09 5.236 6.006 C 5.1940002 5.236 5.152 5.0540004 3.9620001 5.0540004 L 2.66 5.0540004 L 2.66 7.5740004 C 2.66 8.33 2.828 8.47 3.444 8.47 L 4.0740004 8.47 C 5.558 8.47 5.908 7.9100003 6.216 6.9440002 C 6.3840003 6.9440002 6.538 6.972 6.65 7.0140004 C 6.5800004 7.5880003 6.3700004 8.932 6.342 9.044001 C 6.342 9.0720005 6.328 9.086 6.2860003 9.086 C 6.0480003 9.044001 5.978 9.030001 5.6280003 9.030001 L 2.058 9.030001 C 1.61 9.030001 0.81200004 9.044001 0.252 9.058001 C 0.16800001 8.974 0.16800001 8.68 0.252 8.596001 C 1.232 8.554 1.47 8.484 1.47 7.322 L 1.47 1.7080001 C 1.47 0.546 1.232 0.476 0.252 0.43400002 C 0.16800001 0.35000002 0.16800001 0.056 0.252 -0.028 C 0.74200004 -0.014 1.442 0 2.072 0 C 2.7020001 0 3.388 -0.014 3.878 -0.028 C 3.9620001 0.056 3.9620001 0.35000002 3.878 0.43400002 C 2.898 0.476 2.66 0.546 2.66 1.7080001 L 2.66 4.5220003 Z "/>
+        </symbol>
+        <symbol id="gAFB665305D4754FAECAE9C74D0DCDD8D" overflow="visible">
+            <path d="M 2.548 5.012 C 2.226 5.4880004 2.3240001 5.5020003 2.954 5.572 C 3.038 5.656 3.038 5.9500003 2.954 6.0340004 C 2.576 6.02 1.96 6.006 1.5400001 6.006 C 1.12 6.006 0.70000005 6.02 0.33600003 6.0340004 C 0.252 5.9500003 0.252 5.656 0.33600003 5.572 C 0.81200004 5.53 1.204 5.2920003 1.5960001 4.718 L 2.8140001 2.94 C 2.884 2.842 2.884 2.8000002 2.828 2.73 L 1.6520001 1.218 C 1.092 0.504 0.78400004 0.462 0.294 0.43400002 C 0.21000001 0.35000002 0.21000001 0.056 0.294 -0.028 C 0.574 -0.014 0.882 0 1.302 0 C 1.722 0 2.114 -0.014 2.4780002 -0.028 C 2.562 0.056 2.562 0.35000002 2.4780002 0.43400002 C 1.9740001 0.49 1.8620001 0.546 2.17 0.994 L 3.052 2.2680001 C 3.164 2.436 3.22 2.4220002 3.3040001 2.296 L 4.116 1.176 C 4.606 0.504 4.382 0.476 3.934 0.43400002 C 3.8500001 0.35000002 3.8500001 0.056 3.934 -0.028 C 4.354 -0.014 4.816 0 5.32 0 C 5.852 0 6.23 -0.014 6.566 -0.028 C 6.65 0.056 6.65 0.35000002 6.566 0.43400002 C 5.9360003 0.476 5.7260003 0.518 5.1660004 1.316 L 3.9060001 3.094 C 3.8500001 3.1780002 3.8360002 3.22 3.9060001 3.3040001 L 5.0820003 4.802 C 5.6000004 5.46 5.9360003 5.53 6.44 5.572 C 6.524 5.656 6.524 5.9500003 6.44 6.0340004 C 6.1600003 6.02 5.8380003 6.006 5.418 6.006 C 4.998 6.006 4.606 6.02 4.242 6.0340004 C 4.158 5.9500003 4.158 5.656 4.242 5.572 C 4.76 5.5160003 4.914 5.474 4.578 4.998 L 3.6680002 3.7240002 C 3.5700002 3.584 3.5140002 3.598 3.4020002 3.752 Z "/>
+        </symbol>
+        <symbol id="g41F65FF5CDEFC395FC08320CDD4280E3" overflow="visible">
+            <path d="M 4.55 5.572 C 5.306 5.5160003 5.3900003 5.348 5.096 4.6340003 L 3.9620001 1.8900001 C 3.7380002 1.3440001 3.6680002 1.3440001 3.444 1.932 L 2.436 4.6340003 C 2.184 5.306 2.128 5.474 2.8700001 5.572 C 2.954 5.656 2.954 5.9500003 2.8700001 6.0340004 C 2.408 6.02 1.9180001 6.006 1.4560001 6.006 C 0.994 6.006 0.574 6.02 0.154 6.0340004 C 0.07 5.9500003 0.07 5.656 0.154 5.572 C 0.896 5.4880004 0.994 5.264 1.274 4.55 L 3.066 0.126 C 3.15 -0.08400001 3.2340002 -0.16800001 3.4160001 -0.16800001 C 3.556 -0.16800001 3.654 -0.08400001 3.752 0.154 L 5.6140003 4.5360003 C 5.88 5.152 6.0340004 5.5020003 6.8180003 5.572 C 6.9020004 5.656 6.9020004 5.9500003 6.8180003 6.0340004 C 6.538 6.02 6.202 6.006 5.8380003 6.006 C 5.3760004 6.006 4.9 6.02 4.55 6.0340004 C 4.466 5.9500003 4.466 5.656 4.55 5.572 Z "/>
+        </symbol>
+        <symbol id="gCE992FDD00F82896D12588559411C0E3" overflow="visible">
+            <path d="M 2.17 1.1060001 L 2.94 3.1360002 C 3.01 3.318 3.094 3.374 3.43 3.374 L 6.3840003 3.374 L 7.196 1.008 C 7.3640003 0.532 6.8320003 0.476 6.1600003 0.43400002 C 6.076 0.35000002 6.076 0.056 6.1600003 -0.028 C 6.678 -0.014 7.4480004 0 7.9940004 0 C 8.568 0 9.1 -0.014 9.59 -0.028 C 9.674001 0.056 9.674001 0.35000002 9.59 0.43400002 C 9.044001 0.49 8.568 0.532 8.33 1.204 L 5.446 9.212 C 5.236 9.086 4.8580003 8.932 4.676 8.932 L 1.498 1.4280001 C 1.1340001 0.56 0.71400005 0.476 0.098000005 0.43400002 C 0.014 0.35000002 0.014 0.056 0.098000005 -0.028 C 0.462 -0.014 0.924 0 1.3440001 0 C 1.9180001 0 2.618 -0.014 3.1360002 -0.028 C 3.22 0.056 3.22 0.35000002 3.1360002 0.43400002 C 2.604 0.476 1.9460001 0.532 2.17 1.1060001 Z M 3.6820002 3.9620001 C 3.374 3.9620001 3.276 4.004 3.332 4.144 L 4.76 7.7700005 L 4.8440003 7.7700005 L 6.1600003 3.9620001 Z "/>
+        </symbol>
+        <symbol id="g84EC738B8C4742CF902A4A9BE36FFAC5" overflow="visible">
+            <path d="M 9.282001 1.6240001 C 9.352 0.49 9.2960005 0.476 8.386001 0.43400002 C 8.302 0.35000002 8.302 0.056 8.386001 -0.028 C 8.904 -0.014 9.464001 0 9.884001 0 C 10.304 0 10.948 -0.014 11.410001 -0.028 C 11.494 0.056 11.494 0.35000002 11.410001 0.43400002 C 10.458 0.476 10.416 0.532 10.332001 1.694 L 9.912001 7.5880003 C 9.856 8.344 9.926001 8.54 10.878 8.596001 C 10.962 8.68 10.962 8.974 10.878 9.058001 L 9.044001 9.030001 L 6.076 1.932 C 6.02 1.792 5.978 1.7360001 5.9500003 1.7360001 C 5.9220004 1.7360001 5.88 1.8060001 5.8380003 1.9180001 L 2.9680002 9.030001 L 0.938 9.058001 C 0.85400003 8.974 0.85400003 8.68 0.938 8.596001 C 1.904 8.54 1.988 8.512 1.8900001 7.4620004 L 1.33 1.694 C 1.246 0.85400003 1.0780001 0.504 0.28 0.43400002 C 0.19600001 0.35000002 0.19600001 0.056 0.28 -0.028 C 0.70000005 -0.014 1.148 0 1.4840001 0 C 1.82 0 2.38 -0.014 2.8000002 -0.028 C 2.884 0.056 2.884 0.35000002 2.8000002 0.43400002 C 1.876 0.504 1.8060001 0.938 1.876 1.722 L 2.408 7.3360004 L 2.436 7.3360004 L 5.334 0.07 C 5.3760004 -0.028 5.46 -0.14 5.544 -0.14 C 5.6280003 -0.14 5.684 -0.042000003 5.7400002 0.07 L 8.89 7.4760003 L 8.918 7.4760003 Z "/>
+        </symbol>
+        <symbol id="g5BF4044AE3C1666C4DF98B6347561756" overflow="visible">
+            <path d="M 1.4560001 1.33 C 1.0220001 1.33 0.71400005 1.036 0.71400005 0.644 C 0.71400005 0.21000001 1.0780001 0.07 1.33 0.028 C 1.5960001 0 1.8340001 -0.08400001 1.8340001 -0.40600002 C 1.8340001 -0.70000005 1.33 -1.3440001 0.602 -1.526 C 0.602 -1.666 0.63 -1.764 0.72800004 -1.8620001 C 1.5680001 -1.7080001 2.38 -1.036 2.38 -0.056 C 2.38 0.78400004 2.016 1.33 1.4560001 1.33 Z "/>
+        </symbol>
+    </defs>
+</svg>

--- a/packages/preview/droplet/0.3.0/assets/example.typ
+++ b/packages/preview/droplet/0.3.0/assets/example.typ
@@ -1,0 +1,34 @@
+#import "@preview/droplet:0.3.0": dropcap
+
+#set par(justify: true)
+#set text(size: 14pt)
+#set page(
+  width: 11cm + 16pt,
+  height: auto,
+  margin: (x: 1em + 8pt, y: 1em),
+  fill: none,
+  background: pad(0.5pt, box(
+    width: 100%,
+    height: 100%,
+    radius: 4pt,
+    fill: white,
+    stroke: white.darken(10%),
+  )),
+)
+
+#dropcap(
+  height: 3,
+  gap: 4pt,
+  hanging-indent: 1em,
+  overhang: 8pt,
+  font: "Curlz MT",
+)[
+  *Typst* is a new markup-based typesetting system that is designed to be as _powerful_ as LaTeX while being _much easier_ to learn and use. Typst has:
+
+  - Built-in markup for the most common formatting tasks
+  - Flexible functions for everything else
+  - A tightly integrated scripting system
+  - Math typesetting, bibliography management, and more
+  - Fast compile times thanks to incremental compilation
+  - Friendly error messages in case something goes wrong
+]

--- a/packages/preview/droplet/0.3.0/src/droplet.typ
+++ b/packages/preview/droplet/0.3.0/src/droplet.typ
@@ -1,0 +1,191 @@
+#import "extract.typ": extract
+#import "split.typ": split
+#import "util.typ": inline
+
+// Sets the font size so the resulting text height matches the given height.
+//
+// Parameters:
+// - height: The target height of the resulting text.
+// - text-args: Named arguments to be passed to the underlying text element.
+// - body: The content of the text element.
+//
+// Returns: The text with the adjusted size.
+#let sized(height, ..text-args, body) = context {
+  let styled-text = text.with(..text-args.named(), body)
+  let measured = measure(styled-text(1em)).height 
+  let factor = if measured > 0pt { height / measured } else { 1 }
+  styled-text(factor * 1em)
+}
+
+// Resolves the given height to an absolute length.
+//
+// Height can be given as an integer, which is interpreted as the number of
+// lines, or as a length.
+//
+// Requires context.
+#let resolve-height(height) = {
+  if type(height) == int {
+    measure([x\ ] * height).height
+  } else {
+    height.to-absolute()
+  }
+}
+
+// Shows the first letter of the given content in a larger font.
+//
+// If the first letter is not given as a positional argument, it is extracted
+// from the content. The rest of the content is split into two pieces, where
+// one is positioned next to the dropped capital, and the other below it.
+//
+// Parameters:
+// - height: The height of the first letter. Can be given as the number of
+//           lines (integer) or as a length. If set to `auto`, no scaling is
+//           applied.
+// - justify: Whether to justify the text next to the first letter.
+// - gap: The space between the first letter and the text.
+// - hanging-indent: The indent of lines after the first line.
+// - overhang: The amount by which the first letter should overhang into the
+//             margin. Ratios are relative to the width of the first letter.
+// - depth: The minimum space below the first letter. Can be given as the
+//          number of lines (integer) or as a length.
+// - transform: A function to be applied to the first letter.
+// - text-args: Named arguments to be passed to the underlying text element.
+// - body: The content to be shown.
+//
+// Returns: The content with the first letter shown in a larger font.
+#let dropcap(
+  height: 2,
+  justify: auto,
+  gap: 0pt,
+  hanging-indent: 0pt,
+  overhang: 0pt,
+  depth: 0pt,
+  transform: none,
+  ..text-args,
+  body
+) = layout(bounds => {
+  let text-args = text-args
+
+  if height != auto {
+    // Set default top and bottom edge to "bounds" if not specified.
+    if "top-edge" not in text-args.named() {
+      text-args = arguments(..text-args, top-edge: "bounds")
+    }
+    if "bottom-edge" not in text-args.named() {
+      text-args = arguments(..text-args, bottom-edge: "bounds")
+    }
+  }
+
+  let (letter, rest) = if text-args.pos() == () {
+    extract(body)
+  } else {
+    // First letter already given.
+    (text-args.pos().first(), body)
+  }
+
+  if transform != none {
+    letter = context transform(letter)
+  }
+
+  let letter-height = if height == auto {
+    // Don't rescale if height is set to auto.
+    measure(text(..text-args.named(), letter)).height
+  } else {
+    resolve-height(height)
+  }
+
+  let depth = resolve-height(depth)
+
+  // Create dropcap with the height of sample content.
+  let letter = box(
+    height: letter-height + depth,
+    sized(letter-height, letter, ..text-args.named())
+  )
+  let letter-width = measure(letter).width
+
+  // Resolve overhang if given as percentage.
+  let overhang = if type(overhang) == ratio {
+    letter-width * overhang
+  } else if type(overhang) == relative {
+    letter-width * overhang.ratio + overhang.length
+  } else {
+    overhang
+  }
+
+  // Resolve justify if given as auto.
+  let justify = if justify == auto { par.justify } else { justify }
+
+  // Try to justify as many words as possible next to dropcap.
+  let bounded = box.with(width: bounds.width - letter-width - gap + overhang)
+
+  let index = 1
+  let top-position = 0pt
+  let prev-height = 0pt
+  let (first, second, sep) = while true {
+    let (first, second, _) = split(rest, index)
+    let first = {
+      set par(hanging-indent: hanging-indent, justify: justify)
+      first
+    }
+
+    let height = measure(bounded(first)).height
+    let (_, new, sep) = split(first, -1)
+    top-position = calc.max(
+      top-position,
+      height - measure(new).height - par.leading.to-absolute()
+    )
+
+    if top-position >= letter-height + depth - 1e-6pt and height > prev-height {
+      // Limit reached, new element doesn't fit anymore
+      split(rest, index - 1)
+      break
+    }
+
+    if second == none {
+      // All content fits next to dropcap.
+      (first, none, none)
+      break
+    }
+
+    index += 1
+    prev-height = height
+  }
+
+  // Layout dropcap and aside text as grid.
+  set par(justify: justify)
+
+  // Find out whether there is a break between the first and second part.
+  let has-break = type(sep) == content and sep.func() in (linebreak, parbreak)
+  if not has-break {
+    let sep = split(first, -1).at(2)
+    has-break = type(sep) == content and sep.func() in (linebreak, parbreak)
+  }
+
+  // Find elements at boundary.
+  let last-of-first = split(first, -1).at(1)
+  let first-of-second = if second == none { none } else  { split(second, 1).at(0) }
+
+  let func(body) = if inline(last-of-first) {
+    box(body) + linebreak()
+  } else {
+    block(body)
+  }
+
+  func(grid(
+    column-gutter: gap,
+    columns: (letter-width - overhang, 1fr),
+    move(dx: -overhang, letter),
+    {
+      set par(hanging-indent: hanging-indent)
+      first
+      
+      if not has-break and inline(last-of-first) and inline(first-of-second) {
+        linebreak(justify: justify)
+      } 
+    }
+  ))
+
+  if type(sep) == content and sep.func() in (linebreak, parbreak) { sep }
+
+  second
+})

--- a/packages/preview/droplet/0.3.0/src/extract.typ
+++ b/packages/preview/droplet/0.3.0/src/extract.typ
@@ -1,0 +1,155 @@
+#import "util.typ": attach-label, space, splittable, to-string
+
+// Regex for valid characters in front of the dropped capital.
+#let regex-before = regex({
+  "["
+    "\"'"              // Dumb quotes
+    "\p{C}"            // Control characters
+    "\p{Pi}"           // Initial punctuation
+    "\p{Ps}"           // Opening punctuation
+    "\p{Z}"            // Spaces and separators
+    "¹²³\u2070-\u209F" // Superscripts and subscripts
+  "]+"
+})
+
+// Regex for valid characters behind the dropped capital.
+#let regex-after = regex({
+  "["
+    "\."               // Full stop
+    "\"'"              // Dumb quotes / apostrophe
+    "\p{C}"            // Control characters
+    "\p{Pf}"           // Final punctuation
+    "\p{Pe}"           // Closing punctuation
+    "\p{Z}"            // Spaces and separators
+    "\p{M}"            // Combining marks
+    "¹²³\u2070-\u209F" // Superscripts and subscripts
+  "]+"
+})
+
+// Extracts the first letter of the given content.
+//
+// The first letter may be none if the content does not contain any letters.
+// If the first child cannot be split further, that child is returned as the
+// first letter.
+//
+// Returns: A tuple of the first letter and the rest.
+#let extract-first-letter(body) = {
+  // Handle string content.
+  if type(body) == str {
+    let letter = body.clusters().at(0, default: none)
+    if letter == none {
+      return (none, body)
+    }
+    let rest = body.clusters().slice(1).join()
+    return (letter, rest)
+  }
+
+  // Handle text content.
+  if body.has("text") {
+    let (text, ..fields) = body.fields()
+    if "label" in fields { fields.remove("label") }
+    let label = if body.has("label") { body.label }
+    let func(it) = if it != none { body.func()(..fields, it) }
+    let (letter, rest) = extract-first-letter(body.text)
+    return attach-label((letter, func(rest)), label)
+  }
+
+  // Handle content with "body" field.
+  if body.func() in splittable {
+    let (body: text, ..fields) = body.fields()
+    if "label" in fields { fields.remove("label") }
+    let label = if body.has("label") { body.label }
+    let func(it) = if it != none { body.func()(..fields, it) }
+    let (letter, rest) = extract-first-letter(text)
+    return attach-label((letter, func(rest)), label)
+  }
+
+  // Handle styled content.
+  if body.has("child") {
+    let (child, styles, ..fields) = body.fields()
+    if "label" in fields { fields.remove("label") }
+    let label = if body.has("label") { body.label }
+    let func(it) = if it != none { body.func()(it, styles) }
+    let (letter, rest) = extract-first-letter(child)
+    return attach-label((letter, func(rest)), label)
+  }
+
+  // Handle enumeration items (interpreted as text, e.g. "5. Body" or "+ Body")
+  if body.func() == enum.item {
+    let (body, ..fields) = body.fields()
+    let number = fields.at("number", default: none)
+    return if number == none {
+      ("+", body)
+    } else if number < 10 {
+      (str(number), "." + body)
+    } else {
+      (str(number).first(), str(number).slice(1) + "." + body)
+    }
+  }
+
+  // Handle list items (interpreted as text, e.g. "- Body")
+  if body.func() == list.item {
+    return ("-", body.body)
+  }
+
+  // Handle sequences.
+  if body.has("children") {
+    let child-pos = body.children.position(c => {
+      c.func() not in (space, parbreak)
+    })
+
+    if child-pos == none {
+      // There is no non-empty child, so no letter.
+      return (none, body)
+    }
+
+    let child = body.children.at(child-pos)
+    let (letter, rest) = extract-first-letter(child)
+    if body.children.len() > child-pos {
+      rest = (rest, ..body.children.slice(child-pos+1)).join()
+    }
+    return (letter, rest)
+  }
+
+  // Handle unbreakable content.
+  return (body, none)
+}
+
+// Extracts the dropped capital from the given content.
+//
+// The dropped capital contains the first real letter (or number) of the
+// content, but can be preceded by opening punctuation characters, and followed
+// by a sequence of closing punctuation characters.
+//
+// For example, the dropped capital of "Hello, world!" is "H", and the
+// dropped capital of "1. Hello, world!" is "1." including the dot.
+//
+// Returns: A tuple of the dropped capital and the rest.
+#let extract(body) = {
+  let (letter, rest) = extract-first-letter(body)
+  if letter == none {
+    return (none, body)
+  }
+
+  // We can only append punctuation characters if the first letter can be
+  // converted to a string, but not if it's e.g. a 'box' or 'image'.
+  if to-string(letter) != none {
+    // Append opening punctuation characters until the first "real" letter.
+    while to-string(letter).last().match(regex-before) != none {
+      let (next-letter, new-rest) = extract-first-letter(rest)
+      if next-letter == none { break }
+      letter += next-letter
+      rest = new-rest
+    }
+
+    // Append closing punctuation characters.
+    let (next-letter, new-rest) = extract-first-letter(rest)
+    while next-letter != none and to-string(next-letter).match(regex-after) != none {
+      letter += next-letter
+      rest = new-rest
+      (next-letter, new-rest) = extract-first-letter(rest)
+    }
+  }
+
+  return (letter, rest)
+}

--- a/packages/preview/droplet/0.3.0/src/lib.typ
+++ b/packages/preview/droplet/0.3.0/src/lib.typ
@@ -1,0 +1,1 @@
+#import "droplet.typ": dropcap

--- a/packages/preview/droplet/0.3.0/src/split.typ
+++ b/packages/preview/droplet/0.3.0/src/split.typ
@@ -1,0 +1,131 @@
+#import "util.typ": attach-label, space, splittable
+
+// Joins the given children into a single content.
+//
+// If the children list is empty, an empty content is returned instead of none.
+#let join(children) = {
+  if children.len() == 0 {
+    []
+  } else {
+    children.join()
+  }
+}
+
+// Gets the number of breakpoints in the given content.
+//
+// A breakpoints must always be at a space. For example, the sequece
+//   ([Hello], [ ], [my world!])
+// has two inner breakpoints:
+//  1. ([Hello],) - ([my world!],) - (sep: [ ])
+//  2. ([Hello my],) - ([world!],) - (sep: " ")
+//
+// Returns: The number of breakpoints.
+#let breakpoints(body) = {
+  if type(body) == str {
+    body.split(" ").len() - 1
+  } else if body.has("text") {
+    breakpoints(body.text)
+  } else if body.has("child") {
+    breakpoints(body.child)
+  } else if body.has("children") {
+    body.children.map(breakpoints).sum(default: 0)
+  } else if body.func() in splittable {
+    breakpoints(body.body)
+  } else if body.func() in (space, linebreak, parbreak) {
+    1
+  } else {
+    0
+  }
+}
+
+// Splits the given content at a given breakpoint index.
+//
+// Content is split at spaces. A sequence can be split at any of its childrens'
+// breakpoints (spaces), but in general not between children.
+//
+// Returns: A tuple of the first and second part.
+#let split(body, index) = {
+  // Shortcut for out-of-bounds indices.
+  if index > breakpoints(body) {
+    return (body, none, none)
+  }
+
+  if index < 0 {
+    return split(body, calc.max(0, breakpoints(body) + index + 1))
+  }
+
+  // Handle string content.
+  if type(body) == str {
+    let words = body.split(" ")
+    let first = words.slice(0, index).join(" ")
+    let second = words.slice(index).join(" ")
+    return (first, second, " ")
+  }
+
+  // Handle text content.
+  if body.has("text") {
+    let (text, ..fields) = body.fields()
+    if "label" in fields { fields.remove("label") }
+    let label = if body.has("label") { body.label }
+    let func(it) = if it != none { body.func()(..fields, it) }
+    let (first, second, sep) = split(text, index)
+    return (..attach-label((func(first), func(second)), label), sep)
+  }
+
+  // Handle content with "body" field.
+  if body.func() in splittable {
+    let (body: text, ..fields) = body.fields()
+    if "label" in fields { fields.remove("label") }
+    let label = if body.has("label") { body.label }
+    let func(it) = if it != none { body.func()(..fields, it) }
+    let (first, second, sep) = split(text, index)
+    return (..attach-label((func(first), func(second)), label), sep)
+  }
+
+  // Handle styled content.
+  if body.has("child") {
+    let (child, styles, ..fields) = body.fields()
+    if "label" in fields { fields.remove("label") }
+    let label = if body.has("label") { body.label }
+    let func(it) = if it != none { body.func()(it, styles) }
+    let (first, second, sep) = split(child, index)
+    return (..attach-label((func(first), func(second)), label), sep)
+  }
+
+  // Handle sequences.
+  if body.has("children") {
+    let first = ()
+    let second = ()
+    let sep = none
+
+    // Find child containing the breakpoint and split it.
+    let sub-index = index
+    for (i, child) in body.children.enumerate() {
+      let child-breakpoints = breakpoints(child)
+
+      // Check if current child contains splitting point.
+      if sub-index <= child-breakpoints {
+        if child.func() not in (space, linebreak, parbreak) {
+          // Push split child (skip trailing spaces)
+          let (child-first, child-second, child-sep) = split(child, sub-index)
+          first.push(child-first)
+          second.push(child-second)
+          sep = child-sep
+        } else {
+          sep = child
+        }
+
+        second += body.children.slice(i + 1)
+        break
+      }
+
+      sub-index -= child-breakpoints
+      first.push(child)
+    }
+
+    return (join(first), join(second), sep)
+  }
+
+  // Handle unbreakable content.
+  return if index == 0 { (none, body, none) } else { (body, none, none) }
+}

--- a/packages/preview/droplet/0.3.0/src/util.typ
+++ b/packages/preview/droplet/0.3.0/src/util.typ
@@ -1,0 +1,94 @@
+// Elements that can be split and have a 'body' field.
+#let splittable = (strong, emph, underline, stroke, overline, highlight)
+
+// Element function of spaces.
+#let space = [ ].func()
+
+// Converts the given content to a string.
+#let to-string(body) = {
+  if type(body) == str {
+    body
+  } else if body.has("text") {
+    to-string(body.text)
+  } else if body.has("child") {
+    to-string(body.child)
+  } else if body.has("children") {
+    body.children.map(to-string).join()
+  } else if body.func() in splittable {
+    to-string(body.body)
+  } else if body.func() == smartquote {
+    // Unfortunately, we can only use "dumb" quotes here.
+    if body.double { "\"" } else { "'" }
+  } else if body.func() == enum.item {
+    if body.has("number") {
+      str(body.number) + ". " + to-string(body.body)
+    } else {
+      "+ " + to-string(body.body)
+    }
+  } else if body.func() == space {
+    " "
+  } else if body.func() == super {
+    let body-string = to-string(body.body)
+    if body-string.match(regex("^[0-9+\-=\(\)ni\s]+$")) != none {
+      body-string
+        .replace("1", "¹")
+        .replace("2", "²")
+        .replace("3", "³")
+        .replace(regex("[04-9]"), it => str.from-unicode(0x2070 + int(it.text)))
+        .replace("+", "\u{207A}")
+        .replace("-", "\u{207B}")
+        .replace("=", "\u{207C}")
+        .replace("(", "\u{207D}")
+        .replace(")", "\u{207E}")
+        .replace("n", "\u{207F}")
+        .replace("i", "\u{2071}")
+    }
+  } else if body.func() == sub {
+    let body-string = to-string(body.body)
+    if body-string.match(regex("^[0-9+\-=\(\)aehk-pstx\s]+$")) != none {
+      body-string
+        .replace(regex("[0-9]"), it => str.from-unicode(0x2080 + int(it.text)))
+        .replace("+", "\u{208A}")
+        .replace("-", "\u{208B}")
+        .replace("=", "\u{208C}")
+        .replace("(", "\u{208D}")
+        .replace(")", "\u{208E}")
+        .replace("a", "\u{2090}")
+        .replace("e", "\u{2091}")
+        .replace("o", "\u{2092}")
+        .replace("x", "\u{2093}")
+        .replace("h", "\u{2095}")
+        .replace("k", "\u{2096}")
+        .replace("l", "\u{2097}")
+        .replace("m", "\u{2098}")
+        .replace("n", "\u{2099}")
+        .replace("p", "\u{209A}")
+        .replace("s", "\u{209B}")
+        .replace("t", "\u{209C}")
+    }
+  }
+}
+
+// Attaches a label after the split elements.
+//
+// The label is only attached to one of the elements, preferring the second
+// one. If both elements are empty, the label is discarded. If the label is
+// empty, the elements remain unchanged.
+#let attach-label((first, second), label) = {
+  if label == none {
+    (first, second)
+  } else if second != none {
+    (first, [#second#label])
+  } else if first != none {
+    ([#first#label], second)
+  } else {
+    (none, none)
+  }
+}
+
+// Returns whether the element is displayed inline.
+//
+// Requires context.
+#let inline(element) = {
+  element != none and measure(h(0.1pt) + element).width > measure(element).width
+}

--- a/packages/preview/droplet/0.3.0/typst.toml
+++ b/packages/preview/droplet/0.3.0/typst.toml
@@ -7,7 +7,7 @@ authors = ["Eric Biedert"]
 repository = "https://github.com/EpicEricEE/typst-droplet"
 license = "MIT"
 description = "Customizable dropped capitals."
-exclude = ["README.md", "assets", "tests"]
+exclude = ["assets", "tests"]
 categories = ["text"]
 keywords = [
   "drop", "dropped", "dropcap", "big", "large", "caps", "capital", "capitals",

--- a/packages/preview/droplet/0.3.0/typst.toml
+++ b/packages/preview/droplet/0.3.0/typst.toml
@@ -1,0 +1,15 @@
+[package]
+name = "droplet"
+version = "0.3.0"
+entrypoint = "src/lib.typ"
+compiler = "0.11.0"
+authors = ["Eric Biedert"]
+repository = "https://github.com/EpicEricEE/typst-droplet"
+license = "MIT"
+description = "Customizable dropped capitals."
+exclude = ["README.md", "assets", "tests"]
+categories = ["text"]
+keywords = [
+  "drop", "dropped", "dropcap", "big", "large", "caps", "capital", "capitals",
+  "initial", "initials", "letter", "letters", "lettrine"
+]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Changelog: 
- Added `depth` parameter for spacing under dropped capital
- Added option to not rescale the dropped capital (by setting height to `auto`)
- Improved paragraph splitting algorithm
- Made (some) sub- and superscripts attach to dropped capital
- Fixed splitting of styled elements
- Fixed trailing line breaks and paragraph breaks
- Replaced deprecated `locate` and `style` calls with context expressions