### PR TITLE
frame-it:1.0.0

### DIFF
--- a/packages/preview/frame-it/1.0.0/LICENSE
+++ b/packages/preview/frame-it/1.0.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Marc Thieme
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/frame-it/1.0.0/README.md
+++ b/packages/preview/frame-it/1.0.0/README.md
@@ -1,0 +1,1 @@
+![Introductory PDF](https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README.svg)

--- a/packages/preview/frame-it/1.0.0/README.typ
+++ b/packages/preview/frame-it/1.0.0/README.typ
@@ -1,0 +1,204 @@
+#import "src/lib.typ": *
+
+#set page(height: auto)
+
+#let (example, feature, variant, syntax) = make-frames(
+  "core-frames",
+  feature: ("Feature",),
+  variant: ("Feature Variant",),
+  example: ("Example", gray),
+  syntax: ("Syntax",),
+)
+
+= Introduction
+#link("https://github.com/marc-thieme/frame-it", text(blue)[Frame-It]) offers a straightforward way to define and use custom environments in your documents. Its syntax is designed to integrate seamlessly with your source code.
+
+Two predefined styles are included by default. You can also create custom styling functions that use the same user-facing API while giving you complete control over the Typst elements in your document.
+
+#feature[Distinct Highlight][Best for occasional use][More noticeable][
+  The default style, `styles.boxy`, is eye-catching and intended to stand out from the surrounding text.
+]
+
+In contrast:
+
+#feature(style: styles.hint)[Unobtrusive Style][Ideal for frequent use][Blends into text flow][
+  The alternative style `styles.hint` highlights text with a subtle colored line along the side, preserving the document's flow.
+]
+
+#example[A different frame kind][
+  You can define different classes or types of frames, which alter the substitute and the frame's color. As shown here, this is an example frame.
+  You can create as many different kinds as you want.
+
+  As long as all kinds use the same identifier with `make-frames`, they share a common counter.
+]
+
+= Quick Start
+Import and define your desired frames:
+
+```typst
+#import "@preview/frame-it:1.0.0"
+
+#let (example, feature, variant, syntax) = make-frames(
+  // This identifies the counter used for all theorems in this definition
+  "counter-id",
+  theorem: ("Theorem",),
+  // For each frame kind, you have to provide its supplement title to be displayed
+  definition: ("Definition",),
+  // You can provide a color or leave it out and it will be generated
+  example: ("Example", gray),
+  // You can add as many as you want
+  corollary: ("Corollary",),
+)
+```
+
+How to use it is explained below. Here is a quick example:
+```typst
+#example[Title][Optional Tag][
+  Body, i.e. large content block for the frame.
+]
+```
+which yields
+#example[Title][Optional Tag][
+  Body, i.e. large content block for the frame.
+]
+
+= Feature List
+
+#let layout-features(style) = [
+  #let (example, feature, variant) = (
+    example.with(style: style),
+    variant.with(style: style),
+    feature.with(style: style),
+  )
+
+  #feature[Element with Title and Content][
+    The simplest way to create an element is by providing a title as the first argument and content as the second.
+  ]
+
+  #variant[Element with Tags][Customizable Tags][!][
+    Elements can include multiple tags placed between the title and the content.
+  ]
+
+  #feature[][
+    If you don’t require a custom title but still want to display the element type, use `[]` as the title placeholder.
+  ]
+
+  #variant[][Single Tag][
+    You can include tags even when no title is provided.
+  ]
+
+  #variant[
+    To omit the header entirely, leave the title parameter empty.
+  ]
+
+  #feature[Element without Content][Optional Tags Only][]
+  For brief elements, use [] as the body to omit the content.
+
+  #feature[Element with Divider][
+    Insert `divide()` to add a divider within your content for a visual break:
+    #divide()
+    And then continue with your text below the divider.
+  ]
+]
+
+The following features are demonstrated in both predefined styles.
+
+== Style Blending into Text Flow
+#layout-features(styles.hint)
+== Boxy Style
+#layout-features(styles.boxy)
+
+#feature[References][
+  Elements can be referenced as usual with `<... tag ...>`.
+] <reference-tag>
+
+For example: @reference-tag.
+
+= Syntax
+You define one or more styles by using the `make-frames` function:
+
+#syntax[Initialization][
+  ```typst
+  #let (example, feature, variant, syntax) = make-frames(
+    "core-frames",
+    feature: ("Feature",),
+    variant: ("Feature Variant",),
+    example: ("Example", gray),
+    syntax: ("Syntax",),
+  )
+  ```
+]
+
+And use them like this:
+
+#syntax[
+  ```typst
+  #feature[Distinct Highlight][Best for occasional use][More noticeable][
+    The default style, `styles.boxy`, is eye-catching and intended to stand out from the surrounding text.
+  ]
+  ```
+]
+
+Or using an explicit styling function:
+
+#syntax[
+  ```typst
+  #variant(style: styles.boxy)[
+    To skip the header entirely, leave the title parameter blank.
+  ]
+  ```
+  This styling function can be provided as default for all frame kinds:
+  ```typst
+  #let (example, feature, variant, syntax) = make-frames(
+    style: styles.hint,
+    "core-frames",
+    feature: ("Feature",),
+    variant: ("Feature Variant",),
+    example: ("Example", gray),
+    syntax: ("Syntax",),
+  )
+  ```
+  Note that this only affects those defined in the same call to `make-frames`.
+]
+
+#syntax[Custom Styling Function][
+  When defining your own styling function, it has to have the following signature:
+  ```typst
+  let factory(title: content, tags: (content), body: content, supplement: string or content, number, args) = …
+  ```
+  The content it returns will be placed into the document without modifications.
+]
+
+#syntax[Styling Dividers][
+  If your custom styling function shall support dividers, it must include a show rule in its body:
+  ```typst
+  show: styling.dividers-as(object-which-will-be-used-as-divider)
+  ```
+]
+
+For more information on how to define your own styling function, please look into the `styling` module.
+
+= Edge Cases
+
+Here are a few edge cases.
+
+#example[Test][Long content example without space for additional elements][
+  #lorem(20)
+]
+
+#example[Example][Tags of various sizes][$sum_sum^sum$][Extra vertical space: #v(1cm)][
+  #lorem(20)
+]
+
+#example[][
+  #example[][
+    #example(style: styles.hint)[][
+      When nested, counters increment from outer to inner elements.
+    ]
+  ]
+]
+
+#example[][
+  Counters continue incrementing sequentially in non-nested elements.
+]
+

--- a/packages/preview/frame-it/1.0.0/justfile
+++ b/packages/preview/frame-it/1.0.0/justfile
@@ -1,0 +1,50 @@
+set unstable
+
+readme-typ-file := 'README.typ'
+
+default:
+    just --list
+
+setup: setup-pre-commit-hooks && _add-assets-to-git-exclude
+    git worktree add assets
+
+[confirm("Add pre-commit hook to .git/hooks/pre-commit?")]
+setup-pre-commit-hooks:
+    touch .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+    echo "just pre-commit" >> .git/hooks/pre-commit
+
+[confirm("Add new worktree 'assets' to '.git/info/exclude'?")]
+_add-assets-to-git-exclude:
+    echo assets >> .git/info/exclude
+
+push-new-readme: (readme-compile "assets/README.svg") && commit-and-push-assets
+
+[confirm("Do you want to commit and push all changes on the assets branch?")]
+[script]
+commit-and-push-assets commit-msg="Update.":
+    cd assets
+    git add .
+    git commit -m {{commit-msg}}
+    git push
+
+readme-watch output="":
+    typst watch {{readme-typ-file}} {{output}}
+
+readme-compile output="" *options="":
+    typst compile {{options}} {{readme-typ-file}} {{output}}
+
+pre-commit: (readme-compile "/dev/null" "-f svg")
+    typos
+    typstyle --check format-all
+
+_version-regex := '[0-9]+\.[0-9]+\.[0-9]+'
+release new-version:
+    @echo Testing if index and staging area are empty
+    test -z "$(git status --porcelain)"
+    sed -Ei 's|#import "@preview/frame-it:{{_version-regex}}"|#import "@preview/frame-it:{{new-version}}"|g' README.typ
+    sed -Ei 's|version = "{{_version-regex}}"|version = "{{new-version}}"|g' typst.toml
+    git add README.typ typst.toml
+    git commit -m "Bump version to {{new-version}}."
+    test -z "$(git status --porcelain)" # Just to make sure we didn't screw up
+    @echo Don\'t forget to open a pull request for the new version!

--- a/packages/preview/frame-it/1.0.0/src/layout.typ
+++ b/packages/preview/frame-it/1.0.0/src/layout.typ
@@ -1,0 +1,67 @@
+#let spawn-frame(
+  style,
+  kind,
+  title,
+  tags,
+  body,
+  supplement,
+  custom-arg,
+) = figure(
+  kind: kind,
+  supplement: supplement,
+  {
+    let caption-id = [
+      Uniquely identify this to make the `show figure`-clause as specific as possible.
+      #(
+        style,
+        kind,
+        title,
+        tags,
+        body,
+        supplement,
+        custom-arg,
+      ).map(repr).join(", ")
+    ]
+    // Offset the counter because our outer helper figure has the same kind.
+    // The outer figure must have the same kind as the inner because the user might rely
+    // on the outer one having the kind he knows when he's writing rules for references
+    counter(figure.where(kind: kind)).update(old => old - 1)
+    // NOTE I don't know the performance impact of this
+    // Inject the customized styling into the caption.
+    // We use the caption because we have access to the supplement and the numbering there.
+    show figure.caption.where(body: caption-id): caption => (
+      context {
+        let number = caption.counter.display(caption.numbering)
+        style(title, tags, body, supplement, number, custom-arg)
+      }
+    )
+
+    figure(caption: caption-id, supplement: none, gap: 0pt, kind: kind, none)
+  },
+)
+
+// Wrap it in a second figure because of three facts:
+// 1. We need to return a type figure to make it labellable
+// 2. We need to specify rules (set and show) to modify caption styling
+// 3. If we specify rules in the block which is returned, a type 'styled' is returned instead of the figure
+#let factory(style, supplement, kind, custom-arg) = (
+  (..title-and-tags, body, style: style, arg: custom-arg) => {
+    assert(
+      title-and-tags.named() == (:),
+      message: "You provided named arguments which are not supported: " + repr(
+        title-and-tags.named(),
+      ),
+    )
+    let title = none
+    let tags = ()
+    if title-and-tags.pos() != () {
+      (title, ..tags) = title-and-tags.pos()
+    }
+    spawn-frame(style, kind, title, tags, body, supplement, arg)
+  }
+)
+
+#let DIVIDE-IDENTIFIER = "__MAKEFRAMES_DIVIDE-IDENTIFIER"
+#let divide() = figure(kind: DIVIDE-IDENTIFIER, supplement: none)[
+  `Error: Dividers not supported by this styling function.`
+]

--- a/packages/preview/frame-it/1.0.0/src/lib.typ
+++ b/packages/preview/frame-it/1.0.0/src/lib.typ
@@ -1,0 +1,18 @@
+#import "styles.typ" as styles
+#import "styling.typ" as styling
+#import "layout.typ": divide
+
+#let make-frames(kind, style: styles.boxy, ..frames) = {
+  import "parse.typ"
+  import "layout.typ"
+
+  for (id, supplement, color) in parse.parse-args(frames) {
+    ((id): layout.factory(style, supplement, kind, color))
+  }
+}
+
+/*
+Definition of styling:
+
+let factory(title: content, tags: (content), body: content, supplement: string or content, number, args)
+*/

--- a/packages/preview/frame-it/1.0.0/src/parse.typ
+++ b/packages/preview/frame-it/1.0.0/src/parse.typ
@@ -1,0 +1,48 @@
+#let calculate-colors(count) = {
+  let samples = for i in range(count) {
+    (i * 100% / count,)
+  }
+  gradient
+    .linear(..color.map.rainbow.rev())
+    .samples(..samples)
+    .map(color => color.lighten(70%).desaturate(50%))
+}
+
+#let parse-args(frames) = {
+  assert(
+    frames.pos() == (),
+    message: "Unexpected positional arguments: " + repr(frames.pos()),
+  )
+
+  // Canonicalize and validate arguments
+  let args = for (id, args) in frames.named() {
+    assert(
+      type(args) == array,
+      message: "Please provide an array of the form '(<substitute name>, [<custom argument passed to styling function>])', where the latter is optional.
+      The problem arises from frame-kind " + repr(id) + " which receives arguments " + repr(args),
+    )
+    let (supplement, col, ..) = args + (
+      auto,
+    ) // Denote color with 'auto' if omitted
+    assert(type(supplement) in (content, str))
+    assert(
+      type(col) in (color, type(auto)),
+      message: "Please provide a color as second arguments: " + supplement + " (was " + type(col) + ")",
+    )
+    ((id, supplement, col),)
+  }
+
+  // Count auto in args and generate colors
+  let auto-count = args.filter(((_, _, col)) => col == auto).len()
+  let generated-colors = calculate-colors(auto-count)
+  let next-color-idx = 0
+
+  // Replace auto with respective colors
+  for (id, supplement, col) in args {
+    if col == auto {
+      col = generated-colors.at(next-color-idx)
+      next-color-idx += 1
+    }
+    ((id, supplement, col),)
+  }
+}

--- a/packages/preview/frame-it/1.0.0/src/styles.typ
+++ b/packages/preview/frame-it/1.0.0/src/styles.typ
@@ -1,0 +1,147 @@
+#import "styling.typ" as styling
+#import "layout.typ": divide
+
+#let body-inset = 0.8em
+#let stroke-width = 0.13em
+#let corner-radius = 5pt
+
+#let boxy(title, tags, body, supplement, number, accent-color) = {
+  assert(
+    type(accent-color) == color,
+    message: "Please provide a color as argument for the frame instance" + supplement,
+  )
+
+  let stroke = accent-color + stroke-width
+
+  let round-bottom-corners-of-tags = body == []
+  let display-title = title not in ([], "")
+  let round-top-left-body-corner = title in ([], none) and tags == ()
+
+  let header() = align(
+    left,
+    {
+      let inset = 0.5em
+
+      let tag-elements = tags
+      if display-title {
+        let title-cell = grid.cell(fill: accent-color, title)
+        tag-elements.insert(0, title-cell)
+      }
+
+      let rounded-corners = (top: corner-radius)
+      if round-bottom-corners-of-tags {
+        rounded-corners.bottom = corner-radius
+      }
+
+      let rendered-tags = if tag-elements == () [] else {
+        let grid-cells = tag-elements.intersperse(grid.vline(stroke: stroke))
+        let tag-grid = grid(columns: tag-elements.len(), align: horizon, inset: inset, ..grid-cells)
+        box(clip: true, stroke: stroke, radius: rounded-corners, tag-grid)
+        h(1fr)
+      }
+
+      let supplement-str = box(inset: inset)[#supplement #number]
+
+      layout(((width: available-width)) => {
+        if measure(rendered-tags + supplement-str).width < available-width {
+          rendered-tags
+          supplement-str
+        } else [
+          #supplement #number \
+          #rendered-tags
+        ]
+      })
+    },
+  )
+
+  let board() = {
+    let round-corners = (bottom: corner-radius, top-right: corner-radius)
+    if round-top-left-body-corner {
+      round-corners.top-left = corner-radius
+    }
+    align(
+      left,
+      block(
+        width: 100%,
+        inset: body-inset,
+        radius: round-corners,
+        stroke: stroke,
+        spacing: 0em,
+        outset: (y: 0em),
+        {
+          // Divide constructs a line where we need to inject the stroke style because we only have access to the color here
+          show: styling.dividers-as({
+            v(body-inset - 1em)
+            line(length: 100% + 2 * body-inset, stroke: stroke)
+            v(body-inset - 1em)
+          })
+          body
+        },
+      ),
+    )
+  }
+
+  let parts = ()
+
+  let rounded-corners = (bottom: corner-radius)
+
+  if title != none {
+    parts.push(header())
+  }
+
+  if body != [] {
+    parts.push(board())
+  }
+
+  stack(..parts)
+}
+
+#let hint(title, tags, body, supplement, number, accent-color) = {
+  let stroke = stroke(
+    thickness: 3.5pt,
+    paint: accent-color,
+    cap: "round",
+  )
+
+  let header = if title == none {
+    none
+  } else {
+    if title != [] {
+      title = [~~#title~]
+    }
+
+    let tag-str = if tags != () {
+      [~(#tags.join(", "))~]
+    } else {
+      []
+    }
+    let supplement-str = text(gray.darken(50%))[#supplement #number]
+    let head-body-separator = if body == [] [] else [:]
+    [~#supplement-str~*#(title)*_#(tag-str)_#head-body-separator~]
+  }
+
+  layout(((width,)) => {
+    let text = {
+      show: styling.dividers-as({
+        v(body-inset - 1em)
+        line(
+          length: 100% + body-inset,
+          start: (-body-inset, 0pt),
+          stroke: accent-color + stroke-width,
+        )
+        v(body-inset - 1em)
+      })
+
+      block(
+        width: width,
+        inset: (left: 0.7em, y: 0.7em),
+        align(left, header + body),
+      )
+    }
+
+    place(line(stroke: stroke, angle: 90deg, length: measure(text).height))
+
+    text
+  })
+}
+

--- a/packages/preview/frame-it/1.0.0/src/styling.typ
+++ b/packages/preview/frame-it/1.0.0/src/styling.typ
@@ -1,0 +1,12 @@
+/*
+ * This file exports functionality needed when writing your own styling function.
+*/
+
+#let dividers-as(divider-element) = (
+  it => {
+    import "layout.typ": DIVIDE-IDENTIFIER
+    show figure.where(kind: DIVIDE-IDENTIFIER): divider-element
+
+    it
+  }
+)

--- a/packages/preview/frame-it/1.0.0/todo.typ
+++ b/packages/preview/frame-it/1.0.0/todo.typ
@@ -1,0 +1,70 @@
+#set heading(numbering: "1.1.1")
+
+= OPEN
+== make color calculation respect predefined colors
+The color gradient calculated should generate colors which are plenty distinct from colors
+given by the user.
+
+= Postponed
+== decentralize theorem definitions
+Right now, we define frames as groups through the `make-frames` call, grouped together
+by their color-gradient and kind.
+However, this is fairly arbitrary. A more flexible system would have one `init-theorem` call
+for each theorem kind.
+The color gradient would need to be externalized. See @externalize-color-gradient.
+
+_Response_: The current system does not create problems for me at all in practice.
+
+== external color gradient handle <externalize-color-gradient>
+Sometimes, we want to group theorems with common/different kinds but at the same time,
+we want the color gradient to go over all of them.
+For this, we should figure out a way to externlize this. Maybe with a counter.
+However, this isn't trivial as we need to figure out how many colors there will be used in total
+before we can do any calculations.
+
+_Response_: Not needed at this point. Too complicated.
+
+= DONE
+== [DONE] As a user, I am able to apply styling as a show rule to naturally change the default style for parts of my file
+Technically, we could use state explicitly or have the factory not apply the show rule yet and enforce that the user sets a show rule.\
+Syntax would probably be `show: set-style(style)`\
+We would need to look into if we need to introduce a new `set-frame-style` variant which does not set the show rule.
+_Scrapped_ because we supply styling in the arguments now.
+
+== [DONE] Hint Styling/Variants
+Which are less intrusive, for example only highlighting the edge of the page in a color.
+
+== [DONE] Style using argument
+We do not like the syntax `#(slim.theorem)[...]` anymore because it is less discoverable, the brace is weird
+and you have to add the slim argument to the `make-frames` destructuring, which is unexpected.
+
+We prefer a syntax where the theorem functions have a positional `style: "slim"` argument.
+
+== [DONE] We want to reduce the styling to one function which can also be supplied customly
+This would open the door for more streamlined styling editions and providing custom styling
+on demnad.
+
+== [DONE] low-emphasize elements
+Sometimes, we like to make a categorical point which doesn't have the same weight
+as our normal theorems.
+This todo adds elements which are visually less distinct
+and spacious as the current design.
+
+DONE: `frame-theorems` exports inline and slim elements where all other frames can also be accessed
+in the altered versions. In the future, when typst supports functions as scopes, we can add
+this preferred syntax:
+```typst
+definition.small[Infinite Primes][...]
+```
+Alternatively, we might add another function which initializes frames without a default
+`definition[][]` export and instead each theorem kind is only a dictionary with all the versions:
+
+This would enable the old syntax again
+```
+definition.small[][]
+```
+
+== [DONE] fix: When caption is overflowing, the caption is displayed below instead of above
+When there is such a long title or tags that they fill the entire width, then the header
+"Definition" for instance, is displayed below the tags and title instead of, more sensibly, above.
+

--- a/packages/preview/frame-it/1.0.0/typst.toml
+++ b/packages/preview/frame-it/1.0.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "frame-it"
+version = "1.0.0"
+entrypoint = "src/lib.typ"
+authors = ["Marc Thieme"]
+repository = "https://github.com/marc-thieme/frame-it"
+license = "MIT"
+keywords = ["theorems", "frames", "custom", "style", "styling", "math", "papers", "notes", "lectures", "scientific writing"]
+categories = ["components", "layout", "report"]
+description = "Beautiful, flexible, and integrated. Display custom frames for theorems, environments, and more. Attractive visuals with syntax that blends seamlessly into the source."


### PR DESCRIPTION

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: [The package](https://github.com/marc-thieme/frame-it/tree/main) provides the possibility to create and customize "frames" to visually emphazize content. These frames can be used to become theorems, definitions, corollaries, etc. The style is completely customizable and even for the same style, different frame types like theorems, definitions, corollaries will still be recognizable and distinct.

Looking like this:
![image](https://github.com/user-attachments/assets/b8d49877-fb39-49b4-9d9b-e4e8d8fc5288)

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [X] selected a name that isn't the most obvious or canonical name for what the package does
- [X] added a `typst.toml` file with all required keys
- [X] added a `README.md` with documentation for my package
- [X] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [X] tested my package locally on my system and it worked
- [X] `exclude`d PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [ ] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.