### PR TITLE
add `.history` exclusion to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ desktop.ini
 
 # Rust
 /bundler/target
+
+# Local History (xyz.local-history)
+.history/


### PR DESCRIPTION
Add exclusion for the automatic `.history` folder generated by the Local History VSCode extension (xyz.local-history).