### PR TITLE
tiptoe:0.2.0

### DIFF
--- a/packages/preview/tiptoe/0.2.0/LICENSE.txt
+++ b/packages/preview/tiptoe/0.2.0/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/tiptoe/0.2.0/README.md
+++ b/packages/preview/tiptoe/0.2.0/README.md
@@ -1,0 +1,322 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/926e2412-c1dd-42e7-b524-ca2a6ed57122">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/2d536138-c74e-4a31-ab7e-1d9b76a37eb0">
+    <img alt="Logo" src="https://github.com/user-attachments/assets/926e2412-c1dd-42e7-b524-ca2a6ed57122">
+  </picture>
+</p>
+
+
+_Arrows for [Typst][typst] paths and other stories._
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Ftiptoe%2Fv0.2.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/tiptoe)
+[![Test Status](https://github.com/Mc-Zen/tiptoe/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/tiptoe/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/tiptoe/blob/main/LICENSE)
+
+---
+
+*Tiptoe* adds configurable arrow tips (and toes) to the functions `line()` and `path()`. Moreover, it adds the geometric primitive `arc()`. 
+
+- [Tiptoe vs. Fletcher](#tiptoe-vs-fletcher)
+- [Available marks](#available-marks)
+- [Mark sizing and styling](#mark-sizing-and-styling)
+- [Mark alignment](#mark-alignment)
+- [Path shortening](#path-shortening)
+- [Combining marks](#combining-marks)
+- [Defining custom marks](#defining-custom-marks)
+- [Arc](#arc)
+- [Difference between built in and tiptoe path](#difference-between-built-in-and-tiptoe-path)
+
+
+The functions `tiptoe.line()` and `tiptoe.path()` act as a drop-in replacement (except that [they are placed by default](#difference-between-built-in-and-tiptoe-path)) for the built-in counterparts − but they are enhanced by additional `tip` and `toe` (you have read the title, what did you expect??) arguments. 
+
+Let us consider a simple example to start off. 
+```typ
+#import "@preview/tiptoe:0.2.0": *
+
+#line(tip: stealth, toe: stealth.with(rev: true))
+#path(
+  tip: triangle, toe: bar,
+  ((0pt, 0pt), (-10pt, 0pt)),
+  ((20pt, 10pt), (0pt, -10pt)),
+  (0pt, 20pt)
+)
+```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/dc2712d0-0ee3-4fe9-ad88-c840cd5304a8">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3d9eb742-e535-4738-b4bc-9e9c51b9490f">
+    <img alt="Basic introductory example" src="https://github.com/user-attachments/assets/dc2712d0-0ee3-4fe9-ad88-c840cd5304a8">
+  </picture>
+</p>
+
+
+
+## Tiptoe vs. [Fletcher][fletcher]
+
+_Before going into the details:_ There exists another awesome package that provides great support for arrows and marks: [Fletcher][fletcher] by [Jollywatt][jollywatt]. If you wonder which package to use, the decision is easy because their use-cases are almost complementary. 
+- Fletcher works with (and needs) [CeTZ][cetz] while
+- Tiptoe does not need (and does not really work with) CeTZ. 
+
+So, if you want to create CeTZ graphics − use Fletcher! If you don't want to use CeTZ − maybe because you just need a single arrow, can't use a canvas, or develop a package that provides graphics utilities − stay here 😉. 
+
+Also note, that the tip sizing and configuration mechanism works quite differently. 
+
+
+## Available marks
+
+Tiptoe comes with a collection of predefined marks, listed below. In [Defining custom marks](#defining-custom-marks), you can learn how to define your own marks. 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/0cea56df-409a-47da-84bb-b38f6aba7721">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/ba07e63f-f18d-4e36-b5b7-2ca3c51fcf50">
+    <img alt="Available predefined marks" src="https://github.com/user-attachments/assets/0cea56df-409a-47da-84bb-b38f6aba7721">
+  </picture>
+</p>
+
+
+## Mark sizing and styling
+
+All predefined marks can be configured through `.with()` calls. Some options (like the `inset` of a stealth arrow) are mark-specific. 
+
+*Be Typst!* If you use a configured mark more than once, define an alias for it. Typst makes it incredibly easy to define variables: 
+```typ
+#let my-mark = stealth.with(rev: true, inset: 20%)
+#line(tip: my-mark)
+```
+
+### Sizing
+
+The size of most arrows is primarily defined by their length and secondarily by their width (exceptions are `bar`, `barb`, `hooks`, and `tikz` which only have a width). Both width and length can be set using
+- a `length` value, such as `10pt`, 
+- or a ratio which is measured relative to the thickness of the line (e.g., `500%` corresponds to 5 times the line thickness),
+- or a combination of both, e.g., `3pt + 450%` (this is btw. the default for the `stealth` mark). 
+This makes it possible to fine-tune the sizing behavior of a mark. By default (`width: auto`), for most marks the width is defined in terms of the length via some predefined ratio. 
+
+
+With the predefined marks, the length/width encompasses the *full* length/width of the mark, independent of the stroke thickness that is used. This is demonstrated below, where the fill is removed through `stealth.with(fill: none)`. 
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/406dc364-e881-4bdb-834d-8df7b5b24e39">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/d0099a57-af6f-4308-aa24-0b098f5fab10">
+    <img alt="Arrow sizing" src="https://github.com/user-attachments/assets/406dc364-e881-4bdb-834d-8df7b5b24e39">
+  </picture>
+</p>
+
+
+
+
+### Colors!
+
+Usually, a mark inherits color and stroke thickness (but not other stroke attributes like `join` or `cap`) from the line that the mark is attached to. In order to override the color, the thickness or both, all marks feature a `stroke` parameter. Additionally, all solid marks feature a `fill` parameter that defaults (when set to `auto`) to the stroke color. 
+
+Below are some examples for mark styling. 
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/371560f0-f702-4e6c-95a4-9f27041a9328">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/62899b1d-5bce-4a1f-bd91-b1ca88c980b6">
+    <img alt="Examples for styling marks" src="https://github.com/user-attachments/assets/371560f0-f702-4e6c-95a4-9f27041a9328">
+  </picture>
+</p>
+
+## More styling 
+
+Apart from `length`, `width`, `fill`, and `stroke`, many marks possess additional styling parameters, such as 
+- the `inset` for the arrows `stealth` and `round`,
+- an arc angle parameter for the marks `barb` and `hooks`,
+
+- and of course the `rev` parameter that allows for reversing all marks where this makes sense. 
+
+The figure below shows the additional parameters that each mark supports. The red line indicates how much the underlying path is shortened (see [Path shortening](#path-shortening)). 
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f8a8a6cf-a441-4e26-95d0-692a34cd39c3">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3c6ee59c-e164-4729-9b34-62cbe450025b">
+    <img alt="Parameters of the predefined marks" src="https://github.com/user-attachments/assets/f8a8a6cf-a441-4e26-95d0-692a34cd39c3">
+  </picture>
+</p>
+
+
+## Mark alignment
+
+Most marks are aligned such that they point _right onto the end_ (or start) of the path. However, for some marks it is more desirable to have them _centered_ at the end (or start). This is for example the case for the `square` and `circle` marker. All markers that are by default centered on the path end have an `align` parameter that can be set to `center` or `end` to configure this behavior. 
+
+The mark alignment for the built-in marks is summarized in the table below. 
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/abfc24b9-393a-4511-acb8-31a5acf08eb1">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/18dc90dc-78f8-4b38-8de6-f02614fa6700">
+    <img alt="Alignment of marks" src="https://github.com/user-attachments/assets/abfc24b9-393a-4511-acb8-31a5acf08eb1">
+  </picture>
+</p>
+
+
+
+## Path shortening
+
+In order to make room for the mark, the path needs to be shortened by some amount. This is trivial for straight segments but not for curved paths. 
+
+The issue is demonstrated in the figure below. In all cases, the arrow is tangent to the curve at its end. In the left panel of the figure, the curve does not enter the arrow in the middle but rather from the side which definitely wouldn't make you look like a good designer when handing in professional work ;) 
+
+To compensate this issue, the path is _transformed_, i.e., shortened by some amount to make it seem nicer. This happens at the cost of the path being not quite the same, but it yields a much prettier result. 
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/0fca915e-b846-4908-ba61-187905c98139">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/cca724ae-3609-4750-bc72-1d49c0b6ee08">
+    <img alt="Path shortening" src="https://github.com/user-attachments/assets/0fca915e-b846-4908-ba61-187905c98139">
+  </picture>
+</p>
+
+
+Not always is it desirable to shorten the path all the way (hey, a little asymmetry simply belongs in life). For this purpose, `path` has a parameter `shorten` which takes ratios between `0%` and `100%` (default). 
+
+
+
+## Combining marks
+
+The function `combine()` makes it quite easy to combine multiple marks into a single new one. It accepts any number of marks and can even process combined marks recursively. 
+
+```typ
+#line(tip: combine(bar, stealth))
+```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/e2b8605d-3b1d-468a-9cb8-ca41a2438883">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/826ada71-092f-4b1e-866e-719189bd09d3">
+    <img alt="How to combine marks" src="https://github.com/user-attachments/assets/e2b8605d-3b1d-468a-9cb8-ca41a2438883">
+  </picture>
+</p>
+
+
+
+
+The combined marks are automatically lined up one after the other, always the next one where the previous one ended. In order to introduce or increase the space between two marks, you may use length values (like `10pt`) or even better ratios (which are measured relative to the line thickness). Negative values are allowed. 
+
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/c73842e0-0355-4055-a10f-66b8b0be413a">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/b7ce8bed-07db-497b-a8de-e0d84394967a">
+    <img alt="Examples for combined arrows and marks" src="https://github.com/user-attachments/assets/c73842e0-0355-4055-a10f-66b8b0be413a">
+  </picture>
+</p>
+
+By default, the path is shortened until the last mark. This behaviour can be overriden by adding an `end` element somewhere in the mark list. The position of the `end` element between the marks defines where the line or path should end. 
+
+
+## Defining custom marks
+
+A mark is just a function that accepts a named `line` argument and that returns a dictionary `(mark: .., end: ..)` where `mark` holds the rendered mark and `end` is a length that specifies the amount by which the line or path needs to be shortened. 
+
+As an example, let us look at a simplified definition of the `bar` mark.
+```typ
+#import tiptoe.utility
+
+#let bar(
+  // mandatory, will be set by line(), path() and arc()
+  line: stroke() 
+  // optional configuration parameters
+  width: 2.4pt + 360%, 
+  stroke: auto, 
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width,) = utility.process-dims(
+    line, width: width
+  )
+
+  (
+    mark: place(path(
+      (0pt, -width / 2),
+      (0pt, width / 2),
+      stroke: stroke
+    )),
+    end: 0pt
+  )
+}
+```
+
+Let us first explain the difference between the parameters `line` and `stroke`:
+- `line` is sort of a _private_ parameter. It is set by the functions `tiptoe.path()`, `tiptoe.line()` and `tiptoe.arc()`, when the mark is realized and contains the stroke used for drawing the path/line/arc. We use it often to make the mark inherit color and thickness. 
+- `stroke` is totally optional for your mark, but all built-in marks have it. It allows the user of the mark to customize its stroke, overriding the stroke inherited from `line`. 
+
+You can add an arbitrary number of other configuration parameters to your mark. 
+
+The module `tiptoe.utility` provides two very useful helpers. The function `process-stroke()` takes the `line` and `stroke` parameter and returns a merged stroke to be used for drawing the mark. The merging obeys the following rules
+- Only `thickness` and `paint` are inherited from `line`. 
+- Thickness and paint are both (independently) only inherited if they are set to `auto` in `stroke`. This makes it for example possible to configure only the color of a mark without changing the thickness. 
+- If `stroke` is `none`, nothing is inherited and `none` is returned. 
+- The merged stroke is guaranteed to have a `thickness` that is not `auto`. 
+
+
+
+
+
+The other helper function `process-dims()` is useful for processing length and/or width of the mark which may be (see the [section about sizing](#sizing)) a `ratio` (in terms of the line thickness), a `length`, or a combination thereof. It takes the `line` and optional `width` and `length` parameters and returns a dictionary with the evaluated `width` and `length` (if they were given). In addition, it can process a width set to `auto` in terms of the length with a coefficient that can be specified with the parameter `default-ratio`. As an example, the `stealth` mark has an automatic width by default which is then 80% of the length. 
+
+Hints for rendering the mark:
+- You only need to take care of the case where the mark is used as a `tip`. The `toe` case is handled automatically. 
+- The path goes from left to right and ends at `(0pt, 0pt)`. The stealth arrow, e.g., points exactly to this coordinate. 
+- The rotation of the mark is fully handled by tiptoe. 
+
+## Arc
+
+Many have noted that (as of now) Typst does not feature a function to draw arcs. This is sometimes unfortunate since circular arcs are not at all trivial to approximate with Bézier curves. 
+
+Until a built-in arc function makes it into the core of Typst, enjoy this one:
+
+```typ
+#let arc(
+  origin: (0pt, 0pt),  // Origin coordinates
+  angle: 0deg,         // Start angle
+  arc: 45deg,          // Arc angle
+  radius: 1cm,         // The radius of the full circle
+  width: auto,         // The width of the full ellipse
+  height: auto,        // The height of the full ellipse
+  stroke: 1pt + black,
+  fill: none,
+  closed: false,       // false, "segment" or "sector"
+  tip: none,           // Mark placed at the start 
+  toe: none,           // Mark placed at the toe
+  shorten: 50%         // Path shortening
+)
+```
+
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f8495d65-eede-4caf-ba1a-cda909351ddf">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/35b561a6-64d3-469b-8496-d4bebda2cdf5">
+    <img alt="Usage of the arc() primitive" src="https://github.com/user-attachments/assets/f8495d65-eede-4caf-ba1a-cda909351ddf">
+  </picture>
+</p>
+
+
+
+
+
+
+
+## Difference between built-in and tiptoe `path()`
+
+
+While the built-in [`path`][typst-path] function returns a block-level element with a size that measures from `(0pt, 0pt)` to the largest (positive) coordinate, the corresponding tiptoe function returns placed content (with zero-width and -height). 
+
+The reasons are
+- It is hard to measure the bounding box properly including the marks. 
+- The behavior of the built-in functions is not particularly useful since they measure only in the positive direction. I suspect that most packages using the drawing primitives wrap them with `place()` anyway. 
+
+
+
+[fletcher]: https://github.com/Jollywatt/typst-fletcher
+[cetz]: https://github.com/cetz-package/cetz
+[jollywatt]: https://github.com/Jollywatt/
+[typst-path]: https://typst.app/docs/reference/visualize/path/
+[typst]: https://typst.app

--- a/packages/preview/tiptoe/0.2.0/src/arc-impl.typ
+++ b/packages/preview/tiptoe/0.2.0/src/arc-impl.typ
@@ -1,0 +1,80 @@
+#let sub(p, q) = p.zip(q).map(((a, b)) => a - b)
+#import "assert.typ": assert-dict-keys
+
+#let bezier-arc(
+  origin: (0pt, 0pt),
+  angle: 0deg,
+  arc: 45deg,
+  radius: 1cm,
+  width: auto,
+  height: auto
+) = {
+
+  // if type(radius) == dictionary {
+  //   assert-dict-keys(dictionary, optional: ("x", "y"))
+  // } else {
+  //   radius = (x: radius, x: radius)
+  // }
+  
+  if arc == 0deg { return () }
+  if width == auto { width = 2 * radius }
+  if height == auto { height = 2 * radius }
+  if calc.abs(arc) > 360deg { arc = 360deg }
+  let num-curves = int(calc.ceil(calc.abs(arc/90deg)))
+  let a = arc / num-curves
+
+  let y0 = calc.sin(a / 2)
+  let x0 = calc.cos(a / 2)
+  let tx = (1 - x0) * 4/3
+  let ty = y0 - tx*x0 / (y0 + 0.0001)
+  let px = (x0, x0 + tx, x0 + tx, x0)
+  let py = (-y0, -ty, ty, y0)
+
+  let sn = calc.sin(angle + a / 2)
+  let cs = calc.cos(angle + a / 2)
+  let points = ()
+  points.push((
+    origin.at(0) + 0.5 * width * (px.at(0)*cs - py.at(0)*sn),
+    origin.at(1) + 0.5 * height * (px.at(0)*sn + py.at(0)*cs)
+  ))
+
+  for i in range(num-curves) {
+    let astart = angle + a * i
+    let sn = calc.sin(astart + a / 2)
+    let cs = calc.cos(astart + a / 2)
+    for j in range(1, 4) {
+      points.push((
+        origin.at(0) + 0.5 * width * (px.at(j)*cs - py.at(j)*sn),
+        origin.at(1) + 0.5 * height * (px.at(j)*sn + py.at(j)*cs)
+      ))
+    }
+  }
+  let coords = (
+    (points.at(0), (0pt, 0pt), sub(points.at(1), points.at(0))), ..points.slice(1).chunks(3).map(
+    ((a, b, c)) => {
+      (c, sub(b, c))
+    }
+  ))
+  coords.last().push((0pt, 0pt))
+  coords
+}
+
+
+#let arc-impl(
+  origin: (0pt, 0pt),
+  angle: 0deg,
+  arc: 6rad,
+  radius: 1cm,
+  stroke: 1pt + black
+) = {
+  path(stroke: stroke, 
+    ..bezier-arc(
+      origin: origin,
+      angle: angle, 
+      arc: arc,
+      radius: radius
+    )
+  )
+}
+
+

--- a/packages/preview/tiptoe/0.2.0/src/arc.typ
+++ b/packages/preview/tiptoe/0.2.0/src/arc.typ
@@ -1,0 +1,41 @@
+#import "arc-impl.typ": bezier-arc
+#import "path.typ": path
+
+#let arc(
+  origin: (0pt, 0pt),
+  angle: 0deg,
+  arc: 45deg,
+  radius: 1cm,
+  width: auto,
+  height: auto,
+  stroke: 1pt + black,
+  fill: none,
+  closed: false,
+  tip: none, 
+  toe: none,
+  shorten: 50%
+) = {
+  let coords = bezier-arc(
+    origin: origin,
+    angle: angle,
+    arc: arc,
+    radius: radius,
+    width: width,
+    height: height,
+  )
+  if closed == "sector" {
+    coords.push(origin)
+  }
+  if closed in ("sector", "segment") {
+    closed = true
+  }
+  path(
+    stroke: stroke,
+    tip: tip,
+    toe: toe,
+    shorten: shorten,
+    fill: fill, closed: closed,
+    ..coords
+  )
+
+}

--- a/packages/preview/tiptoe/0.2.0/src/assert.typ
+++ b/packages/preview/tiptoe/0.2.0/src/assert.typ
@@ -1,0 +1,20 @@
+#let assert-mark(mark, kind: "tip") = {
+  assert(type(mark) == function, message: "Invalid arrow " + kind + ", expected a function but got a " + str(type(mark)) + ". Ensure that you use e.g. `stealth.with(..)` instead of directly writing `stealth(..)`")
+}
+
+#let assert-dict-keys(dict, required: (), optional: ()) = {
+  let keys = dict.keys()
+  
+  for key in required {
+    if key not in keys {
+      assert(false, message: "")
+    }
+  }
+  let possible-keys = required + optional.dict
+  for key in keys {
+    if key not in possible-keys {
+      assert(false, message: "Unexpected key \"" + key + "\"")
+    }
+  }
+  assert(array)
+}

--- a/packages/preview/tiptoe/0.2.0/src/line.typ
+++ b/packages/preview/tiptoe/0.2.0/src/line.typ
@@ -1,0 +1,69 @@
+#import "marks.typ": *
+#import "assert.typ": assert-mark
+
+#let line(
+  start: (0pt, 0pt),
+  end: none,
+  length: 30pt, 
+  angle: 0deg, 
+  stroke: 1pt,
+  tip: none,
+  toe: none
+) = {
+  stroke = std.stroke(stroke)
+  if tip != none { 
+    assert-mark(tip, kind: "tip")
+    tip = tip(line: stroke) 
+  }
+  if toe != none { 
+    assert-mark(toe, kind: "toe")
+    toe = toe(line: stroke) 
+  }
+  context box({
+    let end = end
+    let start = start
+    let angle = angle
+    let length = length
+    if end == none {
+      end = start.zip((length*calc.cos(angle), length*calc.sin(angle))).map(array.sum)
+      if type(length) == ratio {
+        assert(angle in (0deg, 90deg), message: "When `length` is a ratio, the angle can only be 0deg or 90deg, found " + repr(angle)) 
+      } else if length.to-absolute() < 0pt {
+        length *= -1
+        angle += 180deg
+      }
+    } else {
+      let dx = (end.at(0) - start.at(0)).to-absolute() / 1pt
+      let dy = (end.at(1) - start.at(1)).to-absolute() / 1pt
+      angle = calc.atan2(dx, dy)
+      length = 1pt * calc.sqrt(dx*dx + dy*dy)
+    }
+    let original-line = std.line(start: start, angle: angle, length: length, stroke: stroke)
+    
+    let toe-pos = start
+    if toe != none {
+      start.at(0) += calc.cos(angle) * toe.end
+      start.at(1) += calc.sin(angle) * toe.end
+      length -= toe.end
+    }
+    if tip != none {
+      length -= tip.end
+    }
+
+    place(std.line(start: start, angle: angle, length: length, stroke: stroke))
+    
+    if tip != none {
+      place(
+        dx: end.at(0), dy: end.at(1), 
+        rotate(angle, tip.mark)
+      )
+    }
+    if toe != none {
+      place(
+        dx: toe-pos.at(0), dy: toe-pos.at(1), 
+        rotate(angle, scale(x: -100%, toe.mark))
+      )
+    }
+    hide(original-line)
+  })
+}

--- a/packages/preview/tiptoe/0.2.0/src/marks.typ
+++ b/packages/preview/tiptoe/0.2.0/src/marks.typ
@@ -1,0 +1,540 @@
+#import "arc-impl.typ": arc-impl
+#import "utility.typ"
+
+
+
+#let bar(
+  width: 2.4pt + 360%,
+  stroke: auto, 
+  align: center,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width,) = utility.process-dims(
+    line, width: width,
+  )
+  
+  assert(align in (center, end))
+  let offset = if align == end { stroke.thickness / 2 } else { 0pt }
+
+  (
+    mark: place(std.path(
+      (-offset, -width / 2),
+      (-offset, width / 2),
+      stroke: stroke
+    )),
+    end: offset
+  )
+}
+
+
+#let bracket(
+  width: 2.4pt + 360%,
+  length: auto,
+  stroke: auto, 
+  rev: false,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: width, width: length,
+    default-ratio: .3
+  )
+  (width, length) = (length, width)
+  let s = stroke.thickness / 2
+  let y = width / 2 - s
+  let mark = place(std.path(
+    (-length, -y),
+    (-s, -y),
+    (-s, y),
+    (-length, y),
+    stroke: stroke
+  ))
+  if rev {
+    mark = scale(x: -100%, place(mark, dx: length))
+  }
+  (
+    mark: mark,
+    end: if rev { length } else { s }
+  )
+}
+
+
+#let stealth(
+  length: 3pt + 450%,
+  width: auto,
+  inset: 40%,
+  fill: auto,
+  rev: false,
+  stroke: auto,
+  line: stroke()
+) = {
+  let is-auto-stroke = stroke == auto
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: length, width: width,
+    default-ratio: .8
+  )
+  
+  let linewidth = stroke.thickness
+  let Δl = length * inset
+  let dhalf = 0.5 * width
+  let tip-length
+
+  let path = if fill == auto and is-auto-stroke {
+    // very common optimization for filled arrows
+    path(closed: true,
+      (0pt, 0pt), 
+      (-length, dhalf), 
+      (-length + Δl, 0pt), 
+      (-length, -dhalf), 
+      stroke: none, 
+      fill: utility.if-auto(stroke.paint, black)
+    )
+    tip-length = length / 2
+  } else {
+    let tanα = dhalf / length
+    let α = calc.atan(tanα)
+    let sinα  = calc.sin(α)
+    let x3 = 0.5 * linewidth / sinα
+    
+    let (x, x4, y) = if inset == 0% {
+      let x = length - linewidth/2
+      (x, x, tanα * (x - x3))
+    } else {
+      let tanβ = dhalf / Δl
+      let β = calc.atan(tanβ)
+      let x1 = 0.5 * linewidth / calc.sin(β)
+      let x2 = length - Δl - x1 - x3
+      let b = -x2 * tanα
+      let x = b / (tanβ - tanα)
+      let y = tanβ * x
+      let x4 = length - Δl - x1
+      (length - Δl - x1 - x, x4, y)
+    }
+    tip-length = x3
+    path(closed: true,
+      (-x3, 0pt), 
+      (-x, y), 
+      (-x4, 0pt), 
+      (-x, -y), 
+      stroke: std.stroke(
+        thickness: linewidth, 
+        paint: utility.if-auto(stroke.paint, black), 
+        dash: stroke.dash,
+        miter-limit: 7, 
+        join: "miter"
+      ), 
+      fill: utility.chained-if-auto(fill, stroke.paint, black)
+    )
+  }
+
+  
+  let mark = place(path)
+  if rev {
+    mark = scale(x: -100%, place(mark, dx: length))
+  }
+  (
+    mark: mark,
+    end: if rev { length - tip-length } else { length - Δl}
+  )
+}
+
+
+#let triangle = stealth.with(inset: 0%)
+
+#let round(
+  length: 3pt + 450%,
+  width: auto,
+  inset: 40%,
+  rev: false,
+  stroke: auto,
+  fill: auto,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: length, width: width,
+    default-ratio: .8
+  )
+
+  let s = 0.5 * stroke.thickness
+
+  if inset >= 100% {
+    inset = length - stroke.thickness
+  } else {
+    inset = length * inset
+  }
+
+  let mark = place(path(
+    (-s, 0pt),
+    (-length + s, 0.5 * width - s),
+    (-length + inset + s, 0pt),
+    (-length + s, -0.5 * width + s),
+    closed: true,
+    fill: utility.chained-if-auto(fill, stroke.paint, black),
+    stroke: std.stroke(
+      thickness: stroke.thickness, 
+      paint: utility.if-auto(stroke.paint, black), 
+      dash: stroke.dash,
+      miter-limit: 7, 
+      join: "round"
+    )
+  ))
+  
+  let end = length - inset - s
+  
+  if rev {
+    mark = scale(x: -100%, place(mark, dx: length))
+    end = length - s
+  }
+
+  (
+    mark: mark,
+    end: end
+  )
+}
+
+
+#let straight(
+  length: 3pt + 450%,
+  width: auto,
+  rev: false,
+  stroke: auto,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: length, width: width,
+    default-ratio: .8
+  )
+
+  let s = stroke.thickness / 2
+  let α = calc.atan(0.5 * width / length)
+  let tip-length = 0.5 * stroke.thickness / calc.sin(α)
+
+  let mark = place(path(
+    (-length + s, 0.5 * width - s),
+    (-tip-length, 0pt),
+    (-length + s, -0.5 * width + s),
+    stroke: std.stroke(
+      thickness: stroke.thickness, 
+      paint: utility.if-auto(stroke.paint, black), 
+      dash: stroke.dash,
+      miter-limit: 7, 
+      cap: "round"
+    )
+  ))
+
+  
+  if rev {
+    mark = scale(x: -100%, place(mark, dx: length))
+  }
+
+  (
+    mark: mark,
+    end: if rev { length - tip-length } else { tip-length }
+  )
+}
+
+#let diamond(
+  length: 565.69%, 
+  width: auto,
+  fill: auto,
+  stroke: auto,
+  align: center,
+  line: stroke()
+) = { 
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: length, width: width,
+    default-ratio: 1
+  )
+  let dhalf = 0.5 * width
+  let tip-length
+  
+  let tanα = dhalf / length * 2
+  let α = calc.atan(tanα)
+  let tip-length = 0.5 * stroke.thickness / calc.sin(α)
+  let top-length = 0.5 * stroke.thickness / calc.cos(α)
+
+  assert(align in (center, end))
+  let offset = if align == center { length / 2 } else { 0pt }
+
+  let mark = place(dx: offset, path(
+    (-length / 2, dhalf - top-length),
+    (-tip-length, 0pt),
+    (-length / 2, -dhalf + top-length),
+    (-length + tip-length, 0pt),
+    stroke: stroke,
+    closed: true,
+    fill: utility.chained-if-auto(fill, stroke.paint, black)
+  ))
+  
+  (
+    mark: mark,
+    end: length - tip-length - offset
+  )
+}
+
+#let square(
+  length: 400%,
+  width: auto,
+  fill: auto,
+  stroke: auto,
+  align: center,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: length, width: width,
+    default-ratio: 1
+  )
+  assert(align in (center, end))
+  let offset = if align == center { length / 2 } else { 0pt }
+  let s = stroke.thickness / 2
+  let y = width/2 - s
+  let mark = place(dx: offset,
+    path(
+      (-s, y),
+      (-length + s, y),
+      (-length + s, -y),
+      (-s, -y),
+      stroke: stroke, 
+      fill: utility.chained-if-auto(fill, stroke.paint, black),
+      closed: true
+    )
+  )
+
+  (
+    mark: mark, 
+    end: length - s - offset
+  )
+}
+
+
+
+#let circle(
+  length: 400%,
+  width: auto,
+  fill: auto,
+  stroke: auto,
+  align: center,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width, length) = utility.process-dims(
+    line, length: length, width: width,
+    default-ratio: 1
+  )
+  let s = stroke.thickness / 2
+  let y = width / 2 - s
+  
+  assert(align in (center, end))
+  let offset = if align == center { length / 2 } else { 0pt }
+  
+  let mark = place(dx: -length + s + offset, dy: -y,
+    ellipse(
+      width: length - 2 * s,
+      height: width - 2 * s,
+      stroke: stroke, 
+      fill: utility.chained-if-auto(fill, stroke.paint, black),
+    )
+  )
+
+  (
+    mark: mark, 
+    end: length - s - offset
+  )
+}
+
+
+#let rays(
+  n: 4,
+  length: 280%,
+  phase: auto,
+  stroke: auto,
+  align: center,
+  line: stroke()
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (length,) = utility.process-dims(
+    line, length: length
+  )
+  if phase == auto {
+    if n == 4 { phase = 45deg }
+    else { phase = -90deg }
+  }
+  
+  assert(align in (center, end))
+  let offset = if align == end { -length } else { 0pt }
+
+  let mark = for i in range(n) {
+    place(dx: offset, std.line(length: length, angle: phase + 360deg*i/n, stroke: stroke))
+  }
+
+  (
+    mark: mark,
+    end: -offset
+  )
+}
+
+
+
+#let barb(
+  width: 3pt + 450%,
+  arc: 180deg,
+  stroke: auto,
+  rev: false,
+  line: stroke(),
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width,) = utility.process-dims(
+    line, width: width
+  )
+
+  let s = stroke.thickness / 2
+  let radius = width / 2 - s
+
+  let mark = place(
+    arc-impl(
+      origin: (-width / 2, 0pt),
+      angle: -arc / 2,
+      arc: arc,
+      radius: radius,
+      stroke: stroke
+    )
+  )
+  let end = s
+  
+  if rev {
+    mark = scale(x: -100%, place(mark, dx: width / 2))
+    end = radius
+  }
+
+  (
+    mark: mark,
+    end: end
+  )
+}
+
+
+#let hooks(
+  width: 3pt + 450%,
+  arc: 180deg,
+  stroke: auto,
+  rev: false,
+  line: stroke(),
+) = {
+  stroke = utility.process-stroke(line, stroke)
+  let (width,) = utility.process-dims(
+    line, width: width
+  )
+
+  let s = stroke.thickness / 2
+  let r = (width / 2 - s) / 2
+
+  let mark = {
+    place(
+      arc-impl(
+        origin: (-r - s, r),
+        angle: -90deg,
+        arc: arc,
+        radius: r,
+        stroke: stroke
+      )
+    )
+    place(
+      arc-impl(
+        origin: (-r - s, -r),
+        angle: 90deg,
+        arc: -arc,
+        radius: r,
+        stroke: stroke
+      )
+    )
+  }
+  let end = r - s
+  
+  if rev {
+    mark = scale(x: -100%, place(mark, dx: r + s))
+    end = 0pt
+  }
+
+  (
+    mark: mark,
+    end: end + s
+  )
+}
+
+
+
+#let tikz(
+  width: 3pt + 450%,
+  arc: 180deg,
+  stroke: auto,
+  line: stroke(),
+) = {
+  let sharp = false
+  stroke = utility.process-stroke(line, stroke)
+  let (width,) = utility.process-dims(
+    line, width: width
+  )
+  
+  let s = stroke.thickness / 2
+  stroke = if sharp {
+    (thickness: stroke.thickness, paint: stroke.paint, join: "bevel", cap: "butt")
+  } else {
+    (thickness: stroke.thickness, paint: stroke.paint, join: "round", cap: "round")
+  }
+  let x0 = if sharp { stroke.thickness/width*10pt } else { -s }
+  let mark = place(
+    path(
+      stroke: stroke,
+      ((-width*.42, -width/2 + s), (-width*.1, -width*.4)),
+      (x0, 0pt),
+      ((-width*.42, width/2 - s), (width*.1, -width*.4)),
+    )
+  )
+  
+  (
+    mark: mark,
+    end: stroke.thickness
+  )
+}
+
+
+#let combine(
+  line: stroke(), 
+  ..marks
+) = (line: stroke()) => {
+  let marks = marks.pos()
+  let linewidth = utility.if-auto(line.thickness, 1pt)
+  
+  let combined-mark
+  let pos = 0pt
+  let end
+
+  for mark in marks {
+    if mark == std.end {
+      end = pos
+    } else if type(mark) == length {
+      pos += mark
+    } else if type(mark) == ratio {
+      pos += mark * linewidth
+    } else if type(mark) == function {
+      mark = mark(line: line)
+      combined-mark += place(dx: -pos, mark.mark)
+      pos += mark.end
+    }
+  }
+  if end == none {
+    end = pos
+  }
+
+  (
+    mark: combined-mark, 
+    end: end
+  )
+}
+

--- a/packages/preview/tiptoe/0.2.0/src/path.typ
+++ b/packages/preview/tiptoe/0.2.0/src/path.typ
@@ -1,0 +1,105 @@
+#import "marks.typ": *
+#import "assert.typ": assert-mark
+
+#let add(p, q) = p.zip(q).map(array.sum)
+#let sub(p, q) = p.zip(q).map(((a, b)) => a - b)
+#let addorsub(p, q, f) = p.zip(q).map(((a, b)) => a + f*b)
+
+#let extract-bezier-polygon(vertex1, vertex2, rev: false) = {
+  let polygon = ()
+  if type(vertex1.at(0)) == array {
+    let v = vertex1.at(0)
+    if vertex1.len() == 1 { polygon.push(v) }
+    else if vertex1.len() == 2 {
+      polygon += (v, sub(v, vertex1.at(1))).dedup()
+    } else if vertex1.len() == 3 {
+      polygon += (v, add(v, vertex1.at(2))).dedup()
+    }
+  } else {
+    polygon.push(vertex1)
+  }
+  if type(vertex2.at(0)) == array {
+    let v = vertex2.at(0)
+    if vertex2.len() == 1 { polygon.push(v) }
+    else {
+      polygon += (add(v, vertex2.at(1)), v).dedup()
+    } 
+  } else {
+    polygon.push(vertex2)
+  }
+  
+  return polygon
+}
+
+
+
+#let path(
+  ..args, 
+  fill: none,
+  fill-rule: auto,
+  stroke: 1pt,
+  closed: false,
+  tip: none,
+  toe: none,
+  shorten: 100%,
+) = {
+  if args.named().len() != 0 {
+    assert(false, message: "Unexpected named argument \"" + args.named().keys().first() + "\"")
+  }
+  stroke = std.stroke(stroke)
+  assert(type(shorten) in (ratio, dictionary), message: "Expected ratio or dictionary for parameter `shorten`, found " + str(type(shorten)))
+  if type(shorten) == ratio {
+    shorten = (start: shorten, end: shorten)
+  } else if type(shorten) == dictionary {
+    assert(shorten.keys().sorted() == ("end", "start"), message: "Unexpected key, valid keys are \"start\" and \"end\"")
+  }
+  let original-path = std.path(..args.pos())
+  context {
+    let points = args.pos()
+    let original-points = points
+    
+    let treat-mark(mark, i1, i2, pos: start, shorten: 100%) = {
+      mark = mark(line: stroke) 
+      
+      let polygon = extract-bezier-polygon(points.at(i1), points.at(i2))
+      if pos == end { polygon = polygon.rev() }
+      let inner = polygon.at(1)
+      let outer = polygon.at(0)
+      
+      let dx = (outer.at(0) - inner.at(0)).to-absolute() / 1pt
+      let dy = (outer.at(1) - inner.at(1)).to-absolute() / 1pt
+      let angle = calc.atan2(dx, dy)
+      
+      let mark-content = place(
+        dx: outer.at(0), dy: outer.at(1), 
+        rotate(angle, mark.mark)
+      )
+      outer.at(0) -= calc.cos(angle) * mark.end * shorten
+      outer.at(1) -= calc.sin(angle) * mark.end * shorten
+      return (mark-content, outer)
+    }
+    
+    let marks
+    if toe != none and points.len() >= 2 { 
+      assert-mark(toe, kind: "toe")
+      let (mark, end) = treat-mark(toe, 0, 1, pos: start, shorten: shorten.start)
+      if type(points.first().at(0)) == array { points.first().at(0) = end }
+      else { points.first() = end }
+      marks += mark
+    }
+    if tip != none and points.len() >= 2 { 
+      assert-mark(tip, kind: "tip")
+      let (mark, end) = treat-mark(tip, -2, -1, pos: end, shorten: shorten.end)
+      if type(points.last().at(0)) == array { points.last().at(0) = end }
+      else { points.last() = end }
+      marks += mark
+    }
+    
+    let fill-rule = fill-rule
+    if fill-rule == auto {
+      fill-rule = std.path.fill-rule
+    }
+    
+    place(std.path(..points, stroke: stroke, fill: fill, closed: closed, fill-rule: fill-rule)) + marks
+  }
+}

--- a/packages/preview/tiptoe/0.2.0/src/tiptoe.typ
+++ b/packages/preview/tiptoe/0.2.0/src/tiptoe.typ
@@ -1,0 +1,5 @@
+#import "line.typ": line
+#import "path.typ": path
+#import "arc.typ": arc
+#import "utility.typ"
+#import "marks.typ": *

--- a/packages/preview/tiptoe/0.2.0/src/utility.typ
+++ b/packages/preview/tiptoe/0.2.0/src/utility.typ
@@ -1,0 +1,66 @@
+#let if-auto(a, b) = if a == auto { b } else { a }
+#let chained-if-auto(..x) = x.pos().find(it => it != auto)
+
+
+
+#let extract-thickness-and-paint(stroke) = {
+  if-auto(stroke.thickness, 1pt) + if-auto(stroke.paint, black)
+}
+
+#let inherit-thickness-and-paint(stroke, parent: 2) = {
+  if stroke == none { return none } // this is always stronger
+  
+  // strokes might be length, color or dictionary:
+  let parent = std.stroke(parent) 
+  let stroke = std.stroke(stroke) 
+  return std.stroke(
+    paint: if-auto(stroke.paint, parent.paint), 
+    thickness: chained-if-auto(stroke.thickness, parent.thickness, 1pt), 
+    cap: stroke.cap, 
+    join: stroke.join, 
+    dash: stroke.dash, 
+    miter-limit: stroke.miter-limit
+  )
+}
+
+
+#let process-stroke(line, stroke) = {
+  if stroke == auto { 
+    return extract-thickness-and-paint(line)
+  }
+  return inherit-thickness-and-paint(stroke, parent: line)
+}
+
+
+#let process-dims(
+  line, 
+  length: none, 
+  width: none, 
+  default-ratio: .8
+) = {
+  let result = (:)
+  let linewidth = if-auto(line.thickness, 1pt)
+
+  if length != none {
+    result.length = if type(length) == ratio {
+        linewidth * length
+      } else if type(length) == relative {
+        length.length + linewidth * length.ratio
+      } else {
+        length
+      }
+  }
+  
+  if width != none {
+    result.width = if width == auto {
+        result.length * default-ratio
+      } else if type(width) == ratio {
+        linewidth * width
+      } else if type(width) == relative {
+        width.length + linewidth * width.ratio
+      } else {
+        width
+      }
+  }
+  return result
+}

--- a/packages/preview/tiptoe/0.2.0/typst.toml
+++ b/packages/preview/tiptoe/0.2.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tiptoe"
+version = "0.2.0"
+entrypoint = "src/tiptoe.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Arrows and other marks for lines and paths."
+compiler = "0.12.0"
+
+repository = "https://github.com/Mc-Zen/tiptoe"
+keywords = ["arrows", "marks", "primitives", "line", "path", "tip", "arc"]
+categories = ["visualization", "layout"]
+exclude = ["/docs/*", "/tests/*"]


### PR DESCRIPTION
I am submitting
- [x] an update for a package


This release
- Adds support for passing `ratio` for `length`, as long as the angle is either `0deg` or `90deg`. 
- Fixes issues with upcoming Typst version 0.13. 