### PR TITLE
Test PR Workflow with sparse checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Download the whole history for the package timestamps
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -34,7 +34,7 @@ jobs:
             }
             core.setOutput('sparse_checkout_paths', sparseCheckoutPaths);
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             ${{ steps.extract_package.outputs.sparse_checkout_paths }}


### PR DESCRIPTION
# Add a new Test workflow for PR specifically using sparse checkout

Based on the PR title in format `[package]:[version]`, the checkout action
uses `sparse-checkout` to reduce the scope of the test for each PR.


~~Example run at:~~
~~- single package: https://github.com/quachpas/packages/actions/runs/11666315963/job/32480980631~~
~~- multiple package: https://github.com/quachpas/packages/actions/runs/11666311358/job/32480966073~~

Test for PR are separated in a different workflow file `test_pr.yml`.
