### PR TITLE
ez-today:1.0.0

### DIFF
--- a/packages/preview/ez-today/1.0.0/LICENSE
+++ b/packages/preview/ez-today/1.0.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Carlo Schafflik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/ez-today/1.0.0/README.md
+++ b/packages/preview/ez-today/1.0.0/README.md
@@ -1,0 +1,108 @@
+# ez-today
+
+Simply displays the current date with easy to use customization.
+
+## Included languages
+
+German, English, French, Italian, Czech, Portuguese, Slovakian and Polish months can be used out of the box. If you want to use a language that is not included, you can easily add it yourself. This is shown in the customization section below.
+
+## Usage
+
+The usage is very simple, because there is only the `today()` function.
+
+```typ
+#import "@preview/ez-today:1.0.0"
+
+// To get the current date use this
+#ez-today.today()
+```
+
+## Reference
+
+### `today`
+
+Prints the current date with given arguments.
+
+```typ
+#let today(
+  lang: "de",
+  format: "d. M Y",
+  custom-months: ()
+) = { .. }
+```
+
+**Arguments:**
+
+- `lang`: [`str`] &mdash; Select one of the included languages (de, en, fr, it, cs, pt).
+- `format`: [`str`] &mdash; Specify the output format.
+- `custom-months`: [`array`] of [`str`] &mdash; Use custom names for each month. This array must have 12 entries. If this is used, the `lang` argument does nothing.
+
+## Customization
+
+The default output prints the full current date with German months like this:
+
+```typ
+#ez-today.today()   // 11. Oktober 2024
+```
+
+You can choose one of the included languages with the `lang` argument:
+
+```typ
+#ez-today.today(lang: "en")   // 11. October 2024
+#ez-today.today(lang: "fr")   // 11. Octobre 2024
+#ez-today.today(lang: "it")   // 11. Ottobre 2024
+#ez-today.today(lang: "cs")   // 11. Října 2024
+#ez-today.today(lang: "pt")   // 11. Outubro 2024
+#ez-today.today(lang: "sk")   // 11. Októbra 2024
+#ez-today.today(lang: "pl")   // 11. Października 2024
+```
+
+You can also change the format of the output with the `format` argument. Pass any string you want here, but know that the following characters will be replaced with the following:
+
+- `d` &mdash; The current day as a decimal
+- `n` &mdash; The current month as a decimal (`lang` argument does nothing)
+- `m` &mdash; The current month as a zero-padded decimal (`lang` argument does nothing)
+- `M` &mdash; The current month as a string with either the selected language or the custom array
+- `y` &mdash; The current year as a decimal with the last two numbers
+- `Y` &mdash; The current year as a decimal
+
+If you want the current date in ISO 8601 format, you can do so by passing `ISO` to the `format` argument.
+
+Here are some examples:
+
+```typ
+#ez-today.today(format:"ISO")                   // 2024-10-11
+#ez-today.today(lang: "en", format: "M d Y")    // October 11 2024
+#ez-today.today(format: "m-d-y")                // 10-11-24
+#ez-today.today(format: "d/m")                  // 11/10
+#ez-today.today(format: "d.m.Y")                // 11.10.2024
+```
+
+Use the `custom-months` argument to give each month a custom name. You can add a new language or use short terms for each month.
+
+```typ
+// Defining some custom names
+#let my-months = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+// Get current date with custom names
+#ez-today.today(custom-months: my-months, format: "M-y")    // Oct-24
+```
+
+## Changelog
+
+### 1.0.0
+
+- Added support for Slovakian and Polish language by ShinoYumi
+- Added function for ISO 8601 format by ShinoYumi
+- Month numbers with only one digit are now zero-padded
+
+### 0.3.0
+
+- Added support for Portuguese language by Me-At-The-Age-Of-Git
+
+### 0.2.0
+
+- Added support for Czech language by ShinoYumi
+
+### 0.1.0
+
+- First release of ez-today

--- a/packages/preview/ez-today/1.0.0/examples/example.typ
+++ b/packages/preview/ez-today/1.0.0/examples/example.typ
@@ -1,0 +1,15 @@
+#import "../ez-today.typ"
+
+// Default output
+#ez-today.today()
+
+// Custom format with English months
+#ez-today.today(lang: "en", format: "M-d-Y")
+
+// Defining some custom names
+#let my-months = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+// Get current date with custom names
+#ez-today.today(custom-months: my-months, format: "M-y")
+
+// Get the current date in the ISO 8601 format
+#ez-today.today(format: "ISO")

--- a/packages/preview/ez-today/1.0.0/ez-today.typ
+++ b/packages/preview/ez-today/1.0.0/ez-today.typ
@@ -1,0 +1,64 @@
+#let get-month(lang, month) = {
+  let months = ()
+
+  if lang == "de" {
+    months = ("Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember")
+  } else if lang == "en" {
+    months = ("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December")
+  } else if lang == "fr" {
+    months = ("Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre")
+  } else if lang == "it" {
+    months = ("Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre")
+  } else if lang == "cs" {
+    months = ("Ledna", "Února", "Března", "Dubna", "Května", "Června", "Července", "Srpna", "Září", "Října", "Listopadu", "Prosince")
+  } else if lang == "pt" {
+    months = ("Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro")
+  } else if lang == "sk" {
+    months = ("Januára", "Februára", "Marca", "Apríla", "Mája", "Júna", "Júla", "Augusta", "Septembera", "Októbra", "Novembra", "Decembra")
+  } else if lang == "pl" {
+    months = ("Stycznia", "Lutego", "Marca", "Kwietnia", "Maja", "Czerwca", "Lipca", "Sierpnia", "Września", "Października", "Listopada", "Grudnia")
+  } else {
+    return ""
+  }
+
+  months.at(month - 1)
+}
+#let today(lang: "de", format: "d. M Y", custom-months: ()) = {
+  let use-custom = false
+  if custom-months.len() == 12 {
+    use-custom = true
+  }
+
+  // Zero-padding the month number
+  let month-int = datetime.today().month()
+  let month-int-string = [#month-int]
+  if month-int <= 9 {
+      month-int-string = [0] + month-int-string
+  }
+  
+  if format == "ISO" {
+    return [#datetime.today().year()-#month-int-string\-#datetime.today().day()]
+  }
+  
+  for f in format {
+    if f == "d" {
+      [#datetime.today().day()]
+    } else if f == "M" {
+      if use-custom {
+        [#custom-months.at(datetime.today().month() - 1)]
+      } else {
+        [#get-month(lang, datetime.today().month())]
+      }
+    } else if f == "n" {
+      [#datetime.today().month()]
+    } else if f == "m" {
+      [#month-int-string]
+    } else if f == "Y" {
+      [#datetime.today().year()]
+    } else if f == "y" {
+      [#datetime.today().display("[year repr:last_two]")]
+    } else {
+      f
+    }
+  }
+}

--- a/packages/preview/ez-today/1.0.0/typst.toml
+++ b/packages/preview/ez-today/1.0.0/typst.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ez-today"
+version = "1.0.0"
+entrypoint = "ez-today.typ"
+authors = ["Carlo Schafflik"]
+license = "MIT"
+description = "Simply displays the full current date."
+repository = "https://github.com/CarloSchafflik12/typst-ez-today"
+exclude = ["./examples"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

- You can now get the current date in the ISO 8601 format
- Single digit month numbers are now zero-padded
- Added support for Slovakian and Polish language
