### PR TITLE
Always use the filesystem timestamp if Git did not succeed

### DIFF
--- a/bundler/src/timestamp.rs
+++ b/bundler/src/timestamp.rs
@@ -23,7 +23,7 @@ pub fn determine_timestamps(
         .par_iter()
         .map(|p| {
             if has_git {
-                timestamp_for_path_with_git(p)
+                timestamp_for_path_with_git(p).or_else(|_| timestamp_for_path_with_fs(p))
             } else {
                 timestamp_for_path_with_fs(p)
             }


### PR DESCRIPTION
Typst's containers can now include Git. This means that package indexing fails if the mounted folder is not a repository. This PR fixes that by forcing the bundler to always try using the file system to determine the package creation time before erroring out.