### PR TITLE
codly-languages:0.1.6

### DIFF
--- a/packages/preview/codly-languages/0.1.6/README.md
+++ b/packages/preview/codly-languages/0.1.6/README.md
@@ -10,7 +10,7 @@ Pretty simple. Import `codly`. Initialize it. Import `codly-languages`.
 Configure `codly` with the languages. Like this:
 
 ```typst
-#import "@preview/codly:1.1.1": *
+#import "@preview/codly:1.2.0": *
 #show: codly-init
 
 #import "@preview/codly-languages:0.1.6": *

--- a/packages/preview/codly-languages/0.1.6/lib.typ
+++ b/packages/preview/codly-languages/0.1.6/lib.typ
@@ -4,7 +4,7 @@
 // To use:
 //
 // ```typst
-// #import "@preview/codly:1.1.1": *
+// #import "@preview/codly:1.2.0": *
 // #show: codly-init
 //
 // #import "codly-languages.typ": *

--- a/packages/preview/codly-languages/0.1.6/tests/basic-output/test.typ
+++ b/packages/preview/codly-languages/0.1.6/tests/basic-output/test.typ
@@ -1,5 +1,5 @@
 #import "/lib.typ": *
-#import "@preview/codly:1.1.1": *
+#import "@preview/codly:1.2.0": *
 #show: codly-init
 #codly(languages: codly-languages)
 


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package


**Diff**: https://github.com/swaits/typst-collection/compare/codly-languages-0.1.6...codly-languages-new

**Description**: Explain what the package does and why it's useful.

_NO CODE CHANGES... not bumping version_

This change just updates the documentation (and a test) to point to codly:1.2.0.