### PR TITLE
lambdabus:0.1.0

### DIFF
--- a/packages/preview/lambdabus/0.1.0/LICENSE
+++ b/packages/preview/lambdabus/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Luca Schlecker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/lambdabus/0.1.0/README.md
+++ b/packages/preview/lambdabus/0.1.0/README.md
@@ -1,0 +1,13 @@
+# 🪄 Lambdabus 🪄
+
+Lambdabus allows you to parse, normalize and display simple λ-Calculus expressions in Typst with ease.
+
+## Usage
+
+Lambdabus is available on the [Typst Universe](https://typst.app/universe/package/lambdabus/) and it is thus recommended to be imported like this:
+```typst
+#import "@preview/lambdabus:0.1.0" as lmd
+```
+
+## Features/Examples
+![Feature Table](https://raw.github.com/luca-schlecker/typst-lambdabus/v0.1.0/gallery.png)

--- a/packages/preview/lambdabus/0.1.0/lambda.typ
+++ b/packages/preview/lambdabus/0.1.0/lambda.typ
@@ -1,0 +1,218 @@
+#import "printing.typ": expr-to-str
+#import "parsing.typ": parse-literal
+
+#let free-vars(expr) = {
+  if expr.type == "value" {
+    return (expr.name,)
+  } else if expr.type == "application" {
+    return (free-vars(expr.fn) + free-vars(expr.param)).dedup()
+  } else if expr.type == "abstraction" {
+    return free-vars(expr.body).filter(it => it != expr.param)
+  }
+}
+
+#let alpha-conversion-impl(expr, old, new) = {
+  if expr.type == "abstraction" {
+    if expr.param == old {
+      return expr
+    } else {
+      expr.body = alpha-conversion-impl(expr.body, old, new)
+      return expr
+    }
+  } else if expr.type == "application" {
+    expr.fn = alpha-conversion-impl(expr.fn, old, new)
+    expr.param = alpha-conversion-impl(expr.param, old, new)
+    return expr
+  } else if expr.type == "value" {
+    expr.name = new
+    return expr
+  }
+}
+
+#let alpha-conversion(expr, new) = {
+  if type(new) != str {
+    panic("New parameter name has to be of type str")
+  }
+
+  parse-literal(new.codepoints())
+
+  if expr.type != "abstraction" {
+    panic("Can only apply λ-Calculus alpha-conversion on abstraction, got: '" + expr.type + "'")
+  }
+
+  if free-vars(expr).contains(new) {
+    panic("Cannot apply λ-Calculus alpha-conversion (new variable name '" + new + "' already bound): '" + expr-to-str(expr) + "'")
+  }
+
+  let old = expr.param
+  expr.param = new
+
+  return alpha-conversion-impl(expr, old, new)
+}
+
+#let beta-reduction-impl(expr, param, value) = {
+  if expr.type == "value" {
+    if expr.name == param {
+      return value
+    } else {
+      return expr
+    }
+  } else if expr.type == "application" {
+    expr.fn = beta-reduction-impl(expr.fn, param, value)
+    expr.param = beta-reduction-impl(expr.param, param, value)
+    return expr
+  } else if expr.type == "abstraction" {
+    if expr.param == param {
+      return expr
+    } else {
+      if expr.param in free-vars(value) {
+        panic("Cannot apply λ-Calculus beta-reduction (free variable '" + expr.param + "' would be bound): '" + expr-to-str(expr) + "'")
+      } else {
+        expr.body = beta-reduction-impl(expr.body, param, value)
+        return expr
+      }
+    }
+  }
+}
+
+#let beta-reduction(expr) = {
+  if expr.type != "application" {
+    panic("Can only apply λ-Calculus beta-reduction on applications, got: '" + expr.type + "'")
+  }
+
+  if expr.fn.type != "abstraction" {
+    panic("Can only apply λ-Calculus beta-reduction on applications on abstractions, was: '" + expr.fn.type + "'")
+  }
+
+  return beta-reduction-impl(expr.fn.body, expr.fn.param, expr.param)
+}
+
+#let eta-reduction(expr) = {
+  if expr.type != "abstraction" {
+    panic("Can only apply λ-Calculus eta-reduction on abstractions, got: '" + expr.type + "'")
+  }
+
+  if expr.body.type != "application" {
+    panic("Can only apply λ-Calculus eta-reduction on abstractions with an application body, got: '" + expr.body.type + "'")
+  }
+
+  if expr.body.param.type != "value" or expr.body.param.name != expr.param {
+    panic("Can only apply λ-Calculus eta-reduction on abstractions with an application body with the abstraction variable on the right side, got: '" + expr.body.type + "'")
+  }
+
+  return expr.body.fn
+}
+
+#let normalize-is-reducable(expr) = {
+  if expr.type == "value" {
+    return false
+  } else if expr.type == "application" {
+    if expr.fn.type == "abstraction" {
+      return true
+    } else {
+      return normalize-is-reducable(expr.fn) or normalize-is-reducable(expr.param)
+    }
+  } else if expr.type == "abstraction" {
+    return normalize-is-reducable(expr.body)
+  }
+}
+
+#let normalize-reduce(expr) = {
+  if expr.type == "value" {
+    return expr
+  } else if expr.type == "application" {
+    if expr.fn.type == "abstraction" {
+      return beta-reduction(expr)
+    } else {
+      if normalize-is-reducable(expr.fn) {
+        expr.fn = normalize-reduce(expr.fn)
+        return expr
+      } else {
+        expr.param = normalize-reduce(expr.param)
+        return expr
+      }
+    }
+  } else if expr.type == "abstraction" {
+    expr.body = normalize-reduce(expr.body)
+    return expr
+  }
+}
+
+#let normalization-steps(expr) = {
+  let steps = (expr,)
+  while normalize-is-reducable(expr) {
+    expr = normalize-reduce(expr)
+    if expr in steps {
+      panic("λ-Calculus expression not normalizable")
+    }
+    steps.push(expr)
+  }
+  return steps
+}
+
+#let normalize(expr) = {
+  return normalization-steps(expr).last()
+}
+
+#let is-normalizable(expr) = {
+  let prev = (expr,)
+  while normalize-is-reducable(expr) {
+    expr = normalize-reduce(expr)
+    if expr in prev {
+      return false
+    }
+    prev.push(expr)
+  }
+  return true
+}
+
+#let is-normalform(expr) = {
+  if is-normalizable(expr) {
+    return normalize(expr) == expr
+  } else {
+    return false
+  }
+}
+
+#let count-binds(expr) = {
+  if expr.type == "application" {
+    return count-binds(expr.fn) + count-binds(expr.param)
+  } else if expr.type == "abstraction" {
+    return 1 + count-binds(expr.body)
+  } else if expr.type == "value" {
+    return 0
+  }
+}
+
+#let tag(
+  expr,
+  bound-ranks: (:),
+  index: 0,
+) = {
+  let _tag(expr, bound-ranks, index) = tag(
+    expr,
+    bound-ranks: bound-ranks,
+    index: index,
+  )
+
+  if expr.type == "value" {
+    if expr.name in bound-ranks {
+      expr.insert("index", bound-ranks.at(expr.name))
+    }
+
+    return expr
+  } else if expr.type == "application" {
+    expr.fn = _tag(expr.fn, bound-ranks, index)
+    expr.param = _tag(expr.param, bound-ranks, index + count-binds(expr.fn))
+
+    return expr
+  } else if expr.type == "abstraction" {
+    bound-ranks.insert(expr.param, index)
+    expr.insert("index", index)
+    expr.body = _tag(expr.body, bound-ranks, index + 1)
+
+    return expr
+  } else {
+    panic("Not a valid λ-Calculus type: '" + expr.type + "'")
+  }
+}

--- a/packages/preview/lambdabus/0.1.0/lib.typ
+++ b/packages/preview/lambdabus/0.1.0/lib.typ
@@ -1,0 +1,82 @@
+#import "parsing.typ"
+#import "lambda.typ"
+#import "printing.typ"
+
+#let parse(input) = {
+  if type(input) == str {
+    return lambda.tag(parsing.parse-expr(input.codepoints()))
+  } else {
+    panic("Only a string can be parsed as a λ-Calculus expression")
+  }
+}
+
+#let free-vars(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.free-vars(expr)
+}
+
+#let normalize(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.normalize(expr)
+}
+
+#let normalization-steps(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.normalization-steps(expr)
+}
+
+#let is-normalizable(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.is-normalizable(expr)
+}
+
+#let is-normalform(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.is-normalform(expr)
+}
+
+#let alpha(expr, new-var-name) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.alpha-conversion(expr, new-var-name)
+}
+
+#let beta(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.beta-reduction(expr)
+}
+
+#let eta(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return lambda.eta-reduction(expr)
+}
+
+#let to-str(expr) = {
+  if type(expr) == str { expr = parse(expr) }
+  return printing.expr-to-str(expr)
+}
+
+#let display(
+  expr,
+  show-bound: false,
+  colors: (red, green, blue, yellow, orange, black, fuchsia).map(it => it.transparentize(80%)),
+  highlight-bound: none,
+  implicit-parenthesis: false,
+) = {
+  let h = if show-bound {
+    if highlight-bound == none {
+      (var, rank) => highlight(
+        var,
+        fill: colors.at(calc.rem(rank, colors.len())),
+        radius: 0.2em,
+        extent: 0.05em
+      )
+    } else {
+      highlight-bound
+    }
+  } else {
+    (var, rank) => var
+  }
+
+  if type(expr) == str { expr = parse(expr) }
+  return printing.display-expr(expr, h, implicit-parenthesis)
+}

--- a/packages/preview/lambdabus/0.1.0/parsing.typ
+++ b/packages/preview/lambdabus/0.1.0/parsing.typ
@@ -1,0 +1,106 @@
+#let is-literal(input) = {
+  return input.len() == 1 and input.first() not in ("λ", " ", ".", "\\", "(", ")")
+}
+
+#let parse-literal(input) = {
+  if is-literal(input) {
+    return (type: "value", name: input.first())
+  } else {
+    panic("Not a valid λ-Calculus Literal: '" + input.join() + "'")
+  }
+}
+
+#let parse-abstraction(input, parse-expr) = {
+  let result = (
+    type: "abstraction",
+    param: (),
+    body: (),
+  )
+
+  if input.remove(0) not in ("λ", "\\") {
+    panic("Not a valid λ-Calculus Abstraction (needs to begin with λ or \\): '" + input.join() + "'")
+  }
+
+  let char = input.remove(0)
+  if is-literal(char) {
+    result.param = char
+  } else if char == "." {
+    panic("Not a valid λ-Calculus Abstraction (missing parameter): '" + "λ" + char + input.join() + "'")
+  } else {
+    panic("Not a valid λ-Calculus Abstraction (invalid parameter '" + char + "'): '" + input.join() + "'")
+  }
+
+  char = input.remove(0)
+  if char == "." {
+    result.body = parse-expr(input)
+  } else if char == " " {
+    result.body = parse-abstraction(
+      ("λ",) + input,
+      parse-expr
+    )
+  } else {
+    panic("Not a valid λ-Calculus Abstraction (invalid parameter '" + char + "'): '" + input.join() + "'")
+  }
+
+  return result
+}
+
+#let parse-parenthesis(input, parse-expr) = {
+  if input.first() != "(" or input.last() != ")" {
+    panic("Not a valid λ-Calculus expression (wrong parenthesis placement): '" + input.join() + "'")
+  }
+
+  return parse-expr(input.slice(1, -1))
+}
+
+#let find-application-space(input) = {
+  let last-space = none
+  let in-abstr = false
+  let in-par = 0
+  for (index, value) in input.enumerate() {
+    if value in ("λ", "\\") { in-abstr = true }
+    else if value == "." { in-abstr = false }
+    else if value == "(" { in-par += 1 }
+    else if value == ")" { in-par -= 1 }
+    
+    if value == " " and in-abstr == false and in-par == 0 {
+      last-space = index
+    }
+  }
+
+  return last-space
+}
+
+#let parse-application(input, parse-expr) = {
+  let last-space = find-application-space(input)
+  if last-space == none {
+    panic("Not a valid λ-Calculus application (missing space): '" + input.join() + "'")
+  } else {
+    let fn = parse-expr(input.slice(0, last-space))
+    let param = parse-expr(input.slice(last-space + 1))
+
+    return (
+      type: "application",
+      fn: fn,
+      param: param,
+    )
+  }
+}
+
+#let parse-expr(input) = {
+  if input.len() == 0 {
+    panic("λ-Calculus expression must not be empty")
+  }
+
+  if input.first() in ("λ", "\\") {
+    return parse-abstraction(input, parse-expr)
+  } else if find-application-space(input) != none {
+    return parse-application(input, parse-expr)
+  } else if input.first() == "(" {
+    return parse-parenthesis(input, parse-expr)
+  } else if is-literal(input) {
+    return parse-literal(input)
+  } else {
+    panic("Not a valid λ-Calculus expression: '" + input.join() + "'")
+  }
+}

--- a/packages/preview/lambdabus/0.1.0/printing.typ
+++ b/packages/preview/lambdabus/0.1.0/printing.typ
@@ -1,0 +1,64 @@
+#let expr-to-str(expr) = {
+  if expr.type == "value" {
+    return expr.name
+  } else if expr.type == "application" {
+    let left = if expr.fn.type == "abstraction" {
+      "(" + expr-to-str(expr.fn) + ")"
+    } else {
+      expr-to-str(expr.fn)
+    }
+    let right = if expr.param.type in ("application", "abstraction") {
+      "(" + expr-to-str(expr.param) + ")"
+    } else {
+      expr-to-str(expr.param)
+    }
+    
+    return left + " " + right
+  } else if expr.type == "abstraction" {
+    return "λ" + expr.param + "." + expr-to-str(expr.body)
+  }
+}
+
+#let display-expr(
+  expr,
+  highlight,
+  implicit-parenthesis,
+) = {
+  let display(expr) = display-expr(expr, highlight, implicit-parenthesis)
+  let par(content, ..fill) = text(..fill)[(] + content + text(..fill)[)]
+
+  if expr.type == "value" {
+    if "index" in expr {
+      highlight(expr.name, expr.index)
+    } else {
+      expr.name
+    }
+  } else if expr.type == "application" {
+    if implicit-parenthesis {
+      par(fill: gray)[#display(expr.fn) #display(expr.param)]
+    } else {
+      let left = if expr.fn.type == "abstraction" {
+        par(display(expr.fn))
+      } else {
+        display(expr.fn)
+      }
+
+      let right = if expr.param.type in ("application", "abstraction") {
+        par(display(expr.param))
+      } else {
+        display(expr.param)
+      }
+
+      [#left #right]
+    }
+    
+  } else if expr.type == "abstraction" {
+    let content = [λ] + highlight(expr.param, expr.index) + [.] + display(expr.body)
+
+    if implicit-parenthesis {
+      par(content, fill: gray)
+    } else {
+      content
+    }
+  }
+}

--- a/packages/preview/lambdabus/0.1.0/typst.toml
+++ b/packages/preview/lambdabus/0.1.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lambdabus"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Luca Schlecker <@luca-schlecker>"]
+license = "MIT"
+description = "Easily parse, normalize and display simple λ-Calculus expressions."
+repository = "https://github.com/luca-schlecker/typst-lambdabus"
+keywords = ["lambda", "calculus"]
+categories = ["fun"]


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Lambdabus allows you to parse, normalize and display simple λ-Calculus expressions in Typst with ease.
It currently supports:
- Lambda Expression Parsing from String
- α-, β- and η-Reductions
- Normal-order Reduction
- Printing including color-coded bound variables and implicit parenthesis
- Syntax Tree
- Free Variables
- Checks wether an expression is normalizable or in normal form

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE