### PR TITLE
frame-it:1.1.2

### DIFF
--- a/packages/preview/frame-it/1.1.2/LICENSE
+++ b/packages/preview/frame-it/1.1.2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Marc Thieme
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/frame-it/1.1.2/README.md
+++ b/packages/preview/frame-it/1.1.2/README.md
@@ -365,6 +365,34 @@ rule to your frames. Here is a list of examples:
 
 </div>
 
+Beware that internally, this has to create two distinct figures for
+technical reason. In general, this approach will be less robust than
+using the `show: frame-style()` function.
+
+When you want to change the styling used for a passage of your document,
+you can just add more `show: frame-style()` rules:
+```typst
+#show: frame-style(styles.boxy)
+#example[In boxy style][]
+#show: frame-style(styles.hint)
+#example[In hint Style][]
+```
+
+I usually define the abbreviations for the show rule:
+
+```typst
+// Define once
+#let boxy(document) = {show: frame-style(styles.boxy); document}
+#let hint(document) = {show: frame-style(styles.hint); document}
+
+// Use changing the style used
+#show: boxy
+#example[In boxy style]
+#example[Also in boxy style]
+#show: hint
+#example[In hint style]
+```
+
 ## Custom Styling
 
 Internally, there is nothing special about the predefined styles. The

--- a/packages/preview/frame-it/1.1.2/README.md
+++ b/packages/preview/frame-it/1.1.2/README.md
@@ -1,0 +1,422 @@
+> [!NOTE]
+> This is the version of the readme adapted for the Github Readme.
+  This adaption is less than ideal.
+  If you want to copy text and have a faithful render, go to [this link](https://html-preview.github.io/?url=https://github.com/marc-thieme/frame-it/blob/assets/README.html).
+## Introduction
+
+[Frame-It](https://github.com/marc-thieme/frame-it) offers a
+straightforward way to define and use custom environments in your
+documents. Its syntax is designed to integrate seamlessly with your
+source code.
+
+Two predefined styles are included by default. You can also create
+custom styling functions that use the same user-facing API while giving
+you complete control over the Typst elements in your document.
+
+<div id="frame-wrapper-1">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-0.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-0.svg"> </picture> 
+
+</div>
+
+In contrast:
+
+<div id="frame-wrapper-2">
+
+<figure>
+<div id="frame-wrapper-3">
+<div id="frame-wrapper-3">
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-1.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-1.svg"> </picture> 
+</div>
+</div>
+</figure>
+
+</div>
+
+The default styles are merely functions with the correct signature. If
+they don't appeal to you, you have complete freedom to define custom
+styling functions yourself.
+
+<div id="frame-wrapper-5">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-2.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-2.svg"> </picture> 
+
+</div>
+
+## Quick Start
+
+Import and define your desired frames:
+
+```typst
+#import "@preview/frame-it:1.1.2": *
+
+#let (example, feature, variant, syntax) = frames(
+  feature: ("Feature",),
+  // For each frame kind, you have to provide its supplement title to be displayed
+  variant: ("Variant",),
+  // You can provide a color or leave it out and it will be generated
+  example: ("Example", gray),
+  // You can add as many as you want
+  syntax: ("Syntax",),
+)
+// This is necessary. Don't forget this!
+#show: frame-style(styles.boxy)
+```
+
+How to use it is explained below. Here is a quick example:
+```typst
+#example[Title][Optional Tag][
+  Body, i.e. large content block for the frame.
+]
+```
+
+which yields
+
+<div id="frame-wrapper-6">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-3.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-3.svg"> </picture> 
+
+</div>
+
+## Feature List
+
+The following features are demonstrated in all predefined styles.
+
+### Seamlessly hightight parts of your document
+
+<div id="frame-wrapper-7">
+
+<div id="frame-wrapper-7">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-4.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-4.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-9">
+
+<div id="frame-wrapper-9">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-5.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-5.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-11">
+
+<div id="frame-wrapper-11">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-6.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-6.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-13">
+
+<div id="frame-wrapper-13">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-7.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-7.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-15">
+
+<div id="frame-wrapper-15">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-8.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-8.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-17">
+
+<div id="frame-wrapper-17">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-9.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-9.svg"> </picture> 
+
+</div>
+
+</div>
+
+For brief elements, use \[\] as the body to omit the content.
+
+<div id="frame-wrapper-19">
+
+<div id="frame-wrapper-19">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-10.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-10.svg"> </picture> 
+
+</div>
+
+</div>
+
+### Highlight parts distinctively
+
+<div id="frame-wrapper-21">
+
+<div id="frame-wrapper-21">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-11.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-11.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-23">
+
+<div id="frame-wrapper-23">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-12.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-12.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-25">
+
+<div id="frame-wrapper-25">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-13.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-13.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-27">
+
+<div id="frame-wrapper-27">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-14.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-14.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-29">
+
+<div id="frame-wrapper-29">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-15.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-15.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-31">
+
+<div id="frame-wrapper-31">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-16.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-16.svg"> </picture> 
+
+</div>
+
+</div>
+
+For brief elements, use \[\] as the body to omit the content.
+
+<div id="frame-wrapper-33">
+
+<div id="frame-wrapper-33">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-17.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-17.svg"> </picture> 
+
+</div>
+
+</div>
+
+### A third Alternative
+
+We recently a third style, namely `styles.thmbox`:
+
+<div id="frame-wrapper-35">
+
+<div id="frame-wrapper-35">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-18.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-18.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-37">
+
+<div id="frame-wrapper-37">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-19.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-19.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-39">
+
+<div id="frame-wrapper-39">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-20.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-20.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-41">
+
+<div id="frame-wrapper-41">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-21.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-21.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-43">
+
+<div id="frame-wrapper-43">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-22.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-22.svg"> </picture> 
+
+</div>
+
+</div>
+
+<div id="frame-wrapper-45">
+
+<div id="frame-wrapper-45">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-23.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-23.svg"> </picture> 
+
+</div>
+
+</div>
+
+For brief elements, use \[\] as the body to omit the content.
+
+<div id="frame-wrapper-47">
+
+<div id="frame-wrapper-47">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-24.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-24.svg"> </picture> 
+
+</div>
+
+</div>
+
+### Miscellaneous
+
+#### HTML
+
+We were one of the first packages to add support for html! This means
+you can use our frames for example if you're writing an html wiki or
+blog in typst or using typst to get a headstart writing your website.
+
+<div id="frame-wrapper-49">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-25.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-25.svg"> </picture> 
+
+</div>
+
+#### General
+
+Internally, every frame is just a `figure` where the `kind` is set to
+`"frame"` (or a different custom value). As such, most things that can
+be done to a figure can be done with a frame as well. Whenever you would
+like to do something custom but don't know if it is supported, try
+achieving it with a normal figure first and then apply the same show
+rule to your frames. Here is a list of examples:
+
+<div id="frame-wrapper-50">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-26.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-26.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-51">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-27.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-27.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-52">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-28.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-28.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-53">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-29.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-29.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-54">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-30.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-30.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-55">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-31.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-31.svg"> </picture> 
+
+</div>
+
+## Custom Styling
+
+Internally, there is nothing special about the predefined styles. The
+only requirement for any styling function is to adhere to the following
+function signature interface:
+
+<div id="frame-wrapper-56">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-32.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-32.svg"> </picture> 
+
+</div>
+
+where `arg` is going to be the value passed behind the supplement for
+each frame variant in the `frames` function. For the predefined styles,
+this is the color of the frames. When defining your own styling
+function, it has to have the following signature:
+
+The content returned will be placed as–is in the document.
+
+<div id="frame-wrapper-57">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-33.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-33.svg"> </picture> 
+
+</div>
+
+For more information on how to define your own styling function, please
+look into the `styling` module.
+
+## Edge Cases
+
+Here are a few edge cases. Temporarily, they do not work because
+
+<div id="frame-wrapper-58">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-34.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-34.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-59">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-35.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-35.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-60">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-36.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-36.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-65">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-37.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-37.svg"> </picture> 
+
+</div>

--- a/packages/preview/frame-it/1.1.2/README.md
+++ b/packages/preview/frame-it/1.1.2/README.md
@@ -347,6 +347,19 @@ rule to your frames. Here is a list of examples:
 
 </div>
 
+For example, you can create an outline which only contains some
+intentional of your frames like so. The `figure` function includes a
+parameter for including a figure in the outline.
+
+```typst
+// By default, don't include frames in outlines by default
+#show figure.where(kind: "frame"): set figure(outlined: false)
+// Create the outline
+#outline(target: figure.where(kind: "frame"))
+// Explicitly include a frame in the outline with the `outlined` parameter.
+#example(outlined: true)[Important frame][For the outline]
+```
+
 <div id="frame-wrapper-53">
 
  <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-29.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-29.svg"> </picture> 
@@ -421,9 +434,9 @@ The content returned will be placed as–is in the document.
 For more information on how to define your own styling function, please
 look into the `styling` module.
 
-## Edge Cases
+## Experimentl APIs
 
-Here are a few edge cases. Temporarily, they do not work because
+These APIs are still experimental and subject to change. Use sparingly.
 
 <div id="frame-wrapper-58">
 
@@ -431,11 +444,28 @@ Here are a few edge cases. Temporarily, they do not work because
 
 </div>
 
+For example, you can use this to color the entries in a outline
+according to the color of the frame:
+
+```typst
+#show outline.entry: it => {
+  let color = inspect.lookup-frame-info(it.element).color
+  text(fill: color.saturate(70%), it)
+}
+#outline(target: figure.where(kind: "frame"))
+```
 <div id="frame-wrapper-59">
 
  <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-35.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-35.svg"> </picture> 
 
 </div>
+
+Whenever possible, try to discern it using the figures kind instead of
+this function.
+
+## Edge Cases
+
+Here are a few edge cases.
 
 <div id="frame-wrapper-60">
 
@@ -443,8 +473,20 @@ Here are a few edge cases. Temporarily, they do not work because
 
 </div>
 
-<div id="frame-wrapper-65">
+<div id="frame-wrapper-61">
 
  <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-37.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-37.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-62">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-38.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-38.svg"> </picture> 
+
+</div>
+
+<div id="frame-wrapper-67">
+
+ <picture> <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-dark-39.svg"> <img src="https://raw.githubusercontent.com/marc-thieme/frame-it/refs/heads/assets/README-svg-light-39.svg"> </picture> 
 
 </div>

--- a/packages/preview/frame-it/1.1.2/README.typ
+++ b/packages/preview/frame-it/1.1.2/README.typ
@@ -250,18 +250,32 @@ Here is a list of examples:
     To skip the header entirely, leave the title parameter blank.
   ]
   ```
-  Beware that internally, this has to second two figures for technical reason.
-  In general, this approach will be less robust than using the `show: frame-style()` function.
-  #divide()
-  When you want to change the styling used for a passage of your document,
-  you can just add more `show: frame-style()` rules:
-  ```typst
-  #show: frame-style(styles.boxy)
-  #example[In boxy style][]
-  #show: frame-style(styles.hint)
-  #example[In hint Style][]
-  ```
 ]
+Beware that internally, this has to create two distinct figures for technical reason.
+In general, this approach will be less robust than using the `show: frame-style()` function.
+
+When you want to change the styling used for a passage of your document,
+you can just add more `show: frame-style()` rules:
+```typst
+#show: frame-style(styles.boxy)
+#example[In boxy style][]
+#show: frame-style(styles.hint)
+#example[In hint Style][]
+```
+
+I usually define the abbreviations for the show rule:
+```typst
+// Define once
+#let boxy(document) = {show: frame-style(styles.boxy); document}
+#let hint(document) = {show: frame-style(styles.hint); document}
+
+// Use changing the style used
+#show: boxy
+#example[In boxy style]
+#example[Also in boxy style]
+#show: hint
+#example[In hint style]
+```
 
 = Custom Styling
 Internally, there is nothing special about the predefined styles.

--- a/packages/preview/frame-it/1.1.2/README.typ
+++ b/packages/preview/frame-it/1.1.2/README.typ
@@ -1,0 +1,315 @@
+#import "@preview/frame-it:1.1.2": *
+#import "src/utils/html.typ": *
+
+#let base-color-arg = (:)
+#let text-color = black
+#let background-color = white
+#if sys.inputs.at("theme", default: "light") == "dark" {
+  text-color = rgb(240, 246, 252)
+  background-color = rgb("#0d1117")
+  base-color-arg.base-color = blue.darken(40%).desaturate(25%)
+}
+#let example-color = text-color.mix((text-color.negate(), 590%)).mix(gray)
+
+#let (example, feature, variant, syntax) = frames(
+  ..base-color-arg,
+  feature: "Feature",
+  variant: ("Feature Variant",),
+  example: ("Example", example-color),
+  syntax: ("Syntax",),
+)
+
+#set text(text-color)
+#set text(17pt)
+
+#let wants-svg-frames = sys.inputs.at("svg-frames", default: "false") != "false"
+#show figure.where(kind: "frame"): it => context if (
+  wants-html() and wants-svg-frames
+) {
+  html.frame({
+    v(2mm)
+    block(width: 24cm, it)
+    v(2mm)
+  })
+} else { it }
+#show: it => context if wants-html() and not wants-svg-frames {
+  show raw.where(lang: "typst"): html.elem.with(
+    "code",
+    attrs: (class: "language-typst"),
+  )
+  it
+} else if not wants-html() {
+  set page(fill: background-color)
+  set page(height: auto, margin: 4mm)
+  it
+} else { it }
+
+#show: frame-style(styles.boxy)
+
+= Introduction
+#link("https://github.com/marc-thieme/frame-it", text(blue)[Frame-It]) offers a straightforward way to define and use custom environments in your documents. Its syntax is designed to integrate seamlessly with your source code.
+
+Two predefined styles are included by default. You can also create custom styling functions that use the same user-facing API while giving you complete control over the Typst elements in your document.
+
+#feature[Distinct Highlight][Best for occasional use][More noticeable][
+  The default style, `styles.boxy`, is eye-catching and intended to stand out from the surrounding text.
+]
+
+In contrast:
+
+#feature(
+  style: styles.hint,
+)[Unobtrusive Style][Ideal for frequent use][Blends into text flow][
+  The alternative style `styles.hint` highlights text with a subtle colored line along the side, preserving the document's flow.
+]
+
+The default styles are merely functions with the correct signature.
+If they don't appeal to you, you have complete freedom to define custom styling functions yourself.
+
+#example[A different frame kind][
+  You can define different classes or types of frames, which alter the substitute and the frame's color. As shown here, this is an example frame.
+  You can create as many different kinds as you want.
+
+  As long as all kinds use the same identifier with `frames`, they share a common counter.
+]
+
+= Quick Start
+Import and define your desired frames:
+
+```typst
+#import "@preview/frame-it:1.1.2": *
+
+#let (example, feature, variant, syntax) = frames(
+  feature: ("Feature",),
+  // For each frame kind, you have to provide its supplement title to be displayed
+  variant: ("Variant",),
+  // You can provide a color or leave it out and it will be generated
+  example: ("Example", gray),
+  // You can add as many as you want
+  syntax: ("Syntax",),
+)
+// This is necessary. Don't forget this!
+#show: frame-style(styles.boxy)
+```
+
+How to use it is explained below. Here is a quick example:
+```typst
+#example[Title][Optional Tag][
+  Body, i.e. large content block for the frame.
+]
+```
+which yields
+#example[Title][Optional Tag][
+  Body, i.e. large content block for the frame.
+]
+
+= Feature List
+
+#let layout-features() = [
+  #feature[Element with Title and Content][
+    The simplest way to create an element is by providing a title as the first argument and content as the second.
+  ]
+
+  #variant[Element with Tags][Customizable Tags][Multiple][
+    Elements can include multiple tags placed between the title and the content.
+  ]
+
+  #feature[][
+    If you don’t require a custom title but still want to display the element type, use `[]` as the title placeholder.
+  ]
+
+  #variant[][Single Tag][Next tag][
+    You can include tags even when no title is provided.
+  ]
+
+  #variant[
+    To omit the header entirely, leave the title parameter empty.
+  ]
+
+  #feature[Element without Content][Optional Tags Only][]
+  For brief elements, use [] as the body to omit the content.
+
+  #feature[Element with Divider][
+    Insert `divide()` to add a divider within your content for a visual break:
+    #divide()
+    And then continue with your text below the divider.
+  ]
+]
+
+The following features are demonstrated in all predefined styles.
+
+== Seamlessly hightight parts of your document
+#[
+  #show: frame-style(styles.hint)
+  #layout-features()
+]
+== Highlight parts distinctively
+#[
+  #show: frame-style(styles.boxy)
+  #layout-features()
+]
+== A third Alternative
+#[
+  #show: frame-style(styles.thmbox)
+  We recently a third style, namely `styles.thmbox`:
+  #layout-features()
+]
+== Miscellaneous
+=== HTML
+We were one of the first packages to add support for html!
+This means you can use our frames for example if you're writing an html wiki or blog in typst
+or using typst to get a headstart writing your website.
+#feature[HTML export][
+  Due to the currently experimental nature of the feature, you need to pass two CLI–flags when
+  compiling your document with the frames to html:
+  ```
+  typst compile --features html --input html-frames=true --format html FILE.typ
+  ```
+]
+
+=== General
+Internally, every frame is just a `figure` where the `kind` is set to `"frame"` (or a different custom value).
+As such, most things that can be done to a figure can be done with a frame as well.
+Whenever you would like to do something custom but don't know if it is supported,
+try achieving it with a normal figure first and then apply the same show rule to your frames.
+Here is a list of examples:
+
+#variant[Labels and References][
+  Elements can be referenced as expected by appending `<label>` and referencing it:
+  ```typst
+  #syntax[Labels and References] <labels-and-refs>
+  Referencing with @labels-and-refs.
+  ```
+] <reference-tag>
+// For example: @reference-tag.
+
+#variant[Break frames across pages][
+  If you want to make your frames breakable across pages,
+  you have to use the show rule known from the official typst docs:
+  ```typst
+  #show figure.where(kind: "frame"): set block(breakable: true)
+  ```
+  To turn off breakability, you can use the corresponding show rule
+  ```typst
+  #show figure.where(kind: "frame"): set block(breakable: false)
+  ```
+]
+
+#syntax[Per–frame custom figure parameters][Frame outline][
+  All named arguments passed to a frame–function like `example[][]` are going to be passed
+  to the figure function which places the frame in the document.
+  #divide()
+  For example, you can create an outline which only contains some intentional of your frames like so.
+  The `figure` function includes a parameter for including a figure in the outline.
+  ```typst
+  // By default, don't include a frame
+  #show figure.where(kind: "frame"): set figure(outlined: false)
+  // Create the outline
+  #outline(target: figure.where(kind: "frame"))
+  // Include a frame in the outline with the `outlined` parameter.
+  #example(outlined: true)[Important frame][For the outline]
+  ```
+
+]
+
+#variant[Different numbering][
+  Numbering in figures is a bit of a mess.
+  Natively, you are limited to one number and a format suffix/prefix.
+  With that, you can do the following.
+  ```typst
+  #show figure.where(kind: "frame"): set figure(numbering: "a)")
+  ```
+  If you want to do more advanced and nested numbering, you can look into external packages for that.
+  When trying to make a system apply to the frames, remember that they are just figures with a specific kind.
+
+  In the background, there are also some show rules doing the styling for the frames.
+  However, these should only get in the way when you are doing some esoteric manipulation of the figure captions.
+]
+
+#syntax[Different kind][for the underlying figures][
+  When you have multiple different groups of frames you need to style independently,
+  you can provide an arbitrary `kind` to the `frames` function.
+
+  ```typst
+  #let (syntax,) = frames(
+    syntax: ("Syntax",),
+  )
+  #let (note,) = frames(
+    kind: "other-kind"
+    note: ("Note",),
+  )
+  #show: frame-style(styles.boxy)
+  #show: frame-style(kind: "other-kind", styles.hint)
+  ```
+]
+
+#syntax[Change the styling][
+  To use a different styling function for just one frame, you can provide `style: styles.hint` as an extra argument:
+  ```typst
+  #variant(style: styles.hint)[
+    To skip the header entirely, leave the title parameter blank.
+  ]
+  ```
+  Beware that internally, this has to second two figures for technical reason.
+  In general, this approach will be less robust than using the `show: frame-style()` function.
+  #divide()
+  When you want to change the styling used for a passage of your document,
+  you can just add more `show: frame-style()` rules:
+  ```typst
+  #show: frame-style(styles.boxy)
+  #example[In boxy style][]
+  #show: frame-style(styles.hint)
+  #example[In hint Style][]
+  ```
+]
+
+= Custom Styling
+Internally, there is nothing special about the predefined styles.
+The only requirement for any styling function is to adhere to the following
+function signature interface:
+
+
+#syntax[Interface for custom styling function][
+  ```typst
+  #let custom-styling(title, tags, body, supplement, number, arg)
+  ```
+]
+where `arg` is going to be the value passed behind the supplement for each frame variant in the `frames` function.
+For the predefined styles, this is the color of the frames.
+When defining your own styling function, it has to have the following signature:
+
+The content returned will be placed as–is in the document.
+
+#syntax[Styling Dividers][
+  If your custom styling function shall support dividers, it must include a show rule in its body:
+  ```typst
+  #show: styling.dividers-as(object-which-will-be-used-as-divider)
+  ```
+]
+
+For more information on how to define your own styling function, please look into the `styling` module.
+
+= Edge Cases
+
+Here are a few edge cases. Temporarily, they do not work because
+
+#example[Test][Long tag example without space for the supplement][notice the number moves up][
+  #lorem(20)
+]
+
+#example[Example][Tags of various sizes][$sum_sum^sum$][Extra vertical space: #v(1cm)][
+  (Leads to formatting errors in html export because support is missing)\
+  #lorem(20)
+]
+
+#example[Nested][
+  #example[][
+    #example(style: styles.hint)[][
+      When nested, counters increment from outer to inner elements.
+    ]
+  ]
+]
+
+#example[][
+  Counters continue incrementing sequentially in non-nested elements.
+]

--- a/packages/preview/frame-it/1.1.2/README.typ
+++ b/packages/preview/frame-it/1.1.2/README.typ
@@ -1,4 +1,4 @@
-#import "src/lib.typ": *
+#import "@preview/frame-it:1.1.2": *
 #import "src/utils/html.typ": *
 
 #let base-color-arg = (:)

--- a/packages/preview/frame-it/1.1.2/README.typ
+++ b/packages/preview/frame-it/1.1.2/README.typ
@@ -1,4 +1,4 @@
-#import "@preview/frame-it:1.1.2": *
+#import "src/lib.typ": *
 #import "src/utils/html.typ": *
 
 #let base-color-arg = (:)
@@ -195,22 +195,21 @@ Here is a list of examples:
   ```
 ]
 
-#syntax[Per–frame custom figure parameters][Frame outline][
-  All named arguments passed to a frame–function like `example[][]` are going to be passed
+#feature[Per–frame custom figure parameters][Frame outline][
+  All named parameters passed to a frame–function like `example[][]` are going to be passed
   to the figure function which places the frame in the document.
-  #divide()
-  For example, you can create an outline which only contains some intentional of your frames like so.
-  The `figure` function includes a parameter for including a figure in the outline.
-  ```typst
-  // By default, don't include a frame
-  #show figure.where(kind: "frame"): set figure(outlined: false)
-  // Create the outline
-  #outline(target: figure.where(kind: "frame"))
-  // Include a frame in the outline with the `outlined` parameter.
-  #example(outlined: true)[Important frame][For the outline]
-  ```
-
 ]
+
+For example, you can create an outline which only contains some intentional of your frames like so.
+The `figure` function includes a parameter for including a figure in the outline.
+```typst
+// By default, don't include frames in outlines by default
+#show figure.where(kind: "frame"): set figure(outlined: false)
+// Create the outline
+#outline(target: figure.where(kind: "frame"))
+// Explicitly include a frame in the outline with the `outlined` parameter.
+#example(outlined: true)[Important frame][For the outline]
+```
 
 #variant[Different numbering][
   Numbering in figures is a bit of a mess.
@@ -303,9 +302,36 @@ The content returned will be placed as–is in the document.
 
 For more information on how to define your own styling function, please look into the `styling` module.
 
+= Experimentl APIs
+These APIs are still experimental and subject to change. Use sparingly.
+
+#syntax[Retrieving information of a frame][Experimental][
+  When you want to do more intricate styling for your frames, sometimes it is necessary to
+  obtain all the information which.
+
+  For this, use the `inspect.lookup-frame-info(figure)` function.
+  Given a figure (which represents a frame), it returns a dictionary with the entries
+  `title`, `tags`, `body`, `supplement`, `color`.
+
+  When the provided figure is not a frame, this function throws an error.
+]
+For example, you can use this to color the entries in a outline according to the color of the frame:
+```typst
+#show outline.entry: it => {
+  let color = inspect.lookup-frame-info(it.element).color
+  text(fill: color.saturate(70%), it)
+}
+#outline(target: figure.where(kind: "frame"))
+```
+
+#syntax[Checking whether a figure is a frame][Experimental][
+  In order to test whether a figure is a frame, use the `inspect.is-frame(figure)` function.
+]
+Whenever possible, try to discern it using the figures kind instead of this function.
+
 = Edge Cases
 
-Here are a few edge cases. Temporarily, they do not work because
+Here are a few edge cases.
 
 #example[Test][Long tag example without space for the supplement][notice the number moves up][
   #lorem(20)
@@ -327,3 +353,12 @@ Here are a few edge cases. Temporarily, they do not work because
 #example[][
   Counters continue incrementing sequentially in non-nested elements.
 ]
+
+// Tests
+#context {
+  let frames = query(figure.where(kind: "frame"))
+  for frame in query(figure.where(kind: "frame")) {
+    assert(inspect.is-frame(frame), message: repr(frame))
+    assert(type(inspect.lookup-frame-info(frame).color) == color)
+  }
+}

--- a/packages/preview/frame-it/1.1.2/src/bundled-layout.typ
+++ b/packages/preview/frame-it/1.1.2/src/bundled-layout.typ
@@ -1,0 +1,102 @@
+// DEPRECATED. This file is deprecated. Use `layout.typ` instead.
+// The implementation in `layout.typ` is simpler and more robust.
+#let encode-caption-id(
+  kind,
+  title,
+  tags,
+  body,
+  supplement,
+  custom-arg,
+) = [
+  Uniquely identify this to make the `show figure`-clause as specific as possible.
+  #(
+    (
+      kind,
+      title,
+      tags,
+      body,
+      supplement,
+      custom-arg,
+    )
+      .map(repr)
+      .join(", ")
+  )
+]
+
+#let spawn-bundled-frame(
+  style,
+  kind,
+  title,
+  tags,
+  body,
+  supplement,
+  custom-arg,
+) = figure(
+  kind: kind + "-wrapper",
+  supplement: supplement,
+  outlined: false,
+  {
+    let caption-id = encode-caption-id(
+      kind,
+      title,
+      tags,
+      body,
+      supplement,
+      custom-arg,
+    )
+    // Offset the counter because our outer helper figure has the same kind.
+    // The outer figure must have the same kind as the inner because the user might rely
+    // on the outer one having the kind he knows when he's writing rules for references
+    // NOTE I don't know the performance impact of this
+    // Inject the customized styling into the caption.
+    // We use the caption because we have access to the supplement and the numbering there.
+    show figure.caption.where(body: caption-id): caption => (
+      context {
+        let number = caption.counter.display(caption.numbering)
+        style(title, tags, body, supplement, number, custom-arg)
+      }
+    )
+
+    // Make figure breakable.
+    // In order to use this, you also need to explicitly use the show rule defined in the layout package.
+    // We recommend scoping this show rule if you do not want it to apply for every frame.
+    // The alternative possibility is in turn to wrap a single frame into an unbreakable block.
+    // See: https://typst.app/docs/reference/model/figure/#figure-behaviour
+    // See: https://github.com/marc-thieme/frame-it/issues/1
+    show figure.where(kind: kind, supplement: none): set block(breakable: true)
+
+    figure(caption: caption-id, supplement: none, gap: 0pt, kind: kind, none)
+  },
+)
+
+// Wrap it in a second figure because of three facts:
+// 1. We need to return a type figure to make it labellable
+// 2. We need to specify rules (set and show) to modify caption styling
+// 3. If we specify rules in the block which is returned, a type 'styled' is returned instead of the figure
+#let bundled-factory(style, supplement, kind, custom-arg) = (
+  (..title-and-tags, body, style: style, arg: custom-arg) => {
+    let title = none
+    let tags = ()
+    if title-and-tags.pos() != () {
+      (title, ..tags) = title-and-tags.pos()
+    }
+    spawn-bundled-frame(
+      style,
+      kind,
+      title,
+      tags,
+      body,
+      supplement,
+      arg,
+      ..title-and-tags.named(),
+    )
+  }
+)
+
+// DEPRECATED
+#let breakable-frames(kind, breakable: true) = (
+  it => {
+    show figure.where(kind: kind): set block(breakable: breakable)
+    it
+  }
+)

--- a/packages/preview/frame-it/1.1.2/src/inspect.typ
+++ b/packages/preview/frame-it/1.1.2/src/inspect.typ
@@ -1,0 +1,27 @@
+#import "utils/encode.typ": retrieve-info-from-code, code-has-info-attached
+
+#let lookup-frame-info(figure) = {
+  assert(
+    code-has-info-attached(figure.caption.body),
+    message: "You can only provide figures to `lookup-frame-info`"
+      + "which represent frame-it–frames",
+  )
+
+  let (
+    title,
+    tags,
+    body,
+    supplement,
+    custom-arg,
+  ) = retrieve-info-from-code(figure.caption.body)
+
+  (
+    title: title,
+    tags: tags,
+    body: body,
+    supplement: supplement,
+    color: custom-arg,
+  )
+}
+
+#let is-frame(figure) = code-has-info-attached(figure.caption.body)

--- a/packages/preview/frame-it/1.1.2/src/layout.typ
+++ b/packages/preview/frame-it/1.1.2/src/layout.typ
@@ -1,0 +1,127 @@
+#import "styling.typ"
+
+#let unique-frame-metadata-tag = "_THIS-IS-METADATA-USED-FOR-FRAME-IT-FRAMES"
+
+// Encode info as invisible metadata so when rendered in outline, only the title is seen
+#let encode-title-and-info(title, info) = (
+  metadata(unique-frame-metadata-tag) + metadata(info) + title
+)
+#let retrieve-info-from-code(code) = code.children.at(1).value
+#let code-has-info-attached(code) = (
+  "children" in code.fields().keys()
+    and code.children.first().fields().at("value", default: "")
+      == unique-frame-metadata-tag
+)
+
+#let spawn-frame(
+  kind,
+  title,
+  tags,
+  body,
+  supplement,
+  custom-arg,
+  ..figure-params,
+) = {
+  let frame-info = (
+    title,
+    tags,
+    body,
+    supplement,
+    custom-arg,
+  )
+  figure(
+    caption: encode-title-and-info(title, frame-info),
+    supplement: supplement,
+    kind: kind,
+    ..figure-params,
+    none,
+  )
+}
+
+#let __frame-id-counter-state = state("__frame-it_frame-id-state", 1)
+
+#let frame-style(
+  kind,
+  style,
+) = document => {
+  // Don't restrict to correct kind. We already discern between framees and user–figures
+  // inspecting the metadata. This way, the user can manipulate the kind if desired.
+  show figure.caption: caption => {
+    let code = caption.body
+    if not code-has-info-attached(code) {
+      caption
+    } else {
+      let number = context caption.counter.display(caption.numbering)
+      let (
+        title,
+        tags,
+        body,
+        supplement,
+        custom-arg,
+      ) = retrieve-info-from-code(code)
+      style(title, tags, body, supplement, number, custom-arg)
+    }
+  }
+  show: styling.dividers-as[
+    `Error: Dividers not supported by this styling function.`
+  ]
+
+  import "utils/html.typ": elem-ident, elem-ignore
+  show figure
+    .where(kind: kind)
+    .or(figure.where(kind: kind + "-wrapper")): it => {
+    // Necessary because html-figure unfortunately inserts padding we don't want
+    let id = __frame-id-counter-state.get()
+    __frame-id-counter-state.update(it => it + 1)
+    let figure-id = "frame-wrapper-" + str(id)
+    let style-code = {
+      "#" + figure-id + " > figure {"
+      "  margin-left: 0px;"
+      "  margin-right: 0px;"
+      "}"
+    }
+    // If not html, this will just equate to { it }
+    elem-ignore("style", style-code)
+    elem-ident("div", id: figure-id, it)
+  }
+  document
+}
+
+#let frame-factory(kind, supplement, custom-arg) = (
+  (..title-and-tags, body, style: auto, arg: custom-arg) => {
+    let title = none
+    let tags = ()
+    if title-and-tags.pos() != () {
+      (title, ..tags) = title-and-tags.pos()
+    }
+    if style == auto {
+      spawn-frame(
+        kind,
+        title,
+        tags,
+        body,
+        supplement,
+        arg,
+        ..title-and-tags.named(),
+      )
+    } else {
+      figure(
+        kind: kind + "-wrapper",
+        supplement: supplement,
+        outlined: false,
+        {
+          show: frame-style(kind, style)
+          spawn-frame(
+            kind,
+            title,
+            tags,
+            body,
+            supplement,
+            custom-arg,
+            ..title-and-tags.named(),
+          )
+        },
+      )
+    }
+  }
+)

--- a/packages/preview/frame-it/1.1.2/src/layout.typ
+++ b/packages/preview/frame-it/1.1.2/src/layout.typ
@@ -1,16 +1,8 @@
 #import "styling.typ"
-
-#let unique-frame-metadata-tag = "_THIS-IS-METADATA-USED-FOR-FRAME-IT-FRAMES"
-
-// Encode info as invisible metadata so when rendered in outline, only the title is seen
-#let encode-title-and-info(title, info) = (
-  metadata(unique-frame-metadata-tag) + metadata(info) + title
-)
-#let retrieve-info-from-code(code) = code.children.at(1).value
-#let code-has-info-attached(code) = (
-  "children" in code.fields().keys()
-    and code.children.first().fields().at("value", default: "")
-      == unique-frame-metadata-tag
+#import "utils/encode.typ": (
+  encode-title-and-info,
+  retrieve-info-from-code,
+  code-has-info-attached,
 )
 
 #let spawn-frame(

--- a/packages/preview/frame-it/1.1.2/src/lib.typ
+++ b/packages/preview/frame-it/1.1.2/src/lib.typ
@@ -1,0 +1,50 @@
+#import "styling.typ" as styling: divide
+#import "bundled-layout.typ": breakable-frames
+
+#let styles = {
+  import "styles/boxy.typ": boxy
+  import "styles/hint.typ": hint
+  import "styles/thmbox.typ": thmbox
+  (boxy: boxy, hint: hint, thmbox: thmbox)
+}
+
+// DEPRECATED. Use `frames` and `show: frame-style()` instead
+#let make-frames(
+  kind,
+  style: styles.boxy,
+  base-color: purple.lighten(60%).desaturate(40%),
+  ..frames,
+) = {
+  import "parse.typ": fill-missing-colors
+  import "bundled-layout.typ": bundled-factory
+
+  for (id, supplement, color) in fill-missing-colors(base-color, frames) {
+    ((id): bundled-factory(style, supplement, kind, color))
+  }
+}
+
+#let default-kind = "frame"
+
+#let frames(
+  kind: default-kind,
+  base-color: purple.lighten(60%).desaturate(40%),
+  ..frames,
+) = {
+  import "parse.typ": fill-missing-colors
+  import "layout.typ": frame-factory
+
+  for (id, supplement, color) in fill-missing-colors(base-color, frames) {
+    ((id): frame-factory(kind, supplement, color))
+  }
+}
+
+#let frame-style(kind: default-kind, style) = {
+  import "layout.typ" as layout
+  layout.frame-style(kind, style)
+}
+
+/*
+Definition of styling:
+
+let factory(title: content, tags: (content), body: content, supplement: string or content, number, args)
+*/

--- a/packages/preview/frame-it/1.1.2/src/lib.typ
+++ b/packages/preview/frame-it/1.1.2/src/lib.typ
@@ -1,5 +1,6 @@
 #import "styling.typ" as styling: divide
 #import "bundled-layout.typ": breakable-frames
+#import "inspect.typ" as inspect
 
 #let styles = {
   import "styles/boxy.typ": boxy

--- a/packages/preview/frame-it/1.1.2/src/parse.typ
+++ b/packages/preview/frame-it/1.1.2/src/parse.typ
@@ -1,0 +1,54 @@
+#let calculate-colors(base-color, count) = (
+  range(count)
+    .map(i => (
+      i / count * 360deg
+    ))
+    .map(rotation => base-color.rotate(rotation))
+)
+
+#let fill-missing-colors(
+  base-color,
+  frames,
+) = {
+  assert(
+    frames.pos() == (),
+    message: "Unexpected positional arguments: " + repr(frames.pos()),
+  )
+
+  // Canonicalize and validate arguments
+  let args = for (id, args) in frames.named() {
+    if type(args) != array {
+      args = (args,)
+    }
+    let (supplement, col, ..) = (
+      args
+        + (
+          auto,
+        )
+    ) // Denote color with 'auto' if omitted
+    assert(type(supplement) in (content, str))
+    assert(
+      type(col) in (color, type(auto)),
+      message: "Please provide a color as second arguments: "
+        + supplement
+        + " (was "
+        + repr(type(col))
+        + ")",
+    )
+    ((id, supplement, col),)
+  }
+
+  // Count auto in args and generate colors
+  let auto-count = args.filter(((_, _, col)) => col == auto).len()
+  let generated-colors = calculate-colors(base-color, auto-count)
+  let next-color-idx = 0
+
+  // Replace auto with respective colors
+  for (id, supplement, col) in args {
+    if col == auto {
+      col = generated-colors.at(next-color-idx)
+      next-color-idx += 1
+    }
+    ((id, supplement, col),)
+  }
+}

--- a/packages/preview/frame-it/1.1.2/src/styles/boxy.typ
+++ b/packages/preview/frame-it/1.1.2/src/styles/boxy.typ
@@ -1,0 +1,204 @@
+#import "../styling.typ" as styling
+#import "../utils/html.typ": css, span, div, hr, target-choose
+
+#let body-inset = 0.8em
+#let stroke-width = 0.13em
+#let corner-radius = 5pt
+
+#let boxy-html(title, tags, body, supplement, number, accent-color) = {
+  let has-body = body != []
+  let has-title = title not in ([], "", none)
+  let has-headers = int(has-title) + tags.len() > 0
+  let body-only = title == none
+  let header-contents = tags
+  if has-title {
+    header-contents.insert(0, title)
+  }
+
+  let header-styles = (
+    padding: "5px 10px",
+    border: (stroke-width, "solid", accent-color),
+    margin-left: "-2px",
+  )
+  if has-body {
+    header-styles.border-bottom = none
+  }
+  let first-header-elem-css-overlay = {
+    (
+      margin-left: 0,
+      border-top-left-radius: corner-radius,
+    )
+    if not has-body {
+      (border-bottom-left-radius: corner-radius)
+    }
+  }
+  let last-header-elem-css-overlay = {
+    (
+      border-top-right-radius: corner-radius,
+    )
+    if not has-body {
+      (border-bottom-right-radius: corner-radius)
+    }
+  }
+  let html-suppl = span(
+    css(
+      ..header-styles,
+      border-color: "transparent",
+      margin-left: if has-headers { auto } else { 0 },
+      mragin-right: body-inset,
+    ),
+    supplement + " " + number,
+  )
+  let headers-html() = {
+    let header-contents = if has-title {
+      (title, ..tags)
+    } else {
+      tags
+    }
+    let header-css = (header-styles,) * header-contents.len()
+    header-css.first() += first-header-elem-css-overlay
+    header-css.last() += last-header-elem-css-overlay
+
+    if has-title {
+      header-css.first() += (background-color: accent-color)
+    }
+    for (content, css-dict) in header-contents.zip(header-css) {
+      span(css(..css-dict), content)
+    }
+  }
+  if not body-only {
+    div(
+      css(display: "flex", align-items: center),
+      {
+        if has-headers {
+          headers-html()
+        }
+        html-suppl
+      },
+    )
+  }
+  if has-body {
+    show: styling.dividers-as({
+      let css-dict = (
+        border: 0,
+        height: stroke-width,
+        background: accent-color,
+        margin: (0, -body-inset),
+      )
+      hr(css(css-dict))
+    })
+    let css-dict = (
+      border: (stroke-width, "solid", accent-color),
+      border-radius: (0, corner-radius, corner-radius, corner-radius),
+      padding: body-inset,
+    )
+    if not has-headers {
+      css-dict.border-top-left-radius = corner-radius
+    }
+    div(
+      css(css-dict),
+      body,
+    )
+  }
+}
+
+#let boxy-paged(title, tags, body, supplement, number, accent-color) = {
+  assert(
+    type(accent-color) == color,
+    message: "Please provide a color as argument for the frame instance"
+      + supplement,
+  )
+
+  let stroke = accent-color + stroke-width
+
+  let round-bottom-corners-of-tags = body == []
+  let display-title = title not in ([], "")
+  let round-top-left-body-corner = title in ([], none) and tags == ()
+
+  let header() = align(
+    left,
+    {
+      let inset = 0.5em
+
+      let tag-elements = tags
+      if display-title {
+        let title-cell = grid.cell(fill: accent-color, title)
+        tag-elements.insert(0, title-cell)
+      }
+
+      let rounded-corners = (top: corner-radius)
+      if round-bottom-corners-of-tags {
+        rounded-corners.bottom = corner-radius
+      }
+
+      let rendered-tags = if tag-elements == () [] else {
+        let grid-cells = tag-elements.intersperse(grid.vline(stroke: stroke))
+        let tag-grid = grid(columns: tag-elements.len(), align: horizon, inset: inset, ..grid-cells)
+        box(clip: true, stroke: stroke, radius: rounded-corners, tag-grid)
+        h(1fr)
+      }
+
+      let supplement-str = box(inset: inset)[#supplement #number]
+
+      layout(((width: available-width)) => {
+        if measure(rendered-tags + supplement-str).width < available-width {
+          rendered-tags
+          supplement-str
+        } else [
+          #supplement #number \
+          #rendered-tags
+        ]
+      })
+    },
+  )
+
+  let board() = {
+    let round-corners = (bottom: corner-radius, top-right: corner-radius)
+    if round-top-left-body-corner {
+      round-corners.top-left = corner-radius
+    }
+    align(
+      left,
+      block(
+        width: 100%,
+        inset: body-inset,
+        radius: round-corners,
+        stroke: stroke,
+        spacing: 0em,
+        outset: (y: 0em),
+        {
+          // Divide constructs a line where we need to inject the stroke style because we only have access to the color here
+          show: styling.dividers-as({
+            v(-0.5em + stroke-width)
+            line(
+              start: (-body-inset, 0em),
+              length: 100% + 2 * body-inset,
+              stroke: stroke,
+            )
+            v(-0.5em + stroke-width)
+          })
+          body
+        },
+      ),
+    )
+  }
+
+  let parts = ()
+
+  let rounded-corners = (bottom: corner-radius)
+
+  if title != none {
+    parts.push(header())
+  }
+
+  if body != [] {
+    parts.push(board())
+  }
+
+  stack(..parts)
+}
+
+#let boxy(title, tags, body, supplement, number, accent-color) = target-choose(
+  html: () => boxy-html(title, tags, body, supplement, number, accent-color),
+  paged: boxy-paged(title, tags, body, supplement, number, accent-color),
+)

--- a/packages/preview/frame-it/1.1.2/src/styles/hint.typ
+++ b/packages/preview/frame-it/1.1.2/src/styles/hint.typ
@@ -1,0 +1,101 @@
+#import "../styling.typ" as styling
+#import "../utils/html.typ": css, span, div, hr, target-choose
+
+#let body-inset = 0.8em
+#let stroke-width = 0.13em
+#let line-width = 3.5pt
+
+#let header-suppl(title, tags, body, supplement, number) = {
+  if title == none {
+    none
+  } else {
+    if title != [] {
+      title = [~~#title~]
+    }
+
+    let tag-str = if tags != () {
+      [~(#tags.join(", "))~]
+    } else {
+      []
+    }
+    let supplement-str = context {
+      let header-color = text.fill.mix((text.fill.negate(), 20%))
+      text(header-color)[#supplement #number]
+    }
+    let head-body-separator = if body == [] [] else [:]
+    [~#supplement-str~*#(title)*_#(tag-str)_#head-body-separator~]
+  }
+}
+
+#let hint-html(title, tags, body, supplement, number, accent-color) = {
+  let has-body = body != []
+  let has-title = title not in ([], "", none)
+  let has-headers = int(has-title) + tags.len() > 0
+  let body-only = title == none
+  show: styling.dividers-as(
+    hr(
+      css(
+        background: accent-color,
+        height: stroke-width,
+        border: 0,
+        margin: (body-inset, -body-inset),
+      ),
+    ),
+  )
+  div(
+    css(
+      border-left: (line-width, "solid", accent-color),
+      padding: body-inset,
+    ),
+    {
+      header-suppl(title, tags, body, supplement, number)
+      body
+    },
+  )
+}
+
+#let hint-paged(title, tags, body, supplement, number, accent-color) = {
+  let stroke = stroke(
+    thickness: line-width,
+    paint: accent-color,
+    cap: "round",
+  )
+
+  let header = header-suppl(title, tags, body, supplement, number)
+  layout(((width,)) => {
+    let text = {
+      show: styling.dividers-as({
+        v(body-inset - 1em)
+        line(
+          length: 100% + body-inset,
+          start: (-body-inset, 0pt),
+          stroke: accent-color + stroke-width,
+        )
+        v(body-inset - 1em)
+      })
+
+      block(
+        width: width,
+        stroke: (left: stroke),
+        inset: (left: 0.7em, y: 0.7em),
+        align(left, header + body),
+      )
+    }
+
+    // At both ends of the line drawn by the border, we overlay lines which
+    // extend them by rounded ends. This looks better.
+    let length = 0.2em // Arbitrary; if too long, could extend into page margins
+    place(line(stroke: stroke, angle: 90deg, length: length))
+    text
+    place(line(stroke: stroke, angle: 90deg, length: -length))
+    // We prefer this setup to only using the block border because we want the
+    // rounded edges. We prefer it to one contiguous line because then the
+    // line would be missing if the hint breaks across two or more pages.
+    // See: https://github.com/marc-thieme/frame-it/issues/1
+  })
+}
+
+#let hint(title, tags, body, supplement, number, accent-color) = target-choose(
+  html: () => hint-html(title, tags, body, supplement, number, accent-color),
+  paged: hint-paged(title, tags, body, supplement, number, accent-color),
+)

--- a/packages/preview/frame-it/1.1.2/src/styles/thmbox.typ
+++ b/packages/preview/frame-it/1.1.2/src/styles/thmbox.typ
@@ -1,0 +1,140 @@
+#import "../styling.typ" as styling
+#import "../utils/html.typ": css, span, div, hr, target-choose
+
+#let line-width = 3pt
+#let body-inset = 1em
+#let text-color(accent-color) = (
+  accent-color.mix((text.fill.lighten(80%), 100%)).saturate(60%)
+)
+
+
+#let thmbox-html(title, tags, body, supplement, number, accent-color) = {
+  let has-body = body != []
+  let has-title = title not in ([], "", none)
+  let has-headers = int(has-title) + tags.len() > 0
+  let body-only = title == none
+  div(
+    css(
+      border-left: (line-width, "solid", accent-color),
+      padding: body-inset,
+    ),
+    {
+      if not body-only {
+        context div(
+          css(
+            ..(
+              if has-headers {
+                (
+                  display: "flex",
+                  justify-content: "space-between",
+                  align-items: center,
+                )
+              } else { (:) }
+            ),
+            color: text-color(accent-color),
+          ),
+          {
+            if has-title {
+              div(css(flex: "1.7 1 1", text-align: left), strong(title))
+            }
+            let is-first = true
+            for tag in tags {
+              div(css(flex: "1 1 1", text-align: center), tag)
+              is-first = false
+            }
+            div(
+              css(
+                flex: "1.7 1 1",
+                text-align: if has-headers { right } else { left },
+              ),
+              strong(supplement + " " + number),
+            )
+          },
+        )
+      }
+      show: styling.dividers-as(
+        hr(
+          css(
+            background: accent-color,
+            height: 0.18em,
+            border: 0,
+            margin: (0, 0, 0, -body-inset),
+          ),
+        ),
+      )
+      body
+    },
+  )
+}
+
+// Credits to https://github.com/s15n/typst-thmbox
+#let thmbox-paged(title, tags, body, supplement, number, accent-color) = {
+  let bar = stroke(paint: accent-color, thickness: line-width)
+
+  show: styling.dividers-as({
+    line(
+      length: 100% + 1em,
+      start: (-1em, 0pt),
+      stroke: accent-color + line-width * 0.8,
+    )
+    v(-0.2em)
+  })
+
+  block(
+    stroke: (
+      left: bar,
+    ),
+    inset: (
+      left: 1em,
+      top: 0.6em,
+      bottom: 0.6em,
+    ),
+    spacing: 1.2em,
+  )[
+    #set align(left)
+    // Title bar
+    #if title != none {
+      block(
+        above: 0em,
+        below: 1.2em,
+        context [
+          #set text(text-color(accent-color), weight: "bold")
+          #if title != [] {
+            title
+            h(3fr)
+            for tag in tags {
+              text(tag, weight: "regular")
+              h(1fr)
+            }
+            h(2fr)
+          }
+          #supplement #number
+        ],
+      )
+    }
+    // Body
+    #if body != [] {
+      block(
+        inset: (
+          right: 1em,
+        ),
+        spacing: 0em,
+        width: 100%,
+        body,
+      )
+    }
+  ]
+}
+
+#let thmbox(
+  title,
+  tags,
+  body,
+  supplement,
+  number,
+  accent-color,
+) = target-choose(
+  html: () => thmbox-html(title, tags, body, supplement, number, accent-color),
+  paged: thmbox-paged(title, tags, body, supplement, number, accent-color),
+)
+

--- a/packages/preview/frame-it/1.1.2/src/styling.typ
+++ b/packages/preview/frame-it/1.1.2/src/styling.typ
@@ -1,0 +1,15 @@
+/*
+ * This file mainly exports functionality needed when writing your own styling function.
+ */
+#let divide() = metadata("THIS-IS-METADATA-TO-BE-REPLACED-BY-CUSTOM-STYLING-PER-STYLING-FUNCTION")
+
+#let dividers-as(divider-element) = (
+  document => {
+    show metadata: it => if it == divide() {
+      divider-element
+    } else {
+      it
+    }
+    document
+  }
+)

--- a/packages/preview/frame-it/1.1.2/src/utils/encode.typ
+++ b/packages/preview/frame-it/1.1.2/src/utils/encode.typ
@@ -1,0 +1,13 @@
+#let _unique-frame-metadata-tag = "_THIS-IS-METADATA-USED-FOR-FRAME-IT-FRAMES"
+
+// Encode info as invisible metadata so when rendered in outline, only the title is seen
+#let encode-title-and-info(title, info) = (
+  metadata(_unique-frame-metadata-tag) + metadata(info) + title
+)
+#let retrieve-info-from-code(code) = code.children.at(1).value
+#let code-has-info-attached(code) = (
+  "children" in code.fields().keys()
+    and code.children.first().fields().at("value", default: "")
+      == _unique-frame-metadata-tag
+)
+

--- a/packages/preview/frame-it/1.1.2/src/utils/html.typ
+++ b/packages/preview/frame-it/1.1.2/src/utils/html.typ
@@ -1,0 +1,90 @@
+#let wants-html() = {
+  let html-frames = sys.inputs.at("html-frames", default: "false")
+  assert(
+    html-frames in ("true", "false"),
+    message: html-frames
+      + " is not valid for `--input html-frames={true|false}`",
+  )
+  (
+    html-frames == "true" and target() == "html"
+  )
+}
+
+#let target-choose(html: auto, paged: auto) = context {
+  assert(
+    html != auto and paged != auto,
+    message: "Please provide options for both `html` and `paged`.",
+  )
+  if wants-html() {
+    if type(html) == function { html() } else { html }
+  } else {
+    if type(paged) == function { paged() } else { paged }
+  }
+}
+
+#let elem(tag, body, ..attrs) = {
+  assert(attrs.pos() == (), message: "You can only provide named arguments.")
+  assert(
+    wants-html(),
+    message: "You can only use the `elem` function in an HTML context.",
+  )
+  let body-arg = if type(body) == function { body() } else { body }
+  html.elem(tag, attrs: attrs.named(), body-arg)
+}
+
+#let elem-ignore(tag, body, ..attrs) = {
+  assert(attrs.pos() == (), message: "You can only provide named arguments.")
+  if wants-html() {
+    let body-arg = if type(body) == function { body() } else { body }
+    html.elem(tag, attrs: attrs.named(), body-arg)
+  }
+}
+
+#let elem-ident(tag, body, ..attrs) = {
+  assert(attrs.pos() == (), message: "You can only provide named arguments.")
+  if wants-html() {
+    let body-arg = if type(body) == function { body() } else { body }
+    html.elem(tag, attrs: attrs.named(), body-arg)
+  } else {
+    body
+  }
+}
+
+#let span(style, body, ..attrs) = elem(
+  "span",
+  body,
+  style: style,
+  ..attrs,
+)
+#let div(style, body, ..attrs) = elem("div", body, style: style, ..attrs)
+#let hr(style, ..attrs) = elem("hr", style: style, ..attrs, none)
+
+#let css(..args) = {
+  assert(
+    args.pos().map(type) in ((), (dictionary,)),
+    message: "CSS function only accepts named arguments or one dictionary.",
+  )
+  let css-dict = if args.pos().len() == 1 {
+    assert(args.named() == (:))
+    args.pos().first()
+  } else {
+    args.named()
+  }
+
+  let parse(val) = if type(val) == color {
+    val.to-hex()
+  } else if type(val) != str {
+    repr(val)
+  } else {
+    val
+  }
+
+  for (key, value) in css-dict {
+    value = if type(value) == array {
+      value.map(parse).join(" ")
+    } else {
+      parse(value)
+    }
+    key + ": " + value + "; "
+  }
+}

--- a/packages/preview/frame-it/1.1.2/typst.toml
+++ b/packages/preview/frame-it/1.1.2/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "frame-it"
+version = "1.1.2"
+entrypoint = "src/lib.typ"
+authors = ["Marc Thieme"]
+repository = "https://github.com/marc-thieme/frame-it"
+license = "MIT"
+keywords = ["theorems", "frames", "custom", "style", "styling", "math", "papers", "notes", "lectures", "scientific writing", "html"]
+categories = ["components", "layout", "report"]
+description = "Beautiful, flexible, and integrated. Display custom frames for theorems, environments, and more. Attractive visuals with syntax that blends seamlessly into the source."


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->
### Description
[The package](https://github.com/marc-thieme/frame-it/tree/main) provides the possibility to create and customize "frames" to visually emphazize content. These frames can be used to become theorems, definitions, corollaries, etc. The style is completely customizable and even for the same style, different frame types like theorems, definitions, corollaries will still be recognizable and distinct.

Looking like this:
![image](https://github.com/user-attachments/assets/b8d49877-fb39-49b4-9d9b-e4e8d8fc5288)
### Changes
- Add inspection functions `lookup-frame-info` and `is-frame`
- Add suggestions for abbreviations to readme
- Fix compilation without feature flag html

In the last pullrequest ( #2035 ), I added html support to my packages.
Unfortnately, unbeknowst to me, this completely broke any compilation if `--features html` is not passed.
Therefore, this update is very important. At the moment, using my package breaks all compilation once one of my functions i used.

The reason for the breakage was that not only `html.elem` gives an error but also just using the `target()` function gives an error. To fix it, I added a further check for `--input html-frames=true` before ever calling `target()`.
Now, I also added a test case (in my [justfile](https://github.com/marc-thieme/frame-it/blob/main/justfile) ) which tests for compilation when the feature flag is not set.
<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [ ] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
