### PR TITLE
glossarium:0.5.1

### DIFF
--- a/packages/preview/glossarium/0.5.1/CHANGELOG.md
+++ b/packages/preview/glossarium/0.5.1/CHANGELOG.md
@@ -1,0 +1,134 @@
+# Changelog
+
+## 0.5.1
+
+> [!TIP]
+> New group options have been added: `print-glossary(groups: array<str>)` to
+> display only the specified groups.
+> ```typ
+> #print-glossary(
+>   // ...
+>   groups: ("Group A", "Group B", "") // "" is the default group
+> )
+> ```
+> and `print-glossary(group-heading-level: int)` to set the heading level for
+> groups regardless of the previous heading level.
+> ```typ
+> #print-glossary(
+>   // ...
+>   group-heading-level: 3
+> )
+> ```
+
+> [!TIP]
+> A new parameter `print-glossary(minimum-ref: int)` has been added to filter
+> entries with a minimum number of references.
+> ```typ
+> #print-glossary(
+>   // ...
+>   minimum-ref: 2
+> )
+> ```
+
+> [!TIP]
+> New counting functions have been added: `count-all-refs` and `there-are-refs`
+> in addition to `count-refs`.
+> ```typ
+> #context count-all-refs()
+> #context if there-are-refs() [
+>   = Glossary
+> ]
+> ```
+
+> [!NOTE]
+> - Fix terms references for long-only terms.
+> - Fix missing commas in fast start
+
+> [!NOTE]
+> Add missing changelog!
+
+
+## 0.5.0
+
+> [!WARNING]
+> Starting from Typst v0.12.0 and later, only a single level of indirection
+> in the description is supported. This means that the description of an entry
+> cannot contain another glossary reference with more than once. See the example
+> at
+> [`references-in-description`](https://github.com/typst-community/glossarium/blob/master/tests/non-regression/references-in-description.typ)
+
+> [!NOTE]
+> Fix `figure.caption` alignement for glossary entries.
+
+> [!NOTE]
+> Allow terms to have either `short` or `long` or both.
+
+## 0.4.2
+
+> [!TIP]
+> For Typst v0.12.0 and later
+> A new function is introduced `register-glossary`.
+> Recommended usage is the following:
+> ```diff
+>  #import "@preview/glossarium:0.4.0": make-glossary, register-glossary, print-glossary, gls, glspl
+>  #show: make-glossary
+> + #let entry-list = (...)
+> + #register-glossary(entry-list)
+> ... // Your document body
+>  #print-glossary(
+> - (
+> -   ...
+> - )
+> +  entry-list
+>  )
+> ```
+
+> [!TIP]
+> An interface for user customization has been provided through parameters in
+> `print-glossary`. See the documentation in
+> [`advanced-docs`](https://github.com/typst-community/glossarium/blob/master/advanced-docs/main.pdf)
+> for more details.
+
+> [!NOTE]
+> Deprecate `location` argument in queries
+
+> [!TIP]
+> `short` is no longer **required**, but **semi-optional**.
+> Accept `short` or `long` for an entry, but not neither.
+
+## 0.4.1
+
+- Resolved an issue causing Glossarium to crash when all entries had a defined, non-empty group.
+
+## 0.4.0
+
+- Support for plurals has been implemented, showcased in [examples/plural-example/main.typ](examples/plural-example). Contributed by [@St0wy](https://github.com/St0wy).
+- The behavior of the gls and glspl functions has been altered regarding calls on undefined glossary keys. They now cause panics. Contributed by [@St0wy](https://github.com/St0wy).
+
+## 0.3.0
+
+- Introducing support for grouping terms in the glossary. Use the optional and case-sensitive key `group` to assign terms to specific groups. The appearanceof the glossary can be customized with the new parameter `enable-group-pagebreak`, allowing users to insert page breaks between groups for better organization. Contributed by [indicatelovelace](https://github.com/indicatelovelace).
+
+## 0.2.6
+
+### Added
+
+- A new boolean parameter `disable-back-references` has been introduced. If set to true, it disable the back-references (the page number at the end of the description of each term). Please note that disabling back-references only disables the display of the page number, if you don't have any references to your glossary terms, they won't show up unless the parameter `show-all` has been set to true.
+
+## 0.2.5
+
+### Fixed
+
+- Fixed a bug where there was 2 space after a reference. Contributed by [@drupol](https://github.com/drupol)
+
+## 0.2.4
+
+### Fixed
+
+- Fixed a bug where the reference would a long ref even when "long" was set to false. Contributed by [@dscso](https://github.com/dscso)
+
+### Changed
+
+- The glossary appearance have been improved slightlyby. Contributed by [@JuliDi](https://github.com/JuliDi)
+
+## Previous versions did not have a changelog entry

--- a/packages/preview/glossarium/0.5.1/LICENSE
+++ b/packages/preview/glossarium/0.5.1/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) [2023] [Enib Community]
+Copyright (c) [Typst Community]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/glossarium/0.5.1/README.md
+++ b/packages/preview/glossarium/0.5.1/README.md
@@ -1,0 +1,180 @@
+# Typst glossary
+
+> [!TIP]
+> Glossarium is based in great part of the work of [Sébastien d'Herbais de Thun](https://github.com/Dherse) from his master thesis available at: <https://github.com/Dherse/masterproef>. His glossary is available under the MIT license [here](https://github.com/Dherse/masterproef/blob/main/elems/acronyms.typ).
+
+Glossarium is a simple, easily customizable typst glossary inspired by [LaTeX glossaries package](https://www.ctan.org/pkg/glossaries) . You can see various examples showcasing the different features in the `examples` folder.
+
+![Screenshot](.github/example.png)
+
+## Manual
+
+## Fast start
+
+```typ
+#import "@preview/glossarium:0.5.1": make-glossary, register-glossary, print-glossary, gls, glspl
+#show: make-glossary
+#let entry-list = (
+  (
+    key: "kuleuven",
+    short: "KU Leuven",
+    long: "Katholieke Universiteit Leuven",
+    description: "A university in Belgium.",
+  ),
+  // Add more terms
+)
+#register-glossary(entry-list)
+// Your document body
+#print-glossary(
+ entry-list
+)
+```
+
+### Import and setup
+
+This manual assume you have a good enough understanding of typst markup and scripting.
+
+For Typst 0.6.0 or later import the package from the typst preview repository:
+
+```typ
+#import "@preview/glossarium:0.5.1": make-glossary, register-glossary, print-glossary, gls, glspl
+```
+
+For Typst before 0.6.0 or to use **glossarium** as a local module, download the package files into your project folder and import `glossarium.typ`:
+
+```typ
+#import "glossarium.typ": make-glossary, register-glossary, print-glossary, gls, glspl
+```
+
+After importing the package and before making any calls to `gls`,` print-glossary` or `glspl`, please ***MAKE SURE*** you add this line
+```typ
+#show: make-glossary
+```
+
+> *WHY DO WE NEED THAT ?* : In order to be able to create references to the terms in your glossary using typst ref syntax `@key` glossarium needs to setup some [show rules](https://typst.app/docs/tutorial/advanced-styling/) before any references exist. This is due to the way typst works, there is no workaround.
+>
+>Therefore I recommend that you always put the `#show: ...` statement on the line just below the `#import` statement.
+
+### Registering the glossary
+
+First we have to define the terms.
+A term is a [dictionary](https://typst.app/docs/reference/types/dictionary/) as follows:
+
+| Key           | Type              | Required/Optional | Description                                                                                  |
+| ------------- | ----------------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| `key`         | string            | required          | Case-sensitive, unique identifier used to reference the term.                                |
+| `short`       | string            | semi-optional     | The short form of the term replacing the term citation.                                      |
+| `long`        | string or content | semi-optional     | The long form of the term, displayed in the glossary and on the first citation of the term.  |
+| `description` | string or content | optional          | The description of the term.                                                                 |
+| `plural`      | string or content | optional          | The pluralized short form of the term.                                                       |
+| `longplural`  | string or content | optional          | The pluralized long form of the term.                                                        |
+| `group`       | string            | optional          | Case-sensitive group the term belongs to. The terms are displayed by groups in the glossary. |
+
+```typ
+#let entry-list = (
+  // minimal term
+  (
+    key: "kuleuven",
+    short: "KU Leuven"
+  ),
+  // a term with a long form and a group
+  (
+    key: "unamur",
+    short: "UNamur",
+    long: "Namur University",
+    group: "Universities"
+  ),
+  // a term with a markup description
+  (
+    key: "oidc",
+    short: "OIDC",
+    long: "OpenID Connect",
+    description: [
+      OpenID is an open standard and decentralized authentication protocol promoted by the non-profit
+      #link("https://en.wikipedia.org/wiki/OpenID#OpenID_Foundation")[OpenID Foundation].
+    ],
+    group: "Acronyms",
+  ),
+  // a term with a short plural
+  (
+    key: "potato",
+    short: "potato",
+    // "plural" will be used when "short" should be pluralized
+    plural: "potatoes",
+    description: [#lorem(10)],
+  ),
+  // a term with a long plural
+  (
+    key: "dm",
+    short: "DM",
+    long: "diagonal matrix",
+    // "longplural" will be used when "long" should be pluralized
+    longplural: "diagonal matrices",
+    description: "Probably some math stuff idk",
+  ),
+)
+```
+
+Then the terms are passed as a list to `register-glossary`
+
+```typ
+#register-glossary(entry-list)
+```
+
+### Printing the glossary
+
+Now, you can display the glossary using the `print-glossary` function.
+
+```typ
+#print-glossary(entry-list)
+```
+
+By default, the terms that are not referenced in the document are not shown in the glossary, you can force their appearance by setting the `show-all` argument to true.
+
+You can also disable the back-references by setting the parameter `disable-back-references` to `true`.
+
+By default, group breaks use `linebreaks`. This behaviour can be changed by setting the `user-group-break` parameter to `pagebreak()`, or `colbreak()`, or any other function that returns the `content` you want.
+
+You can call this function from anywhere in your document.
+
+### Referencing terms.
+
+Referencing terms is done using the key of the terms using the `gls` function or the reference syntax.
+
+```typ
+// referencing the OIDC term using gls
+#gls("oidc")
+// displaying the long form forcibly
+#gls("oidc", long: true)
+
+// referencing the OIDC term using the reference syntax
+@oidc
+```
+
+#### Handling plurals
+
+You can use the `glspl` function and the references supplements to pluralize terms.
+The `plural` key will be used when `short` should be pluralized and `longplural` will be used when `long` should be pluralized. If the `plural` key is missing then glossarium will add an 's' at the end of the short form as a fallback.
+
+```typ
+#glspl("potato")
+```
+
+Please look at the examples regarding plurals.
+
+#### Overriding the text shown
+
+You can also override the text displayed by setting the `display` argument.
+
+```typ
+#gls("oidc", display: "whatever you want")
+```
+
+## Final tips
+
+I recommend setting a show rule for the links to that your readers understand that they can click on the references to go to the term in the glossary.
+
+```typ
+#show link: set text(fill: blue.darken(60%))
+// links are now blue !
+```

--- a/packages/preview/glossarium/0.5.1/glossarium.typ
+++ b/packages/preview/glossarium/0.5.1/glossarium.typ
@@ -1,0 +1,9 @@
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#import "themes/default.typ": gls, agls, glspl, make-glossary, register-glossary, print-glossary, gls-key, gls-short, gls-artshort, gls-plural, gls-long, gls-artlong, gls-longplural, gls-description, gls-group, get-entry-back-references, count-refs, count-all-refs, there-are-refs

--- a/packages/preview/glossarium/0.5.1/themes/default.typ
+++ b/packages/preview/glossarium/0.5.1/themes/default.typ
@@ -1,0 +1,1028 @@
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// glossarium figure kind
+#let __glossarium_figure = "glossarium_entry"
+
+// prefix of label for references query
+#let __glossary_label_prefix = "__gls:"
+
+// global state containing the glossary entry and their location
+// A glossary entry is a `dictionary`.
+// See `__normalize_entry_list`.
+#let __glossary_entries = state("__glossary_entries", (:))
+
+// glossarium version
+#let glossarium_version = "0.5.1"
+
+// error prefix
+#let __glossarium_error_prefix = "glossarium@" + glossarium_version + " error : "
+
+// Errors types
+#let __key_not_found = "key_not_found"
+#let __attribute_is_empty = "attribute_is_empty"
+#let __glossary_is_empty = "glossary_is_empty"
+#let __entry_has_neither_short_nor_long = "entry_has_neither_short_nor_long"
+#let __unknown_error = "unknown_error"
+
+// __error_message(key, kind, ..kwargs) -> str
+// Generate an error message
+//
+// # Arguments
+//  key (str): the key of the term
+//  kind (str): the kind of the error
+//  kwargs (arguments): additional arguments
+//
+// # Returns
+// The error message
+#let __error_message(key, kind, ..kwargs) = {
+  let msg = none
+  let kwargs = kwargs.named() // convert arguments sink to dictionary
+
+  // Generate the error message
+  if kind == __key_not_found {
+    msg = "key '" + key + "' not found"
+  } else if kind == __attribute_is_empty {
+    let attr = kwargs.at("attr")
+    msg = "requested attribute " + attr + "is empty for key '" + key + "'"
+  } else if kind == __entry_has_neither_short_nor_long {
+    msg = "entry '" + key + "' has neither short nor long form"
+  } else if kind == __glossary_is_empty {
+    msg = "glossary is empty. Use `register-glossary(entry-list)` immediately after `make-glossary`."
+  } else {
+    msg = "unknown error"
+  }
+
+  // return the error message
+  return __glossarium_error_prefix + msg
+}
+
+// __query_labels_with_key(loc, key, before: false) -> array<label>
+// Query the labels with the key
+//
+// # Arguments
+//  loc (location): the location of the reference
+//  key (str): the key of the term
+//  before (bool): if true, it will query the labels before the location
+//
+// # Returns
+// The labels with the key
+#let __query_labels_with_key(loc, key, before: false) = {
+  if before {
+    return query(
+      selector(label(__glossary_label_prefix + key)).before(
+        loc,
+        inclusive: false,
+      ),
+    )
+  } else {
+    return query(selector(label(__glossary_label_prefix + key)))
+  }
+}
+
+// __get_entry_with_key(loc, key) -> dictionary
+// Get an entry from the glossary
+//
+// # Arguments
+//  loc (location): the location of the reference
+//  key (str): the key of the term
+//
+// # Returns
+// The entry of the term
+//
+// # Panics
+// If the key is not found, it will raise a `key_not_found` error
+#let __get_entry_with_key(loc, key) = {
+  let entries = if sys.version <= version(0, 11, 1) {
+    __glossary_entries.final()
+  } else {
+    __glossary_entries.at(loc)
+  }
+  if key in entries {
+    return entries.at(key)
+  } else {
+    panic(__error_message(key, __key_not_found))
+  }
+}
+
+// __is_first_or_long(loc, key, long: none) -> bool
+// Check if the key is the first reference to the term or long form is requested
+//
+// # Arguments
+//  loc (location): the location of the reference
+//  key (str): the key of the term
+//  long (bool): if true, it will return true if the long form is requested
+//
+// # Returns
+// True if the key is the first reference to the term or long form is requested
+#let __is_first_or_long(loc, key, long: none) = {
+  let gloss = __query_labels_with_key(loc, key, before: true)
+  return gloss == () or long == true
+}
+
+#let __has_attribute(entry, key) = {
+  let attr = entry.at(key, default: "")
+  return attr != "" and attr != []
+}
+#let has-short(entry) = __has_attribute(entry, "short")
+#let has-long(entry) = __has_attribute(entry, "long")
+#let has-artshort(entry) = __has_attribute(entry, "artshort")
+#let has-artlong(entry) = __has_attribute(entry, "artlong")
+#let has-plural(entry) = __has_attribute(entry, "plural")
+#let has-longplural(entry) = __has_attribute(entry, "longplural")
+#let has-description(entry) = __has_attribute(entry, "description")
+#let has-group(entry) = __has_attribute(entry, "group")
+
+// __link_and_label(key, text, prefix: none, suffix: none) -> contextual content
+// Build a link and a label
+//
+// # Arguments
+//  key (str): the key of the term
+//  text (content): the text to be displayed
+//  prefix (str|content): the prefix to be added to the label
+//  suffix (str|content): the suffix to be added to the label
+//
+// # Returns
+// The link and the entry label
+#let __link_and_label(key, text, prefix: none, suffix: none) = (
+  context {
+    return [#prefix#link(
+        label(key),
+        text,
+      )#suffix#label(__glossary_label_prefix + key)]
+  }
+)
+
+// gls(key, suffix: none, long: none, display: none) -> contextual content
+// Reference to term
+//
+// # Arguments
+//  key (str): the key of the term
+//  suffix (str): the suffix to be added to the short form
+//  long (bool): enable/disable the long form
+//  display (str): override text to be displayed
+//
+// # Returns
+// The link and the entry label
+#let gls(key, suffix: none, long: none, display: none) = {
+  context {
+    let entry = __get_entry_with_key(here(), key)
+
+    // Attributes
+    let ent-long = entry.at("long", default: "")
+    let ent-short = entry.at("short", default: "")
+
+    // Conditions
+    let is-first-or-long = __is_first_or_long(here(), key, long: long)
+    let has-long = has-long(entry)
+    let has-short = has-short(entry)
+
+    // Link text
+    // 1. If `display` attribute is provided, use it
+    // 2. Else, if
+    //  a. The entry is referenced for the first time OR long form is explicitly requested
+    //      AND
+    //  b. The entry has a nonempty `long` attribute
+    //      AND
+    //  c. long form is not disabled
+    // 3. Else, return the `short` attribute + suffix
+    // Priority order:
+    //  1. `gls(key, display: "text")` will return `text`
+    //  2. `gls(key, long: false)` will return `short+suffix`
+    //  3. If attribute `long` is empty, `gls(key)` will return `short+suffix`
+    //  4. The first `gls(key)` will return `long (short+suffix)`
+    //  5. `gls(key, long: true)` will return `long (short+suffix)`
+    let link-text = []
+    if display != none {
+      link-text += [#display]
+    } else if is-first-or-long and has-long and long != false {
+      if has-short {
+        link-text += [#ent-long (#ent-short#suffix)]
+      } else {
+        link-text += [#ent-long]
+      }
+    } else {
+      link-text += [#ent-short#suffix]
+    }
+
+    return __link_and_label(entry.key, link-text)
+  }
+}
+
+// agls(key, suffix: none, long: none) -> contextual content
+// Reference to term with article
+//
+// # Arguments
+//  key (str): the key of the term
+//  suffix (str|content): the suffix to be added to the short form
+//  long (bool): enable/disable the long form
+//
+// # Returns
+// The link and the entry label
+#let agls(key, suffix: none, long: none) = {
+  context {
+    let entry = __get_entry_with_key(here(), key)
+
+    // Attributes
+    let ent-long = entry.at("long", default: "")
+    let ent-short = entry.at("short", default: "")
+    let ent-artlong = entry.at("artlong", default: "a")
+    let ent-artshort = entry.at("artshort", default: "a")
+
+    // Conditions
+    let is-first-or-long = __is_first_or_long(here(), key, long: long)
+    let has-long = has-long(entry)
+    let has-short = has-short(entry)
+
+    // Link text
+    let link-text = none
+    let article = none
+    if is-first-or-long and has-long and long != false {
+      if has-short {
+        link-text += [#ent-long (#ent-short#suffix)]
+      } else {
+        link-text += [#ent-long]
+      }
+      article = ent-artlong
+    } else if has-short {
+      // Default to short
+      link-text = [#ent-short#suffix]
+      article = ent-artshort
+    } else {
+      link-text += [#ent-long#suffix]
+      article = ent-artlong
+    }
+
+    // Return
+    return __link_and_label(entry.key, link-text, prefix: [#article ])
+  }
+}
+
+// glspl(key, long: none) -> contextual content
+// Reference to term with plural form
+//
+// # Arguments
+//  key (str): the key of the term
+//  long (bool): enable/disable the long form
+//
+// # Returns
+// The link and the entry label
+#let glspl(key, long: none) = {
+  context {
+    let default-plural-suffix = "s"
+    let entry = __get_entry_with_key(here(), key)
+
+    // Attributes
+    let ent-short = entry.at("short", default: "")
+    let ent-plural = entry.at("plural", default: "")
+    let ent-long = entry.at("long", default: "")
+    let ent-longplural = entry.at("longplural", default: "")
+
+    // Conditions
+    let is-first-or-long = __is_first_or_long(here(), key, long: long)
+    let has-short = has-short(entry)
+    let has-plural = has-plural(entry)
+    let has-long = has-long(entry)
+    let has-longplural = has-longplural(entry)
+
+    let longplural = if not has-longplural and has-long {
+      // Default longplural
+      // if the entry long plural is not provided, then fallback to adding default
+      // default-plural-suffix
+      [#ent-long#default-plural-suffix]
+    } else {
+      [#ent-longplural]
+    }
+
+    let shortplural = if not has-plural {
+      // Default short plural
+      // if the entry plural is not provided, then fallback to adding default
+      // default-plural-suffix
+      [#ent-short#default-plural-suffix]
+    } else {
+      [#ent-plural]
+    }
+
+    // Link text
+    let link-text = if is-first-or-long and has-long and long != false {
+      if has-short {
+        [#longplural (#shortplural)]
+      } else {
+        [#longplural]
+      }
+    } else if has-short {
+      // Default to short
+      [#shortplural]
+    } else {
+      [#longplural]
+    }
+
+    return __link_and_label(entry.key, link-text)
+  }
+}
+
+// __gls_attribute(key, attr) -> contextual str|content
+// Get the specified attribute from entry
+//
+// # Arguments
+// key (str): the key of the term
+// attr (str): the attribute to be retrieved
+//
+// # Returns
+// The attribute of the term
+#let __gls_attribute(key, attr, link: false) = (
+  context {
+    let entry = __get_entry_with_key(here(), key)
+    if link {
+      return __link_and_label(entry.key, entry.at(attr))
+    } else if attr in entry {
+      return entry.at(attr)
+    } else {
+      panic(__error_message(key, __attribute_is_empty, attr: attr))
+    }
+  }
+)
+
+// gls-key(key, link: false) -> str
+// Get the key of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The key of the term
+#let gls-key(key, link: false) = __gls_attribute(key, "key", link: link)
+
+// gls-short(key, link: false) -> str
+// Get the short form of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The short form of the term
+#let gls-short(key, link: false) = __gls_attribute(key, "short", link: link)
+
+// gls-artshort(key, link: false) -> str|content
+// Get the article of the short form
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The article of the short form
+#let gls-artshort(key, link: false) = __gls_attribute(
+  key,
+  "artshort",
+  link: link,
+)
+
+// gls-plural(key, link: false) -> str|content
+// Get the plural form of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The plural form of the term
+#let gls-plural(key, link: false) = __gls_attribute(key, "plural", link: link)
+
+// gls-long(key, link: false) -> str|content
+// Get the long form of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The long form of the term
+#let gls-long(key, link: false) = __gls_attribute(key, "long", link: link)
+
+// gls-artlong(key, link: false) -> str|content
+// Get the article of the long form
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The article of the long form
+#let gls-artlong(key, link: false) = __gls_attribute(key, "artlong", link: link)
+
+// gls-longplural(key, link: false) -> str|content
+// Get the long plural form of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The long plural form of the term
+#let gls-longplural(key, link: false) = __gls_attribute(
+  key,
+  "longplural",
+  link: link,
+)
+
+// gls-description(key, link: false) -> str|content
+// Get the description of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The description of the term
+#let gls-description(key, link: false) = __gls_attribute(
+  key,
+  "description",
+  link: link,
+)
+
+// gls-group(key, link: false) -> str
+// Get the group of the term
+//
+// # Arguments
+//  key (str): the key of the term
+//  link (bool): enable link to glossary
+//
+// # Returns
+// The group of the term
+#let gls-group(key, link: false) = __gls_attribute(key, "group", link: link)
+
+// make-glossary(body) -> content
+// Show rule for glossary
+//
+// # Arguments
+//  body (content): whole document
+//
+// # Usage
+// Transform everything
+// ```typ
+// #show: make-glossary
+// ```
+#let make-glossary(body) = {
+  // Fix figure caption alignement
+  show figure.where(kind: __glossarium_figure): it => if sys.version >= version(0, 12, 0) {
+    align(start, it.caption)
+  } else {
+    it.caption
+  }
+  // Select all figure refs and filter by __glossarium_figure
+  // Transform the ref to the glossary term
+  show ref: r => {
+    if (r.element != none and r.element.func() == figure and r.element.kind == __glossarium_figure) {
+      // call to the general citing function
+      let key = str(r.target)
+      if key.ends-with(":pl") {
+        // Plural ref
+        glspl(str(key).slice(0, -3))
+      } else {
+        // Default ref
+        gls(str(key), suffix: r.citation.supplement)
+      }
+    } else {
+      r
+    }
+  }
+  body
+}
+
+// __normalize_entry_list(entry-list) -> array<dictionary>
+// Add default values to each entry.
+//
+// # Arguments
+//  entry-list (array<dictionary>): the list of entries
+//
+// # Returns
+// The normalized entry list
+#let __normalize_entry_list(entry-list) = {
+  let new-list = ()
+  for entry in entry-list {
+    if not has-short(entry) and not has-long(entry) {
+      panic(__error_message(entry.key, __entry_has_neither_short_nor_long))
+    }
+    new-list.push((
+      key: entry.key,
+      short: entry.at("short", default: ""),
+      artshort: entry.at("artshort", default: "a"),
+      plural: entry.at("plural", default: ""),
+      long: entry.at("long", default: ""),
+      artlong: entry.at("artlong", default: "a"),
+      longplural: entry.at("longplural", default: ""),
+      description: entry.at("description", default: ""),
+      group: entry.at("group", default: ""),
+    ))
+  }
+  return new-list
+}
+
+// get-entry-back-references(entry) -> array<content>
+// Get the back references of the entry
+//
+// # Arguments
+// entry (dictionary): the entry
+//
+// # Returns
+// The back references as an array of links
+#let get-entry-back-references(entry) = {
+  let term-references = __query_labels_with_key(here(), entry.key)
+  return term-references
+    .map(x => x.location())
+    .sorted(key: x => x.page())
+    .fold(
+      (values: (), pages: ()),
+      ((values, pages), x) => {
+        if pages.contains(x.page()) {
+          // Skip duplicate references
+          return (values: values, pages: pages)
+        } else {
+          // Add the back reference
+          values.push(x)
+          pages.push(x.page())
+          return (values: values, pages: pages)
+        }
+      },
+    )
+    .values
+    .map(x => {
+    let page-numbering = x.page-numbering()
+    if page-numbering == none {
+      page-numbering = "1"
+    }
+    return link(x)[#numbering(page-numbering, ..counter(page).at(x))]
+  })
+}
+
+// count-refs(entry) -> int
+// Count the number of references to the entry in the document
+//
+// # Arguments
+// entry (dictionary): the entry
+//
+// # Returns
+// The number of references to the entry
+//
+// # Usage
+// ```typ
+// #context count-refs((key: "potato"))
+// ```
+#let count-refs(entry) = {
+  let refs = __query_labels_with_key(here(), entry.key)
+  return refs.len()
+}
+
+// count-all-refs(entry-list: none, groups: none) -> array<(str, int)>
+// Return the number of references for each entry in the document
+
+// # Arguments
+// entry-list (array<dictionary>): the list of entries. Defaults to all entries
+// groups (array<str>): the list of groups to be considered. `""` is the default group.
+//
+// # Returns
+// The number of references for each entry across the document
+//
+// # Usage
+// ```typ
+// #context count-all-refs()
+// ```
+#let count-all-refs(entry-list: none, groups: none) = {
+  let el = if entry-list == none {
+    __glossary_entries.get().values()
+  } else {
+    entry-list
+  }
+  let g = if groups == none {
+    el.map(x => x.at("group", default: "")).dedup()
+  } else if type(groups) == array {
+    groups
+  } else {
+    panic("groups must be an array of strings, e.g., (\"\",)")
+  }
+  el = el.filter(x => x.at("group", default: "") in g)
+  let counts = el.map(x => (x.key, count-refs(x)))
+  return counts
+}
+
+// there-are-refs(entry-list: none, groups: none) -> bool
+// Check if there are references to the entries in the document
+//
+// # Arguments
+// entry-list (array<dictionary>): the list of entries. Defaults to all entries
+// groups (array<str>): the list of groups to be considered. `""` is the default group.
+//
+// # Returns
+// True if there are references to the entries in the document
+//
+// # Usage
+// ```typ
+// #context if there-are-refs() {
+//   [= Glossary]
+// }
+// ```
+#let there-are-refs(entry-list: none, groups: none) = {
+  let counts = count-all-refs(entry-list: entry-list, groups: groups)
+  return counts.to-dict().values().any(x => x > 0)
+}
+
+
+// default-print-back-references(entry) -> contextual content
+// Print the back references of the entry
+//
+// # Arguments
+// entry (dictionary): the entry
+//
+// # Returns
+// Joined back references
+#let default-print-back-references(entry) = {
+  return get-entry-back-references(entry).join(", ")
+}
+
+// default-print-description(entry) -> content
+// Print the description of the entry
+//
+// # Arguments
+// entry (dictionary): the entry
+//
+// # Returns
+// The description of the entry
+#let default-print-description(entry) = {
+  return entry.at("description")
+}
+
+// default-print-title(entry) -> content
+// Print the title of the entry
+//
+// # Arguments
+// entry (dictionary): the entry
+//
+// # Returns
+// The title of the entry
+#let default-print-title(entry) = {
+  let caption = []
+  let txt = text.with(weight: 600)
+
+  if has-long(entry) and has-short(entry) {
+    caption += txt(emph(entry.short) + [ -- ] + entry.long)
+  } else if has-long(entry) {
+    caption += txt(entry.long)
+  } else {
+    caption += txt(emph(entry.short))
+  }
+  return caption
+}
+
+// default-print-gloss(
+//  entry,
+//  show-all: false,
+//  disable-back-references: false,
+//  minimum-refs: 1,
+//  user-print-title: default-print-title,
+//  user-print-description: default-print-description,
+//  user-print-back-references: default-print-back-references,
+// ) -> contextual content
+// Print the entry
+//
+// # Arguments
+//  entry (dictionary): the entry
+//  show-all (bool): show all entries
+//  disable-back-references (bool): disable back references
+//  minimum-refs (int): minimum number of references to show the entry
+//  ...
+//
+// # Returns
+//  The gloss content
+#let default-print-gloss(
+  entry,
+  show-all: false,
+  disable-back-references: false,
+  minimum-refs: 1,
+  user-print-title: default-print-title,
+  user-print-description: default-print-description,
+  user-print-back-references: default-print-back-references,
+) = (
+  context {
+    let caption = []
+
+    if show-all == true or count-refs(entry) >= minimum-refs {
+      // Title
+      caption += user-print-title(entry)
+
+      // Description
+      if has-description(entry) {
+        // Title - Description separator
+        caption += ": "
+        caption += user-print-description(entry)
+      }
+
+      // Back references
+      if disable-back-references != true {
+        caption += " "
+        caption += user-print-back-references(entry)
+      }
+    }
+
+    return caption
+  }
+)
+
+// default-print-reference(
+//  entry,
+//  show-all: false,
+//  disable-back-references: false,
+//  minimum-refs: 1,
+//  user-print-gloss: default-print-gloss,
+//  user-print-title: default-print-title,
+//  user-print-description: default-print-description,
+//  user-print-back-references: default-print-back-references,
+// ) -> contextual content
+// Print the entry
+//
+// # Arguments
+//  entry (dictionary): the entry
+//  show-all (bool): show all entries
+//  disable-back-references (bool): disable back references
+//  minimum-refs (int): minimum number of references to show the entry
+//  ..;
+//
+// # Returns
+// A glossarium figure+labels
+#let default-print-reference(
+  entry,
+  show-all: false,
+  disable-back-references: false,
+  minimum-refs: 1,
+  user-print-gloss: default-print-gloss,
+  user-print-title: default-print-title,
+  user-print-description: default-print-description,
+  user-print-back-references: default-print-back-references,
+) = {
+  return [
+    #par(
+      hanging-indent: 1em,
+      first-line-indent: 0em,
+    )[
+      #figure(
+        supplement: "",
+        kind: __glossarium_figure,
+        numbering: none,
+        caption: user-print-gloss(
+          entry,
+          show-all: show-all,
+          disable-back-references: disable-back-references,
+          minimum-refs: minimum-refs,
+          user-print-title: user-print-title,
+          user-print-description: user-print-description,
+          user-print-back-references: user-print-back-references,
+        ),
+      )[]#label(entry.key)
+      // The line below adds a ref shorthand for plural form, e.g., "@term:pl"
+      #figure(
+        kind: __glossarium_figure,
+        supplement: "",
+      )[] #label(entry.key + ":pl")
+    ]
+    #parbreak()
+  ]
+}
+
+
+// default-group-break() -> content
+// Default group break
+#let default-group-break() = {
+  return []
+}
+
+// default-print-glossary(
+//  entries,
+//  groups,
+//  show-all: false,
+//  disable-back-references: false,
+//  group-heading-level: none,
+//  minimum-refs: 1,
+//  user-print-reference: default-print-reference
+//  user-group-break: default-group-break,
+//  user-print-gloss: default-print-gloss,
+//  user-print-title: default-print-title,
+//  user-print-description: default-print-description,
+//  user-print-back-references: default-print-back-references,
+// ) -> contextual content
+// Default glossary print function
+//
+// # Arguments
+//  entries (array<dictionary>): the list of entries
+//  groups (array<str>): the list of groups
+//  show-all (bool): show all entries
+//  disable-back-references (bool): disable back references
+//  group-heading-level (int): force the level of the group heading
+//  minimum-refs (int): minimum number of references to show the entry
+//  ...
+//
+// # Warnings
+// A strong warning is given not to override `user-print-reference` without
+// careful consideration of `default-print-reference`'s original implementation.
+// The package's behaviour may break in unexpected ways if not handled correctly.
+//
+// # Returns
+// The glossary content
+#let default-print-glossary(
+  entries,
+  groups,
+  show-all: false,
+  disable-back-references: false,
+  group-heading-level: none,
+  minimum-refs: 1,
+  user-print-reference: default-print-reference,
+  user-group-break: default-group-break,
+  user-print-gloss: default-print-gloss,
+  user-print-title: default-print-title,
+  user-print-description: default-print-description,
+  user-print-back-references: default-print-back-references,
+) = {
+  let body = []
+  if group-heading-level == none {
+    let previous-headings = query(selector(heading).before(here()))
+    if previous-headings.len() != 0 {
+      group-heading-level = previous-headings.last().level + 1
+    } else {
+      group-heading-level = 1
+    }
+  }
+  for group in groups.sorted() {
+    let group-entries = entries.filter(x => x.at("group") == group)
+    let group-ref-counts = group-entries.map(count-refs)
+
+    let print-group = (group != "" and (show-all == true or group-ref-counts.any(x => x >= minimum-refs)))
+
+    // Only print group name if any entries are referenced
+    if print-group {
+      body += [#heading(group, level: group-heading-level)]
+    }
+    for entry in group-entries.sorted(key: x => x.key) {
+
+      body += user-print-reference(
+        entry,
+        show-all: show-all,
+        disable-back-references: disable-back-references,
+        minimum-refs: minimum-refs,
+        user-print-gloss: user-print-gloss,
+        user-print-title: user-print-title,
+        user-print-description: user-print-description,
+        user-print-back-references: user-print-back-references,
+      )
+    }
+
+    body += user-group-break()
+  }
+
+  return body
+}
+
+//  __update_glossary(entries) -> none
+// Update the global state glossary
+//
+// # Arguments
+//  entries (array<dictionary>): the list of entries
+#let __update_glossary(entries) = {
+  __glossary_entries.update(x => {
+    for entry in entries {
+      if entry.key in entries {
+        panic("Duplicate key: " + entry.key)
+      }
+      x.insert(entry.key, entry)
+    }
+    return x
+  })
+}
+
+// register-glossary(entry-list) -> none
+// Register the glossary entries
+//
+// # Arguments
+// entries (array<dictionary>): the list of entries
+#let register-glossary(entry-list) = {
+  if sys.version <= version(0, 11, 1) {
+    return
+  }
+  // Normalize entry-list
+  let entries = __normalize_entry_list(entry-list)
+
+  __update_glossary(entries)
+}
+
+// print-glossary(
+//  entry-list,
+//  groups: (),
+//  show-all: false,
+//  disable-back-references: false,
+//  group-heading-level: none,
+//  minimum-refs: 1,
+//  user-print-glossary: default-print-glossary,
+//  user-print-reference: default-print-reference,
+//  user-group-break: default-group-break,
+//  user-print-gloss: default-print-gloss,
+//  user-print-title: default-print-title,
+//  user-print-description: default-print-description,
+//  user-print-back-references: default-print-back-references,
+// ) -> contextual content
+// Print the glossary
+//
+// # Arguments
+//  entry-list (array<dictionary>): the list of entries
+//  groups (array<str>): the list of groups to be displayed. `""` is the default group.
+//  show-all (bool): show all entries
+//  disable-back-references (bool): disable back references
+//  group-heading-level (int): force the level of the group heading
+//  minimum-refs (int): minimum number of references to show the entry
+//  ...
+//
+// # Warnings
+// A strong warning is given not to override `user-print-reference` without
+// careful consideration of `default-print-reference`'s original implementation.
+// The package's behaviour may break in unexpected ways if not handled correctly.
+//
+// # Usage
+// Print the glossary
+// ```typ
+// print-glossary(entry-list)
+// ```
+#let print-glossary(
+  entry-list,
+  groups: (),
+  show-all: false,
+  disable-back-references: false,
+  group-heading-level: none,
+  minimum-refs: 1,
+  user-print-glossary: default-print-glossary,
+  user-print-reference: default-print-reference,
+  user-group-break: default-group-break,
+  user-print-gloss: default-print-gloss,
+  user-print-title: default-print-title,
+  user-print-description: default-print-description,
+  user-print-back-references: default-print-back-references,
+) = {
+  if entry-list == none {
+    panic("entry-list is required")
+  }
+  if type(groups) != array {
+    panic("groups must be an array")
+  }
+  let entries = ()
+  if sys.version <= version(0, 11, 1) {
+    // Normalize entry-list
+    entries = __normalize_entry_list(entry-list)
+
+    // Update state
+    __update_glossary(entries)
+  } else {
+    context {
+      if __glossary_entries.get().len() == 0 {
+        panic(__error_message(none, __glossary_is_empty))
+      }
+    }
+  }
+
+  // Glossary
+  let body = []
+  body += context {
+    // Entries
+    let el = if sys.version <= version(0, 11, 1) {
+      entries
+    } else if entry-list != none {
+      __glossary_entries.get().values().filter(x => (x.key in entry-list.map(x => x.key)))
+    }
+
+    // Groups
+    let g = if groups == () {
+      el.map(x => x.at("group")).dedup()
+    } else {
+      groups
+    }
+    user-print-glossary(
+      el,
+      g,
+      show-all: show-all,
+      disable-back-references: disable-back-references,
+      group-heading-level: group-heading-level,
+      minimum-refs: minimum-refs,
+      user-print-reference: user-print-reference,
+      user-group-break: user-group-break,
+      user-print-gloss: user-print-gloss,
+      user-print-title: user-print-title,
+      user-print-description: user-print-description,
+      user-print-back-references: user-print-back-references,
+    )
+  }
+
+  // Content
+  body
+}

--- a/packages/preview/glossarium/0.5.1/typst.toml
+++ b/packages/preview/glossarium/0.5.1/typst.toml
@@ -1,0 +1,26 @@
+[package]
+name = "glossarium"
+version = "0.5.1"
+entrypoint = "glossarium.typ"
+authors = ["slashformotion", "Dherse"]
+license = "MIT"
+description = "Glossarium is a simple, easily customizable typst glossary."
+repository = "https://github.com/typst-community/glossarium"
+exclude = [
+    "tbump.toml",
+    "makefile",
+    "flake.nix",
+    "flake.lock",
+    "justfile",
+    "examples",
+    "package.sh",
+    "tests",
+    "advanced-docs",
+    "docs",
+    ".github",
+    ".vscode",
+    ".gtm",
+    ".git",
+    ".gitignore",
+    "**/*.pdf",
+]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

> [!TIP]
> New group options have been added: `print-glossary(groups: array<str>)` to
> display only the specified groups.
> ```typ
> #print-glossary(
>   // ...
>   groups: ("Group A", "Group B", "") // "" is the default group
> )
> ```
> and `print-glossary(group-heading-level: int)` to set the heading level for
> groups regardless of the previous heading level.
> ```typ
> #print-glossary(
>   // ...
>   group-heading-level: 3
> )
> ```

> [!TIP]
> A new parameter `print-glossary(minimum-ref: int)` has been added to filter
> entries with a minimum number of references.
> ```typ
> #print-glossary(
>   // ...
>   minimum-ref: 2
> )
> ```

> [!TIP]
> New counting functions have been added: `count-all-refs` and `there-are-refs`
> in addition to `count-refs`.
> ```typ
> #context count-all-refs()
> #context if there-are-refs() [
>   = Glossary
> ]
> ```

> [!NOTE]
> - Fix terms references for long-only terms.
> - Fix missing commas in fast start

> [!NOTE]
> Add missing changelog!
