### PR TITLE
[typsium:0.0.3] Fix a minor problem in using typst:0.13-

### DIFF
--- a/packages/preview/typsium/0.0.3/lib.typ
+++ b/packages/preview/typsium/0.0.3/lib.typ
@@ -106,5 +106,5 @@
       panic("请查看文档了解支持的语法：" + remaining[0])
     }
   }
-  $display(result)$
+  $upright(display(result))$
 }


### PR DESCRIPTION
Add `upright()` to the final result to keep it upright.