### PR TITLE
zero:0.3.0

### DIFF
--- a/packages/preview/zero/0.3.0/LICENSE
+++ b/packages/preview/zero/0.3.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/zero/0.3.0/README.md
+++ b/packages/preview/zero/0.3.0/README.md
@@ -238,14 +238,16 @@ In addition, you can prefix or suffix a numeral with content wrapped by the func
 )
 ```
 
+
+
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: light)" srcset="docs/figures/nonum.svg">
-    <source media="(prefers-color-scheme: dark)" srcset="docs/figures/nonum-dark.svg">
-    <img alt="Number alignment in tables" src="docs/figures/nonum.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/270ae789-2a8c-44a3-b3a9-0ca588bfbad3">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/dd6bc16a-8fca-4835-a85a-0555a03c7232">
+    <img alt="Number alignment in tables" src="https://github.com/user-attachments/assets/270ae789-2a8c-44a3-b3a9-0ca588bfbad3">
   </picture>
 </p>
-
+  
 
 Zero not only aligns numbers at the decimal point but also at the uncertainty and exponent part. Moreover, by passing a `dictionary` instead of `auto`, a set of `num()` arguments to apply to all numbers in a column can be specified. 
 

--- a/packages/preview/zero/0.3.0/README.md
+++ b/packages/preview/zero/0.3.0/README.md
@@ -1,0 +1,298 @@
+
+# $Z\cdot e^{ro}$
+
+
+_Advanced scientific number formatting._
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fzero%2Fv0.3.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/zero)
+[![Test Status](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/zero/blob/main/LICENSE)
+
+
+- [Introduction](#introduction)
+- [Quick Demo](#quick-demo)
+- [Documentation](#documentation)
+- [Table alignment](#table-alignment)
+- [Zero for third-party packages](#zero-for-third-party-packages)
+
+## Introduction
+
+Proper number formatting requires some love for detail to guarantee a readable and clear output. This package provides tools to ensure consistent formatting and to simplify the process of following established publication practices. Key features are
+- **standardized** formatting,
+- digit [**grouping**](#grouping), e.g., 299 792 458 instead of 299792458,
+- **plug-and-play** number [**alignment in tables**](#table-alignment),
+- quick scientific notation, e.g., `"2e4"` becomes 2×10⁴,
+- symmetric and asymmetric [**uncertainties**](#specifying-uncertainties),
+- [**rounding**](#rounding) in various modes,
+- and some specials for package authors.
+<!-- - and localization? -->
+
+A number in scientific notation consists of three parts of which the latter two are optional. The first part is the _mantissa_ that may consist of an _integer_ and a _fractional_ part. In many fields of science, values are not known exactly and the corresponding _uncertainty_ is then given along with the mantissa. Lastly, to facilitate reading very large or small numbers, the mantissa may be multiplied with a _power_ of 10 (or another base). 
+
+The anatomy of a formatted number is shown in the following figure.
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/7ca9fa48-b732-4f4e-911f-b719e83305be">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/9f10cf22-4b3c-4a3b-b761-7d98c1bcd5c0">
+    <img alt="Anatomy of a formatted number" src="https://github.com/user-attachments/assets/7ca9fa48-b732-4f4e-911f-b719e83305be">
+  </picture>
+</p>
+
+<!-- For generating formatted numbers, *Zero* provides the `num` type along with the types `coefficient`, `uncertainty`, and `power` that allow for fine-grained customization with `show` and `set` rules.  -->
+
+## Quick Demo
+
+| Code | Output | Code | Output |
+|------|--------|------|--------|
+| `num("1.2e4")`        | 1.2×10⁴          | `num[1.2e4]`           | 1.2×10⁴       |
+| `num("-5e-4")`        | −5×10⁻⁴        | `num(fixed: -2)[0.02]` | 2×10⁻²      |
+| `num("9.81+-.01")`    | 9.81±0.01            | `num("9.81+0.02-.01")` | 9.81⁺²₋₁ |
+| `num("9.81+-.01e2")`  | (9.81±0.01)×10²| `num(base: 2)[3e4]`    | 3×2⁴          |
+
+
+
+
+## Documentation
+
+- [Function `num`](#num)
+- [Grouping](#grouping)
+- [Rounding](#rounding)
+- [Uncertainties](#specifying-uncertainties)
+- [Table alignment](#table-alignment)
+
+### `num`
+
+The function `num()` is the heart of *Zero*. It provides a wide range of number formatting utilities and its default values are configurable via `set-num()` which takes the same named arguments as `num()`. 
+
+```typ
+#let num(
+  number:                 str | content | int | float | dictionary | array,
+  digits:                 auto | int = auto,
+  fixed:                  none | int = none,
+
+  decimal-separator:      str = ".",
+  product:                content = sym.times,
+  tight:                  boolean = false,
+  math:                   boolean = true,
+  omit-unity-mantissa:    boolean = true,
+  positive-sign:          boolean = false,
+  positive-sign-exponent: boolean = false,
+  base:                   int | content = 10,
+  uncertainty-mode:       str = "separate",
+  round:                  dictionary,
+  group:                  dictionary,
+)
+```
+- `number: str | content | int | float | array` : Number input; `str` is preferred. If the input is `content`, it may only contain text nodes. Numeric types `int` and `float` are supported but not encouraged because of information loss (e.g., the number of trailing "0" digits or the exponent). The remaining types `dictionary` and `array` are intended for advanced use, see [below](#zero-for-third-party-packages).
+- `digits: auto | int = auto` : Truncates the number at a given (positive) number of decimal places or pads the number with zeros if necessary. This is independent of [rounding](#rounding).
+- `fixed: none | int = none` : If not `none`, forces a fixed exponent. Additional exponents given in the number input are taken into account. 
+- `decimal-separator: str = "."` : Specifies the marker that is used for separating integer and decimal part.
+- `product: content = sym.times` : Specifies the multiplication symbol used for scientific notation. 
+- `tight: boolean = false` : If true, tight spacing is applied between operands (applies to × and ±). 
+- `math: boolean = true` : If set to `false`, the parts of the number won't be wrapped in a `math.equation` wherever feasible. This makes it possible to use `num()` with non-math fonts to some extent. Powers are always rendered in math mode. 
+- `omit-unity-mantissa: boolean = false` : Determines whether a mantissa of 1 is omitted in scientific notation, e.g., 10⁴ instead of 1·10⁴. 
+- `positive-sign: boolean = false` : If set to `true`, positive coefficients are shown with a + sign. 
+- `positive-sign-exponent: boolean = false` : If set to `true`, positive exponents are shown with a + sign. 
+- `base: int | content = 10` : The base used for scientific power notation. 
+- `uncertainty-mode: str = "separate"` : Selects one of the modes `"separate"`, `"compact"`, or `"compact-separator"` for displaying uncertainties. The different behaviors are shown below:
+
+| `"separate"` |  `"compact"` |  `"compact-separator"` |
+|---|---|---|
+| 1.7±0.2 | 1.7(2)  | 1.7(2)   |
+| 6.2±2.1 | 6.2(21) | 6.2(2.1) |
+| 1.7⁺⁰˙̇²₋₀.₅ | 1.7⁺²₋₅ | 1.7⁺²₋₅ |
+| 1.7⁺²˙̇⁰₋₅.₀ | 1.7⁺²⁰₋₅₀ | 1.7⁺²˙̇⁰₋₅.₀ |
+
+- `round: dictionary` : You can provide one or more rounding options in a dictionary. Also see [rounding](#rounding). 
+- `group: dictionary` : You can provide one or more grouping options in a dictionary. Also see [grouping](#grouping). 
+
+Configuration example: 
+```typ
+#set-num(product: math.dot, tight: true)
+```
+
+### Grouping
+
+
+Digit grouping is important for keeping large figures readable. It is customary to separate thousands with a thin space, a period, comma, or an apostrophe (however, we discourage using a period or a comma to avoid confusion since both are used for decimal separators in various countries). 
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/1f53ae33-3e99-483d-ac6a-6e3cbed5484b">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a924f63f-81a0-4ea5-8c88-2fd9373ab4ed">
+    <img alt="Digit grouping" src="https://github.com/user-attachments/assets/1f53ae33-3e99-483d-ac6a-6e3cbed5484b">
+  </picture>
+</p>
+
+
+Digit grouping can be configured with the `set-group()` function. 
+
+
+```typ
+#let set-group(
+  size:       int = 3, 
+  separator:  content = sym.space.thin,
+  threshold:  int = 5
+)
+```
+- `size: int = 3` : Determines the size of the groups. 
+- `separator: content = sym.space.thin` : Separator between groups. 
+- `threshold: int = 5` : Necessary number of digits needed for digit grouping to kick in. Four-digit numbers for example are usually not grouped at all since they can still be read easily. 
+
+
+
+Configuration example: 
+```typ
+#set-group(separator: "'", threshold: 4)
+```
+
+Grouping can be turned off altogether by setting the `threshold` to `calc.inf`. 
+
+
+
+### Rounding
+
+Rounding can be configured with the `set-round()` function. 
+
+```typ
+#let set-round(
+  mode:       none | str = none,
+  precision:  int = 2,
+  pad:        boolean = true,
+  direction:  str = "nearest",
+)
+```
+- `mode: none | str = none` : Sets the rounding mode. The possible options are
+  - `none` : Rounding is turned off. 
+  - `"places"` : The number is rounded to the number of decimal places given by the `precision` parameter. 
+  - `"figures"` : The number is rounded to a number of significant figures given by the `precision` parameter.
+  - `"uncertainty"` : Requires giving an uncertainty value. The uncertainty is 
+     rounded to significant figures according to the `precision` argument and 
+    then the number is rounded to the same number of decimal places as the 
+    uncertainty. 
+- `precision: int = 2` : The precision to round to. Also see parameter `mode`. 
+- `pad: boolean = true` : Whether to pad the number with zeros if the 
+   number has fewer digits than the rounding precision. 
+- `direction: str = "nearest"` : Sets the rounding direction. 
+  - `"nearest"`: Rounding takes place in the usual fashion, rounding to the nearer 
+    number, e.g., 2.34 → 2.3 and 2.36 → 2.4. 
+  - `"down"`: Always rounds down, e.g., 2.38 → 2.3 and 2.30 → 2.3. 
+  - `"up"`: Always rounds up, e.g., 2.32 → 2.4 and 2.30 → 2.3. 
+
+
+
+### Specifying uncertainties
+
+There are two ways of specifying uncertainties:
+- Applying an uncertainty to the least significant digits using parentheses, e.g., `2.3(4)`,
+- Denoting an absolute uncertainty, e.g., `2.3+-0.4` becomes 2.3±0.4. 
+
+Zero supports both and can convert between these two, so that you can pick the displayed style (configured via `uncertainty-mode`, see above) independently of the input style. 
+
+How do uncertainties interplay with exponents? The uncertainty needs to come first, and the exponent applies to both the mantissa and the uncertainty, e.g., `num("1.23+-.04e2")` becomes
+
+    (1.23 ± 0.03)×10²
+
+Note that the mantissa is now put in parentheses to disambiguate the application of the power. 
+
+In some cases, the uncertainty is asymmetric which can be expressed via `num("1.23+0.02-0.01")`
+
+1.23⁺⁰˙̇⁰²₋₀.₀₁
+
+### Table alignment
+
+In scientific publication, presenting many numbers in a readable fashion can be a difficult discipline. A good starting point is to align numbers in a table at the decimal separator. With _Zero_, this can be accomplished by using `ztable`, a wrapper for the built-in `table` function. It features an additional parameter `format` which takes an array of `none`, `auto`, or `dictionary` values to turn on number alignment for specific columns. 
+
+
+```typ
+#ztable(
+  columns: 3,
+  align: center,
+  format: (none, auto, auto),
+  $n$, $α$, $β$,
+  [1], [3.45], [-11.1],
+  ..
+)
+```
+
+Non-number entries (e.g., in the header) are automatically recognized in some cases and will not be aligned. In ambiguous cases, adding a leading or trailing space tells _Zero_ not to apply alignment to this cell, e.g., `[Angle ]` instead of `[Angle]`. 
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/2effb7f0-0d9b-401a-92e1-20461d0c1fcb">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/38c22b93-cf88-4da4-af2c-9e2bbaff6dd4">
+    <img alt="Number alignment in tables" src="https://github.com/user-attachments/assets/2effb7f0-0d9b-401a-92e1-20461d0c1fcb">
+  </picture>
+</p>
+
+In addition, you can prefix or suffix a numeral with content wrapped by the function `nonum[]` to mark it as _not belonging to the number_. The remaining content may still be recognized as a number and formatted/aligned accordingly. 
+```typ
+#ztable(
+  format: (auto,),
+  [#nonum[€]123.0#nonum(footnote[A special number])],
+  [12.111],
+)
+```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/figures/nonum.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/figures/nonum-dark.svg">
+    <img alt="Number alignment in tables" src="docs/figures/nonum.svg">
+  </picture>
+</p>
+
+
+Zero not only aligns numbers at the decimal point but also at the uncertainty and exponent part. Moreover, by passing a `dictionary` instead of `auto`, a set of `num()` arguments to apply to all numbers in a column can be specified. 
+
+```typ
+#ztable(
+  columns: 4,
+  align: center,
+  format: (none, auto, auto, (digits: 1)),
+  $n$, $α$, $β$, $γ$,
+  [1], [3.45e2], [-11.1+-3], [0],
+  ..
+)
+```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/c96941bc-f002-4b93-b2cd-705c8104682f">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/28eb1df3-5292-441f-b1e9-ad472b80891b">
+    <img alt="Advanced number alignment in tables" src="https://github.com/user-attachments/assets/c96941bc-f002-4b93-b2cd-705c8104682f">
+  </picture>
+</p>
+
+## Zero for third-party packages
+
+This package provides some useful extras for third-party packages that generate formatted numbers (for example graphics libraries). 
+
+Instead of passing a `str` to `num()`, it is also possible to pass a dictionary of the form
+```typ
+(
+  mantissa:  str | int | float,
+  e:         none | str,
+  pm:        none | array
+)
+```
+This way, parsing the number can be avoided which makes especially sense for packages that generate numbers (e.g., tick labels for a diagram axis) with independent mantissa and exponent. 
+
+Furthermore, `num()` also allows `array` arguments for `number` which allows for more efficient batch-processing of numbers with the same setup. In this case, the caller of the function needs to provide `context`. 
+
+
+## Changelog
+
+### Version 0.3.0
+- Adds `nonum[]` function that can be used to mark content in cells as _not belonging to the number_. The remaining content may still be recognized as a number and formatted/aligned accordingly. The content wrapped by `nonum[]` is preserved. 
+- Fixes number alignment tables with new version Typst 0.12. 
+
+### Version 0.2.0
+- Adds support for using non-math fonts for `num` via the option `math`. This can be activated by calling `#set-num(math: false)`. 
+- Performance improvements for both `num()` and `ztable(9)`
+
+### Version 0.1.0

--- a/packages/preview/zero/0.3.0/src/assertations.typ
+++ b/packages/preview/zero/0.3.0/src/assertations.typ
@@ -1,0 +1,46 @@
+
+/// Check that a given value is one of the given string options
+/// and prints a suitable error message suggesting the possible
+/// values. 
+#let assert-option(
+  /// Value to check -> any
+  value, 
+  /// Name of the parameter -> str
+  name, 
+  /// Possible options -> array
+  options
+) = {
+  if value not in options {
+    options = options.map(x => "\"" + x + "\"")
+    if options.len() == 2 {
+      options = options.join(" or ")
+    } else {
+      options = options.slice(0, -1).join(", ") + ", or " + options.last()
+    }
+    assert(
+      false, message: "Expected " + options + " for `" + name + "`, got " + "\"" + value + "\""
+    )
+  }
+}
+
+
+/// Checks that a given set of `arguments` contains only named
+/// arguments contained in `dict`. Otherwise, the function panicks
+/// with a suitable error message. 
+#let assert-settable-args(args, dict, name: none) = {
+  if args.pos().len() != 0 {
+    let message = "Unexpected argument: " + repr(args.pos().first())
+    if name != none {
+      message += " in `" + name + "`"
+    }
+    assert(false, message: message)
+  }
+  for (arg, _) in args.named() {
+    if arg in dict { continue }
+    let message = "Unexpected argument: " + arg
+    if name != none {
+      message += " in `" + name + "`"
+    }
+    assert(false, message: message)
+  }
+}

--- a/packages/preview/zero/0.3.0/src/formatting.typ
+++ b/packages/preview/zero/0.3.0/src/formatting.typ
@@ -1,0 +1,260 @@
+#import "state.typ": num-state, group-state
+#import "parsing.typ": *
+
+
+#let sequence-constructor = $$.body.func()
+
+/// Creates an equation from a sequence. This function leaves the
+/// `block` attribute unset. 
+#let make-equation(sequence) = {
+  math.equation(sequence-constructor(sequence))
+}
+
+#assert.eq(make-equation((sym.minus, [2])).body, $-2$.body)
+
+
+
+/// Formats a sign. If the sign is the ASCII character "-", the minus
+/// unicode symbol "−" is returned. Otherwise, "+" is returned but only 
+/// if `positive-sign` is set to true. In all other cases, the result is
+/// `none`. 
+#let format-sign(sign, positive-sign: false) = {
+  if sign == "-" { return sym.minus }
+  else if sign == "+" and positive-sign { return sym.plus }
+}
+
+#assert.eq(format-sign("-", positive-sign: false), sym.minus)
+#assert.eq(format-sign("+", positive-sign: false), none)
+#assert.eq(format-sign("-", positive-sign: true), sym.minus)
+#assert.eq(format-sign("+", positive-sign: true), sym.plus)
+#assert.eq(format-sign(none, positive-sign: true), none)
+
+
+
+/// Inserts group separators (e.g., thousand separators if `group-size` is 3)
+/// into a sequence of digits. 
+/// - x (str): Input sequence. 
+/// - invert (boolean): If `false`, the separators are inserted counting from
+///   right-to-left (as customary for integers), if `true`, they are inserted
+///   from left-to-right (for fractionals). 
+#let insert-group-separators(
+  x, 
+  invert: false,
+  threshold: 5,
+  size: 3,
+  separator: sym.space.thin
+) = {
+  if x.len() < threshold { return x }
+  
+  if not invert { x = x.rev() }
+  let chunks = x.codepoints().chunks(size)
+  if not invert { chunks = chunks.rev().map(array.rev) }
+  return chunks.intersperse(separator).flatten().join()
+}
+
+#assert.eq(insert-group-separators("123"), "123")
+#assert.eq(insert-group-separators("1234"), "1234")
+#assert.eq(insert-group-separators("12345", separator: " "), "12 345")
+#assert.eq(insert-group-separators("123456", separator: " "), "123 456")
+#assert.eq(insert-group-separators("1234567", separator: " "), "1 234 567")
+#assert.eq(insert-group-separators("12345678", separator: " "), "12 345 678")
+#assert.eq(insert-group-separators("12345678", separator: " ", size: 2), "12 34 56 78")
+#assert.eq(insert-group-separators("1234", separator: " ", threshold: 3), "1 234")
+
+#assert.eq(insert-group-separators("1234", separator: " ", threshold: 3, invert: true), "123 4")
+#assert.eq(insert-group-separators("1234567", separator: " ", threshold: 3, invert: true), "123 456 7")
+#assert.eq(insert-group-separators("1234567", separator: " ", size: 2, threshold: 3, invert: true), "12 34 56 7")
+
+
+
+#let contextual-group(x, invert: false) = {
+  insert-group-separators(x, invert: invert)
+}
+
+
+/// Takes a sequence of digits and returns a new sequence of length `digits`. 
+/// If the input sequence is too short, a corresponding number of trailing
+/// zeros is appended. Exceeding inputs are truncated. 
+#let fit-decimals(x, digits) = {
+  let len = x.len()
+  if len == digits or digits == auto { return x }
+  if len < digits { return x + "0" * (digits - len) }
+  if len > digits { return x.slice(0, digits) }
+}
+
+#assert.eq(fit-decimals("345", 3), "345")
+#assert.eq(fit-decimals("345", 4), "3450")
+#assert.eq(fit-decimals("345", 2), "34")
+
+
+
+
+#let format-integer = it => {
+  // int, group
+  if type(it.group) == dictionary and it.int != none { it.int = insert-group-separators(it.int, ..it.group) }
+  if it.int == "" { it.int = "0" }
+  it.int
+}
+
+
+
+#let format-fractional = it => {
+  // frac, group, digits, decimal-separator?
+  let frac = fit-decimals(it.frac, it.digits)
+  if frac.len() == 0 { return none }
+  if type(it.group) == dictionary { frac = insert-group-separators(frac, invert: true, ..it.group) }
+  it.decimal-separator + frac
+}
+
+
+
+#let format-comma-number = it => {
+  // sign, int, frac, digits, group, positive-sign
+  let frac = format-fractional((frac: it.frac, group: it.group, digits: it.digits, decimal-separator: it.decimal-separator))
+  
+  return format-sign(it.sign, positive-sign: it.positive-sign) + format-integer((int: it.int, group: it.group)) + frac
+}
+
+
+
+#let format-uncertainty = it => {
+  /// pm, digits, mode, concise, tight
+  let pm = it.pm
+  if pm == none { return () }
+  let is-symmetric = type(pm.first()) != array
+  if is-symmetric { pm = (pm,) }
+
+  if it.concise {
+    let compact-pm = (
+      it.mode == "compact" or 
+      (it.mode == "compact-separator" and pm.map(x => x.first().trim("0")).all(x => x.len() == 0))
+    )
+      
+    if compact-pm {
+      pm = pm.map(x => utility.shift-decimal-left(..x, -it.digits))
+      it.digits = auto
+    }
+  }
+
+  pm = pm.map(((int, frac)) => 
+    format-comma-number((
+      sign: none, int: int, frac: frac, digits: it.digits, group: false, positive-sign: false, decimal-separator: it.decimal-separator
+    ))
+  )
+  if is-symmetric {
+    if it.concise { ("(", pm.first(), ")") }
+    else {
+      (
+        math.class("normal", none),
+        math.class(if it.tight {"normal"} else {"binary"}, sym.plus.minus),
+        pm.first()
+      )
+    }
+  } else {
+     (
+      math.attach(
+        none, 
+        t: sym.plus + pm.at(0), 
+        b: sym.minus + pm.at(1)
+      ),
+    )
+  }
+}
+
+
+
+#let format-power = it => {
+  /// x, base, product, positive-sign-exponent, tight, 
+  if it.exponent == none { return () }
+  
+  let (sign, integer, fractional) = decompose-signed-float-string(it.exponent)
+  let exponent = format-comma-number((sign: sign, int: integer, frac: fractional, digits: auto, group: false, positive-sign: it.positive-sign-exponent, decimal-separator: it.decimal-separator))
+
+  let power = math.attach([#it.base], t: [#exponent])
+  if it.product == none { (power,) }
+  else {
+    (
+      box(),
+      math.class(if it.tight {"normal"} else {"binary"}, it.product),
+      power
+    )
+  }
+}
+
+
+
+#let show-num-impl = it => {
+  /// sign, int, frac, e, pm, 
+  /// digits
+  /// omit-unity-mantissa, uncertainty-mode, positive-sign
+  
+  let omit-mantissa = (
+    it.omit-unity-mantissa and it.int == "1" and
+    it.frac == "" and it.e != none and it.pm == none and it.digits == 0
+  )
+
+  let concise-uncertainty = it.uncertainty-mode != "separate"
+
+
+  
+
+  let integer = (
+    sign: it.sign,
+    int: if omit-mantissa { none } else { it.int },
+    decimal-separator: it.decimal-separator,
+    group: it.group
+  )
+  
+
+  let uncertainty = (
+    pm: it.pm,
+    digits: it.digits,
+    concise: concise-uncertainty,
+    tight: it.tight,
+    mode: it.uncertainty-mode,
+    decimal-separator: it.decimal-separator
+  )
+  
+  
+  let power = (
+    exponent: it.e, 
+    base: it.base,
+    product: if omit-mantissa {none} else {it.product},
+    positive-sign-exponent: it.positive-sign-exponent,
+    tight: it.tight,
+    decimal-separator: it.decimal-separator
+  )
+  
+  let integer-part = (
+    format-sign(it.sign, positive-sign: it.positive-sign),
+    format-integer(integer),
+  )
+  
+  let fractional-part = (
+    format-fractional((frac: it.frac, group: it.group, digits: it.digits, decimal-separator: it.decimal-separator)),
+  )
+
+  let uncertainty-part = format-uncertainty(uncertainty)
+
+  if concise-uncertainty {
+    fractional-part += uncertainty-part
+    uncertainty-part = ()
+  } 
+  
+  
+  if it.pm != none and it.e != none and not concise-uncertainty {
+    integer-part = ("(",) + integer-part
+    uncertainty-part.push(")")
+  }
+  
+  let result = (
+    integer-part,
+    fractional-part,
+    uncertainty-part,
+    format-power(power),
+  )
+  return result
+}
+
+
+

--- a/packages/preview/zero/0.3.0/src/impl.typ
+++ b/packages/preview/zero/0.3.0/src/impl.typ
@@ -1,0 +1,5 @@
+// Access to implementation for third-party packages. Note: this API may be unstable. 
+#import "formatting.typ"
+#import "parsing.typ"
+#import "utility.typ"
+#import "rounding.typ"

--- a/packages/preview/zero/0.3.0/src/num.typ
+++ b/packages/preview/zero/0.3.0/src/num.typ
@@ -1,0 +1,241 @@
+#import "state.typ": num-state, group-state, round-state
+#import "formatting.typ": *
+#import "rounding.typ": *
+#import "assertations.typ": *
+#import "parsing.typ" as parsing: nonum
+
+#let update-state(state, args, name: none) = {
+  state.update(s => {
+    assert-settable-args(args, s, name: name)
+    s + args.named()
+  })
+}
+
+
+#let set-num(..args) = update-state(num-state, args, name: "set-num")
+
+#let set-group(..args) = {
+  num-state.update(s => {
+    assert-settable-args(args, s.group, name: "set-group")
+    s.group += args.named()
+    s
+  })
+}
+
+#let set-round(..args) = {
+  num-state.update(s => {
+    assert-settable-args(args, s.round, name: "set-round")
+    s.round += args.named()
+    s
+  })
+}
+
+
+#let contextual-round(int, frac, pm, round-state) = {
+  round(
+    int, frac, 
+    mode: round-state.mode,
+    precision: round-state.precision,
+    direction: round-state.direction,
+    pad: round-state.pad,
+    pm: pm
+  )
+}
+
+
+
+#let show-num = it => {
+  
+  // Process input
+  let info
+  if type(it.number) == dictionary {
+    info = it.number
+    if "mantissa" in info {
+      let mantissa = info.mantissa 
+      if type(mantissa) in (int, float) { mantissa = str(mantissa).replace(sym.minus, "-") }
+      let (sign, int, frac) = parsing.decompose-signed-float-string(mantissa)
+      info += (sign: sign, int: int, frac: frac)
+    }
+    if "sign" not in info {info.sign = "" }
+  } else {
+    let num-str = number-to-string(it.number)
+    if num-str == none {
+      assert(false, message: "Cannot parse the number `" + repr(it.number) + "`")
+    }
+    info = decompose-normalized-number-string(num-str)
+  }
+
+  /// Maybe shift exponent
+  if it.fixed != none {
+    let e = if info.e == none { 0 } else { int(info.e) }
+    info.e = str(it.fixed).replace(sym.minus, "-")
+    (info.int, info.frac) = utility.shift-decimal-left(info.int, info.frac, it.fixed - e)
+  }
+
+  /// Round number and uncertainty
+  if it.round.mode != none {
+    (info.int, info.frac, info.pm) = contextual-round(info.int, info.frac, info.pm, it.round)
+  }
+  
+  let digits = if it.digits == auto { info.frac.len() } else { it.digits }
+  if digits < 0 { assert(false, message: "`digits` needs to be positive, got " + str(digits)) }
+  
+  if info.pm != none {
+    let pm = info.pm
+    if type(pm.first()) != array { pm = (pm,) }
+    digits = calc.max(digits, ..pm.map(array.last).map(str.len))
+  }
+
+  // info.digits = digits
+  it.digits = digits
+
+  // Format number
+  let components = show-num-impl(info + it)
+  let collect = if it.math { make-equation } else { it => it.join() }
+  if it.align == none { return it.prefix + collect(components.join()) + it.suffix }
+
+  let (col-widths, col) = it.align
+  let components = components.map(x => if x == () { none } else { collect(x) })
+  components.at(0) = it.prefix + components.at(0)
+  if it.suffix != none {
+    if components.at(2) == none and components.at(3) == none {
+      components.at(1) += it.suffix
+    } else {
+      components.at(3) += it.suffix
+    }
+  }
+  let widths = components.map(x => if x == none { 0pt } else { measure(x).width })
+  
+  if col-widths != auto {
+    for i in range(4) {
+      let alignment = if i == 0 { right } else { left }
+      let content = align(alignment, components.at(i))
+      components.at(i) = box(width: col-widths.at(i), content)
+    }
+  }
+
+  [#components.join()#metadata((col,) + widths)<__pillar-num__>]
+}
+
+#let update-num-state(state, args) = {
+  if "round" in args { state.round += args.round; args.remove("round") }
+  if "group" in args { state.group += args.group; args.remove("group") }
+  return state + args
+}
+
+#let num(
+  number, 
+  align: none,
+  state: auto,
+  prefix: none,
+  suffix: none,
+  ..args
+) = {
+  if type(number) == array {
+    let named = args.named()
+    let num-state = if state == auto { num-state.get() } else { state }
+    let round-state = if state == auto { round-state.get() } else { num-state.round }
+    let group-state = if state == auto { group-state.get() } else { num-state.group }
+    if "round" in named { round-state += named.round }
+    if "group" in named { group-state += named.group }
+    let it = num-state + (
+      align: align,
+      ..args.named()
+    )
+    it.round = round-state
+    it.group = group-state
+    return number.map(n => show-num(it + (number: n)))
+  }
+  
+  if state != auto {
+    let it = update-num-state(state, args.named()) + (
+      align: align,
+      number: number,
+      prefix: prefix,
+      suffix: suffix
+    )
+    return show-num(it)
+  }
+  context {
+    let it = update-num-state(num-state.get(), args.named()) + (
+      align: align,
+      number: number,
+      prefix: prefix,
+      suffix: suffix
+    )
+    show-num(it)
+  }
+}
+
+
+
+
+
+
+
+
+
+/*
+
+- Mantissa (value or uncertainty): Doesn't really need a show rule?
+- Power: A rule would be beneficial. Does the multiplier need to be included? 
+
+
+Question: How to pass values on to the nested types
+
+#set num.power(base: [5])
+and then
+#num(power: (base: [4]), "1.23e4")
+
+
+show num.power: it => {
+  - it.exponent [2.3]
+  - it.base [10]
+  - it.multiplier [×] ??
+
+  math.attach([#it.base], t: [#it.exponent])
+
+  or 
+
+  (
+    box(),
+    it.multiplier,
+    math.attach([#it.base], t: [#it.exponent])
+  )
+}
+
+
+show num.exponent: it => {
+  - it.sign
+  - it.integer
+  - it.fractional
+
+  it.sign + format-integer(it.integer) + format-fractional(it.fractional).join()
+}
+
+
+show num.uncertainty: it => {
+  - it.value ([0.2, 0.4])
+  - it.mode
+  - it.symmetric false
+  if it.mode == ...
+  
+  if it.symmetric {
+    return (
+      math.class("normal", none),
+      math.class(if state.tight {"normal"} else {"binary"}, sym.plus.minus),
+      it.value
+    )
+  } else {
+    math.attach(none, t: sym.plus + it.value.at(0), b: sym.minus + it.value.at(1)),
+  }
+}
+
+show num.num: it => {
+  
+}
+
+
+
+*/
+

--- a/packages/preview/zero/0.3.0/src/parsing.typ
+++ b/packages/preview/zero/0.3.0/src/parsing.typ
@@ -1,0 +1,246 @@
+#import "utility.typ"
+
+/// Converts a content value into a string if it contains only text nodes. 
+/// Otherwise, `none` is returned. 
+#let content-to-string(x) = {
+  if x.has("text") { return x.text }
+  if x.has("children") and x.children.len() != 0 and x.children.all(x => x.has("text")) {
+    return x.children.map(x => x.text).join()
+  }
+  return none
+}
+
+#assert.eq(content-to-string([123]), "123")
+#assert.eq(content-to-string([123 231.]), "123 231.")
+#assert.eq(content-to-string([123] + [34]), "12334")
+#assert.eq(content-to-string([a $a$]), none)
+
+
+/// Converts a content value into a string if it contains only text nodes. 
+/// Otherwise, `none` is returned. 
+#let content-to-stringw(x) = {
+  let prefix = none
+  let suffix = none
+  if x.has("text") { return (x.text, prefix, suffix) }
+  if x.has("children") and x.children.len() != 0 {
+    if x.children.all(x => x.has("text")){
+      return (x.children.map(x => x.text).join(), prefix, suffix)
+    }
+    let main = none
+    for child in x.children {
+      if child.has("text") { main += child.text }
+      else if child.func() == highlight {
+        if main == none { prefix = child.body }
+        else { suffix = child.body }
+      }
+      else { return none }
+    }
+    return (main, prefix, suffix)
+  }
+  return none
+}
+
+#let nonum = highlight
+#assert.eq(content-to-stringw[alpha ], none)
+#assert.eq(content-to-stringw[#nonum[€]12], ("12", [€], none))
+#assert.eq(content-to-stringw[#nonum[€]12.43#nonum[#footnote[1]]], ("12.43", [€], footnote[1]))
+
+/// Converts a number into a string if the input is either
+/// - an integer or a float,
+/// - a string,
+/// - or a content value that contains only text nodes but does not start 
+///   or end with a space. 
+/// In case of a failure, `none` is returned. 
+/// The output is normalized, meaning that both decimals separators "," and 
+/// "." are unified to "." and the minus symbol "−" is replaced by the 
+/// ASCII "-" character. 
+#let number-to-string(number) = {
+  let result
+  if type(number) == str { result = number }
+  else if type(number) in (int, float) { result = str(number) }
+  else if type(number) == content  { result = content-to-string(number) } 
+  else { result = none }
+  if result == none { return none }
+  return result.replace(",", ".").replace(sym.minus, "-")
+}
+
+#let number-to-stringw(number) = {
+  let result
+  if type(number) == str { result = number }
+  else if type(number) in (int, float) { result = str(number) }
+  else if type(number) == content  { result = content-to-stringw(number) } 
+  else { result = none }
+  if result == none { return none }
+  if type(result) != array { result = (result, none, none) }
+  result.at(0) = result.at(0).replace(",", ".").replace(sym.minus, "-")
+  return result
+}
+
+#assert.eq(number-to-string("123"), "123")
+#assert.eq(number-to-string("-2.0"), "-2.0")
+#assert.eq(number-to-string(sym.minus + "2,0"), "-2.0")
+#assert.eq(number-to-string[2], "2")
+#assert.eq(number-to-string[-2.1], "-2.1")
+#assert.eq(number-to-string[-2.], "-2.")
+#assert.eq(number-to-string[2.], "2.")
+#assert.eq(number-to-string[-.1], "-.1")
+#assert.eq(number-to-string(100), "100")
+#assert.eq(number-to-string(-101.24), "-101.24")
+
+// unparsable inputs
+#assert.eq(number-to-string[], none)
+#assert.eq(number-to-string[$a + b$], none)
+#assert.eq(number-to-string[2 ], none)
+#assert.eq(number-to-string[ 2], none)
+#assert.eq(number-to-string[ 2343.23 ], none)
+#assert.eq(str(sym.plus), "+")
+
+
+
+/// Decomposes a string representing an unsigned floating point into
+/// integer and fractional part. If either part is not present, it is
+/// returned as an empty string. Returns `(integer, fractional)`.
+/// Expects a normalized input string (see @number-to-string).
+///
+/// *Example:*
+/// #example(`decompose-unsigned-float-string("9.81")`
+#let decompose-unsigned-float-string(x) = {
+  let components = x.split(".")
+  if components.len() == 1 { components.push("") }
+  else if components.len() > 2 {assert(false, message: "weird number `" + x + "`")}
+  components
+}
+
+#assert.eq(decompose-unsigned-float-string("23.2"), ("23", "2"))
+#assert.eq(decompose-unsigned-float-string("23."), ("23", ""))
+#assert.eq(decompose-unsigned-float-string("23"), ("23", ""))
+#assert.eq(decompose-unsigned-float-string(".34"), ("", "34"))
+
+
+
+/// Decomposes a string representing a (possibly signed) floating point 
+/// into integer and fractional part. If either part is not present, it 
+/// is returned as an empty string. Returns `(sign, integer, fractional)` 
+/// where the sign is either `"+"` or `"-"`. 
+/// Expects a normalized input string (see @number-to-string).
+///
+/// *Example:*
+/// #example(`decompose-signed-float-string("-9.81")`
+#let decompose-signed-float-string(x) = {
+  let sign = "+"
+  if x.starts-with("-") {
+    sign = "-"
+    x = x.slice(1)
+  } else if x.starts-with("+") { x = x.slice(1) }
+  return (sign, ) + decompose-unsigned-float-string(x)
+}
+
+#assert.eq(decompose-signed-float-string("23.2"), ("+", "23", "2"))
+#assert.eq(decompose-signed-float-string("+23."), ("+", "23", ""))
+#assert.eq(decompose-signed-float-string("-23"), ("-", "23", ""))
+#assert.eq(decompose-signed-float-string("-.34"), ("-", "", "34"))
+#assert.eq(decompose-signed-float-string(sym.plus + ".34"), ("+", "", "34"))
+
+
+
+/// Decomposes a normalized number string into sign, integer, fractional,
+/// uncertainty and exponent. Here, normalized means that the decimal separator
+/// is `"."`, and `"+"`, `"-"` is used for all signs (as opposed to 
+/// `sym.minus`). 
+///
+/// Sign, integer and fractional part are guaranteed to be valid (however, 
+/// the latter two may be empty strings) while the uncertainty and the 
+/// exponent may be none if not present. 
+///
+///
+/// *Example:*
+/// #example(`decompose-normalized-number-string("-10.2+-.3e3")`)
+#let decompose-normalized-number-string(x) = {
+  let original-number = x
+  let e
+  let pm
+  let sign = "+"
+  if "e" in x {
+    let components = x.split("e")
+    if components.len() > 2 { 
+      assert(false, message: "Error while parsing `" + original-number + "`: Asymmetric uncertainties must be specified on both sides")
+    }
+    (x, e) = components
+  }
+  if x.starts-with("-") {
+    sign = "-"
+    x = x.slice(1)
+  } else if x.starts-with("+") { x = x.slice(1) }
+
+  let normalize-pm = false
+  let pm-count = int("+" in x) + int("-" in x)
+  if pm-count == 2 {
+    if "+-" in x { (x, pm) = x.split("+-") }
+    else {
+      let p
+      let m
+      (x, m) = x.split("-")
+      assert("+" in x, message: "Error while parsing `" + original-number + "`: Asymmetric uncertainties must start with the positive component")
+      (x, p) = x.split("+")
+      pm = (p, m)
+    }
+  } else if pm-count == 1 {
+    assert(false, message: "Error while parsing `" + original-number + "`: Asymmetric uncertainties must be specified on both sides")
+  } else if "(" in x {
+    (x, pm) = x.split("(")
+    assert(pm.ends-with(")"), message: "Error while parsing `" + original-number + "`: Unclosed parenthesized uncertainty")
+    pm = pm.trim(")")
+    normalize-pm = true
+  }
+  let (integer, fractional) = decompose-unsigned-float-string(x)
+  if pm != none {
+    if type(pm) == array {
+      pm = pm.map(decompose-unsigned-float-string)
+    } else {
+      pm = decompose-unsigned-float-string(pm)
+    }
+    
+    if normalize-pm {
+      pm = utility.shift-decimal-left(..pm, fractional.len())
+    }
+  }
+  return (int: integer, frac: fractional, sign: sign, pm: pm, e: e)
+}
+
+
+#assert.eq(
+  decompose-normalized-number-string("-10e3"), 
+  (sign: "-", int: "10", frac: "", pm: none, e: "3")
+)
+#assert.eq(
+  decompose-normalized-number-string("+2.4+-0.1"), 
+  (sign: "+", int: "2", frac: "4", pm: ("0", "1"), e: none)
+)
+#assert.eq(
+  decompose-normalized-number-string("+.4+0.1-0.2e-10"), 
+  (sign: "+", int: "", frac: "4", pm: (("0", "1"), ("0", "2")), e: "-10")
+)
+#assert.eq(
+  decompose-normalized-number-string(".4(2)"), 
+  (sign: "+", int: "", frac: "4", pm: ("", "2"), e: none)
+)
+#assert.eq(
+  decompose-normalized-number-string(".4333(2)"), 
+  (sign: "+", int: "", frac: "4333", pm: ("", "0002"), e: none)
+)
+#assert.eq(
+  decompose-normalized-number-string(".4333(200)"), 
+  (sign: "+", int: "", frac: "4333", pm: ("", "0200"), e: none)
+)
+#assert.eq(
+  decompose-normalized-number-string(".43(200)"), 
+  (sign: "+", int: "", frac: "43", pm: ("2", "00"), e: none)
+)
+#assert.eq(
+  decompose-normalized-number-string("2(2)"), 
+  (sign: "+", int: "2", frac: "", pm: ("2", ""), e: none)
+)
+#assert.eq(
+  decompose-normalized-number-string("2.3(2.9)"), 
+  (sign: "+", int: "2", frac: "3", pm: ("", "29"), e: none)
+)

--- a/packages/preview/zero/0.3.0/src/rounding.typ
+++ b/packages/preview/zero/0.3.0/src/rounding.typ
@@ -1,0 +1,209 @@
+#import "assertations.typ": *
+
+#let count-leading-zeros(integer-string) = {
+  integer-string.len() - integer-string.trim("0", at: start).len()
+}
+
+
+/// Rounds an integer given as a string of digits to a given digit place. 
+/// The rounding direction may be `"nearest"`, `"up"`, or `"down"`. 
+#let round-integer(num-string, digit, dir: "nearest") = {
+  if digit == 0 { return "" }
+  if dir == "down" {
+    return num-string.slice(0, digit)
+  } else if dir == "up" {
+    let x = float(num-string.slice(0, digit) + "." + num-string.slice(digit))
+    num-string = str(int(calc.ceil(x)))
+  } else if dir == "nearest" {
+    let x = float(num-string.slice(0, digit) + "." + num-string.slice(digit))
+    num-string = str(int(calc.round(x)))
+  }
+  if digit > num-string.len() {
+    num-string = "0" * (digit - num-string.len()) + num-string
+  }
+  return num-string
+}
+
+#assert.eq(round-integer("123", 2, dir: "down"), "12")
+#assert.eq(round-integer("123", 1, dir: "down"), "1")
+#assert.eq(round-integer("9989823", 7, dir: "down"), "9989823")
+#assert.eq(round-integer("123", 0, dir: "down"), "")
+
+#assert.eq(round-integer("120", 2, dir: "up"), "12")
+#assert.eq(round-integer("123", 2, dir: "up"), "13")
+#assert.eq(round-integer("1200000000002", 2, dir: "up"), "13")
+#assert.eq(round-integer("999000003", 3, dir: "up"), "1000")
+
+#assert.eq(round-integer("2234", 1, dir: "nearest"), "2")
+#assert.eq(round-integer("2234", 0, dir: "nearest"), "")
+#assert.eq(round-integer("0022", 3, dir: "nearest"), "002")
+#assert.eq(round-integer("0395", 3, dir: "nearest"), "040")
+#assert.eq(round-integer("999", 2, dir: "nearest"), "100")
+
+
+
+/// Rounds or pads a number given by an integer part and a fractional part
+/// to a given number of total digits (including the integer digits). The 
+/// rounding direction may be `"nearest"`, `"up"`, or `"down"`. 
+/// The number `total-digits` cannot be negative. If it exceeds the number
+/// of available digits and `pad` is set to `true`, the number is padded
+/// with zeros. 
+#let round-or-pad(int, frac, total-digits, dir: "nearest", pad: true) = {
+  total-digits = calc.max(0, total-digits)
+  let number = int + frac
+  if total-digits < number.len() {
+    number = round-integer(number, total-digits, dir: dir)
+    let new-int-digits = int.len() + number.len() - total-digits
+    if total-digits < int.len() {
+      number += "0" * (int.len() - total-digits)
+    }
+    
+    int = number.slice(0, new-int-digits)
+    frac = number.slice(new-int-digits)
+  } else if pad {
+    frac += "0" * (total-digits - number.len())
+  }
+  return (int, frac)
+}
+
+
+
+/// Rounds (or pads) a number given by an integer part and a fractional part. 
+/// Different modes are supported. 
+#let round(
+  /// Integer part. -> str
+  int, 
+  /// Fractional part. -> str
+  frac,
+  /// Rounding mode.
+  /// - `"places"`: The number is rounded to the number of places after the 
+  ///   decimal point given by the `precision` parameter. 
+  /// - `"figures"`: The number is rounded to a number of significant figures.
+  /// - `"uncertainty"`: Requires giving the uncertainty. The uncertainty is rounded
+  ///   to significant figures given by the `precision` argument and then the number
+  ///   is rounded to the same number of places as the uncertainty. 
+  mode: none,
+  /// The precision to round to. See parameter `mode` for the different modes. -> int
+  precision: 2,
+  /// Rounding direction. 
+  /// - `"nearest"`: Rounding takes place in the usual fashion, rounding to the nearer 
+  ///   number, e.g., 2.34 -> 2.3 and 2.36 -> 2.4. 
+  /// - `"down"`: Always rounds down, e.g., 2.38 -> 2.3, 2.30 -> 2.3. 
+  /// - `"up"`: Always rounds up, e.g., 2.32 -> 2.4, 2.30 -> 2.3. 
+  /// -> str
+  direction: "nearest",
+  /// Determines whether the number should be padded with zeros if the number has less
+  /// digits than the rounding precision. 
+  /// -> boolean
+  pad: true,
+  /// Uncertainty
+  pm: none
+) = {
+  if mode == none { return (int, frac, pm) }
+  if mode == "uncertainty" and pm == none { return (int, frac, pm) }
+
+  
+
+  assert-option(mode, "round-mode", ("places", "figures", "uncertainty"))
+  assert-option(direction, "round-direction", ("nearest", "up", "down"))
+  
+  let round-digit = precision
+  if mode == "places" {
+    round-digit += int.len()
+  } else if mode == "figures" {
+    let full-number = int + frac
+    let leading-zeros = full-number.len() - full-number.trim("0", at: start).len()
+    round-digit += leading-zeros
+  }
+
+  if mode == "uncertainty" {
+    let round-digit-pm
+    let is-symmetric = type(pm.first()) != array
+    if is-symmetric { 
+      round-digit-pm = count-leading-zeros(pm.join()) + precision
+      pm = round-or-pad(..pm, round-digit-pm, dir: direction, pad: true)
+      round-digit = round-digit-pm + int.len() - pm.first().len()
+    } else {
+      let place = calc.max(
+        ..pm.map(u => count-leading-zeros(u.join()) + precision - u.first().len())
+      )
+      round-digit = place + int.len()
+      pm = pm.map(u => round-or-pad(..u, place + u.first().len(), dir: direction, pad: true))
+    }
+  }
+
+  return (..round-or-pad(int, frac, round-digit, dir: direction, pad: pad), pm)
+}
+
+
+#let round-places = round.with(mode: "places")
+#let round-figures = round.with(mode: "figures")
+
+#assert.eq(round("23", "5", mode: none), ("23", "5", none))
+
+#assert.eq(round-places("1", "234", precision: 3), ("1", "234", none))
+#assert.eq(round-places("1", "234", precision: 2), ("1", "23", none))
+#assert.eq(round-places("1", "234", precision: 1), ("1", "2", none))
+#assert.eq(round-places("1", "234", precision: 0), ("1", "", none))
+#assert.eq(round-places("23", "534", precision: -1), ("20", "", none))
+#assert.eq(round-places("12345", "534", precision: -3), ("12000", "", none))
+#assert.eq(round-places("2", "234", precision: -3), ("0", "", none))
+#assert.eq(round-places("", "0022", precision: 3), ("", "002", none))
+
+#assert.eq(round-places("1", "1", precision: 0), ("1", "", none))
+#assert.eq(round-places("1", "1", precision: 3), ("1", "100", none))
+#assert.eq(round-places("1", "1", precision: 5), ("1", "10000", none))
+#assert.eq(round-places("1", "1", precision: 5), ("1", "10000", none))
+#assert.eq(round-places("1", "1", precision: 5, pad: false), ("1", "1", none))
+
+
+#assert.eq(round-figures("1", "234", precision: 4), ("1", "234", none))
+#assert.eq(round-figures("1", "234", precision: 3), ("1", "23", none))
+#assert.eq(round-figures("1", "234", precision: 2), ("1", "2", none))
+#assert.eq(round-figures("1", "234", precision: 1), ("1", "", none))
+#assert.eq(round-figures("1", "234", precision: 0), ("0", "", none))
+#assert.eq(round-figures("1", "234", precision: -1), ("0", "", none))
+
+#assert.eq(round-figures("1", "2", precision: 4), ("1", "200", none))
+#assert.eq(round-figures("1", "2", precision: 4, pad: false), ("1", "2", none))
+
+#assert.eq(round-figures("0", "00126", precision: 2), ("0", "0013", none))
+#assert.eq(round-figures("0", "000126", precision: 3), ("0", "000126", none))
+
+
+
+#assert.eq(round-places("99", "92", precision: 2), ("99", "92", none))
+#assert.eq(round-places("99", "92", precision: 0), ("100", "", none))
+#assert.eq(round-places("99", "99", precision: 1), ("100", "0", none))
+#assert.eq(round-places("99", "99", precision: -1), ("100", "", none))
+#assert.eq(round-places("1", "299995", precision: 5), ("1", "30000", none))
+#assert.eq(round-places("1", "299994", precision: 5), ("1", "29999", none))
+#assert.eq(round-places("523", "", precision: -2), ("500", "", none))
+
+
+#assert.eq(round("42", "3734", pm: ("", "0025"), precision: 2, mode: "uncertainty"), ("42", "3734", ("", "0025")))
+#assert.eq(round("42", "3734", pm: ("", "0025"), precision: 1, mode: "uncertainty"), ("42", "373", ("", "003")))
+#assert.eq(round("42", "3734", pm: ("2", "2"), precision: 1, mode: "uncertainty"), ("42", "", ("2", "")))
+#assert.eq(round("42", "3734", pm: ("2", "2"), precision: 2, mode: "uncertainty"), ("42", "4", ("2", "2")))
+#assert.eq(round("42", "3734", pm: ("2", "2"), precision: 3, mode: "uncertainty"), ("42", "37", ("2", "20")))
+
+#assert.eq(round("4211", "3734", pm: ("230", "2"), precision: 1, mode: "uncertainty"), ("4200", "", ("200", "")))
+
+#assert.eq(round("1", "23", pm: ("0", "2"), precision: 1, mode: "uncertainty"), ("1", "2",  ("0", "2")))
+#assert.eq(round("123", "9", pm: ("020", ""), precision: 1, mode: "uncertainty"), ("120", "",  ("020", "")))
+#assert.eq(
+  round("1", "23", pm: (("0", "2"), ("0", "3")), precision: 1, mode: "uncertainty"), 
+  ("1", "2",  (("0", "2"), ("0", "3")))
+)
+#assert.eq(
+  round("123", "9", pm: (("020", ""), ("30", "")), precision: 1, mode: "uncertainty"), 
+  ("120", "",  (("020", ""), ("30", "")))
+)
+#assert.eq(
+  round("1", "23", pm: (("0", "24"), ("0", "3")), precision: 1, mode: "uncertainty"), 
+  ("1", "2",  (("0", "2"), ("0", "3")))
+)
+#assert.eq(
+  round("1", "23", pm: (("0", "04"), ("0", "3")), precision: 1, mode: "uncertainty"), 
+  ("1", "23",  (("0", "04"), ("0", "30")))
+)

--- a/packages/preview/zero/0.3.0/src/state.typ
+++ b/packages/preview/zero/0.3.0/src/state.typ
@@ -1,0 +1,30 @@
+#let default-state = (
+  digits: auto,
+  fixed: none,
+  product: sym.times,
+  decimal-separator: ".",
+  tight: false,
+  omit-unity-mantissa: false,
+  positive-sign: false,
+  positive-sign-exponent: false,
+  base: 10,
+  uncertainty-mode: "separate",
+  math: true,
+  group: (
+    size: 3, 
+    separator: sym.space.thin,
+    threshold: 5
+  ),
+  round: (
+    mode: none,
+    precision: 2,
+    pad: true,
+    direction: "nearest",
+  )
+)
+#let num-state = state("num-state", default-state)
+
+#let group-state = state("group-state", default-state.group)
+
+#let round-state = state("round-state", default-state.round)
+

--- a/packages/preview/zero/0.3.0/src/utility.typ
+++ b/packages/preview/zero/0.3.0/src/utility.typ
@@ -1,0 +1,31 @@
+
+/// Takes a number by integer and fractional part and
+/// shifts specified number of digits left. Negative values
+/// for `digits` produce a right-shift. Numbers are automatically
+/// padded with zeros but both integer and fractional parts
+/// may become "empty" when they are zero. 
+#let shift-decimal-left(integer, fractional, digits) = {
+  if digits < 0 {
+    let available-digits = calc.min(-digits, fractional.len())
+    integer += fractional.slice(0, available-digits)
+    integer += "0" * (-digits - available-digits)
+    fractional = fractional.slice(available-digits)
+    if integer.starts-with("0") {
+      integer = (integer + ";").trim("0").slice(0,-1)
+    }
+  } else {
+    let available-digits = calc.min(digits, integer.len())
+    fractional = integer.slice(integer.len() - available-digits) + fractional
+    fractional = "0" * (digits - available-digits) + fractional
+    integer = integer.slice(0, integer.len() - available-digits)
+  }
+  return (integer, fractional)
+}
+
+#assert.eq(shift-decimal-left("123", "456", 0), ("123", "456"))
+#assert.eq(shift-decimal-left("123", "456", 2), ("1", "23456"))
+#assert.eq(shift-decimal-left("123", "456", 5), ("", "00123456"))
+#assert.eq(shift-decimal-left("123", "456", -2), ("12345", "6"))
+#assert.eq(shift-decimal-left("123", "456", -5), ("12345600", ""))
+#assert.eq(shift-decimal-left("0", "0012", -4), ("12", ""))
+#assert.eq(shift-decimal-left("0", "0012", -2), ("", "12"))

--- a/packages/preview/zero/0.3.0/src/zero.typ
+++ b/packages/preview/zero/0.3.0/src/zero.typ
@@ -1,0 +1,4 @@
+#import "impl.typ"
+#import "num.typ": num, nonum, set-num, set-group, set-round
+#import "state.typ": default-state
+#import "ztable.typ": ztable

--- a/packages/preview/zero/0.3.0/src/ztable.typ
+++ b/packages/preview/zero/0.3.0/src/ztable.typ
@@ -1,0 +1,73 @@
+#import "num.typ": num, number-to-stringw
+#import "state.typ": num-state
+
+// #let ptable-counter = counter("__pillar-table__")
+
+#let is-normal-cell(cell, format, default: none) = {
+  format.at(cell.x, default: default) == none or number-to-stringw(cell.body) == none 
+}
+    
+#let call-num(cell, format, col-widths: auto, default: none, state: auto) = context{
+  let (numeral, prefix, suffix) = number-to-stringw(cell.body)
+  let cell-fmt = format.at(cell.x, default: default)
+  let args = if type(cell-fmt) == dictionary { cell-fmt } else { () }
+  num(numeral, prefix: prefix, suffix: suffix, state: state, align: (col-widths: col-widths, col: cell.x), ..args) 
+}
+
+
+
+#let ztable(..children, format: none) = {
+  if format == none { return table(..children) }
+  assert.eq(type(format), array, message: "The parameter `format` requires an array argument, got " + repr(format))
+
+
+  
+  
+  let table = context {
+    let state = num-state.get()
+    
+    let table-end = query(selector(<__pillar-table__>).after(here())).first().location()
+    
+    let number-infos = query(selector(<__pillar-num__>)
+      .after(here())
+      .before(table-end))
+      .map(x => x.value)
+
+    
+    // let debug-info = (counter: ptable-counter.get(), d: number-infos)
+
+
+    if number-infos.len() == 0 { // first layout pass
+      return {
+        show table.cell: it => {
+          if is-normal-cell(it, format) { it }
+          else { call-num(it, format, state: state) }
+        }    
+        table(..children)
+      }
+    }
+  
+    // second layout pass
+    let aligned-columns = range(format.len()).filter(x => format.at(x) != none)
+    let col-widths = (none,) * format.len()
+    for col in aligned-columns {
+      let filtered-cells = number-infos.filter(x => x.at(0) == col)
+      col-widths.at(col) = range(1, 5)
+        .map(i => calc.max(0pt, ..filtered-cells.map(x => x.at(i))))
+    }
+      
+    show table.cell: it => {
+      if is-normal-cell(it, format) { it }
+      else {
+        let content = box(
+          inset: it.inset,
+          call-num(it, format, col-widths: col-widths.at(it.x), state: state)
+        )
+        if it.align == auto { content }
+        else { align(it.align, content) }
+      }
+    }
+    table(..children)
+  }
+  table + [#metadata(none)<__pillar-table__>]
+}

--- a/packages/preview/zero/0.3.0/typst.toml
+++ b/packages/preview/zero/0.3.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zero"
+version = "0.3.0"
+entrypoint = "src/zero.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Advanced scientific number formatting."
+compiler = "0.11.0"
+
+repository = "https://github.com/Mc-Zen/zero"
+keywords = ["number", "table", "siunitx", "numeral", "alignment", "formatting"]
+categories = ["visualization", "layout"]
+exclude = ["/docs/*", "/tests/*"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] an update for a package

- Adds a `nonum[]` function that can be used to mark content in cells as _not belonging to the number_. The remaining content may still be recognized as a number and formatted/aligned accordingly. The content wrapped by `nonum[]` is preserved. 
- Fixes number alignment tables with new version Typst 0.12. Apparently `context` for measurements is now not anymore provided by default within show rules
