### PR TITLE
Ignore PDF files for packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ desktop.ini
 
 # Rust
 /bundler/target
+
+# PDF files for packages
+packages/**/*.pdf


### PR DESCRIPTION
This adds an entry to the `.gitignore` file to ignore all (new) PDF files for packages. Avoids that every single package maintainer may have it's own `.gitignore` file to achieve the same result... :smile: 

```
find packages/ -name .gitignore | wc -l 
154
```

Related to https://github.com/typst/packages/pull/1595#discussion_r1922043640