### PR TITLE
remove outdated template code from touying 0.3.2

### DIFF
--- a/packages/preview/touying/0.3.2/typst.toml
+++ b/packages/preview/touying/0.3.2/typst.toml
@@ -9,8 +9,3 @@ repository = "https://github.com/touying-typ/touying"
 keywords = ["presentation", "slides", "lecture", "touying"]
 categories = ["presentation"]
 exclude = ["examples"]
-
-[template]
-path = "template"
-entrypoint = "main.typ"
-thumbnail = "thumbnail.png"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Touying have a issue: https://github.com/touying-typ/touying/issues/159

In short, users will browse the old touying 0.3.2 template in webapp, which will cause misunderstanding, so I hope to delete this old version code of template. In my opinion, deleting these fields should not affect the normal use of users, and even if there is, it should not be used like this. So can I remove outdated template from touying 0.3.2? Anyway, thanks!