### PR TITLE
README.md: document a command-line script to produce thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ Required for submissions to this repository:
   will automatically be excluded from the package files and must not be
   referenced anywhere in the package.
 
+   If you have ImageMagick and [oxipng] installed, you could produce
+   a thumbnail file `thumbnail.png` from `foo.typ` as follows:
+   
+   ```shell
+   typst compile foo.typ
+   magick -density 250 foo.pdf[0] -flatten thumbnail.png
+   oxipng -o 2 thumbnail.png
+   ```
+   
+   (`foo.pdf[0]` selects the first page, `-flatten` uses white
+   rather than transparent background, and `-o 2` is a good
+   optimisation level for `oxipng`.)
+
 Template packages must specify at least one category in `package.categories`.
 
 If you're submitting a template, please test that it works locally on your


### PR DESCRIPTION
The packaging guidelines ask for a thumbnail, but without suggesting how to produce it. It's a bit annoying to reconstruct this knowledge, and it is something that should be easily scriptable so that template authors can easily update their thumbnails as they update their templates.

(Note: I opened a forum thread with these instructions, which may suggest alternative approaches: https://forum.typst.app/t/a-command-line-and-a-makefile-rule-to-build-thumbnails/3262 )