### PR TITLE
Stable hashes for archives

### DIFF
--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -308,6 +308,7 @@ fn build_archive(dir_path: &Path, manifest: &PackageManifest) -> anyhow::Result<
     let mut buf = vec![];
     let compressed = flate2::write::GzEncoder::new(&mut buf, flate2::Compression::default());
     let mut builder = tar::Builder::new(compressed);
+    builder.mode(tar::HeaderMode::Deterministic);
 
     let mut overrides = ignore::overrides::OverrideBuilder::new(dir_path);
     for exclusion in &manifest.package.exclude {

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -456,7 +456,7 @@ fn validate_typst_file(path: &Path, name: &str) -> anyhow::Result<()> {
         bail!("{name} is missing");
     }
 
-    if path.extension().map_or(true, |ext| ext != "typ") {
+    if path.extension().is_none_or(|ext| ext != "typ") {
         bail!("{name} must have a .typ extension");
     }
 


### PR DESCRIPTION
By default, the `tar` crate will copy attributes such as the modification time (`mtime`) from the filesystem. By setting the `HeaderMode` to `Deterministic` on the archive builder, a constant timestamp is used (stable values are also used for other files).

The modification time changed was stable on a local clone of the package repository, but it would change in CI because GitHub Actions would do a fresh clone on every run, and Git doesn't track the modification date.

This should guarantee that the archive we build are always the same if the actual contents of the files did not change.

Also fixes a clippy warning.

Fixes #2043