### PR TITLE
lilaq:0.2.0

### DIFF
--- a/packages/preview/lilaq/0.2.0/LICENSE
+++ b/packages/preview/lilaq/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/lilaq/0.2.0/README.md
+++ b/packages/preview/lilaq/0.2.0/README.md
@@ -1,0 +1,137 @@
+
+
+![social-card](https://github.com/user-attachments/assets/d1d9eab9-deb8-4cd2-9dd5-78c26418ca98)
+
+<!-- _Data visualization with [Typst](https://typst.app)_ -->
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Flilaq-project%2Flilaq%2Fv0.2.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/lilaq)
+[![Test Status](https://github.com/lilaq-project/lilaq/actions/workflows/run_tests.yml/badge.svg)](https://github.com/lilaq-project/lilaq/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/lilaq-project/lilaq/blob/main/LICENSE)
+[![Static Badge](https://img.shields.io/badge/documentation-736ad9)](https://lilaq.org/)
+
+_Lilaq is a powerful plotting library for [Typst](https://typst.app/)._
+
+
+----
+
+
+
+You can install the package by cloning the repository and importing Lilaq with
+```typ
+#import "@preview/lilaq:0.2.0" as lq
+```
+
+The documentation lives at https://lilaq.org. 
+
+## Demos
+Clicking on any demo image below will bring you to the respective page of the documentation that shows how to create this plot. 
+
+
+<table>
+<tr>
+    <th>Line plots</th>
+    <th>Scatter</th>
+    <th>Contour</th>
+</tr>
+<tr>
+<td>
+
+[![simple plot demo](https://github.com/user-attachments/assets/c71886e0-e0a9-499e-848f-18580b1da523)](https://lilaq.org/docs/quickstart#the-first-plot)
+
+</td>
+
+<td>
+
+[![scatter](https://github.com/user-attachments/assets/a1cf3019-b306-44a0-b28f-a2bb6fa522eb)](https://lilaq.org/docs/reference/scatter)
+
+</td>
+<td>
+
+[![contour](https://github.com/user-attachments/assets/b60d8bac-faf6-4465-bd78-0687f3912108)](https://lilaq.org/docs/reference/contour)
+
+</td>
+</tr>
+<tr>
+    <th>Boxplot</th>
+    <th>Quiver</th>
+    <th>Styled marks</th>
+</tr>
+<tr>
+<td>
+
+[![boxplot](https://github.com/user-attachments/assets/09b1251a-46b3-488f-aab8-451d950c044c)](https://lilaq.org/docs/reference/boxplot)
+
+</td>
+<td>
+
+[![quiver](https://github.com/user-attachments/assets/98f10346-2686-4c0c-8955-8a42465e65aa)](https://lilaq.org/docs/reference/quiver)
+
+</td>
+<td>
+
+[![marks](https://github.com/user-attachments/assets/26e9e478-1599-4ded-9e6d-7fe0193ae6b9)](https://lilaq.org/docs/examples/styled-marks)
+
+</td>
+</tr>
+</table>
+
+
+
+<table>
+<tr>
+    <th>Spectrum with secondary axis</th>
+    <th>Climograph with twin axis</th>
+</tr>
+<tr>
+<td>
+
+[![spectrum plot](https://github.com/user-attachments/assets/2fe1b3e3-14b3-43ba-b117-e20151203a9c)](https://lilaq.org/docs/examples/dual-axis)
+
+</td>
+<td>
+
+[![climograph](https://github.com/user-attachments/assets/4151bca1-67f5-41e3-aef3-b4d2e4c07eb9)](https://lilaq.org/docs/examples/climograph)
+
+</td>
+</tr>
+<tr>
+    <th>Bar plot with numbers</th>
+    <th>Multiple twin axes</th>
+</tr>
+<tr>
+<td>
+
+[![bars with numbers](https://github.com/user-attachments/assets/c7e0edda-0b16-472b-83e3-1d639fc9c2b1)](https://lilaq.org/docs/examples/bar-plot-with-numbers)
+
+</td>
+<td>
+
+[![twin axes](https://github.com/user-attachments/assets/b2706289-24a8-4e6d-bde0-119f13552855)](https://lilaq.org/docs/tutorials/axis#independent-axes-twin-axes)
+
+</td>
+</tr>
+</table>
+
+
+
+
+<table>
+<tr>
+    <th>Plot within a plot</th>
+    <th>Koch snowflake fractal</th>
+</tr>
+<tr>
+<td>
+
+[![weierstrass function](https://github.com/user-attachments/assets/0181795f-9b5d-4552-9be3-c85ddcdba83a)](https://lilaq.org/docs/examples/plot-within-a-plot)
+
+</td>
+<td>
+
+[![koch snowflake fractal](https://github.com/user-attachments/assets/14e5a26e-fd13-41ff-be73-817730e77dbf)](https://lilaq.org/docs/examples/koch-snowflake)
+
+</td>
+</tr>
+</table>
+
+

--- a/packages/preview/lilaq/0.2.0/src/algorithm/boxplot.typ
+++ b/packages/preview/lilaq/0.2.0/src/algorithm/boxplot.typ
@@ -1,0 +1,41 @@
+#import "../math.typ": percentile
+
+
+
+#assert.eq(percentile((1,2,3), 50%), 2)
+#assert.eq(percentile((1,2,3), 25%), 1.5)
+#assert.eq(percentile((1,2,3), 0%), 1)
+#assert.eq(percentile((1,2,3), 100%), 3)
+
+
+#let boxplot-statistics(x, whiskers: 1.5) = {
+  x = x.sorted()
+  let stat = (
+    mean: x.sum() / x.len(),
+    median: percentile(x, 50%),
+    q1: percentile(x, 25%),
+    q3: percentile(x, 75%),
+    min: x.at(0),
+    max: x.at(-1),
+  )
+  let iqr = stat.q3 - stat.q1
+  let whisker-low = stat.q1 - iqr * whiskers
+  let whisker-high = stat.q3 + iqr * whiskers
+
+  let wlo = x.filter(x => x >= whisker-low)
+  let whi = x.filter(x => x <= whisker-high)
+  whisker-low = calc.min(stat.q1, wlo.at(0, default: stat.q1))
+  whisker-high = calc.max(stat.q3, whi.at(-1, default: stat.q1))
+  
+  
+  stat.inter-quartile-range = iqr
+  stat.whisker-high = whisker-high
+  stat.whisker-low = whisker-low
+
+  stat.outliers = x.filter(x => x < whisker-low or x > whisker-high)
+
+  stat
+}
+
+#boxplot-statistics((-12,1,100,1,1,1,2,3,4,5,6))
+#boxplot-statistics((range(9)) + (40,))

--- a/packages/preview/lilaq/0.2.0/src/algorithm/contour.typ
+++ b/packages/preview/lilaq/0.2.0/src/algorithm/contour.typ
@@ -1,0 +1,818 @@
+#import "../math.typ": vec
+
+/// Computes the orientation of a polygon, returns `left` if the polygon is 
+/// lefthanded (counter-clockwise) and `right` if it is righthanded (clockwise). 
+#let compute-polygon-orientation(..arr) = {
+  arr = arr.pos()
+  let r = arr.zip(arr.slice(1))
+    .map(((A, B)) => (A.at(0) - B.at(0)) * (A.at(1) + B.at(1)))
+  let s = r.sum(default: 0)
+  if s < -0.0000000000001 { return right } 
+  else if s > 0.000000000001 { return left }
+}
+// #assert.eq(compute-polygon-orientation( (5, −5),
+//         (−5, −5),
+//         (−1.6666666666666665, −5),
+//         (1.666666666666667, −5),
+//         (5, −5),), none)
+#assert.eq(compute-polygon-orientation((0,0), (0,1), (1,1), (1,0)), right)
+#assert.eq(compute-polygon-orientation((0,0), (1,0), (1,1), (0,1)), left)
+#assert.eq(compute-polygon-orientation((0,0), (1,0)), none)
+#assert.eq(compute-polygon-orientation((0,0), (0,1)), none)
+
+
+      
+/// Retrieves the center coordinate of a hyperbolic paraboloid (HP) surface
+/// given by the parameter values u=v=0.5. 
+/// p1 ·-----· p2
+///    |  · ←|
+/// p4 ·-----· p3
+#let get-hp-center-z(z1, z2, z3, z4) = {
+  return 0.25 * (z1 + z2 + z3 + z4)
+}
+
+
+/// Given two points $p_1$, $p_2$ in 3D space, find whether the line between
+/// theses points intersects a plane $z=z_0$ and at which coordinates $(x,y)$. 
+/// Returns `none` if the segment does not intersect the plane between $p_1$
+/// and $p_2$.
+#let intersect-z-plane(p1, p2, z0) = {
+  let (dx, dy, dz) = vec.subtract(p2, p1)
+  if dz == 0 /*and z0 != p1.at(2)*/ { return none }
+  let ratio = (z0 - p1.at(2)) / dz
+  if ratio < 0 or ratio > 1 { return none }
+  return (p1.at(0) + ratio*dx, p1.at(1) + ratio*dy)
+}
+
+#assert.eq(intersect-z-plane((0,0,0), (2,0,1), .2), (.4, 0))
+#assert.eq(intersect-z-plane((0,0,0), (2,0,1), 1), (2, 0))
+#assert.eq(intersect-z-plane((0,0,0), (2,0,1), 1.1), none)
+#assert.eq(intersect-z-plane((0,0,0), (2,0,1), -.01), none)
+
+
+/// Given a list of (oriented) segments as pairs of points, returns
+/// a list of polygons constructed from connected components in the set of 
+/// segments. The orientation plays a role. 
+#let group-segments(segments) = {
+  let cycles = ()
+  while segments.len() > 0 {
+    let segment = segments.pop()
+    let k = segments
+    let (p1, p2) = segment
+    let cycle = (p1, p2)
+    let start = segment
+    while true {
+      let pos = segments.position(x => x.first() == p2)
+      if pos != none {
+        start = segments.remove(pos)
+        p2 = start.last()
+        cycle.push(p2)
+      } else {
+        break
+      }
+    }
+    cycle = cycle.rev()
+    p1 = cycle.last()
+    while true {
+      let pos = segments.position(x => x.last() == p1)
+      if pos != none {
+        p1 = segments.remove(pos).first()
+        cycle.push(p1)
+      } else {
+        break
+      }
+    }
+    cycles.push(cycle)
+  }
+  return cycles
+}
+
+
+#let close-path-at-boundaries(path, boundaries: (xmin: 0, xmax: 1, ymin: 0, ymax: 1)) = {
+  let corners = (
+    (boundaries.xmax, boundaries.ymax), 
+    (boundaries.xmax, boundaries.ymin), 
+    (boundaries.xmin, boundaries.ymin), 
+    (boundaries.xmin, boundaries.ymax)
+  )
+  if path.first() == path.last() { return path.rev() }
+  let get-case(point) = {
+    let case = 0
+    
+  }
+  let get-edge(point) = {
+    if point.at(1) == boundaries.ymax { return 0 } // top
+    if point.at(1) == boundaries.ymin { return 2 } // bottom
+    if point.at(0) == boundaries.xmax { return 1 } // right
+    if point.at(0) == boundaries.xmin { return 3 } // left
+    let k = point
+    return none
+  }
+  let edge1 = get-edge(path.last())
+  let edge2 = get-edge(path.first())
+  if none in (edge1, edge2) { return none }
+
+  
+  let edges = (edge1, edge2)
+
+  let rrange(a, b) = {
+    if a < b { a+= 4}
+    let r = calc.rem(1 - 3, 4)
+    
+    if a <= b { range(a, b) }
+    else { 
+      return range(b, a).rev() 
+    } 
+  }
+  let f = rrange(edge1, edge2)
+  if calc.rem-euclid(edge1 - edge2, 4) > 2 {
+    f = rrange(edge2, edge1).rev()
+  } else {
+    f = rrange(edge1, edge2)
+  }
+  for i in f {
+    path.push(corners.at(calc.rem(i, 4)))
+  }
+  path.push(path.first())
+  return path.rev()
+}
+
+
+#let mod-distance(a, b, div) = {
+  let diff =  b - a
+  calc.abs(calc.rem(diff, div))
+}
+#assert.eq(mod-distance(0, 1, 4), 1)
+#assert.eq(mod-distance(1, 0, 4), 1)
+#assert.eq(mod-distance(1, 2, 4), 1)
+#assert.eq(mod-distance(0, 2, 4), 2)
+// #assert.eq(mod-distance(3, 0, 4), 1)
+#assert.eq(mod-distance(2, 2, 4), 0)
+#assert.eq(mod-distance(0, 2, 4), 2)
+#assert.eq(mod-distance(2, 0, 4), 2)
+
+#assert.eq(mod-distance(0, 5, 4), 1)
+
+#let close-path-at-boundaries(path, boundaries: (xmin: 0, xmax: 1, ymin: 0, ymax: 1)) = {
+  let corners = (
+    (boundaries.xmax, boundaries.ymax), 
+    (boundaries.xmax, boundaries.ymin), 
+    (boundaries.xmin, boundaries.ymin), 
+    (boundaries.xmin, boundaries.ymax)
+  )
+  if path.len() == 0 or path.first() == path.last() { return path.rev() }
+  let get-edge(point) = {
+    if point.at(1) == boundaries.ymax { return 0 } // top
+    if point.at(1) == boundaries.ymin { return 2 } // bottom
+    if point.at(0) == boundaries.xmax { return 1 } // right
+    if point.at(0) == boundaries.xmin { return 3 } // left
+    return none
+  }
+  
+  let edge1 = get-edge(path.last())
+  let edge2 = get-edge(path.first())
+  if none in (edge1, edge2) { return none }
+
+  
+  if edge1 == edge2 {
+    path.push(path.first())
+    return path.rev()
+  } else if calc.rem(edge1 + 2, 4) == edge2 { // opposite edges
+    if edge1 in (0,2) { // top/bottom
+      let mid-x = 0.5 * (boundaries.xmax - boundaries.xmin)
+      // if path.last().at(0) < mid-x
+      let vertices = (corners.at(0), corners.at(1))
+      if edge1 == 2 { vertices = vertices.rev() }
+      path += vertices
+    } else { // left/right
+      let vertices = (corners.at(3), corners.at(0))
+      // let vertices = (corners.at(2), corners.at(1))
+      if edge1 == 1 { vertices = vertices.rev() }
+      path += vertices
+      if path.last().last() < -3 {
+        let k = path
+      }
+    }
+  } else {
+    if calc.rem(edge1 + 1, 4) == edge2 {
+      path.push(corners.at(edge1))
+    } else if calc.rem(edge2 + 1, 4) == edge1 {
+      path.push(corners.at(edge2))
+    } else { assert(false) }
+  }
+  path.push(path.first())
+  return path.rev()
+  
+  let edges = (edge1, edge2)
+
+  let rrange(a, b) = {
+    if a < b { a+= 4}
+    let r = calc.rem(1 - 3, 4)
+    
+    if a <= b { range(a, b) }
+    else { 
+      return range(b, a).rev() 
+    } 
+  }
+  let f = rrange(edge1, edge2)
+  if calc.rem-euclid(edge1 - edge2, 4) > 2 {
+    f = rrange(edge2, edge1).rev()
+  } else {
+    f = rrange(edge1, edge2)
+  }
+  for i in f {
+    path.push(corners.at(calc.rem(i, 4)))
+  }
+  path.push(path.first())
+  return path.rev()
+}
+
+
+#let test-close-boundaries(curve, result) = {
+  let test-boundaries = (xmin: 0, xmax: 1, ymin: 0, ymax: 1)
+  let closed-curve = close-path-at-boundaries(curve, boundaries: test-boundaries)
+  if result != none {
+    assert.eq(closed-curve, result.rev())
+  }
+  box(width: 1cm, height: 1cm, fill: luma(90%), {
+    let transform(p) = (p.at(0)*1cm, 1cm - p.at(1)*1cm)
+    let vertices = closed-curve.map(transform)
+    place(std.curve(
+      std.curve.move(vertices.first()),
+      ..vertices.slice(1).map(std.curve.line),
+    )) 
+  })
+}
+// #test-close-boundaries((), ())
+#test-close-boundaries(((.5,0), (1,.5)),
+  ((.5, 0), (1, .5), (1, 0), (.5, 0))
+)
+#test-close-boundaries(((1,.5), (.5,0)),
+  ((1, .5), (.5, 0), (1, 0), (1, .5))
+)
+#test-close-boundaries(((1,.5), (.5,1)),
+  ((1, .5), (.5, 1), (1, 1), (1, .5))
+)
+#test-close-boundaries(((.5,1), (1,.5)),
+  ((.5, 1), (1, .5), (1, 1), (.5, 1))
+)
+#test-close-boundaries(((0,.5), (.5,1)),
+  ((0, .5), (.5, 1), (0, 1), (0, .5))
+)
+#test-close-boundaries(((.5,1), (0,.5)),
+  ((.5, 1), (0, .5), (0, 1), (.5, 1))
+)
+#test-close-boundaries(((0,.5), (.5,0)),
+  ((0, .5), (.5, 0), (0, 0), (0, .5))
+)
+#test-close-boundaries(((.5,0), (0,.5)),
+  ((.5, 0), (0, .5), (0, 0), (.5, 0))
+)
+
+#test-close-boundaries(((.2,0), (.5, .5), (.8, 0)),
+  ((.2,0), (.5, .5), (.8, 0), (.2, 0))
+)
+#test-close-boundaries(((.2, 1), (.5, .5), (.8, 1)),
+  ((.2, 1), (.5, .5), (.8, 1), (.2, 1))
+)
+#test-close-boundaries(((0, .2), (.5, .5), (0, .8)),
+  ((0, .2), (.5, .5), (0, .8), (0, .2))
+)
+#test-close-boundaries(((1, .2), (.5, .5), (1, .8)),
+  ((1, .2), (.5, .5), (1, .8), (1, .2))
+)
+
+#test-close-boundaries(((1, 0), (0, 1)),
+  none
+)
+#test-close-boundaries(((0, 1), (1, 0)),
+  none
+)
+#test-close-boundaries(((1, 1), (0, 0)),
+  none
+)
+#test-close-boundaries(((0, 0), (1, 1)),
+  none
+)
+
+
+#test-close-boundaries(((1, 0), (0, .5)),
+  none
+)
+#test-close-boundaries(((1, 0), (.5, 1)),
+  none
+)
+#test-close-boundaries(((0, .2), (1, .3)),
+  none
+)
+#test-close-boundaries(((0, .7), (1, .8)),
+  none
+)
+
+#test-close-boundaries(((1, 0), (1, 1)),  none)
+#test-close-boundaries(((1, 1), (1, 0)),  none)
+
+
+
+#let generate-contour(x, y, z, level, z-range: 1) = {
+  let get-z(i, j) = { z.at(i).at(j) }
+  let get-p(i, j) = { (x.at(i), y.at(j), z.at(i).at(j)) }
+
+  let blocks = ()
+  for i in range(x.len() - 1) {
+    for j in range(y.len() - 1) {
+      let zs = (get-z(i, j), get-z(i+1, j), get-z(i, j+1), get-z(i+1,j+1))
+      if calc.min(..zs) <= level and calc.max(..zs) >= level {
+        blocks.push((i, j))
+      }
+    }
+  } 
+
+  let segments = ()
+  while blocks.len() > 0 {
+    let (i, j) = blocks.pop()
+    /*
+    0: → (0,0) -> (1,0)
+    1: ↓ (1,0) -> (1,1)
+    2: ← (1,1) -> (0,1)
+    3: ↑ (0,1) -> (0,0)
+    */
+    let qqqs = ((0,0), (1,0), (1,1), (0,1), (0,0))
+    let intersections = ()
+    for edge in range(4) {
+      let (Ax, Ay) = qqqs.at(edge)
+      let (Bx, By) = qqqs.at(edge + 1)
+      let p1 = get-p(Ax + i, Ay + j)
+      let p2 = get-p(Bx + i, By + j)
+      if edge < 2 { (p1, p2) = (p2, p1) }
+      let interpolation = intersect-z-plane(p1, p2, level)
+      if interpolation == p2.slice(0,2) and edge > 2 {
+        // edge += 1
+      }
+      if interpolation != none {
+        intersections.push((edge, interpolation))
+      }
+    }
+    intersections = intersections.dedup(key: x => x.at(1))
+    let sort-intersection-tuple(i1, i2) = {
+      let corner = qqqs.at(i2.at(0))
+      if corner == i2.at(1) {
+        // (i1, i2) = (i2, i1)
+      }
+      if get-z(..vec-add(corner, (i,j))) < level {
+        (i1, i2) = (i2, i1)
+      }
+      return (i1.at(1), i2.at(1))
+    }
+    
+    // assert(intersections.len() in (2,4))
+    if intersections.len() == 2 {
+      segments.push(sort-intersection-tuple(..intersections))
+    } else if intersections.len() == 4 {
+      let z0 = get-hp-center-z(get-z(i, j), get-z(i+1, j), get-z(i, j+1), get-z(i+1,j+1))
+      let (a,b,c,d) = intersections
+      if calc.abs(z0 - level) < 1e-6* z-range {
+        let center = (0.5*(x.at(i) + x.at(i+1)), 0.5*(y.at(j) + y.at(j+1)))
+        let (c1, c2) = (center, center)
+        c1.at(0) += 1e-30
+        c2.at(0) -= 1e-30
+        c1.at(0) += .2
+        c2.at(0) -= .2
+        if get-z(i, j) > level{ (c1, c2) = (c2, c1)}
+        let seg1 = sort-intersection-tuple(a, d)
+        let seg2 = sort-intersection-tuple(b, c)
+        segments.push((seg1.at(0), c1))
+        segments.push((seg2.at(0), c2))
+        
+        if get-z(i, j) > level {
+          (c1, c2) = (c2, c1)
+        }
+        segments.push((c2, seg1.at(1)))
+        segments.push((c1, seg2.at(1)))
+        // segments.push((a,b,c,d))
+      } else if z0 > level {
+        if get-z(i, j) > level {
+          (b, d) = (d, b)
+        }
+        segments.push(sort-intersection-tuple(a,d))
+        segments.push(sort-intersection-tuple(c,b))
+        // segments.push((a,d,b,c))
+      } else if level > z0 {
+        if get-z(i, j) > level {
+          (d, b) = (b, d)
+        }
+        segments.push(sort-intersection-tuple(a,b))
+        segments.push(sort-intersection-tuple(c,d))
+        // segments.push((a,c,b,d))
+      } 
+    } else {
+      // segments.push(sort-intersection-tuple(..intersections.slice(0,2)))
+      // let o = (i,j)
+      // assert(false)
+    }
+  }
+  let paths = group-segments(segments)
+  return paths
+}
+
+#let lshift(a) = 2*a
+
+#let bw-or(a,b) = {
+    let c = 0;
+    let n = 1;
+    while ((a > 0) or (b > 0)) {
+      if ((calc.rem(a, 2) == 1) or (calc.rem(b, 2) == 1)) {
+          c += n;    
+      }
+      a = calc.quo(a, 2);
+      b = calc.quo(b, 2);
+      n = n * 2;
+    }
+    return c;
+}
+
+#assert.eq(bw-or(0b00, 0b11), 0b11)
+#assert.eq(bw-or(0b010001, 0b110100), 0b110101)
+
+#let compute-case(corners-z, level) = {
+  let case = 0
+  for z in corners-z {
+    case = bw-or(lshift(case), if z > level {1} else {0})
+  }
+  if case == 0 {
+    if corners-z.filter(x => x == level).len() == 2 {
+      for z in corners-z {
+        case = bw-or(lshift(case), if z >= level {1} else {0})
+      }
+    }
+  }
+  return case
+}
+
+#assert.eq(compute-case((-1,-1,-1,-1), 0), 0)
+#assert.eq(compute-case((1,1,1,1), 0), 15)
+#assert.eq(compute-case((-1,-1,-1,1), 0), 1)
+#assert.eq(compute-case((-1,-1,1,-1), 0), 2)
+#assert.eq(compute-case((-1,-1,1,1), 0), 3)
+#assert.eq(compute-case((-1,1,-1,-1), 0), 4)
+
+#assert.eq(compute-case((-1,-1,-1,1), 0), 1)
+#assert.eq(compute-case((0,0,-1,-1), 0), 12)
+
+
+
+#let generate-contour(x, y, z, level, z-range: 1) = {
+  let z-eps = 1e-6 * z-range
+  let x-eps = 1e-17 * (x.last() - x.first())
+  
+  let get-z(i, j) = { z.at(j).at(i) }
+  let get-p(i, j) = { (x.at(i), y.at(j), z.at(j).at(i)) }
+
+  let blocks = ()
+  for i in range(x.len() - 1) {
+    for j in range(y.len() - 1) {
+      let zs = (get-z(i, j), get-z(i+1, j), get-z(i, j+1), get-z(i+1,j+1))
+      if calc.min(..zs) <= level and calc.max(..zs) >= level {
+        blocks.push((i, j))
+      }
+    }
+  } 
+
+  let segments = ()
+  while blocks.len() > 0 {
+    let (i, j) = blocks.pop()
+    let corners = ((0,0), (1,0), (1,1), (0,1))
+    let case = compute-case(corners.map(corner => get-p(..vec.add((i, j), corner)).at(2)), level)
+    let qqqs = ((0,0), (1,0), (1,1), (0,1), (0,0))
+
+    let get-edge-intersection(edge) = {
+      let (Ax, Ay) = qqqs.at(edge)
+      let (Bx, By) = qqqs.at(edge + 1)
+      let p1 = get-p(Ax + i, Ay + j)
+      let p2 = get-p(Bx + i, By + j)
+      if edge < 2 { (p1, p2) = (p2, p1) }
+      
+      let interpolation = intersect-z-plane(p1, p2, level)
+      interpolation
+    }
+    let get-line-segment(edge1, edge2) = ((edge2, edge1).map(get-edge-intersection),)
+    
+    let z0 = get-hp-center-z(get-z(i, j), get-z(i+1, j), get-z(i, j+1), get-z(i+1,j+1))
+
+    let cases = (
+      () => (),
+      () => get-line-segment(3,2),
+      () => get-line-segment(2,1),
+      () => get-line-segment(3,1),
+      () => get-line-segment(1,0),
+      () => {
+        if calc.abs(z0 - level) < z-eps {
+          let (i0,i1,i2,i3) = (0,1,2,3).map(get-edge-intersection)
+          let center = (i0.at(0), i1.at(1))
+          let (c1, c2) = (center, center)
+          c1.at(0) += x-eps
+          c2.at(0) -= x-eps
+          
+          ((i0, c2), (c2, i3), (i2, c1), (c1, i1))
+        } else if z0 > level {
+          get-line-segment(3,0) + get-line-segment(1,2)
+        } else if z0 < level {
+          get-line-segment(1,0) + get-line-segment(3,2)
+        }
+      },
+      () => get-line-segment(2,0),
+      () => get-line-segment(3,0),
+      () => get-line-segment(0,3),
+      () => get-line-segment(0,2),
+      () => {
+        if calc.abs(z0 - level) < z-eps {
+          let (i0,i1,i2,i3) = (0,1,2,3).map(get-edge-intersection)
+          let center = (i0.at(0), i1.at(1))
+          let (c1, c2) = (center, center)
+          c1.at(0) -= x-eps
+          c2.at(0) += x-eps
+          
+          ((i1, c2), (c2, i0), (i3, c1), (c1, i2))
+        } else if z0 > level {
+          get-line-segment(0,1) + get-line-segment(2,3)
+        } else if z0 < level {
+          get-line-segment(0,3) + get-line-segment(2,1)
+        }
+      },
+      () => get-line-segment(0,1),
+      () => get-line-segment(1,3),
+      () => get-line-segment(1,2),
+      () => get-line-segment(2,3),
+      () => (),
+    )
+    let k = (i,j,case, (get-z(i, j), get-z(i+1, j), get-z(i, j+1), get-z(i+1,j+1)))
+    segments += cases.at(case)()
+  }
+  let paths = group-segments(segments.dedup())
+  return paths
+}
+
+#let generate-contours(x, y, z, levels, z-range: 1) = {
+  return levels.map(level => generate-contour(x, y, z, level, z-range: z-range))
+}
+        
+#let gen-contour-1rect = generate-contour.with((0,1), (0,1))
+
+
+#let test-contour-case(x: (0,1), y: (0,1), z, level, answer) = {
+  let z-flat = z.flatten()
+  let (min, max) = (calc.min(..z-flat), calc.max(..z-flat))
+  if min == max {min -=1 }
+  let contour = generate-contour(x, y, z, level)
+  assert.eq(contour, answer)
+  box(width: 2cm, height: 2cm, stroke: .5pt,
+    {
+      let sq = box.with(width: 1cm, height: 1cm)
+      let cmap = color.map.icefire
+      let cmap = (blue, yellow, red)
+      let grad = gradient.linear(..cmap)
+      let get-clr(z) = grad.sample((z - min)/(max - min)*100%)
+      for i in range(x.len()) {
+        for j in range(y.len()) {
+          place(
+            dx: i * 1cm, dy: 1cm - j*1cm,
+            sq(fill: get-clr(z.at(j).at(i)))
+          ) 
+        }
+      }
+      let transform(p) = (p.at(0)*2cm, 2cm - p.at(1)*2cm)
+      contour.map(contour-path => {
+        contour-path = contour-path.map(transform)
+        place(curve(
+          curve.move(contour-path.first()),
+          ..contour-path.slice(1).map(curve.line),
+          stroke: get-clr(level).lighten(20%) + 2pt,
+        )) + place(
+        dx: (contour-path.first()).at(0), 
+        dy: (contour-path.first()).at(1),
+        place(center + horizon, circle(fill: black, radius: 1pt))
+      )}).join()
+    }
+  )
+}
+
+#test-contour-case(
+  x: (-1,0,1), 
+  y: (-5,5), 
+  // ((-1,-1),(0,0),(1,1)), 
+  ((-1,0,1),(-1,0,1)), 
+  0, 
+  ((((0, 5), (0, -5)), ))
+),
+
+#set page(height: auto, width: auto, margin: 1cm)
+
+The dot indicates the start of a curve. A curve is to be oriented such that the _higher_ profile lies _left_ of it. 
+
+
+== No intersection
+
+#set table(align: center)
+
+#table(columns: 3,
+  [Right on], [all below], [all above],
+  test-contour-case(((0,0),(0,0)), 0, ()),
+  test-contour-case(((20,-20),(-20,10)), 50, ()),
+  test-contour-case(((20,-20),(-20,10)), -50, ()),
+)
+
+
+== Saddles
+
+// HP saddle directly through center
+#table(columns: 6, 
+  [Right on], [slightly above], [slightly below],
+  [Right on], [slightly above], [slightly below],
+  test-contour-case(((-1,1),(1,-1)), 0, 
+    (((1, .5), (.5,.5), (.5,0)), ((0,.5), (.5,.5), (.5, 1)))
+  ),
+  test-contour-case(((-1,1),(1,-1)), 0.5, 
+    ((((0,.75), (.25, 1)), ((1,.25), (.75,0))))
+  ),
+  test-contour-case(((-1,1),(1,-1)), -0.5,
+    ((((1,.75), (.75,1)), ((0,.25), (.25, 0))))
+  ),
+  test-contour-case(((1,-1),(-1,1)), 0, 
+    (((.5,1), (.5,.5), (1, .5)), ((.5, 0),(.5,.5), (0,.5)))
+  ),
+  test-contour-case(((1,-1),(-1,1)), 0.5, 
+    ((((.75,1), (1,.75)), ((.25,0), (0,.25))))
+  ),
+  test-contour-case(((1,-1),(-1,1)), -0.5,
+    ((((.25,1), (0,.75)), ((.75,0), (1,.25))))
+  ),
+  [Offset y], [Offset x], [skew below], [], [], [],
+  
+  test-contour-case(
+    ((-3,3),(1,-1)), 
+    0,
+    (((1, .75), (.5,.75), (.5,0)), 
+    ((0,.75), (.5,.75), (.5, 1)))
+  ),
+  test-contour-case(
+    ((-3,1),(3,-1)), 0, 
+    (((1, .5), (.75,.5), (.75,0)), ((0,.5), (.75,.5), (.75, 1)))
+  ),
+  test-contour-case(((-3,3),(3,-1)), 0, 
+    (((1, .75), (.75,1)), ((0,.5), (.5, 0)))
+  ),
+)
+
+
+== Cross to opposite side
+
+#table(columns: 4, 
+  [Left to right], [Right to left], [Top to bottom], [Bottom to top],
+  // o  o
+  // ---→
+  // x  x
+  test-contour-case(((1,0),(2, 6)), 1.5, 
+    ((((0,.5), (1, .25)), ))
+  ),
+  // x  x
+  // ←---
+  // o  o
+  test-contour-case(((2,6),(1, 0)), 1.5, 
+    ((((1,.75), (0, .5)), ))
+  ),
+  // x | o
+  //   |
+  // x ↓ o
+  test-contour-case(((1,2),(0, 6)), 1.5, 
+    ((((.25,1), (.5, 0)), ))
+  ),
+  // o ↑ x
+  //   |
+  // o | x
+  test-contour-case(((2,0),(6,1)), 1.5, 
+    ((((.25,0), (.9,1)), ))
+  ),
+)
+
+// let mesh_ = create-mesh(linspace(-5, 5, num: 3), linspace(-5, 5, num: 2), func)
+
+== Corners
+
+#table(columns: 4,
+  [Bottom to left], [Left to bottom],[Right to bottom],[Bottom to right],
+  // x   x
+  // ←-|
+  // o | x  (o above level)
+  test-contour-case(((6,2),(0,0)), 3, 
+    ((((.75,0), (0,.5)), ))
+  ),
+  // o   o
+  // --|
+  // x ↓ o  (x below level)
+  test-contour-case(((-4,2),(0,0)), -1, 
+    ((((0,.75), (.5,0)), ))
+  ),
+  // x   x
+  //   |--
+  // x ↓ o
+  test-contour-case(((-4,4),(-1,-1)), 0, 
+    ((((1,.8), (.5,0)), ))
+  ),
+  // o   o
+  //   |-→
+  // o | x
+  test-contour-case(((4,-4),(1,1)), 0, 
+    ((((.5,0), (1,.8)), ))
+  ),
+  [Top to right], [Right to top],[Left to top],[Top to left],
+  
+  // x | o
+  //   |-→
+  // x   x
+  test-contour-case(((-4,-4),(-4,4)), 0, 
+    ((((.5,1), (1,.5)), ))
+  ),
+  // o ↑ x
+  //   |--
+  // o   o
+  test-contour-case(((4,4),(4,-4)), 0, 
+    ((((1,.5), (.5,1)), ))
+  ),
+  // o ↑ x
+  // --|
+  // x   x
+  test-contour-case(((-4,-4),(4,-4)), 0, 
+    ((((0,.5), (.5,1)), ))
+  ),
+  // x | o
+  // ←-|
+  // o   o
+  test-contour-case(((4,4),(-4,4)), 0, 
+    ((((.5,1), (0,.5)), ))
+  ),
+
+)
+
+
+== Edge cases
+
+#table(columns: 4,
+  [Top below], [Top above], [Bottom below], [Bottom above],
+  // ·←--·
+  // 
+  // o   o
+  test-contour-case(((3,4),(0,0)), 0, 
+    ((((1,1), (0,1)), ))
+  ),
+  
+  // ·--→·
+  // 
+  // x   x
+  test-contour-case(((-3,-4),(0,0)), 0, 
+    ((((0,1), (1,1)), ))
+  ),
+  
+  // o   o
+  // 
+  // ·--→·
+  test-contour-case(((0,0),(3,4)), 0, 
+    ((((0,0), (1,0)), ))
+  ),
+  
+  // x   x
+  // 
+  // ·←--·
+  test-contour-case(((0,0),(-3,-4)), 0, 
+    ((((1,0), (0,0)), ))
+  ),
+  
+  [Left below], [Left above], [Top below], [Top above],
+  // ·   o
+  // ↓
+  // ·   o
+  test-contour-case(((0,3),(0,4)), 0, 
+    ((((0,1), (0,0)), ))
+  ),
+  
+  // ·   x
+  // ↑
+  // ·   x
+  test-contour-case(((0,-3),(0,-4)), 0, 
+    ((((0,0), (0,1)), ))
+  ),
+  
+  // o   ·
+  //     ↑
+  // o   ·
+  test-contour-case(((3,0),(4,0)), 0, 
+    ((((1,0), (1,1)), ))
+  ),
+  
+  // x   ·
+  //     ↓
+  // x   ·
+  test-contour-case(((-3,0),(-4,0)), 0, 
+    ((((1,1), (1,0)), ))
+  ),
+)
+

--- a/packages/preview/lilaq/0.2.0/src/algorithm/gaussian-kde.typ
+++ b/packages/preview/lilaq/0.2.0/src/algorithm/gaussian-kde.typ
@@ -1,0 +1,9 @@
+
+
+#let gaussian-kde(x, bw-method) = {
+  if type(bw-method) in (int, float) {
+    bw-method = (x => bw-method)
+  }
+  let factor = bw-method()
+  let dim = x.len()
+}

--- a/packages/preview/lilaq/0.2.0/src/algorithm/interpolate.typ
+++ b/packages/preview/lilaq/0.2.0/src/algorithm/interpolate.typ
@@ -1,0 +1,36 @@
+
+
+/// Computes the value at a rational index into an array by performing linear 
+/// interpolation. If the index is an integer, the exact value at the index is 
+/// returned. 
+///
+/// -> int | float
+#let linear(
+  
+  /// Data values to interpolate from. 
+  /// -> array
+  values, 
+
+  /// Rational index into the array. 
+  /// -> int | float
+  index
+  
+) = {
+  let n = values.len()
+  assert(n > 0, message: "An array with at least one element is required for interpolation")
+  assert(0 <= index and index <= n - 1, message: "Index " + str(index) + " out of range for interpolation with array of length " + str(n))
+  if index < 0 { return values.first() }
+  if index >= n - 1 { return values.last() }
+  let lower = calc.floor(index)
+  let upper = lower + 1
+  let t = calc.fract(index)
+  values.at(lower) * (1 - t) + values.at(upper) * t
+}
+
+
+
+#assert.eq(linear((1,2,8), 0), 1)
+#assert.eq(linear((1,2,8), 0.5), 1.5)
+#assert.eq(linear((1,2,8), 1.5), 5)
+#assert.eq(linear((1,2,8), 1), 2)
+#assert.eq(linear((1,2,8), 2), 8)

--- a/packages/preview/lilaq/0.2.0/src/algorithm/ticking.typ
+++ b/packages/preview/lilaq/0.2.0/src/algorithm/ticking.typ
@@ -1,0 +1,606 @@
+#import "../math.typ": *
+#import "../assertations.typ"
+#import "@preview/zero:0.3.3"
+
+
+/// Estimates the number of significant digits from an array of values,
+/// i.e., the number of decimals places 
+#let estimate-significant-digits(values, threshold: 3) = {
+  let range = calc.max(..values) - calc.min(..values)
+  if range == 0 { range = 1 }
+  let range-exponent = calc.floor(calc.log(range))
+  let delta = calc.pow(10., range-exponent - threshold)
+  let guess = calc.max(0, threshold - range-exponent)
+  calc.max(0, ..values.map(val => {
+    let g = guess
+    while g >= 0 {
+      let p = calc.abs(val - calc.round(val, digits: g))
+      if calc.abs(val - calc.round(val, digits: g)) > delta { break }
+      g -= 1
+    }
+    g + 1
+  }))
+}
+
+#assert.eq(estimate-significant-digits((1,)), 0)
+#assert.eq(estimate-significant-digits((2.4, 1)), 1)
+#assert.eq(estimate-significant-digits((2.4, 1.23424), threshold: 5), 5)
+#assert.eq(estimate-significant-digits((2.4, 1.324)), 3)
+#assert.eq(estimate-significant-digits((0.000002, 0.000004)), 6)
+#assert.eq(estimate-significant-digits((0.00000002, 0.00000004)), 8)
+#assert.eq(estimate-significant-digits((2.4e10, 1.324e10)), 0)
+#assert.eq(estimate-significant-digits((2.4e10, -234)), 0)
+#assert.eq(estimate-significant-digits((-334.3, 23.2)), 1)
+#assert.eq(estimate-significant-digits((2.4e-10, 1.324e-10)), 13)
+
+#let get-best-step(a) = {
+  if a >= 1 {assert(false)}
+  let b = int(calc.round(calc.log(base: calc.pow(10, 1/3), a * 10)))
+  return (1, 2, 5, 10).at(b)
+}
+
+#assert.eq(get-best-step(0.1), 1)
+#assert.eq(get-best-step(0.14), 1)
+#assert.eq(get-best-step(0.15), 2)
+#assert.eq(get-best-step(0.2), 2)
+#assert.eq(get-best-step(0.3), 2)
+#assert.eq(get-best-step(0.4), 5)
+#assert.eq(get-best-step(0.5), 5)
+#assert.eq(get-best-step(0.6), 5)
+#assert.eq(get-best-step(0.8), 10)
+#assert.eq(get-best-step(0.9), 10)
+
+#let is-close-to(value, target, offset, step) = {
+  let eps = 1e-14
+  if offset > 0 {
+    let digits = calc.log(offset / step, base: 10)
+    eps = calc.max(1e-10, calc.pow(10., digits - 12))
+    eps = calc.min(0.4999, eps)
+  }
+  return calc.abs(value - target) < eps
+}
+
+/// Returns the smallest number n such that d*n > x
+#let fit-up(x, d, offset: 0) = {
+  let (div, mod) = divmod(x, d)
+  if not is-close-to(mod / d, 0, offset, d) { div += 1 }
+  return div
+}
+/// Returns the largest number n such that d*n < x
+/// The offset can be used to improve numerical precision and obtain
+/// a better result for extremely large or small numbers
+#let fit-down(x, d, offset: 0) = {
+  let (div, mod) = divmod(x, d)
+  if is-close-to(mod / d, 1, offset, d) { div += 1 }
+  return div
+}
+
+#assert.eq(fit-up(-4.2, .2), -21)
+#assert.eq(fit-up(-4.3, .2), -21)
+#assert.eq(fit-up(-4.1, .2), -20)
+#assert.eq(fit-up(4.2, .2), 21)
+#assert.eq(fit-up(4.2, 2), 3)
+#assert.eq(fit-up(4200, 2000), 3)
+#assert.eq(fit-up(-4.2, 5), 0)
+
+#assert.eq(fit-down(7, 2), 3)
+#assert.eq(fit-down(7e30, 2e25, offset: 5e30), 350000)
+#assert.eq(fit-down(-4.2, .2), -21)
+#assert.eq(fit-down(4.2, .2), 21)
+#assert.eq(fit-down(4.2, 2), 2)
+#assert.eq(fit-down(-4.2, 2), -3)
+#assert.eq(fit-down(4200, 2000), 2)
+#assert.eq(fit-down(-4.2, 5), -1)
+
+
+/// Returns the nearest number $x'*10^exp >= x*10^exp$ that is divisible by $d$. 
+#let discretize-up(x, d, exp, offset: 0) = {
+  let dd = d * pow10(exp)
+  return calc.round(fit-up(x, dd, offset: offset) * dd, digits: -exp)
+}
+
+/// Returns the nearest number $x'*10^exp <= x*10^exp$ that is divisible by $d$. 
+#let discretize-down(x, d, exp, offset: 0) = {
+  let dd = d * pow10(exp)
+  return calc.round(fit-down(x, dd, offset: offset) * dd, digits: -exp)
+}
+
+#assert.eq(discretize-up(24, 5, 0), 25)
+#assert.eq(discretize-up(1.2, 2, -1), 1.2)
+#assert.eq(discretize-up(2345.23, 2, 1), 2360)
+#assert.eq(discretize-up(2345.23, 2, 0), 2346)
+#assert.eq(discretize-up(34, 5, 0), 35)
+#assert.eq(discretize-up(1015, 11, 0), 1023)
+#assert.eq(discretize-up(10153823420, 1000, 0), 10153824000)
+#assert.eq(discretize-up(0.1, 2, -2), 0.1)
+#assert.eq(discretize-up(0.23456789, 5, -8), 0.2345679)
+
+#assert.eq(discretize-down(1.2, 2, -7), 1.2)
+#assert.eq(discretize-down(1.2, 2, -1), 1.2)
+#assert.eq(discretize-down(0.23456789, 5, -8), 0.23456785)
+#assert.eq(discretize-down(2345.23, 2, -2), 2345.22)
+#assert.eq(discretize-down(2345.23, 2, -1), 2345.2)
+#assert.eq(discretize-down(2345.23, 2, 0), 2344)
+#assert.eq(discretize-down(2345.23, 2, 1), 2340)
+#assert.eq(discretize-down(2345.23, 2, 2), 2200)
+#assert.eq(discretize-down(2345.23, 2, 3), 2000)
+#assert.eq(discretize-down(34, 5, 0), 30)
+#assert.eq(discretize-down(1015, 11, 0), 1012)
+#assert.eq(discretize-down(10153823420, 1000, 0), 10153823000)
+
+
+
+#let compute-precision-offset(x0, x1, threshold: 100) = {
+  let dx = x1 - x0
+  let avg = (x1 + x0) * 0.5
+  let offset
+  if calc.abs(avg) / dx < threshold { offset = 0 }
+  else {
+    let avg-exponent = calc.log(calc.abs(avg), base: 10)
+    offset = pow10(calc.floor(avg-exponent))
+    if avg < 0 { offset *= -1 }
+  }
+  return offset
+}
+
+// Signature
+#let locate-ticks(
+  x0, x1,  // Input range (may be inverted, i.e. x0 > x1, but not x0 == x1)
+  ..kwargs // We need a sink for unknown (and possible unread) args. 
+) = {
+  return (
+    ticks: (), // Returning an array of ticks is mandatory. 
+    ..args // We may return additional args that can be read by the formatter. 
+  )
+}
+
+
+/// Locate ticks manually on an axis with range $[x_0, x_1]$.
+#let locate-ticks-manual(
+  x0, x1, ticks: (), ..args
+) = (ticks: ticks)//.filter(x => x0 <= x and x <= x1))
+
+#assertations.approx(locate-ticks-manual(2, 200, ticks: (3, 4, 5, 6)).ticks, (3, 4, 5, 6))
+
+
+/// Locate linear ticks on an axis with range $[x_0, x_1]$. The range may be inverted, i.e., 
+/// $x_0>x_1$ but not $x_0 = x_1$. 
+///
+/// This function returns a dictionary with the keys
+/// - `ticks`, containing an array of tick positions,
+/// - `exponent`, holding an automatic exponent $n$ so that the range 
+///   $[t_\mathrm{min}/10^n, t_\mathrm{max}/10^n]$ spans at most 10 for min/max
+///   ticks $t_\mathrm{min}, t_\mathrm{max}$. This exponent may be applied by 
+///   the axis to improve legibility of the ticks and to reduce their length 
+///   when printed. 
+/// - `offset`, containing some offset that may be used by the axis to reduce 
+///   the length of tick labels by subtracting it from all ticks. 
+/// - `significant-digits`: The maximum number of significant digits of the 
+///   returned ticks. This is an optimization for label formatting because this
+///   function has the information for free while a formatter needs to 
+///   expensively estimate it. 
+#let locate-ticks-linear(
+
+  /// The start of the range that is displayed on the axis. 
+  /// -> float
+  x0, 
+
+  /// The end of the range that is displayed on the axis. 
+  /// -> float
+  x1, 
+
+  /// Sets the distance between consecutive ticks. If set to `auto`, the 
+  /// distance will be determined automatically according to 
+  /// `num-ticks-suggestion` and the given range. 
+  /// -> auto | float
+  tick-distance: auto,
+
+  /// Suggested number of ticks to use. This may for example be chosen 
+  /// according to the length of the axis and the font size. 
+  /// -> int | float
+  num-ticks-suggestion: 5, 
+
+  /// The maximum number of ticks to generate. This guard ensures prevents 
+  /// accidental generation of a huge number of ticks. 
+  /// -> int
+  max-ticks: 200,
+
+  /// The density of ticks. This can be used as a qualitative knob to tune
+  /// the number of generated ticks in relation to the suggested number of
+  /// ticks. 
+  /// -> ratio
+  density: 100%,
+
+  ..args
+
+) = {
+  assert.ne(x0, x1, message: "The tick input range cannot be zero")
+  if x1 < x0 {
+    (x1, x0) = (x0, x1)
+  }
+  let dx = x1 - x0
+
+  let step
+  let mantissa
+  let exponent
+  if tick-distance == auto {
+    let approx-step = dx / (num-ticks-suggestion * density / 100%)
+    (mantissa, exponent) = decompose-floating-point(calc.abs(approx-step))
+    step = get-best-step(mantissa)
+    tick-distance = step * pow10(exponent - 1)
+  } else {
+    (mantissa, exponent) = decompose-floating-point(calc.abs(tick-distance))
+    step = tick-distance / pow10(exponent - 1)
+  }
+  
+  
+  
+  let precision-offset = compute-precision-offset(x0, x1)
+  let first-tick-first-guess = calc.quo(x0 - precision-offset, tick-distance) * tick-distance
+
+  let x0-offset = precision-offset + first-tick-first-guess
+
+  let axis-offset = 0 
+  if calc.abs(calc.max(x1, x0) / tick-distance) >= 5000 {
+    let fg = pow10(calc.ceil(calc.log(dx, base: 10) + 1))
+    axis-offset = discretize-down(x0, 1, exponent + 2)
+  if axis-offset == 1.811 {
+    let e = (x0, fg, exponent)
+  }
+  }
+  
+  let first-tick = discretize-up(x0 - x0-offset, step, exponent - 1, offset: precision-offset) + x0-offset
+
+  let num-ticks = fit-down(x1 - x0-offset, tick-distance, offset: precision-offset) - fit-up(x0 - x0-offset, tick-distance, offset: precision-offset) + 1
+
+  // let tt = range(calc.min(max-ticks, num-ticks)).map(x => first-tick + x * tick-distance).map(x=>x/calc.pow(10., exponent))
+
+
+  return (
+    ticks: range(calc.min(max-ticks, num-ticks)).map(x => first-tick + x * tick-distance),
+    tick-distance: tick-distance,
+    // We provide additional args to ease the work of the formatter (in case it is
+    // format-ticks-linear), because right now we have a lot of information. 
+    exponent: exponent, // "Ideal" base-10 exponent to maybe factorize from the ticks. 
+    offset: axis-offset, // "Ideal" offset to maybe subtract from the ticks. 
+    significant-digits: -calc.floor(calc.log(tick-distance)), 
+  )
+}
+
+
+
+// Selected cases
+#assertations.approx(locate-ticks-linear(0, 0.1).ticks.len(), 6)
+#assertations.approx(locate-ticks-linear(0, 0.1).ticks, (0, .02, .04, .06, .08, .1))
+#assertations.approx(locate-ticks-linear(-200, -199).ticks, (-200, -199.8, -199.6, -199.4, -199.2, -199.0))
+#assertations.approx(locate-ticks-linear(100005, 100006).ticks, (100005, 100005.2, 100005.4, 100005.6, 100005.8, 100006))
+#assertations.approx(locate-ticks-linear(115, 116).ticks, (115, 115.2, 115.4, 115.6, 115.8, 116))
+#assertations.approx(locate-ticks-linear(-4.2, 20).ticks, (0, 5, 10, 15, 20))
+#assertations.approx(locate-ticks-linear(-1, 0).ticks, (-1, -.8, -.6, -.4, -.2, 0))
+#assertations.approx(locate-ticks-linear(0, 1).ticks, (0, .2, .4, .6, .8, 1))
+#assertations.approx(locate-ticks-linear(0.1, 1.2).ticks, (.2, .4, .6, .8, 1., 1.2))
+#assertations.approx(locate-ticks-linear(1.2, 0.1).ticks, (1.2, 1., .8, .6, .4, .2).rev())
+#assertations.approx(locate-ticks-linear(1, 20).ticks, (5, 10, 15, 20))
+#assertations.approx(locate-ticks-linear(1e20, 20e20).ticks, (5e20, 10e20, 15e20, 20e20))
+#assertations.approx(locate-ticks-linear(1e45, 20e45).ticks, (5e45, 10e45, 15e45, 20e45))
+
+
+// Inverse axes
+#assertations.approx(locate-ticks-linear(1.25, 0.1).ticks, (1.2, 1.0, .8, .6, .4, .2).rev())
+#assertations.approx(locate-ticks-linear(1, 0).ticks, (0, .2, .4, .6, .8, 1.))
+#assertations.approx(locate-ticks-linear(1.2, 0.1).ticks, (.2, .4, .6, .8, 1, 1.2))
+
+
+// Test negative axes
+#assertations.approx(locate-ticks-linear(-2.2, 20).ticks, (0, 5, 10, 15, 20))
+#assertations.approx(locate-ticks-linear(-4.2, -2).ticks, (-4, -3.5, -3, -2.5, -2))
+#assertations.approx(locate-ticks-linear(-4.2, 8.1).ticks, (-4, -2, 0, 2, 4, 6, 8))
+#assertations.approx(locate-ticks-linear(-116, -115).ticks, (-116, -115.8, -115.6, -115.4, -115.2, -115))
+#assertations.approx(locate-ticks-linear(-16, -15).ticks, (-16, -15.8, -15.6, -15.4, -15.2, -15))
+#assertations.approx(locate-ticks-linear(-0.000000000000003, 0.0005).ticks, (0, .0001, .0002, .0003, .0004, .0005))
+
+
+
+/// Locate linear ticks on a logarithmic axis with range $[x_0, x_1]$. The range may be
+/// inverted, i.e., $x_0>x_1$ but not $x_0 = x_1$. Ticks are placed on powers of the base
+/// or if the range is too large, on every other power of the base (starting with the lower 
+/// limit). In this case, the density of the ticks is determined by `num-ticks-suggestion`. 
+/// This function returns a dictionary with the key `ticks` containing an array of tick
+/// positions. 
+///
+/// - x0 (float): Start of the range. 
+/// - x1 (float): End of the range. 
+/// - base (int): Base of the logarithmic axis. 
+/// - num-ticks-suggestion (int, float): Determines the density of ticks. 
+/// - max-ticks (int): At most this many ticks are returned. This guard ensures that while 
+///     typing a value for tick-distance with live recompilation, that not a humongous number
+///     of ticks is genreated. 
+/// -> dictionary
+#let locate-ticks-log(
+  x0, 
+  x1, 
+  base: 10, 
+  num-ticks-suggestion: 5,
+  max-ticks: 200, 
+  ..args
+) = {
+  if x0 > x1 { (x0 ,x1) = (x1, x0) }
+  let log = calc.log.with(base: base)
+  let Dx = x1 - x0
+  let g = log(x1) - log(x0)
+  if g < 2 { 
+     let tick-info = locate-ticks-linear(x0, x1, ..args) 
+     tick-info.linear = true // notify format-ticks-log that this is actually a "linear" ticking
+     return tick-info
+  }
+  
+  let n0 = calc.ceil(log(x0))
+  let n1 = calc.floor(log(x1))
+  let step = calc.max(1, int(calc.round((n1 - n0) / num-ticks-suggestion)))
+  
+  (
+    ticks: range(calc.min(n1 - n0 + 1, max-ticks), step: step).map(x => calc.pow(base * 1., x + n0)),
+  )
+}
+
+#assertations.approx(locate-ticks-log(1, 1000).ticks, (1, 10, 100, 1000))
+#assertations.approx(locate-ticks-log(1, 1e8).ticks, (1, 100, 1e4, 1e6, 1e8))
+#assertations.approx(locate-ticks-log(0.24, 9, base: 2).ticks, (.25, .5, 1, 2, 4, 8))
+#assertations.approx(locate-ticks-log(1, 1024, base: 2).ticks, (1, 4, 16, 64, 256, 1024))
+#assertations.approx(locate-ticks-log(1, 2).ticks, locate-ticks-linear(1, 2).ticks)
+#assertations.approx(locate-ticks-log(1, 2, base: 2).ticks, locate-ticks-linear(1, 2).ticks)
+
+
+/// Automatically locate linear subticks from an array of ticks. 
+///
+/// - x0 (float): Start of the range. 
+/// - x1 (float): End of the range. 
+/// - num (auto): Number of subticks to put between consecutive ticks. If set to `auto`, 
+///      this defaults to 4 for tick distances basing on 2.5, 5, and 10 and to 3 for tick
+///      distances that base on 2. 
+/// - ticks (array): Ticks produced by some tick locator. 
+/// - tick-distance (auto): Difference between consecutive (major) ticks. If set to `auto`,
+///      the distance is automatically computed from the given ticks. 
+#let locate-subticks-linear(
+  x0, 
+  x1, 
+  num: auto, 
+  ticks: (), 
+  tick-distance: auto, 
+  ..args // important!
+) = {
+  assert.eq(args.pos().len(), 0, message: "Unexpected positional arguments")
+  if ticks.len() == 0 { return () }
+  if tick-distance == auto {
+    if ticks.len() < 2 { return () }
+    tick-distance = ticks.at(1) - ticks.at(0)
+  }
+  if num == auto {
+    let (m, n) = decompose-floating-point(tick-distance)
+    if true in (.1, .25, .5).map(x => calc.abs(m - x) < 1e-7) {
+      num = 4
+    } else {
+      num = 3
+    }
+  }
+  let subticks = ticks.map(x => x + tick-distance / 2)
+  let subticks = ()
+  let base-range = range(1, num + 1).map(x => x * tick-distance / (num + 1))
+  for tick in (ticks.first() - tick-distance,) + ticks {
+    subticks += base-range.map(x => x + tick)
+  }
+  if x0 > x1 { (x0, x1) = (x1, x0) }
+  return (ticks: subticks.filter(x => x0 <= x and x <= x1))
+}
+
+#assertations.approx(locate-subticks-linear(1, 2, ticks: (), num: 1), ())
+#assertations.approx(locate-subticks-linear(1, 2, ticks: (1,), num: 1), ())
+#assertations.approx(locate-subticks-linear(1, 2, ticks: (1, 2), num: 1), (1.5,))
+#assertations.approx(locate-subticks-linear(2, 1, ticks: (1, 2), num: 1), (1.5,))
+#assertations.approx(locate-subticks-linear(1, 2, ticks: (1, 2), num: 3), (1.25,1.5,1.75))
+#assertations.approx(locate-subticks-linear(0, 2, ticks: (1, 2), num: 1), (0.5, 1.5))
+
+// Test for interval enhancement and restriction to [x0, x1]
+#assertations.approx(locate-subticks-linear(1, 3, ticks: (1, 2), num: 3), (1.25, 1.5, 1.75, 2.25, 2.5, 2.75))
+#assertations.approx(locate-subticks-linear(1, 2.5, ticks: (1, 2), num: 3), (1.25, 1.5, 1.75, 2.25, 2.5))
+#assertations.approx(locate-subticks-linear(.5, 1.5, ticks: (1, 2), num: 3), (0.5, 0.75, 1.25, 1.5))
+#assertations.approx(locate-subticks-linear(.55, 1.5, ticks: (1, 2), num: 3), (0.75, 1.25, 1.5))
+
+#assertations.approx(locate-subticks-linear(5, 25, ticks: (11, 21), tick-distance: 10, num: 1), (6, 16,))
+
+
+
+/// Automatically locate logarithmic subticks from an array of ticks. 
+///
+/// - x0 (float): Start of the range. 
+/// - x1 (float): End of the range. 
+/// - subs (array): Which multiples of each tick to mark as with a subtick, e.g., 
+///     `(2,3,4,5,6,7,8,9)`. If set to `auto`, this defaults to `range(2, base)`. 
+/// - ticks (array): Ticks produced by some tick locator. 
+/// - base (float): Base of the logarithmic scale. 
+#let locate-subticks-log(
+  x0, 
+  x1, 
+  subs: auto,
+  ticks: (), 
+  base: auto,
+  ..args // important!
+) = {
+  if ticks.len() == 0 { return () }
+  if base == auto {
+    if ticks.len() < 2 { return () }
+    base = ticks.at(1) / ticks.at(0)
+  }
+  if subs == auto {
+    subs = range(2, calc.floor(base))
+  }
+  let quo = ticks.at(1) / ticks.at(0)
+  let subticks = ()
+  
+  if ticks.len() >= 2 and quo > base {
+    // locate-ticks-log might have skipped base positions
+    // (e.g., chosen 1e3, 1e5, 1e7). Then it makes no sense to display
+    // the small subticks and we could just show the exponential positions
+    let prev = ticks.first() / quo
+    for tick in ticks {
+      let num-divisions = int(calc.round(calc.log(tick / prev, base: base)))
+      let step = int(calc.max(1, calc.round(num-divisions / calc.min(num-divisions, 6))))
+      subticks += range(step, num-divisions, step: step).map(x => calc.pow(base*1., x) * prev)
+      prev = tick
+    }
+  } else {
+    for tick in (ticks.first() / base,) + ticks {
+      subticks += subs.map(x => x * tick)
+    }
+  }
+  if x0 > x1 { (x0, x1) = (x1, x0) }
+  return (ticks: subticks.filter(x => x0 <= x and x <= x1))
+}
+
+#assertations.approx(locate-subticks-log(1, 10, ticks: ()), ())
+#assertations.approx(locate-subticks-log(1, 10, ticks: (3,)), ())
+#assertations.approx(locate-subticks-log(1, 10, ticks: (1, 10)), range(2, 10))
+#assertations.approx(locate-subticks-log(.25, 20, ticks: (1, 10)), range(3, 10).map(x=>x/10) + range(2, 10) + (20,))
+
+
+
+
+#let format-ticks-manual(
+  tick-info, labels: (), ..args
+) = {
+  assert(tick-info.ticks.len() == labels.len(), message: "When providing manual ticks and labels, the number of ticks and labels needs to match. ")
+  return (labels, 0, 0)
+}
+
+
+
+#let format-ticks-naive(
+  ticks-info,
+  ..args 
+) = {
+  return (ticks-info.ticks.map(str), 0, 0)
+}
+
+
+
+#let num(
+  value, 
+  e: none, 
+  digits: auto, 
+  base: 10, omit-unit-mantissa: true
+) = {
+  if digits != auto {
+    digits = calc.max(0, digits)
+  }
+  if e != none { 
+    e = str(e)
+  }
+  zero.num(
+    (
+      mantissa: str(value).replace(sym.minus, "-"), 
+      pm: none, 
+      e: e
+    ), 
+    base: base, 
+    digits: digits, 
+    omit-unity-mantissa: omit-unit-mantissa
+  )
+}
+
+
+#let default-generate-tick-label(
+  value, 
+  exponent: 0, 
+  digits: auto, 
+  simple: false
+) = {
+  if simple {
+    if exponent == 0 { return $#value$ }
+    return $#value dot 10^#exponent$
+  }
+  if exponent == 0 { exponent = none }
+  return num(value, e: exponent, digits: digits)
+}
+
+
+#let format-ticks-linear(
+  ticks-info,     // dictionary
+  exponent: auto, // auto | int | "inline"
+  offset: auto,   // auto | int | float
+  auto-exponent-threshold: 3,
+  ..args // important
+) = {
+
+  if offset == auto {
+    offset = ticks-info.at("offset", default: 0)
+  } else {
+    assert(type(offset) in (int, float), message: "Offsets need to be of integer or float type")
+  }
+  
+  let additional-exponent = 0 // extra exp that will be shown on the axis
+  let inline-exponent = 0     // extra exp that is shown for each tick
+
+  let inherited-exponent = ticks-info.at("exponent", default: 0)
+  if exponent == auto {
+    if calc.abs(inherited-exponent) >= auto-exponent-threshold {
+      additional-exponent = inherited-exponent
+    }
+  } else if exponent == "inline" {
+    if calc.abs(inherited-exponent) >= auto-exponent-threshold {
+      inline-exponent = inherited-exponent
+    }
+  } else {
+    assert.eq(type(exponent), int, message: "Exponents need to be of integer type")
+    additional-exponent = exponent
+  }
+
+
+  let preapplied-exponent = inline-exponent + additional-exponent
+  let preapplied-factor = 1 / pow10(preapplied-exponent)
+  let ticks = ticks-info.ticks.map(x => (x - offset) * preapplied-factor)
+
+  
+  let significant-digits = ticks-info.at("significant-digits", default: none)
+  if significant-digits == none {
+    significant-digits = estimate-significant-digits(ticks)
+  } else {
+    significant-digits += preapplied-exponent
+  }
+  
+  let labels = ticks
+   .map(calc.round.with(digits: significant-digits))
+   .map(default-generate-tick-label.with(
+     exponent: inline-exponent,
+     digits: significant-digits
+   )
+  )
+  return (labels, additional-exponent, offset)
+}
+
+
+#let format-ticks-log(
+  tick-info, 
+  base: 10,
+  exponent: auto, 
+  auto-exponent-threshold: 3,
+  round-exponent-digits: 4, 
+  base-label: auto,
+  ..args
+) = {
+  // Sometimes the log ticker resorts to linear ticking and then this is better
+  if "linear" in tick-info and tick-info.linear {
+    return format-ticks-linear(tick-info, exponent: exponent, auto-exponent-threshold, auto-exponent-threshold)
+  }
+  if base-label == auto { 
+    if base == calc.e { base-label = $e$}
+    else { base-label = base }
+  }
+  let ticks = tick-info.ticks
+  if exponent == auto {
+    let num = num.with(1, omit-unit-mantissa: true, base: base-label)
+    return (ticks.map(x => num(e: calc.round(calc.log(x, base: base), digits: round-exponent-digits))), 0, 0)
+  } else {
+    return (ticks.map(num), 0, 0)
+  }
+}
+

--- a/packages/preview/lilaq/0.2.0/src/assertations.typ
+++ b/packages/preview/lilaq/0.2.0/src/assertations.typ
@@ -1,0 +1,114 @@
+
+/// Assert that two floats or arrays are equal up to a (configurable) epsilon. 
+#let approx(
+  /// First value.
+  a, 
+  /// Second value.
+  b, 
+  /// Epsilon.
+  eps: 1e-12
+) = {
+  return true
+  if type(a) == array and type(b) == array {
+    assert(a.len() == b.len(), message: "Non-matching array lengths " + repr(a) + " / " + repr(b))
+    for (x, y) in a.zip(b) {
+      if calc.abs(x - y) >= eps {
+        assert(false, message: repr(a) + " was not approx equal to " + repr(b) )
+      }
+    }
+  } else {
+    assert(calc.abs(a - b) < eps, message: str(a) + " and " + str(b) + " are not equal up to " + str(eps))
+    
+  }
+}
+
+
+#approx(1, 1)
+#approx((5e45, 1e46, 1.4999999999999999e46, 2e46), (5e45, 1e46, 1.5e46, 2e46))
+
+
+
+/// Assert that coordinate arrays passed to plots have the same length. 
+#let assert-matching-data-dimensions(
+  /// Array of $x$ coordinates. 
+  x, 
+  /// Array of $y$ coordinates. 
+  y, 
+  /// Other coordinate arrays (e.g., error bars) that should match the length of $x$ and $y$ coordinates. Only named arguments are accepted. 
+  ..args,
+  /// Function name. This can be used to improve the error message. Entries where the value is not an array are ignored. This is useful for cases like `xerr` that also take a single value. 
+  fn-name: "", 
+) = {
+  let prefix = ""
+  if fn-name != "" { prefix = "`" + fn-name + "()`: " }
+
+  if y != none {
+    assert(
+      x.len() == y.len(), 
+      message: prefix + "The dimensions for x (" + str(x.len()) + ") and y (" + str(y.len()) + ") don't match"
+    )
+  }
+  
+  for (key, value) in args.named() {
+    if value == none { continue }
+    if type(value) != array { continue }
+    
+    assert(
+      x.len() == value.len(), 
+      message: prefix + "The dimensions for x (" + str(x.len()) + ") and " + key + " (" + str(value.len()) + ") don't match"
+    )
+  }
+}
+
+
+/// Assert that there are no additional named arguments in an argument sink. 
+#let assert-no-named(
+  /// Argument sink.
+  args, 
+  /// Function name. This can be used to improve the error message. 
+  fn: ""
+) = {
+  if args.named().len() == 0 { return }
+  
+  assert(false,
+    message: "Unexpected named argument \"" + args.named().keys().first() + "\"" + if fn == "" {""} else {
+      " in function " + fn + "()"
+    }
+  )
+}
+
+#let assert-dict-keys(
+  dict, 
+  mandatory: (),
+  optional: (),
+  name: "",
+  message: auto
+) = {
+  name += " "
+  for key in mandatory {
+    if key not in dict {
+      if message == auto {
+        message = name + "dictionary expects key `" + key + "`"
+      }
+      assert(
+        false,
+        message: message
+      )
+    }
+    let _ = dict.remove(key)
+  }
+  for key in dict.keys() {
+    if key not in optional {
+      
+      if message == auto {
+        message = name + "dictionary found unexpected key `" + key + "` (expected " + (mandatory + optional).join(", ", last: ", or ") + ")"
+      }
+      assert(
+        false,
+        message: message
+      )
+    }
+  }
+}
+
+// #assert-dict-keys((a: 12, b: "", c: "a"), mandatory: ("a", "b"), optional: ("c",))

--- a/packages/preview/lilaq/0.2.0/src/bounds.typ
+++ b/packages/preview/lilaq/0.2.0/src/bounds.typ
@@ -1,0 +1,190 @@
+
+#let get-length(x, container-length) = {
+  if type(x) == length { return x }
+  if type(x) == ratio { return x * container-length}
+  if type(x) == relative { return x.length + x.ratio * container-length}
+}
+
+#assert.eq(get-length(3cm, 234cm), 3cm)
+#assert.eq(get-length(50%, 224cm), 112cm)
+#assert.eq(get-length(50% + 3cm, 224cm), 115cm)
+
+
+#let update-bounds(former, bounds, width: 0cm, height: 0cm) = (
+  left: calc.min(former.left, get-length(bounds.left, width).to-absolute()), 
+  top: calc.min(former.top, get-length(bounds.top, height).to-absolute()),
+  right: calc.max(former.right, get-length(bounds.right, width).to-absolute()),
+  bottom: calc.max(former.bottom, get-length(bounds.bottom, height).to-absolute()),
+)
+
+#context assert.eq(update-bounds(
+  (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt),
+  (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt),
+), (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+
+#context assert.eq(update-bounds(
+  (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt),
+  (left: -10pt, right: 20pt, top: -20pt, bottom: 100pt),
+), (left: -10pt, right: 20pt, top: -20pt, bottom: 100pt))
+
+#context assert.eq(update-bounds(
+  (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt),
+  (left: -3em, right: 20pt + 1em, top: -20pt, bottom: 2em + 1pt),
+), (left: -33pt, right: 31pt, top: -20pt, bottom: 23pt))
+
+
+
+
+#let create-bounds() = (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt)
+
+
+#let offset-bounds(bounds, offset) = (
+  left: bounds.left + offset.at(0),
+  top: bounds.top + offset.at(1),
+  right: bounds.right + offset.at(0),
+  bottom: bounds.bottom + offset.at(1),
+)
+
+
+#let place-with-bounds(
+  content, 
+  dx: 0pt, 
+  dy: 0pt, 
+  pad: 0pt,
+  alignment: top + left, 
+  content-alignment: auto,
+  wrap-in-box: false
+) = {
+  if alignment.x == none { alignment = alignment.y + center }
+  else if alignment.y == none { alignment = alignment.x + horizon }
+  if content-alignment == auto { content-alignment = alignment.inv() }
+  else if content-alignment == "inside" { content-alignment = alignment }
+
+  let size = measure(content)
+  if pad != 0pt {
+    if type(pad) != dictionary {
+      pad = (x: pad, y: pad)
+    }
+    if content-alignment.y == bottom { pad.y *= -1 }
+    else if content-alignment.y == horizon { pad.y *= 0 }
+    dy += pad.y
+    if content-alignment.x == right { pad.x *= -1 }
+    else if content-alignment.x == center { pad.x *= 0 }
+    dx += pad.x
+  }
+  
+
+  let (ddx, ddy) = (dx, dy)
+  
+  if wrap-in-box {
+    content = box(..size, content)
+  }
+  let content = place(content-alignment, content)
+  
+  if alignment.x == right { dx += 100% }
+  else if alignment.x == center { dx += 50% }
+  if alignment.y == bottom { dy += 100% }
+  else if alignment.y == horizon { dy += 50% }
+  
+  if content-alignment.x == right { dx -= size.width }
+  else if content-alignment.x == center { dx -= 0.5 * size.width }
+  if content-alignment.y == bottom { dy -= size.height }
+  else if content-alignment.y == horizon { dy -= 0.5 * size.height }
+  let bounds = (
+    left: dx, 
+    right: dx + size.width,
+    top: dy,
+    bottom: dy + size.height
+  )
+  (place(alignment, content, dx: ddx, dy: ddy), bounds)
+}
+
+
+
+#let place-and-show-bounds(content, alignment, ca: auto, pad: 0pt) = context {
+  let ca = ca
+  if ca == auto { ca = alignment.inv() }
+  let (content, bounds) = place-with-bounds(alignment: alignment, content, content-alignment: ca, pad: pad)
+  
+  place(dx: bounds.left, dy: bounds.top, box(width: bounds.right - bounds.left, height: bounds.bottom - bounds.top))
+  
+  content
+}
+#place-and-show-bounds([JOO], top , ca: right)
+
+#rect(
+  width: 6cm, height: 4cm, inset: 0pt,
+  {
+    set box(fill: green.lighten(50%))
+    place-and-show-bounds([Top right], right + top)
+    place-and-show-bounds([Bottom right], right + bottom)
+    place-and-show-bounds([Top left], left + top)
+    place-and-show-bounds([Bottom left], left + bottom)
+    place-and-show-bounds([Top], top + center)
+    place-and-show-bounds([Bottom], bottom + center)
+    place-and-show-bounds([Middle], horizon + center)
+    place-and-show-bounds([Right], horizon + right)
+    place-and-show-bounds([Left], horizon + left)
+
+    set box(fill: purple.lighten(50%))
+    place-and-show-bounds([Top right], right + top, ca: right + top)
+    place-and-show-bounds([Bottom right], right + bottom, ca: right + bottom)
+    place-and-show-bounds([Top left], left + top, ca: left + top)
+    place-and-show-bounds([Bottom left], left + bottom, ca: left + bottom)
+    place-and-show-bounds([Top], top + center, ca: top + center)
+    place-and-show-bounds([Bottom], bottom + center, ca: bottom + center)
+    place-and-show-bounds([Middle], horizon + center, ca: horizon + center)
+    place-and-show-bounds([Right], horizon + right, ca: horizon + right)
+    place-and-show-bounds([Left], horizon + left, ca: horizon + left)
+  }
+)
+\
+
+#rect(
+  width: 6cm, height: 4cm, inset: 0pt,
+  {
+    set box(fill: red.lighten(50%))
+    place-and-show-bounds([Top right], right + top, ca: center + horizon)
+    place-and-show-bounds([Bottom right], right + bottom, ca: center + horizon)
+    place-and-show-bounds([Top left], left + top, ca: center + horizon)
+    place-and-show-bounds([Bottom left], left + bottom, ca: center + horizon)
+    place-and-show-bounds([Top], top + center, ca: center + horizon)
+    place-and-show-bounds([Bottom], bottom + center, ca: center + horizon)
+    place-and-show-bounds([Middle], horizon + center, ca: center + horizon)
+    place-and-show-bounds([Right], horizon + right, ca: center + horizon)
+    place-and-show-bounds([Left], horizon + left, ca: center + horizon)
+  }
+)
+
+
+With auto padding
+
+#rect(
+  width: 6cm, height: 4cm, inset: 0pt,
+  {
+    set box(fill: green.lighten(50%))
+    place-and-show-bounds = place-and-show-bounds.with(pad: 5pt)
+    
+    place-and-show-bounds([Top right], right + top)
+    place-and-show-bounds([Bottom right], right + bottom)
+    place-and-show-bounds([Top left], left + top)
+    place-and-show-bounds([Bottom left], left + bottom)
+    place-and-show-bounds([Top], top + center)
+    place-and-show-bounds([Bottom], bottom + center)
+    place-and-show-bounds([Middle], horizon + center)
+    place-and-show-bounds([Right], horizon + right)
+    place-and-show-bounds([Left], horizon + left)
+
+    set box(fill: purple.lighten(50%))
+    place-and-show-bounds([Top right], right + top, ca: right + top)
+    place-and-show-bounds([Bottom right], right + bottom, ca: right + bottom)
+    place-and-show-bounds([Top left], left + top, ca: left + top)
+    place-and-show-bounds([Bottom left], left + bottom, ca: left + bottom)
+    place-and-show-bounds([Top], top + center, ca: top + center)
+    place-and-show-bounds([Bottom], bottom + center, ca: bottom + center)
+    place-and-show-bounds([Middle], horizon + center, ca: horizon + center)
+    place-and-show-bounds([Right], horizon + right, ca: horizon + right)
+    place-and-show-bounds([Left], horizon + left, ca: horizon + left)
+    place-and-show-bounds([JOO], top + right, ca: left)
+  }
+)

--- a/packages/preview/lilaq/0.2.0/src/colorbar.typ
+++ b/packages/preview/lilaq/0.2.0/src/colorbar.typ
@@ -1,0 +1,18 @@
+#import "model/diagram.typ": diagram
+#import "plot/rect.typ": rect
+
+
+
+#let colorbar(plot) = {
+  let cinfo = plot.cinfo
+  diagram(
+    width: .3cm, 
+    xaxis: (ticks: none), 
+    yaxis: (position: right, mirror: (:)),
+    grid: none,
+    // ylabel: "color",
+    ylim: (cinfo.min, cinfo.max),
+    yscale: cinfo.norm,
+    rect(0%, 0%, width: 100%, height: 100%, fill: gradient.linear(..cinfo.colormap.stops(), angle: -90deg))
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/data.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/data.typ
@@ -1,0 +1,391 @@
+// Functions to extract data from custom elements and types, as well as associated constants.
+
+// Type constants:
+
+// Used by typeinfos
+#let type-key = "__elembic_type"
+// To be used by any custom type instances
+#let custom-type-key = "__elembic_custom_type"
+// Used by custom types themselves
+#let custom-type-data-key = "__elembic_custom_type_data"
+
+// Element constants:
+
+// Prefix for the labels added to shown elements.
+#let lbl-show-head = "__elembic_element_shown_"
+
+// Prefix for the labels added outside shown elements.
+// This is used to be able to effectively apply show-set rules to them.
+#let lbl-outer-head = "__elembic_element_outer_"
+
+// Prefix for counters of elements.
+// This is only used if the element isn't 'refable'.
+#let lbl-counter-head = "__elembic_element_counter_"
+
+// Prefix for the figure kind used by 'refable' elements.
+// This is not to be confused with figures containing the elements.
+// This is the kind for a hidden figure used for ref purposes.
+#let lbl-ref-figure-kind-head = "__elembic_element_refable_"
+
+// Custom label applied to the hidden reference figure when the user specifies their own label.
+#let lbl-ref-figure-label-head = "__elembic_element_ref_figure_label_"
+
+// Label for the hidden figure used for references.
+#let lbl-ref-figure = <__elembic_element_ref_figure>
+
+// Label for context blocks which have access to the virtual stylechain.
+#let lbl-get = <__elembic_element_get>
+
+// Label for metadata indicating an element's initial properties post-construction.
+#let lbl-tag = <__elembic_element_tag>
+
+// Label for metadata indicating a rule's parameters.
+#let lbl-rule-tag = <__elembic_element_rule>
+
+// Label for metadata which stores the global data.
+// In practice, this label is never present in the document
+// unless one accidentally leaks the 'bibliography.title'
+// override from our workaround.
+#let lbl-data-metadata = <__elembic_element_global_data_metadata>
+
+#let lbl-stateful-mode = <__elembic_element_stateful_mode>
+#let lbl-normal-mode = <__elembic_element_normal_mode>
+#let lbl-auto-mode = <__elembic_element_auto_mode>
+
+// Prefix for labels added by 'select' to matched elements.
+// These labels are not specific to eids.
+#let lbl-global-where-head = "__elembic_element_global_where_"
+
+// Special dictionary key to indicate this is a prepared rule.
+#let prepared-rule-key = "__elembic-prepared-rule"
+
+// Special dictionary key which stores element context and other data.
+#let stored-data-key = "__elembic_stored_element_data"
+
+#let element-key = "__elembic_element"
+#let element-data-key = "__elembic_element_data"
+#let global-data-key = "__elembic_element_global_data"
+#let filter-key = "__elembic_element_filter"
+
+#let sequence = [].func()
+
+// Special values that can be passed to a type or element's constructor to retrieve some data or show
+// some behavior.
+#let special-data-values = (
+  // Indicate that the constructor should return the type or element's data.
+  get-data: 0,
+  // Indicate that the constructor should return an element filter.
+  get-where: 1,
+)
+
+// Extract data from a type's or element's constructor, as well as convert
+// a custom type or element instance into a dictionary with keys such as body (for elements only),
+// fields and func, allowing you to access its fields and information when given content (for elements)
+// or the type instance (for types).
+//
+// When given content that is not a custom element, 'body' will be the given value,
+// 'fields' will be 'body.fields()' and 'func' will be 'body.func()'.
+//
+// The returned 'data-kind' indicates which kind of data was retrieved.
+#let data(it) = {
+  if type(it) == function {
+    it(__elembic_data: special-data-values.get-data)
+  } else if type(it) == dictionary and element-key in it {
+    (data-kind: "element", ..it)
+  } else if type(it) == dictionary and custom-type-data-key in it {
+    (data-kind: "custom-type-data", ..it)
+  } else if type(it) == dictionary and custom-type-key in it {
+    it.at(custom-type-key)
+  } else if type(it) == dictionary and stored-data-key in it {
+    it.at(stored-data-key)
+  } else if type(it) != content {
+    (data-kind: "unknown", body: it, fields: (:), func: none, eid: none, fields-known: false, valid: false)
+  } else if (
+    it.has("label")
+    and str(it.label).starts-with(lbl-show-head)
+  ) {
+    // Decomposing an element inside a show rule
+    it.children.at(1).value
+  } else if it.func() == sequence and it.children.len() >= 2 {
+    let last = it.children.last()
+    if (
+      last.at("label", default: none) == lbl-tag
+      // Workaround for 0.11.0 weirdly placing some 'meta' element sometimes
+      or sys.version < version(0, 12, 0) and {
+        last = it.children.at(it.children.len() - 2)
+        last.at("label", default: none) == lbl-tag
+      }
+    ) {
+      // Decomposing a recently-constructed (but not placed) element
+      last.value
+    } else {
+      (data-kind: "content", body: it, fields: it.fields(), func: it.func(), eid: none, fields-known: false, valid: false)
+    }
+  } else if (
+    it.has("label")
+    and str(it.label).starts-with(lbl-outer-head)
+  ) {
+    (data-kind: "incomplete-element-instance", body: it, fields: (:), func: (:), eid: str(it.label).slice(lbl-outer-head.len()), fields-known: false, valid: false)
+  } else {
+    (data-kind: "content", body: it, fields: it.fields(), func: it.func(), eid: none, fields-known: false, valid: false)
+  }
+}
+
+// Obtain the fields of a type instance or element instance (custom or not).
+//
+// SAMPLE USAGE:
+//
+// #show e.selector(elem): it => {
+//   let fields = e.fields(it)
+//   [Hello #fields.name!]
+// }
+#let fields(it) = {
+  let info = data(it)
+
+  if type(info) == dictionary and "data-kind" in info {
+    if info.data-kind in ("content", "element-instance", "type-instance") {
+      return info.fields
+    }
+  }
+
+  (:)
+}
+
+// Obtain context at an element's site.
+//
+// SAMPLE USAGE:
+//
+// 1. In show rules:
+//
+// #show e.selector(elem): it => {
+//   let (get, ..) = e.ctx(it)
+//   let other-elem-ctx = get(other-elem)
+//   [The other element field was set to #other-elem-ctx.field at that point!]
+// }
+//
+// 2. In element declarations:
+//
+// #e.element.declare(
+//   ...
+//   synthesize: it => {
+//     // Get context for other element
+//     it.some-field = (e.ctx(it).get)(other-elem).field
+//   },
+//   ...
+// )
+#let ctx(it) = {
+  let info = data(it)
+  if type(info) == dictionary and "ctx" in info {
+    info.ctx
+  } else {
+    none
+  }
+}
+
+// Obtain an element's or type's scope (usually a module with important definitions).
+//
+// SAMPLE USAGE:
+//
+// #let subelem = e.scope(elem).subelem
+#let scope(it) = {
+  let info = data(it)
+  if type(info) == dictionary and "scope" in info {
+    info.scope
+  } else {
+    none
+  }
+}
+
+/// Obtain an element's or custom type's constructor function.
+/// For native elements, this will be equivalent to `it.func()`.
+///
+/// Useful in custom element show rules, for example.
+///
+/// This is equivalent to `e.data(it).func`.
+///
+/// SAMPLE USAGE:
+///
+/// ```typ
+/// #show selector.or(e.selector(elem1), e.selector(elem2)): it => {
+///   // Will be either elem1 or elem2
+///   let elem = e.func(it)
+///   // 'elem == elem1' works, but comparing 'eid's is recommended
+///   if e.eid(elem) == e.eid(elem1) {
+///     [This is elem1]
+///   } else {
+///     [This is elem2]
+///   }
+/// }
+/// ```
+///
+/// - it (any): element/custom type instance (or element/custom type itself) to get the constructor from
+/// -> function | none
+#let func(it) = {
+  let info = data(it)
+  if type(info) == dictionary and "func" in info {
+    info.func
+  } else {
+    none
+  }
+}
+
+/// Obtain an element's eid. It uniquely distinguishes this element from others,
+/// even if they have the same name, by including both its prefix and name.
+///
+/// This is equivalent to `e.data(elem).eid`.
+///
+/// - elem (any): custom element (or an instance of it) to get 'eid' from
+/// -> function | none
+#let eid(it) = {
+  let info = data(it)
+  if type(info) == dictionary and "eid" in info {
+    info.eid
+  } else {
+    none
+  }
+}
+
+/// Obtain a custom type's tid. It uniquely distinguishes a custom type from
+/// others, even if they have the same name, by including both its prefix and
+/// name. Returns `none` on invalid input.
+///
+/// This is equivalent to `e.data(typ).tid`.
+///
+/// - typ (any): custom type (or an instance of it) to get 'tid' from
+/// -> function | none
+#let tid(it) = {
+  let info = data(it)
+  if type(info) == dictionary and "tid" in info {
+    info.tid
+  } else {
+    none
+  }
+}
+
+// Obtain an element's counter.
+//
+// USAGE:
+//
+// #context {
+//   [The element counter value is #e.counter(elem).get().first()]
+// }
+#let counter_(elem) = {
+  let info = data(elem)
+
+  if type(info) == dictionary and "data-kind" in info and (info.data-kind == "element" or info.data-kind == "element-instance") {
+    info.counter
+  } else {
+    assert(false, message: "e.counter: this is not an element")
+  }
+}
+
+/// Get the name of a content's constructor function as a string.
+///
+/// Returns 'none' on invalid input.
+///
+/// USAGE:
+///
+/// ```typ
+/// assert.eq(func-name(my-elem()), "my-elem")
+/// assert.eq(func-name([= abc]), "heading")
+/// ```
+///
+/// - c (content): content to get the constructor function of
+/// -> function | none
+#let func-name(c) = {
+  if type(c) == function {
+    let func-data = data(c)
+    return if "name" in func-data {
+      func-data.name
+    } else {
+      none
+    }
+  } else if type(c) != content {
+    return none
+  }
+  let name = repr(c.func())
+  if c.func() == sequence {
+    let element-data = data(c)
+    if "eid" in element-data and element-data.eid != none {
+      name = if "name" in element-data and type(element-data.name) == str { element-data.name } else { "unknown custom element" }
+    }
+  }
+  name
+}
+
+#let _letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-"
+
+/// This is used to obtain a debug representation of custom elements and types.
+///
+/// Also supports native types (just calls `repr()` for them).
+///
+/// - value (any): value to represent
+/// - depth (int): current depth (must start at 0, conservative limit of 10 for now)
+/// -> str
+#let repr_(value, depth: 0) = {
+  if depth >= 10 {
+    return repr(value)
+  }
+  let typename = ""
+  let value-type = type(value)
+  if value-type == content and value.func() == sequence {
+    let value-data = data(value)
+    if "eid" in value-data and value-data.eid != none {
+      value = value-data.fields
+      value-type = dictionary
+      typename = if "name" in value-data and type(value-data.name) == str {
+        value-data.name
+      } else {
+        "unknown-element"
+      }
+    }
+  }
+
+  if value-type == dictionary {
+    let pairs = if typename != "" {
+      // Element fields => sort
+      value.pairs().sorted(key: ((k, _)) => k)
+    } else if custom-type-key in value {
+      let type-data = value.at(custom-type-key)
+
+      let id = type-data.id
+
+      typename = if "name" in id {
+        id.name
+      } else if id == "custom type" {
+        return if custom-type-data-key in value {
+          "custom-type(name: " + repr(value.name) + ", tid: " + repr(value.tid) + ")"
+        } else {
+          "custom-type()"
+        }
+      } else {
+        str(id)
+      }
+
+      type-data.fields.pairs().sorted(key: ((k, _)) => k)
+    } else {
+      value.pairs()
+    }
+
+    typename
+    "("
+    pairs.map(((k, v)) => {
+      if k.codepoints().all(c => c in _letters) {
+        k
+      } else {
+        repr(k)
+      }
+
+      ": "
+
+      repr_(v, depth: depth + 1)
+    }).join(", ")
+    ")"
+  } else if value-type == array {
+    "("
+    value.map(repr_.with(depth: depth + 1)).join(", ")
+    ")"
+  } else {
+    repr(value)
+  }
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/element.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/element.typ
@@ -1,0 +1,2079 @@
+#import "data.typ": data, lbl-show-head, lbl-outer-head, lbl-counter-head, lbl-ref-figure-kind-head, lbl-ref-figure-label-head, lbl-ref-figure, lbl-get, lbl-tag, lbl-rule-tag, lbl-data-metadata, lbl-stateful-mode, lbl-normal-mode, lbl-auto-mode, lbl-global-where-head, prepared-rule-key, stored-data-key, element-key, element-data-key, global-data-key, filter-key, special-data-values, custom-type-key, custom-type-data-key, type-key
+#import "fields.typ" as field-internals
+#import "types/base.typ"
+#import "types/types.typ"
+
+#let element-version = 1
+
+// Basic elements for our document tree analysis
+#let sequence = [].func()
+#let space = [ ].func()
+#let styled = { set text(red); [a] }.func()
+#let state-update-func = state(".").update(1).func()
+#let counter-update-func = counter(".").update(1).func()
+
+// Potential modes for configuration of styles.
+// This defines how we declare a set rule (or similar)
+// within a certain scope.
+#let style-modes = (
+  // Normal mode: we store metadata in a bibliography.title set rule.
+  //
+  // Before doing so, we retrieve the original value for bibliography.title,
+  // allowing us to restore it later. The effect is that the library is
+  // fully hygienic, that is, the change to bibliography.title is not perceptible.
+  //
+  // The downside is that retrieving the original value for bibliography.title costs
+  // an additional nested context { } call, of which there is a limit of 64. This means
+  // that, in this mode, you can have up to 32 non-consecutive set rules.
+  normal: 0,
+
+  // leaky mode: similar to normal mode, but we don't try to preserve the value of bibliography.title
+  // after applying our changes to the document. This doubles the limit to up to 64 non-consecutive
+  // set rules since we no longer have an extra step to retrieve the old value, but, as a downside,
+  // we lose the original value of bibliography.title. While, in a future change, we might be able to
+  // preserve the FIRST known value, we can't generally preserve its value at later points, so the
+  // value of bibliography.title is effectively frozen before the first custom set rule.
+  //
+  // This mode should be used by package authors which know there won't be a bibliography (or, really,
+  // any custom user input) at some point to avoid consuming the set rule cost. End users can also use
+  // this mode if they hit a "max show rule depth exceeded" error.
+  //
+  // Note that this mode can only be enabled on individual set rules.
+  leaky: 1,
+
+  // Stateful mode: this is entirely different from the other modes and should only be set by the end
+  // user (not by packages). This stores the style chain - and, thus, set rules' updated fields - in
+  // a 'state()'. This is more likely to be slower and lead to trouble as it triggers at least one
+  // document relayout. However, **this mode does not have a set rule limit.** Therefore, it can be
+  // used as a last resort by the end user if they can't fix the "max show rule depth exceeded error".
+  //
+  // Enabling this mode is as simple as using `#show: e.stateful.toggle(true)` at the beginning of the
+  // document. This will trigger a compatibility behavior where existing set rules will push to the
+  // state, even if they're not in the stateful mode. It will also push existing set rule data into
+  // the style 'state()'. Therefore, existing set rules are compatible with stateful mode, but this
+  // only effectively fixes the error if the set rules are individually switched to stateful mode
+  // with `e.stateful.set_` instead of `e.set_`.
+  stateful: 2
+)
+
+// When on stateful mode, this state holds the sequence of 'data' for each scope.
+// The last element on the list is the "current" data.
+#let style-state = state("__elembic_element_state", ())
+
+// Default library-wide data.
+#let default-global-data = (
+  (global-data-key): true,
+
+  // Keep track of versions in case we need some backwards-compatibility behavior
+  // in the future.
+  version: element-version,
+
+  // If the style state should be read by set rules as the user has
+  // enabled stateful mode with `#shoW: e.stateful.toggle(true)`.
+  stateful: false,
+
+  // First known bib title.
+  // This is used by leaky mode to attempt to preserve the correct bibliography.title
+  // property. Evidently, it's not perfect, and leaky mode should be avoided.
+  first-bib-title: (),
+
+  // How many 'where rules' have been applied so far to all
+  // elements. This is needed as, for each 'where rule', we have
+  // to apply a unique label to matching elements, so we increase
+  // this 'counter' by one each time.
+  where-rule-count: 0,
+
+  // Per-element data (set rules and other style chain info).
+  elements: (:)
+)
+
+// Default per-element data.
+#let default-data = (
+  (element-data-key): true,
+
+  version: element-version,
+
+  // Chain for foldable fields, that is, fields which have special behavior
+  // when changed through more than one set rule. By default, specifying the
+  // same field in two subsequent set rules will have the innermost set rule
+  // override the value from the previous one, but this can be overridden
+  // for certain types where it makes sense to combine the two values in
+  // some way instead. For example, stroke fields have custom folding: if
+  // you specify 4pt for a stroke field in one set rule and orange in another,
+  // the final stroke will be 4pt + orange, not orange.
+  //
+  // This data structure has an entry for each changed foldable field, laid out as follows:
+  // (
+  //   foldable-field-name: (
+  //     folder: auto or (outer, inner) => combined value  // how to combine two values, auto = simple sum, equivalent to (a, b) => a + b
+  //     default: stroke(),  // default value for this field to begin folding. This is 'field.default' unless 'required = true'.
+  //                         // Then, it is the type's default.
+  //     values: (4pt, orange, ...)  // list of all set values for this field (length = amount of times this field was changed)
+  //                                 // only 'values' is used if possible, for efficiency. E.g.: values.sum(default: stroke())
+  //     data: (                                   // list to associate each value with the real style chain index and name.
+  //       (index: 3, name: none, value: 4pt),     // If 'revoke' or 'reset' are used, this list is used instead
+  //       (index: 5, name: none, value: orange),  // so we can know which values were revoked.
+  //       ...
+  //     )
+  //   ),
+  //   ...
+  // )
+  //
+  // The final argument passed to the constructor, if any, also has to be folded with the latest folded value,
+  // or with the field's default value if nothing was changed. However, that step is done separately. So, if
+  // no set rules change a particular foldable field, it is not present in this dictionary at all.
+  fold-chain: (:),
+
+  // The current accumulated styles (overridden values for arguments) for the element.
+  chain: (),
+
+  // Maps each style in the chain to some data.
+  // This is used to assign names to styles, so they can be revoked later.
+  data-chain: (),
+
+  // All known names, so we can be aware of invalid revoke rules.
+  names: (:),
+
+  // List of active revokes, of the form:
+  // (index: last-chain-index, revoking: name-revoked, name: none / name of the revoke itself)
+  revoke-chain: ()
+)
+
+/// This is meant to be used in a show rule of the form `#show ref: e.ref` to ensure
+/// references to custom elements work properly.
+///
+/// Please use [`e.prepare`](#eprepare) as it does that automatically, and more if
+/// necessary.
+///
+/// - args (arguments): ref and extra arguments
+/// -> content
+#let ref_(..args) = {
+  assert(args.pos().len() > 0, message: "element.ref: expected at least one positional argument (reference or label)")
+  let first-arg = args.pos().first()
+
+  set ref(..args.named())
+  show ref: it => {
+    if (
+      it.element == none
+      or it.element.has("label") and str(it.element.label).starts-with(lbl-ref-figure-label-head)
+      or type(it.target) != label
+    ) {
+      // This is known to be a reference to a custom element
+      // (or the target is not something we can deal with, i.e. not a label)
+      return it
+    }
+
+    let info = data(it.element)
+    if type(info) == dictionary and "data-kind" in info and info.data-kind == "element-instance" {
+      let supplement = if it.has("supplement") and it.supplement != none {
+        (supplement: it.supplement)
+      } else {
+        (:)
+      }
+
+      // Convert into a reference towards the reference figure
+      let converted-label = label(lbl-ref-figure-label-head + str(it.target))
+      let reference = ref(converted-label, ..supplement)
+
+      if "custom-ref" in info and info.custom-ref != none {
+        show ref.where(target: converted-label): [#info.custom-ref]
+
+        reference
+      } else {
+        reference
+      }
+    } else {
+      it
+    }
+  }
+
+  if type(first-arg) == content and first-arg.func() == ref {
+    first-arg
+  } else {
+    ref(..args)
+  }
+}
+
+// Changes stateful mode settings within a certain scope.
+// This function will sync all data between all modes (data from normal mode
+// goes to state and data from stateful mode goes to normal mode).
+//
+// Setting it to 'true' tells all set rules to update the state, and also ensures
+// getters retrieve the value from the state, even if not explicitly aware of
+// stateful mode.
+//
+// By default, this function will not trigger any changes if one attempts to
+// change the stateful mode to its current value. This behavior can be disabled
+// with 'force: true', though that is not expected to make a difference in any way.
+#let toggle-stateful-mode(enable, force: false) = doc => {
+  context {
+    let previous-bib-title = bibliography.title
+    [#context {
+      let (global-data, was-first-bib-title) = if (
+        type(bibliography.title) == content
+        and bibliography.title.func() == metadata
+        and bibliography.title.at("label", default: none) == lbl-data-metadata
+      ) {
+        (bibliography.title.value, false)
+      } else {
+        ((..default-global-data, first-bib-title: previous-bib-title), true)
+      }
+
+      set bibliography(title: previous-bib-title)
+
+      if global-data.stateful != enable or force {
+        if not enable {
+          // Enabling stateful mode => use data from the style chain
+          //
+          // Disabling stateful mode => need to sync stateful with non-stateful,
+          // so we use data from the state
+          let chain = style-state.get()
+          global-data = if chain == () {
+            default-global-data
+          } else {
+            chain.last()
+          }
+
+          // Store the first known bib title in the state as well
+          if global-data.first-bib-title == () and was-first-bib-title {
+            global-data.first-bib-title = previous-bib-title
+          }
+        }
+
+        // Notify both modes about it (non-stateful and stateful)
+        global-data.stateful = enable
+
+        let (show-normal, show-stateful) = if enable {
+          // TODO: Have a way to keep track of previous toggles and undo them
+          (none, it => it.value.body)
+        } else {
+          (it => it.value.body, none)
+        }
+
+        show lbl-auto-mode: none
+        show lbl-normal-mode: show-normal
+        show lbl-stateful-mode: show-stateful
+
+        // Sync data with style chain for non-stateful modes
+        show lbl-get: set bibliography(title: [#metadata(global-data)#lbl-data-metadata])
+
+        // Sync data with state for stateful mode
+        // Push at the start of the scope, pop at the end
+        [#style-state.update(chain => {
+          chain.push(global-data)
+          chain
+        })#doc#style-state.update(chain => {
+          _ = chain.pop()
+          chain
+        })]
+      } else {
+        // Nothing to do: it is already toggled to this value
+        doc
+      }
+    }#lbl-get]
+  }
+}
+
+/// Prepare a selector similar to 'element.where(..args)'
+/// which can be used in "show sel: set". Receives a filter
+/// generated by'element.with(fields)' or '(element-data.where)(fields)'.
+///
+/// This works by applying a show rule to all element instances and,
+/// if they match, they receive a unique label to be matched
+/// by that selector. The selector is then provided to the callback function.
+///
+/// Each requested selector is passed as a separate parameter to the callback.
+/// You must wrap the remainder of the document that depends on those selectors
+/// in this callback.
+///
+/// USAGE:
+///
+/// ```typ
+/// #e.select(superbox.with(fill: red), superbox.with(width: auto), (red-superbox, auto-superbox) => {
+///   // Hide superboxes with red fill or auto width
+///   show red-superbox: none
+///   show auto-superbox: none
+///
+///   // This one is hidden
+///   #superbox(fill: red)
+///
+///   // This one is hidden
+///   #superbox(width: auto)
+///
+///   // This one is kept
+///   #superbox(fill: green, width: 5pt)
+/// })
+/// ```
+///
+/// - args (function): filters in the format 'element.with(field-a: a, field-b: b)'. Note that you must write fields' names even if they are positional.
+/// - receiver (function): receives one requested selector per filter as separate arguments, must return content.
+/// -> content
+#let select(..args, receiver) = {
+  assert(args.named() == (:), message: "element.select: unexpected named arguments")
+  assert(type(receiver) == function, message: "element.select: last argument must be a function receiving each prepared selector as a separate argument")
+
+  let filters = args.pos()
+
+  // (eid: ((index, filter), ...))
+  // The idea is to apply all filters for a given eid at once
+  let filters-by-eid = (:)
+  // (eid: sel)
+  let labels-by-eid = (:)
+  let ordered-eids = ()
+
+  let i = 0
+  for filter in filters {
+    if type(filter) == function {
+      filter = filter(__elembic_data: special-data-values.get-where)
+    }
+
+    if type(filter) != dictionary or filter-key not in filter {
+      if type(filter) == selector {
+        assert(false, message: "element.select: Typst-native selectors cannot be specified here, only those of custom elements")
+      }
+      assert(false, message: "element.select: expected a valid filter, such as 'custom-element' or 'custom-element.with(field-name: value, ...)', got " + base.typename(filter))
+    }
+
+    if "eid" in filter {
+      if "sel" not in filter {
+        assert(false, message: "element.select: filter did not have the element's selector")
+      }
+      if filter.eid in labels-by-eid and labels-by-eid.at(filter.eid) != filter.sel {
+        assert(false, message: "element.select: filter had a different selector from the others for the same element ID, check if you're not using conflicting library versions (could also be a bug)")
+      } else if filter.eid not in labels-by-eid {
+        labels-by-eid.insert(filter.eid, filter.sel)
+      }
+
+      if filter.eid in filters-by-eid {
+        filters-by-eid.at(filter.eid).push((i, filter))
+      } else {
+        filters-by-eid.insert(filter.eid, ((i, filter),))
+        ordered-eids.push(filter.eid)
+      }
+    } else {
+      assert(false, message: "element.select: non-element-specific filters are not supported yet\n  hint: try removing this filter: " + repr(filter))
+    }
+    i += 1
+  }
+
+  context {
+    let previous-bib-title = bibliography.title
+    [#context {
+      let global-data = if (
+        type(bibliography.title) == content
+        and bibliography.title.func() == metadata
+        and bibliography.title.at("label", default: none) == lbl-data-metadata
+      ) {
+        bibliography.title.value
+      } else {
+        (..default-global-data, first-bib-title: previous-bib-title)
+      }
+
+      if global-data.stateful {
+        let chain = style-state.get()
+        global-data = if chain == () {
+          default-global-data
+        } else {
+          chain.last()
+        }
+      }
+
+      // Amount of 'where rules' so far, so we can
+      // assign a unique number to each query
+      let rule-counter = global-data.where-rule-count
+
+      // Generate labels by counting up, and update counter
+      let matching-labels = range(0, filters.len()).map(i => label(lbl-global-where-head + str(rule-counter + i)))
+      rule-counter += matching-labels.len()
+      global-data.where-rule-count = rule-counter
+
+      // Provide labels to the body, one per filter
+      // These labels only match the shown bodies of
+      // elements with matching field values
+      let body = receiver(..matching-labels)
+
+      // Apply show rules to the body to add labels to matching elements
+      let styled-body = ordered-eids.fold(body, (acc, eid) => {
+        let filters = filters-by-eid.at(eid)
+        show labels-by-eid.at(eid): it => {
+          let data = data(it)
+          let tag = [#metadata(data)#lbl-tag]
+          let fields = data.fields
+
+          let labeled-it = it
+          for (i, filter) in filters {
+            // Check if all positional and named arguments match
+            if type(fields) == dictionary and filter.fields.pairs().all(((k, v)) => k in fields and fields.at(k) == v) {
+              // Add corresponding label and preserve tag so 'data(it)' still works
+              labeled-it = [#[#labeled-it#tag]#matching-labels.at(i)]
+            }
+          }
+
+          labeled-it
+        }
+
+        acc
+      })
+
+      set bibliography(title: previous-bib-title)
+
+      // Increase where rule counter for further where rules
+      if global-data.stateful {
+        style-state.update(chain => {
+          chain.push(global-data)
+          chain
+        })
+
+        styled-body
+
+        style-state.update(chain => {
+          _ = chain.pop()
+          chain
+        })
+      } else {
+        show lbl-get: set bibliography(title: [#metadata(global-data)#lbl-data-metadata])
+        styled-body
+      }
+    }#lbl-get]
+  }
+}
+
+// Apply set and revoke rules to the current per-element data.
+#let apply-rules(data, rules) = {
+  for rule in rules {
+    let kind = rule.kind
+    if kind == "set" {
+      let (element, args) = rule
+      let (eid, default-data, fields) = element
+      if eid in data {
+        data.at(eid).chain.push(args)
+      } else {
+        data.insert(eid, (..default-data, chain: (args,)))
+      }
+
+      if rule.name != none {
+        let element-data = data.at(eid)
+        let index = element-data.chain.len() - 1
+
+        // Lazily fill the data chain with 'none'
+        data.at(eid).data-chain += (none,) * (index - element-data.data-chain.len())
+        data.at(eid).data-chain.push((kind: "set", name: rule.name))
+        data.at(eid).names.insert(rule.name, true)
+      }
+
+      if fields.foldable-fields != (:) and args.keys().any(n => n in fields.foldable-fields) {
+        // A foldable field was specified in this set rule, so we need to record the fold
+        // data in the corresponding data structures separately for later.
+        let element-data = data.at(eid)
+        let index = element-data.chain.len() - 1
+        for (field-name, fold-data) in fields.foldable-fields {
+          if field-name in args {
+            let value = args.at(field-name)
+            let value-data = (index: index, name: rule.name, value: value)
+            if field-name in element-data.fold-chain {
+              data.at(eid).fold-chain.at(field-name).values.push(value)
+              data.at(eid).fold-chain.at(field-name).data.push(value-data)
+            } else {
+              data.at(eid).fold-chain.insert(
+                field-name,
+                (
+                  folder: fold-data.folder,
+                  default: fold-data.default,
+                  values: (value,),
+                  data: (value-data,)
+                )
+              )
+            }
+          }
+        }
+      }
+    } else if kind == "revoke" {
+      for (name, _) in data {
+        // Can only revoke what's before us.
+        // If this element has no rules with this name, there is nothing to revoke;
+        // we shouldn't revoke names that come after us (inner rules).
+        // Note that this potentially includes named revokes as well.
+        if rule.revoking in data.at(name).names {
+          data.at(name).revoke-chain.push((kind: "revoke", name: rule.name, index: data.at(name).chain.len(), revoking: rule.revoking))
+
+          if rule.name != none {
+            data.at(name).names.insert(rule.name, true)
+          }
+        }
+      }
+    } else if kind == "reset" {
+      // Whether the list of elements that this reset applies to is restricted.
+      let filtering = rule.eids != ()
+      for (name, element-data) in data {
+        // Can only revoke what's before us.
+        // If this element has no rules, no need to add a reset.
+        if (not filtering or name in rule.eids) and element-data.chain != () {
+          data.at(name).revoke-chain.push((kind: "reset", name: rule.name, index: element-data.chain.len()))
+
+          if rule.name != none {
+            data.at(name).names.insert(rule.name, true)
+          }
+        }
+      }
+    } else {
+      assert(false, message: "element: invalid rule kind '" + rule.kind + "'")
+    }
+  }
+
+  data
+}
+
+// Prepare rule(s), returning a function `doc => ...` to be used in
+// `#show: rule`. The rule is attached as metadata to the returned
+// content so it can still be accessed outside of a show rule.
+//
+// This is where we execute our main machinery to apply rules to the
+// document, that is, modifications to the global data of custom
+// elements. This is done in different ways depending on the mode:
+//
+// - In normal mode, we create 'get rule' points by annotating
+// context blocks with `#lbl-get`. Any modifications to the global
+// data are stored as 'set bibliography(title: metadata with data)'
+// scoped to context blocks with that label. Therefore, we can access
+// the data by retrieving bibliography.title inside those blocks.
+//
+// The downside is that the entire document is wrapped in context,
+// so 'max show rule depth exceeded' errors can occur.
+//
+// - In leaky mode, it is similar, but we reset bibliography.title
+// to an arbitrary value instead of having two context blocks to
+// ensure it remains unchanged.
+//
+// - In stateful mode, we don't wrap anything around the document,
+// removing the 'max show rule depth exceeded' problem. Rather, we
+// place a state update at the start and another at the end of the
+// scope, respectively updating the global data and then undoing
+// the update, ensuring it only applies to that scope.
+//
+// The downside is that this uses 'state()', which can lead to
+// relayouts (slower) and even diverging layout.
+#let prepare-rule(rule) = {
+  let rules = if rule.kind == "apply" { rule.rules } else { (rule,) }
+
+  doc => {
+    let rule = rule
+    let rules = rules
+    let mode = rule.mode
+
+    // If there are two 'show:' in a row, flatten into a single set of rules
+    // instead of running this function multiple times, reducing the
+    // probability of accidental nested function limit errors.
+    //
+    // Note that all rules replace the document with
+    // [#context { ... doc .. }[#metadata(doc: doc, rule: rule)#lbl-rule-tag]]
+    // We get the second child to extract the original rule information.
+    // If 'doc' has the form above, this means the user wrote
+    // #show: rule1
+    // #show: rule2
+    // which we want to unify. So we check children len == 2 and unify if the tag is there.
+    //
+    // But we also want to accept some parbreaks before, i.e.
+    //
+    // #show: rule1
+    //
+    // #show: rule2
+    //
+    // This generates a doc of the form
+    // [#parbreak()[#context { ... doc .. }[#metadata(doc: doc, rule: rule)#lbl-rule-tag]]]
+    // So we also check for children len >= 2 (although == 2 is enough in that case) and
+    // strip any leading parbreaks / spaces / linebreaks, moving them to the new 'doc' (they
+    // now receive the rules, which is technically incorrect, but in practice is only a problem
+    // if you have a show rule on parbreak or space or something, which is odd).
+    //
+    // Note also that
+    // #show: rule1
+    //
+    // // hello world!
+    // // hello world!
+    // // hello world!
+    //
+    // #show: rule2
+    //
+    // produces
+    // [#parbreak()#space()#space()#parbreak()[... rule substructure with metadata... ]]
+    // which makes the need for stripping multiple kinds of whitespace explicit.
+    // We limit at 100 to prevent unbounded search.
+    //
+    // We also need to consider the case with
+    // #show: rule1
+    // #set native(field: value)
+    // #show: rule2
+    //
+    // in which case the document structure (from rule1's view) is
+    //
+    // styled(child: [... rule2 ...], styles: ..)
+    //
+    // Worse, there could be parbreaks around the set rule:
+    //
+    // #show: rule1
+    //
+    // #set native(field: value)
+    //
+    // #show: rule2
+    //
+    // leading to
+    //
+    // sequence(parbreak(), styled(child: sequence(parbreak(), [ ... rule2 ... ]), styles: ..))
+    //
+    // so we need to perform a document tree walk to lift rule2 and transform this into
+    //
+    // #show: apply(
+    //   rule1
+    //   rule2
+    // )
+    //
+    // #set native(field: value)
+    // ...
+    //
+    // Tree walk is performed as follows:
+    //
+    // this rule
+    //   \
+    //   sequence
+    //      \ space  parbreak ... sequence
+    //                              \ space parbreak ... styled (styles = S)
+    //                                                       \ sequence
+    //                                                             \ space parbreak ... inner rule!
+    //                                                                                    \ (rule.doc, rule.rule)
+    // We store each tree level in 'wrappers' so we can reconstruct this document structure without 'rule!'.
+    // In the case above, that would correspond to
+    // wrappers = ((sequence, (space, parbreak, ...)), (sequence, space, parbreak, ...), (styled, S), (sequence, space, parbreak, ...))
+    // and 'rule' would become 'potential-doc'.
+    //
+    // We would then wrap 'rule.doc' in reverse order, adding after the sequence prefix or
+    // making it the styled child, producing
+    //
+    // this rule + inner rule
+    //   \
+    //   (sequence,     apply(this rule, inner rule))
+    //      \ space  parbreak ... sequence
+    //                              \ space parbreak ... styled (styles = S)
+    //                                                       \ sequence
+    //                                                             \ space parbreak ... rule.doc
+    //
+    // as desired. That is, we move the inner rule up into this rule in order to only consume 1 from
+    // the rule limit, which is valid since the rule won't apply to spaces, parbreaks, and styled.
+    // Of course, there could be show rules towards a different structure, but we assume that the user
+    // understands that show rules on spacing may cause unexpected behavior.
+    let potential-doc = [#doc]
+    let wrappers = ()
+    let max-depth = 150
+    // Acceptable content types for set rule lifting.
+    // These are content types that are leaves and we usually don't expect them to
+    // be replaced in a show rule by an actual custom element.
+    // If we find something that isn't here, e.g. a block, we stop searching as we can't lift any further rules.
+    // We also exclude anything with a label since that indicates there might be a show rule application incoming.
+    let whitespace-funcs = (parbreak, space, linebreak, h, v, state-update-func, counter-update-func)
+    // Content types we can peek at.
+    let recursing-funcs = (styled, sequence)
+    let loop-prefix = none
+    let loop-children = ()
+    let loop-last = none
+
+    while max-depth > 0 {
+      // Child is #{
+      //    set something(abc: def)
+      //    show something: else
+      //    [some stuff]
+      // }
+      if potential-doc.func() == styled {
+        max-depth -= 1
+        wrappers.push((styled, potential-doc.styles))
+
+        // 'Recursively' check the child
+        potential-doc = [#potential-doc.child]
+      } else if (
+        // Child is #[
+        //   (parbreak)
+        //   (space)
+        //   #[ sequence, rule or more styles ]
+        // ]
+        potential-doc.func() == sequence
+        and { loop-children = potential-doc.children; loop-children.len() >= 2 }  // something like 'if let Sequence(children) = potential-doc { ... }'
+        and { loop-last = loop-children.last(); loop-last.func() in recursing-funcs }
+        and max-depth - loop-children.len() > 0
+        and {
+          loop-prefix = loop-children.slice(0, -1);
+          loop-prefix.all(t => (t.func() in whitespace-funcs or t == []) and t.at("label", default: none) == none)
+        }
+      ) {
+        max-depth -= loop-children.len()
+        wrappers.push((sequence, loop-prefix))
+
+        // 'Recursively' check the last child
+        potential-doc = loop-last
+      } else {
+        break
+      }
+    }
+
+    // Merge with the closest rule application below us, "moving" it upwards
+    // and reducing the rule count by 1
+    if (
+      potential-doc.func() == sequence
+      and potential-doc.children.len() == 2
+      and potential-doc.children.last().at("label", default: none) == lbl-rule-tag
+    ) {
+      let last = potential-doc.children.last()
+      let inner-rule = last.value.rule
+
+      // Process all rules below us together with this one
+      if inner-rule.kind == "apply" {
+        // Note: apply should automatically distribute modes across its children,
+        // so it's okay if we don't inherit its own mode here.
+        rules += inner-rule.rules
+      } else {
+        rules.push(inner-rule)
+      }
+
+      // We assume 'apply' already checked its own rules.
+      // Therefore, we only need to fold a single time.
+      // Don't check all rules every time again.
+      if (
+        inner-rule.mode == style-modes.stateful
+        or mode != style-modes.stateful and inner-rule.mode == style-modes.leaky
+        or mode == auto
+      ) {
+        // Prioritize more explicit modes:
+        // stateful > leaky > normal
+        mode = inner-rule.mode
+      }
+
+      // Convert this into an 'apply' rule
+      rule = ((prepared-rule-key): true, version: element-version, kind: "apply", rules: rules, mode: mode)
+
+      // Place what's inside, don't place the context block that would run our code again
+      doc = last.value.doc
+
+      // Reconstruct the document structure.
+      // Must be in reverse (innermost wrapper to outermost).
+      for (func, data) in wrappers.rev() {
+        if func == styled {
+          doc = styled(doc, data)
+        } else {
+          // (sequence, prefix)
+          // Re-add stripped whitespace and stuff
+          doc = data.join() + doc
+        }
+      }
+    }
+
+    // Stateful mode: no context, just push in a state at the start of the scope
+    // and pop to previous data at the end.
+    let stateful = {
+      style-state.update(chain => {
+        let global-data = if chain == () {
+          default-global-data
+        } else {
+          chain.last()
+        }
+
+        assert(
+          global-data.stateful,
+          message: "element rule: cannot use a stateful rule without enabling the global stateful toggle\n  hint: write '#show: e.stateful.toggle(true)' somewhere above this rule, or at the top of the document to apply to all"
+        )
+
+        global-data.elements = apply-rules(global-data.elements, rules)
+
+        chain.push(global-data)
+        chain
+      })
+      doc
+      style-state.update(chain => {
+        _ = chain.pop()
+        chain
+      })
+    }
+
+    // Normal mode: two nested contexts: one retrieves the current bibliography title,
+    // and the other retrieves the title with metadata and restores the current title.
+    let normal = context {
+      let previous-bib-title = bibliography.title
+      [#context {
+        let global-data = if (
+          type(bibliography.title) == content
+          and bibliography.title.func() == metadata
+          and bibliography.title.at("label", default: none) == lbl-data-metadata
+        ) {
+          bibliography.title.value
+        } else {
+          (..default-global-data, first-bib-title: previous-bib-title)
+        }
+
+        if global-data.stateful {
+          if mode == auto {
+            // User chose something else.
+            // Don't even place anything.
+            return none
+          } else {
+            // Use state instead!
+            return {
+              set bibliography(title: previous-bib-title)
+              stateful
+            }
+          }
+        }
+
+        global-data.elements = apply-rules(global-data.elements, rules)
+
+        set bibliography(title: previous-bib-title)
+        show lbl-get: set bibliography(title: [#metadata(global-data)#lbl-data-metadata])
+        doc
+      }#lbl-get]
+    }
+
+    let body = if mode == auto {
+      // Allow user to pick the mode through show rules.
+      // Note: picking leaky mode has no effect on show rule depth, so we don't allow choosing
+      // it globally. For it to make a difference, it must be explicitly chosen.
+      [#metadata((body: stateful))#lbl-stateful-mode]
+      [#metadata((body: normal))#lbl-normal-mode]
+      [#normal#lbl-auto-mode]
+    } else if mode == style-modes.normal {
+      normal
+    } else if mode == style-modes.leaky {
+      [#context {
+        let global-data = if (
+          type(bibliography.title) == content
+          and bibliography.title.func() == metadata
+          and bibliography.title.at("label", default: none) == lbl-data-metadata
+        ) {
+          bibliography.title.value
+        } else {
+          // Bibliography title wasn't overridden, so we can use it
+          (..default-global-data, first-bib-title: bibliography.title)
+        }
+
+        let first-bib-title = global-data.first-bib-title
+        if first-bib-title == () {
+          // Nobody has seen the bibliography title (bug?)
+          first-bib-title = auto
+        }
+
+        if global-data.stateful {
+          if mode == auto {
+            // User chose something else.
+            // Don't even place anything.
+            return none
+          } else {
+            // Use state instead!
+            return {
+              set bibliography(title: first-bib-title)
+              stateful
+            }
+          }
+        }
+
+        global-data.elements = apply-rules(global-data.elements, rules)
+
+        set bibliography(title: first-bib-title)
+        show lbl-get: set bibliography(title: [#metadata(global-data)#lbl-data-metadata])
+        doc
+      }#lbl-get]
+    } else if mode == style-modes.stateful {
+      stateful
+    } else {
+      panic("element rule: unknown mode: " + repr(mode))
+    }
+
+    // Add the rule tag after each rule application.
+    // This allows extracting information about the rule before it is applied.
+    // It also allows combining the rule with an outer rule before application,
+    // as we do earlier.
+    [#body#metadata((doc: doc, rule: rule))#lbl-rule-tag]
+  }
+}
+
+/// Apply a set rule to a custom element. Check out the Styling guide for more information.
+///
+/// Note that this function only accepts non-required fields (that have a `default`).
+/// Any required fields must always be specified at call site and, as such, are always
+/// be prioritized, so it is pointless to have set rules for those.
+///
+/// Keep in mind the limitations when using set rules, as well as revoke, reset and
+/// apply rules.
+///
+/// As such, when applying many set rules at once, please use `e.apply` instead
+/// (or specify them consecutively so `elembic` does that automatically).
+///
+/// USAGE:
+///
+/// ```typ
+/// #show: e.set_(superbox, fill: red)
+/// #show: e.set_(superbox, optional-pos-arg1, optional-pos-arg2)
+///
+/// // This call will be equivalent to:
+/// // #superbox(required-arg, optional-pos-arg1, optional-pos-arg2, fill: red)
+/// #superbox(required-arg)
+/// ```
+///
+/// - elem (function): element to apply the set rule on
+/// - fields (arguments): optional fields to set (positionally or named, depending on the field)
+/// -> function
+#let set_(elem, ..fields) = {
+  if type(elem) == function {
+    elem = data(elem)
+  }
+  assert(type(elem) == dictionary, message: "element.set_: please specify the element's constructor or data in the first parameter")
+  let args = (elem.parse-args)(fields, include-required: false)
+
+  prepare-rule(
+    ((prepared-rule-key): true, version: element-version, kind: "set", name: none, mode: auto, element: (eid: elem.eid, default-data: elem.default-data, fields: elem.fields), args: args)
+  )
+}
+
+/// Apply multiple rules (set rules, etc.) at once.
+///
+/// These rules do not count towards the "set rule limit" observed in 'Limitations';
+/// `apply` itself will always count as a single rule regardless of the amount of rules
+/// inside it (be it 5, 50, or 500). Therefore,
+/// **it is recommended to group rules together under `apply` whenever possible.**
+///
+/// Note that Elembic will automatically wrap consecutive rules (only whitespace
+/// or native set/show rules inbetween) into a single `apply`, bringing the same benefit.
+///
+/// USAGE:
+///
+/// ```typ
+/// #show: e.apply(
+///   set_(elem, fields),
+///   set_(elem, fields)
+/// )
+/// ```
+///
+/// - mode (int): style mode given by the `style-modes` dictionary
+/// - args (arguments): rules to apply
+/// -> function
+#let apply(mode: auto, ..args) = {
+  assert(args.named() == (:), message: "element.apply: unexpected named arguments")
+  assert(mode == auto or mode == style-modes.normal or mode == style-modes.leaky or mode == style-modes.stateful, message: "element.apply: invalid mode, must be auto or e.style-modes.(normal / leaky / stateful)")
+
+  let rules = args.pos().map(
+    rule => {
+      assert(type(rule) == function, message: "element.apply: invalid rule of type " + str(type(rule)) + ", please use 'set_' or some other function from this library to generate it")
+
+      // Call it as if it we were in a show rule.
+      // It will have some trailing metadata indicating its arguments.
+      let inner = rule([])
+      let rule-data = inner.children.last().value.rule
+
+      if rule-data.kind == "apply" {
+        // Flatten 'apply'
+        rule-data.rules
+      } else {
+        (rule-data,)
+      }
+    }
+  ).sum(default: ())
+
+  if mode == auto {
+    mode = rules.fold(auto, (mode, rule) => {
+      if (
+        rule.mode == style-modes.stateful
+        or mode != style-modes.stateful and rule.mode == style-modes.leaky
+        or mode == auto
+      ) {
+        // Prioritize more explicit modes:
+        // stateful > leaky > normal
+        rule.mode
+      } else {
+        mode
+      }
+    })
+  }
+
+  if mode != auto {
+    rules = rules.map(r => r + (mode: mode))
+  }
+
+  // Set this apply rule's mode as an optimization, but note that we have forcefully altered
+  // its children's modes above.
+  prepare-rule(((prepared-rule-key): true, version: element-version, kind: "apply", rules: rules, mode: mode))
+}
+
+/// Name a certain rule. Use `e.apply` to name a group of rules.
+/// This is used to be able to revoke the rule later with `e.revoke`.
+///
+/// Please note that, at the moment, each rule can only have
+/// one name. This means that applying multiple `named` on
+/// the same set of rules will simply replace the previous
+/// names.
+///
+/// However, more than one rule can have the same name, allowing both to be
+/// revoked at once if needed.
+///
+/// USAGE:
+///
+/// ```typ
+/// #show: e.named(
+///   "cool set",
+///   e.set_(elem, fields)
+/// )
+/// ```
+///
+/// - name (str): The name to give to the rule.
+/// - rule (function): The rule to apply this name to.
+/// -> function
+#let named(name, rule) = {
+  assert(type(name) == str, message: "element.named: rule name must be a string, not " + str(type(name)))
+  assert(name != "", message: "element.named: name must not be empty")
+  assert(type(rule) == function, message: "element.named: this is not a valid rule (not a function), please use functions such as 'set_' to create one.")
+
+  let rule = rule([]).children.last().value.rule
+  if rule.kind == "apply" {
+    let i = 0
+    while i < rule.rules.len() {
+      let inner-rule = rule.rules.at(i)
+      assert(inner-rule.kind in ("set", "revoke", "reset"), message: "element.named: can only name set, revoke and reset rules at this moment, not '" + inner-rule.kind + "'")
+
+      rule.rules.at(i).insert("name", name)
+
+      i += 1
+    }
+  } else {
+    assert(rule.kind in ("set", "revoke", "reset"), message: "element.named: can only name set, revoke and reset rules at this moment, not '" + rule.kind + "'")
+    rule.insert("name", name)
+  }
+
+  // Re-prepare the rule
+  prepare-rule(rule)
+}
+
+/// Revoke all rules with a certain name.
+///
+/// This is intended to be used in a specific scope,
+/// and temporary. This means you are supposed to only revoke the rule
+/// for a short portion of the document. If you wish to do the opposite,
+/// that is, only apply the rule for a short portion for the document
+/// (and have it never apply again afterwards), then please just scope
+/// the set rule itself instead.
+///
+/// USAGE:
+///
+/// ```typ
+/// #show: e.named("name", set_(element, fields))
+/// ...
+/// #[
+///   #show: e.revoke("name")
+///   // rule 'name' doesn't apply here
+///   ...
+/// ]
+///
+/// // Applies here again
+/// ...
+/// ```
+///
+/// - name (str): name of rules to be revoked
+/// - mode (int): style mode given by the `style-modes` dictionary
+/// -> function
+#let revoke(name, mode: auto) = {
+  assert(type(name) == str, message: "element.revoke: rule name must be a string, not " + str(type(name)))
+  assert(mode == auto or mode == style-modes.normal or mode == style-modes.leaky or mode == style-modes.stateful, message: "element.revoke: invalid mode, must be auto or e.style-modes.(normal / leaky / stateful)")
+
+  prepare-rule(((prepared-rule-key): true, version: element-version, kind: "revoke", revoking: name, name: none, mode: mode))
+}
+
+/// Temporarily revoke all active set rules for certain elements (or even all elements if none are specified).
+/// Applies only to the current scope, like other rules.
+///
+/// USAGE:
+///
+/// ```typ
+/// #show: e.set_(element, fill: red)
+/// #[
+///   // Revoke all previous set rules on 'element' for this scope
+///   #show: e.reset(element)
+///   #element[This is using the default fill (not red)]
+/// ]
+///
+/// // Rules not revoked outside the scope
+/// #element[This is using red fill]
+/// ```
+///
+/// - args (arguments): elements whose rules should be reset, or none to reset all rules
+/// - mode (int): style mode given by the `style-modes` dictionary
+/// -> function
+#let reset(..args, mode: auto) = {
+  assert(args.named() == (:), message: "element.reset: unexpected named arguments")
+  assert(mode == auto or mode == style-modes.normal or mode == style-modes.leaky or mode == style-modes.stateful, message: "element.reset: invalid mode, must be auto or e.style-modes.(normal / leaky / stateful)")
+
+  let filters = args.pos().map(it => if type(it) == function { data(it) } else { x })
+  assert(filters.all(x => type(x) == dictionary and "eid" in x), message: "element.reset: invalid arguments, please provide a function or element data with at least an 'eid'")
+
+  prepare-rule(((prepared-rule-key): true, version: element-version, kind: "reset", eids: filters.map(x => x.eid), name: none, mode: mode))
+}
+
+// Stateful variants
+#let stateful-set(..args) = {
+  apply(set_(..args), mode: style-modes.stateful)
+}
+#let stateful-apply = apply.with(mode: style-modes.stateful)
+#let stateful-revoke = revoke.with(mode: style-modes.stateful)
+#let stateful-reset = reset.with(mode: style-modes.stateful)
+
+// Leaky variants
+#let leaky-set(..args) = {
+  apply(set_(..args), mode: style-modes.leaky)
+}
+#let leaky-apply = apply.with(mode: style-modes.leaky)
+#let leaky-revoke = revoke.with(mode: style-modes.leaky)
+#let leaky-reset = reset.with(mode: style-modes.leaky)
+
+// Apply revokes and other modifications to the chain and generate a final set
+// of fields.
+#let fold-styles(chain, data-chain, revoke-chain, fold-chain) = {
+  // Map name -> up to which index (exclusive) it is revoked.
+  //
+  // Importantly, a revoke at index B will apply to
+  // all rules with the revoked name before that index.
+  // If that revoke rule is, itself, revoked, that either
+  // completely eliminates the name from being revoked,
+  // or it simply leads the name to be revoked up to
+  // an index A < B. That, or it was also being revoked
+  // by another unrevoked revoke rule at index C > B,
+  // in which case the name is still revoked up to C.
+  // In all cases, the name is always revoked from the
+  // start until some end index. Otherwise, it isn't
+  // revoked at all (end index 0).
+  let active-revokes = (:)
+
+  let first-active-index = 0
+
+  // Revoke revoked revokes by analyzing revokes in reverse
+  // order: a revoke that came later always takes priority.
+  for revoke in revoke-chain.rev() {
+    // This revoke will revoke rules named 'revoking' up to 'index' in the chain, which
+    // automatically revokes revoke rules before it as well, since they were added when
+    // the chain length was smaller (or the same), and 'index' is always the chain length
+    // at the moment the revoke rule was added.
+    //
+    // We don't explicitly add revoke rules to the chain as their order in the revoke-chain
+    // list is enough to know which revoke rules can revoke others, and the index indicates
+    // which set rules are revoked.
+    //
+    // Regarding the first part of the AND, note that, if a name is already revoked up to
+    // index C from a later revoke (since we're going in reverse, so this one appears earlier
+    // than the previous ones), then revoking it up to index B <= C for this revoke is
+    // unnecessary since the index interval [0, B) is already contained in [0, C).
+    //
+    // In other words, only the last revoke for a particular name matters, which is the
+    // first one we find in this loop.
+    //
+    // (As you can see, we assume above that, if revoke 1 comes before revoke 2 in the revoke-chain
+    // (before reversing), with revoke 1 applying up to chain index B and revoke 2 up to index C,
+    // then B <= C. This is enforced in 'prepare-rules' as we analyze revokes and push their
+    // information to the chain in order (outer to inner / earlier to later).)
+    if revoke.kind == "revoke" and revoke.revoking not in active-revokes and (revoke.name == none or revoke.name not in active-revokes) {
+      active-revokes.insert(revoke.revoking, revoke.index)
+    } else if revoke.kind == "reset" and (revoke.name == none or revoke.name not in active-revokes) {
+      // Applying a reset, so we delete everything before this index and stop revoking since
+      // any revokes before this reset won't count anymore.
+      first-active-index = revoke.index
+
+      chain = if chain.len() <= first-active-index {
+        ()
+      } else {
+        chain.slice(first-active-index)
+      }
+
+      data-chain = if data-chain.len() <= first-active-index {
+        ()
+      } else {
+        data-chain.slice(first-active-index)
+      }
+
+      for (field-name, fold-data) in fold-chain {
+        let first-fold-index = fold-data.data.position(d => d.index >= first-active-index)
+        if first-fold-index == none {
+          // All folded values removed.
+          // The caller will be responsible for joining the default value with the
+          // final arguments (without any chain values inbetween) if that's necessary.
+          _ = fold-chain.remove(field-name)
+        } else {
+          fold-chain.at(field-name).values = fold-data.values.slice(first-fold-index)
+          fold-chain.at(field-name).data = fold-data.data.slice(first-fold-index)
+        }
+      }
+
+      // No need to analyze any further revoke rules since everything was reset.
+      break
+    }
+  }
+
+  if active-revokes != (:) {
+    let i = first-active-index
+    for data in data-chain {
+      if data != none and data.name in active-revokes and i < active-revokes.at(data.name) {
+        // Nullify changes at this stage
+        chain.at(i) = (:)
+      }
+
+      i += 1
+    }
+
+    for (field-name, fold-data) in fold-chain {
+      let filtered-data = fold-data.data.filter(d => d.name == none or d.name not in active-revokes or d.index >= active-revokes.at(d.name))
+      if filtered-data == () {
+        _ = fold-chain.remove(field-name)
+      } else {
+        fold-chain.at(field-name).data = filtered-data
+        fold-chain.at(field-name).values = filtered-data.map(d => d.value)
+      }
+    }
+  }
+
+  let final-values = chain.sum(default: (:))
+
+  // Apply folds separately (their fields' values are meaningless in the above dict)
+  for (field-name, fold-data) in fold-chain {
+    final-values.at(field-name) = if fold-data.values == () {
+      fold-data.default
+    } else if fold-data.folder == auto {
+      fold-data.default + fold-data.values.sum()
+    } else {
+      fold-data.values.fold(fold-data.default, fold-data.folder)
+    }
+  }
+
+  final-values
+}
+
+// Retrieves the final chain data for an element, after applying all set rules so far.
+#let get-styles(element, elements: (:)) = {
+  if type(element) == function {
+    element = data(element)
+  }
+  let (eid, default-fields) = if type(element) == dictionary and "eid" in element and "default-fields" in element {
+    (element.eid, element.default-fields)
+  } else {
+    assert(false, message: "element.get: expected element (function / data dictionary), received " + str(type(element)))
+  }
+
+  let element-data = elements.at(eid, default: default-data)
+  let folded-chain = if element-data.revoke-chain == default-data.revoke-chain and element-data.fold-chain == default-data.fold-chain {
+    element-data.chain.sum(default: (:))
+  } else {
+    fold-styles(element-data.chain, element-data.data-chain, element-data.revoke-chain, element-data.fold-chain)
+  }
+
+  // No need to do extra folding like in constructor:
+  // if a foldable field hasn't been specified, it is either equal to
+  // its default, or it is a required field which has no default and
+  // thus it is not returned here since it can't be set.
+  default-fields + folded-chain
+}
+
+/// Reads the current values of element fields after applying set rules.
+///
+/// The callback receives a 'get' function which can be used to read the
+/// values for a given element. The content returned by the function, which
+/// depends on those values, is then placed into the document.
+///
+/// USAGE:
+/// ```typ
+/// #show: e.set_(elem, fill: green)
+/// // ...
+/// #e.get(get => {
+///   // OK
+///   assert(get(elem).fill == green)
+/// })
+/// ```
+///
+/// - receiver (function):
+/// -> content
+#let prepare-get(receiver) = context {
+  let previous-bib-title = bibliography.title
+  [#context {
+    let global-data = if (
+      type(bibliography.title) == content
+      and bibliography.title.func() == metadata
+      and bibliography.title.at("label", default: none) == lbl-data-metadata
+    ) {
+      bibliography.title.value
+    } else {
+      (..default-global-data, first-bib-title: previous-bib-title)
+    }
+
+    if global-data.stateful {
+      let chain = style-state.get()
+      global-data = if chain == () {
+        default-global-data
+      } else {
+        chain.last()
+      }
+    }
+
+    set bibliography(title: previous-bib-title)
+    receiver(get-styles.with(elements: global-data.elements))
+  }#lbl-get]
+}
+
+// Obtain a Typst selector to use to match this element in show rules or in the outline.
+#let selector(elem, outline: false, outer: false) = {
+  if outline {
+    assert(not outer, message: "element.selector: cannot have 'outline: true' and 'outer: true' at the same time, please pick one selector")
+    let elem-data = data(elem)
+    assert("outline-sel" in elem-data, message: "element.selector: this isn't a valid element")
+    assert(elem-data.outline-sel != none, message: "element.selector: this element isn't outlinable\n  hint: try asking its author to define it as such with 'outline: auto', 'outline: (caption: [...])' or 'outline: (caption: it => ...)'")
+    elem-data.outline-sel
+  } else if outer {
+    data(elem).outer-sel
+  } else {
+    data(elem).sel
+  }
+}
+
+
+
+/// Applies necessary show rules to the entire document so that custom elements behave
+/// properly. This is usually only needed for elements which have custom references,
+/// since, in that case, the document-wide rule `#show ref: e.ref` is required.
+/// **It is recommended to always use `e.prepare` when using Elembic.**
+///
+/// However, **some custom elements also have their own `prepare` functions.** (Read
+/// their documentation to know if that's the case.) Then, you may specify their functions
+/// as parameters to this function, and this function will run the `prepare` function of
+/// each element. Not specifying any elements will just run the default rules, which may
+/// still be important.
+///
+/// As an example, an element may use its own `prepare` function to apply some special
+/// behavior to its `outline`.
+///
+/// USAGE:
+/// ```rs
+/// // Apply default rules + special rules for these elements (if they need it)
+/// #show: e.prepare(elemA, elemB)
+///
+/// // Apply default rules only
+/// #show: e.prepare()
+/// ```
+/// - args (arguments): element functions which need special preparation, or none to just apply default rules
+/// -> function
+#let prepare(
+  ..args
+) = {
+  assert(args.named() == (:), message: "element.prepare: unexpected named arguments")
+  let default-rules = doc => {
+    show ref: ref_
+
+    doc
+  }
+
+  if args.pos() == () {
+    return default-rules
+  }
+
+  let elems = args.pos().map(data)
+
+  if elems.len() == 1 and type(args.pos().first()) == content {
+    assert(false, message: "element.prepare: expected (optional) element functions as arguments, not the document\n  hint: write '#show: e.prepare()', not '#show: e.prepare' - note the parentheses")
+  }
+
+  assert(elems.all(it => it.data-kind == "element"), message: "element.prepare: positional arguments must be elements")
+  let prepares = elems.filter(elem => "prepare" in elem and elem.prepare != none).map(elem => elem.prepare.with(elem.func))
+
+  doc => {
+    show: default-rules
+    prepares.fold(doc, (acc, prepare) => prepare(acc))
+  }
+}
+
+/// Creates a new element, returning its constructor. Read the "Creating custom elements"
+/// chapter for more information.
+///
+/// USAGE:
+///
+/// ```typ
+/// #import "@preview/elembic:X.X.X" as e: field
+///
+/// // For references to apply
+/// #show: e.prepare()
+///
+/// #let elem = e.element.declare(
+///   "elem",
+///   prefix: "@preview/my-package,v1",
+///   display: it => {
+///     [== #it.title]
+///     block(fill: it.fill)[#it.inner]
+///   },
+///   fields: (
+///     field("fill", e.types.option(e.types.paint)),
+///     field("inner", content, default: [Hello!]),
+///     field("title", content, default: [Hello!]),
+///   ),
+///   reference: (
+///     supplement: [Elem],
+///     numbering: "1"
+///   ),
+///   outline: (caption: it => it.title),
+/// )
+///
+/// #outline(target: e.selector(elem, outline: true))
+///
+/// #elem()
+/// #elem(title: [abc], label: <abc>)
+/// @abc
+/// ```
+///
+/// - name (str): The element's name.
+/// - prefix (str): The element's prefix, used to distinguish it from elements with the same name. This is usually your package's name alongside a (major) version.
+/// - display (function): Function `fields => content` to display the element.
+/// - fields (array): Array with this element's fields.
+/// - parse-args (auto | function): Optional override for the built-in argument parser
+/// (or `auto` to keep as is).  Must be in the form
+/// `function(args, include-required: bool) => dictionary`, where `include-required: true`
+/// means required fields are enforced (constructor), while `include-required: false` means
+/// they are forbidden (set rules).
+/// - typecheck (bool): Set to `false` to disable field typechecking.
+/// - allow-unknown-fields (bool): Set to `true` to allow users to specify unknown
+/// fields to your element. They are not typechecked and are simply forwarded to
+/// the element's fields by the argument parser.
+/// - template (none | function): Optional function displayed element => content to define overridable default set rules for your elements, such as paragraph settings. Users can override these settings with show-set rules on elements.
+/// - prepare (none | function): Optional function (element, document) => content
+/// to define show and set rules that should be applied to the whole document for your
+/// element to properly function.
+/// - construct (none | function): Optional function that overrides the default
+/// element constructor, returning arbitrary content. This should be used over
+/// manually wrapping the returned constructor as it ensures set rules and data
+/// extraction from the constructor still work.
+/// - scope (none | dictionary | module): Optional scope with associated data for your
+/// element. This could be a module with constructors for associated elements, for
+/// instance. This value can be accessed with `e.scope(elem)`, e.g.
+/// `#import e.scope(elem): sub-elem`.
+/// - count (none | function): Optional function `counter => (content | function fields => content)`
+/// which inserts a counter step before the element. Ensures the element's display function has
+/// updated context to get the latest counter value (after the step / update) with
+/// `e.counter(it).get()`. Defaults to `counter.step` to step the counter once before
+/// each element placed.
+/// - labelable (bool): Defaults to `true`, allows specifying `#element(label: <abc>)`, which
+/// not only ensures show rules on that label work and have access to the element's final fields,
+/// but also allows referring to that element. When `false`, the element may have a field
+/// named `label` instead, but it won't have these effects.
+/// - reference (none | (supplement: none | str | content | function fields => str | content, numbering: none | str | function fields => str | function, custom: none | function fields => content)):
+/// When not `none`, allows referring to the new element with Typst's built-in
+/// `@ref` syntax. Requires the user to execute `#show: e.prepare()` at the top
+/// of their document (it is part of the default rules, so `prepare` needs no
+/// arguments there). Specify either a `supplement` and `numbering` for references
+/// looking like "Name 2", and/or `custom` to show some fully customized content
+/// for the reference instead.
+/// - outline (none | auto | dictionary):
+/// Accepts either `auto` or a dictionary of the form
+/// `(caption: str | content | function fields => content)`.
+/// When not `none`, allows creating an outline for the element's appearances
+/// with `#outline(target: e.selector(elem, outline: true))`. When set to `auto`,
+/// the entries will display "Name 2" based on reference information. When a caption
+/// is specified, it will display as "Name 2: caption", unless supplement and numbering
+/// for reference are both none.
+/// - synthesize (none | function): Can be set to a function `fields => fields` to
+/// override final values of fields, or create new fields based on final values of
+/// fields, before the first show rule. When computing new fields based on other
+/// fields, please specify those new fields in the fields array with
+/// `synthesized: true`. This forbids the user from specifying them manually,
+/// but allows them to filter based on that field.
+/// - contextual (bool): When set to `true`, functions `fields => something` for
+/// other options, including `display`, will be able to access the current
+/// values of set rules with `(e.ctx(fields).get)(other-elem)`. In addition,
+/// an additional context block is created, so that you may access the correct
+/// values for `native-elem.field` in the context. In practice, this is a bit
+/// expensive, and so this option shouldn't be enabled unless you need precisely
+/// `bibliography.title`, or you really need to get set rule information from
+/// other elements within functions such as `synthesize` or `display`.
+/// -> function
+#let declare(
+  name,
+  display: none,
+  fields: none,
+  prefix: none,
+  parse-args: auto,
+  typecheck: true,
+  allow-unknown-fields: false,
+  template: none,
+  prepare: none,
+  construct: none,
+  scope: none,
+  count: counter.step,
+  labelable: true,
+  reference: none,
+  outline: none,
+  synthesize: none,
+  contextual: false,
+) = {
+  assert(type(display) == function, message: "element.declare: please specify a show rule in 'display:' to determine how your element is displayed.")
+
+  let fields-hint = if type(fields) == dictionary { "\n  hint: check if you didn't forget to add a trailing comma for a single field: write 'fields: (field,)', not 'fields: (field)'" } else { "" }
+  assert(type(fields) == array, message: "element.declare: please specify an array of fields, creating each field with the 'field' function. It can be empty with '()'." + fields-hint)
+  assert(prefix != none, message: "element.declare: please specify a 'prefix: ...' for your type, to distinguish it from types with the same name. If you are writing a package or template to be used by others, please do not use an empty prefix.")
+  assert(type(prefix) == str, message: "element.declare: the prefix must be a string, not '" + str(type(prefix)) + "'")
+  assert(parse-args == auto or type(parse-args) == function, message: "element.declare: 'parse-args' must be either 'auto' (use built-in parser) or a function (default arg parser, fields: dictionary, typecheck: bool) => (user arguments, include-required: true (required fields must be specified - in constructor) / false (required fields must be omitted - in set rules)) => dictionary with parsed fields.")
+  assert(type(typecheck) == bool, message: "element.declare: the 'typecheck' argument must be a boolean (true to enable typechecking, false to disable).")
+  assert(type(allow-unknown-fields) == bool, message: "element.declare: the 'allow-unknown-fields' argument must be a boolean.")
+  assert(template == none or type(template) == function, message: "element.declare: 'template' must be 'none' or a function displayed element => content (usually set rules applied on the displayed element). This is used to add a set of overridable set rules to the element, such as paragraph settings.")
+  assert(prepare == none or type(prepare) == function, message: "element.declare: 'prepare' must be 'none' or a function (element, document) => styled document (used to apply show and set rules to the document).")
+  assert(count == none or type(count) == function, message: "element.declare: 'count' must be 'none', a function counter => counter step/update element, or a function counter => final fields => counter step/update element.")
+  assert(synthesize == none or type(synthesize) == function, message: "element.declare: 'synthesize' must be 'none' or a function element fields => element fields.")
+  assert(contextual == auto or type(contextual) == bool, message: "element.declare: 'contextual' must be 'auto' (true if using a contextual feature) or a boolean (true to wrap the output in a 'context { ... }', false to not).")
+  assert(construct == none or type(construct) == function, message: "element.declare: 'construct' must be 'none' (use default constructor) or a function receiving the original constructor and returning the new constructor.")
+  assert(scope == none or type(scope) in (dictionary, module), message: "element.declare: 'scope' must be either 'none', a dictionary or a module")
+  assert(type(labelable) == bool, message: "element.declare: 'labelable' must be a boolean (true to enable the special 'label' constructor argument, false to disable it)")
+  assert(
+    reference == none
+    or type(reference) == dictionary
+      and reference.keys().all(x => x in ("supplement", "numbering", "custom"))
+      and ("supplement" not in reference or reference.supplement == none or type(reference.supplement) in (str, content, function))
+      and ("numbering" not in reference or reference.numbering == none or type(reference.numbering) in (str, function))
+      and ("custom" not in reference or reference.custom == none or type(reference.custom) == function),
+    message: "element.declare: 'reference' must be 'none' or a dictionary (supplement: \"Name\" or [Name] or function fields => supplement, numbering: \"1.\" or function fields => (str / function numbers => content), custom (optional): none (default) or function fields => content)."
+  )
+  assert(
+    reference == none or "supplement" in reference and "numbering" in reference or "custom" in reference,
+    message: "element.declare: reference must either have 'custom', or have both 'supplement' and 'numbering' (or all three, though 'custom' has priority when displaying references)."
+  )
+  assert(
+    outline == none
+    or outline == auto
+    or type(outline) == dictionary
+      and "caption" in outline,
+    message: "element.declare: 'outline' must be 'none', 'auto' (to use data from 'reference') or a dictionary with 'caption'."
+  )
+  assert(outline != auto or reference != none, message: "element.declare: if 'outline' is set to 'auto', 'reference' must be specified and not be 'none'.")
+  assert(labelable or reference == none, message: "element.declare: 'labelable' must be true for 'reference' to not be 'none'")
+
+  if contextual == auto {
+    // Provide separate context for synthesize.
+    // By default, assume it isn't needed.
+    contextual = synthesize != none
+  }
+
+  let eid = base.unique-id("e", prefix, name)
+  let lbl-show = label(lbl-show-head + eid)
+  let lbl-outer = label(lbl-outer-head + eid)
+  let ref-figure-kind = if reference == none and outline == none { none } else { lbl-ref-figure-kind-head + eid }
+  // Use same counter as hidden figure for ease of use
+  let counter-key = lbl-counter-head + eid
+  let element-counter = counter(counter-key)
+  let count = if count == none { none } else { count(element-counter) }
+  let count-needs-fields = type(count) == function
+  let custom-ref = if reference != none and "custom" in reference and type(reference.custom) == function { reference.custom } else { none }
+
+  let supplement-type = if reference == none or "supplement" not in reference {
+    none
+  } else {
+    type(reference.supplement)
+  }
+  let numbering-type = if reference == none or "numbering" not in reference {
+    none
+  } else {
+    type(reference.numbering)
+  }
+  let caption-type = if outline == none or outline == auto {
+    none
+  } else {
+    type(outline.caption)
+  }
+
+  let fields = field-internals.parse-fields(fields, allow-unknown-fields: allow-unknown-fields)
+  let (all-fields, user-fields, foldable-fields) = fields
+
+  if labelable and "label" in all-fields {
+    assert(false, message: "element.declare: labelable element cannot have a conflicting 'label' field\n  hint: you can set 'labelable: false' to disable the special label parameter, but note that it will then be impossible to refer to your element")
+  }
+
+  let default-arg-parser = field-internals.generate-arg-parser(
+    fields: fields,
+    general-error-prefix: "element '" + name + "': ",
+    field-error-prefix: field-name => "field '" + field-name + "' of element '" + name + "': ",
+    typecheck: typecheck
+  )
+
+  let parse-args = if parse-args == auto {
+    default-arg-parser
+  } else {
+    let parse-args = parse-args(default-arg-parser, fields: fields, typecheck: typecheck)
+    if type(parse-args) != function {
+      assert(false, message: "element.declare: 'parse-args', when specified as a function, receives the default arg parser alongside `fields: fields dictionary` and `typecheck: bool`, and must return a function (the new arg parser), and not " + base.typename(parse-args))
+    }
+
+    parse-args
+  }
+
+  let default-fields = fields.user-fields.values().map(f => if f.required { (:) } else { ((f.name): f.default) }).sum(default: (:))
+
+  let set-rule = set_.with((parse-args: parse-args, eid: eid, default-data: default-data, fields: fields))
+
+  let get-rule(receiver) = prepare-get(g => receiver(g((eid: eid, default-fields: default-fields))))
+
+  // Prepare a filter which should be passed to 'select()'.
+  // This function will specify which field values for this
+  // element should be matched.
+  let where(..args) = {
+    assert(args.pos().len() == 0, message: "unexpected positional arguments\nhint: here, specify positional fields as named arguments, using their names")
+    let args = args.named()
+
+    if not allow-unknown-fields {
+      // Note: 'where' on synthesized fields is legal,
+      // so we check 'all-fields' rather than 'user-fields'.
+      let unknown-fields = args.keys().filter(k => k not in all-fields and (not labelable or k != "label"))
+      if unknown-fields != () {
+        let s = if unknown-fields.len() == 1 { "" } else { "s" }
+        assert(false, message: "element.where: element '" + name + "': unknown field" + s + " " + unknown-fields.map(f => "'" + f + "'").join(", "))
+      }
+    }
+
+    ((filter-key): true, kind: "where", eid: eid, fields: args, sel: lbl-show)
+  }
+
+  let elem-data = (
+    (element-key): true,
+    version: element-version,
+    name: name,
+    eid: eid,
+    scope: scope,
+    set_: set-rule,
+    get: get-rule,
+    where: where,
+    sel: lbl-show,
+    outer-sel: lbl-outer,
+    outline-sel: if outline == none { none } else { figure.where(kind: ref-figure-kind) },
+    counter: element-counter,
+    parse-args: parse-args,
+    default-data: default-data,
+    default-global-data: default-global-data,
+    default-fields: default-fields,
+    user-fields: user-fields,
+    all-fields: all-fields,
+    fields: fields,
+    typecheck: typecheck,
+    allow-unknown-fields: allow-unknown-fields,
+    template: template,
+    prepare: prepare,
+    default-constructor: none,
+    func: none,
+  )
+
+  // Figure placed for referencing to work.
+  let ref-figure(tag, synthesized-fields, ref-label) = {
+    let numbering = if numbering-type == str {
+      reference.numbering
+    } else if numbering-type == function {
+      let numbering = (reference.numbering)(synthesized-fields)
+      assert(type(numbering) in (str, function), message: "element: 'reference.numbering' must be a function fields => numbering (a string or a function), but returned " + str(type(numbering)))
+      numbering
+    } else {
+      none
+    }
+
+    let number = if numbering == none { none } else { element-counter.display(numbering) }
+
+    let caption = if caption-type == function {
+      (caption: (outline.caption)(synthesized-fields))
+    } else if caption-type in (str, content) {
+      (caption: [#outline.caption])
+    } else if outline == auto {
+      if (
+        "supplement" in reference and "numbering" in reference
+        or "custom-ref" not in tag
+        or tag.custom-ref == none
+      ) {
+        // Add some caption so it is displayed with the supplement and
+        // number, but remove useless separator
+        (caption: figure.caption(separator: "")[])
+      } else {
+        // No supplement or number, but there are custom reference
+        // contents, so we display that
+        (caption: tag.custom-ref)
+      }
+    } else {
+      (:)
+    }
+
+    let ref-figure = [#figure(
+      supplement: if supplement-type in (str, content) {
+        [#reference.supplement]
+      } else if supplement-type == function {
+        (reference.supplement)(synthesized-fields)
+      } else {
+        []
+      },
+
+      numbering: if number == none { none } else { _ => number },
+
+      kind: ref-figure-kind,
+
+      ..caption
+    )[#[]#metadata(tag)#lbl-tag]#ref-label]
+
+    let tagged-figure = [#[#ref-figure#metadata(tag)#lbl-tag]#lbl-ref-figure]
+
+    show figure: none
+
+    tagged-figure
+  }
+
+  // Sentinel for 'unspecified value'
+  let _missing() = {}
+  let std-label = label
+
+  let default-constructor(..args, __elembic_data: none, __elembic_func: auto, label: _missing) = {
+    if __elembic_func == auto {
+      __elembic_func = default-constructor
+    }
+
+    let default-constructor = default-constructor.with(__elembic_func: __elembic_func)
+    if __elembic_data != none {
+      return if __elembic_data == special-data-values.get-data {
+        (data-kind: "element", ..elem-data, func: __elembic_func, default-constructor: default-constructor)
+      } else if __elembic_data == special-data-values.get-where {
+        if label == _missing {
+          where(..args)
+        } else {
+          where(..args, label: label)
+        }
+      } else {
+        assert(false, message: "element: invalid data key to constructor: " + repr(__elembic_data))
+      }
+    }
+
+    let labeling = false
+    let ref-label = none
+    if labelable {
+      if label == _missing {
+        label = none
+      } else if type(label) == std-label {
+        ref-label = std-label(lbl-ref-figure-label-head + str(label))
+        labeling = true
+      } else if label != none {
+        assert(false, message: "element '" + name + "': expected label or 'none' for 'label', found " + base.typename(label))
+      }
+    } else if label == _missing {
+      label = none
+    } else {
+      // Also parse label as a field if we don't want element to be labelable
+      args = arguments(..args, label: label)
+    }
+
+    let args = parse-args(args, include-required: true)
+
+    // Step the counter early if we don't need additional context
+    let early-step = if not count-needs-fields { count }
+
+    let inner = early-step + [#context {
+      let previous-bib-title = bibliography.title
+      [#context {
+        set bibliography(title: previous-bib-title)
+
+        let (global-data, data-changed) = if (
+          type(bibliography.title) == content
+          and bibliography.title.func() == metadata
+          and bibliography.title.at("label", default: none) == lbl-data-metadata
+        ) {
+          (bibliography.title.value, false)
+        } else {
+          ((..default-global-data, first-bib-title: previous-bib-title), true)
+        }
+
+        if global-data.stateful {
+          let chain = style-state.get()
+          global-data = if chain == () {
+            default-global-data
+          } else {
+            chain.last()
+          }
+        }
+
+        let element-data = global-data.elements.at(eid, default: default-data)
+
+        let constructed-fields = if (
+          element-data.revoke-chain == default-data.revoke-chain
+          and (
+            foldable-fields == (:)
+            or element-data.fold-chain == default-data.fold-chain
+            and args.keys().all(f => f not in foldable-fields)
+          )
+        ) {
+          // Sum the chain of dictionaries so that the latest value specified for
+          // each property wins.
+          default-fields + element-data.chain.sum(default: (:)) + args
+        } else {
+          // We can't just sum, we need to filter and fold first.
+          // Memoize this operation through a function.
+          let outer-chain = default-fields + fold-styles(element-data.chain, element-data.data-chain, element-data.revoke-chain, element-data.fold-chain)
+          let finalized-chain = outer-chain + args
+
+          // Fold received arguments with outer chain or defaults
+          for (field-name, fold-data) in foldable-fields {
+            if field-name in args {
+              let outer = outer-chain.at(field-name, default: fold-data.default)
+              if fold-data.folder == auto {
+                finalized-chain.at(field-name) = outer + args.at(field-name)
+              } else {
+                finalized-chain.at(field-name) = (fold-data.folder)(outer, args.at(field-name))
+              }
+            }
+          }
+
+          finalized-chain
+        }
+
+        let shown = {
+          let tag = (
+            data-kind: "element-instance",
+            body: none,
+            fields: constructed-fields,
+            func: __elembic_func,
+            scope: scope,
+            default-constructor: default-constructor,
+            name: name,
+            eid: eid,
+            ctx: if contextual {
+              (get: get-styles.with(elements: global-data.elements))
+            } else { none },
+            counter: element-counter,
+            reference: reference,
+            custom-ref: none,
+            fields-known: true,
+            valid: true
+          )
+
+          if contextual {
+            // Use context for synthesize as well
+            context {
+              let synthesized-fields = if synthesize == none {
+                constructed-fields
+              } else {
+                // Pass contextual information to synthesize
+                // Remove it afterwards to ensure the final tag's 'fields' won't
+                // have its own copy of the tag
+                let new-fields = synthesize(constructed-fields + ((stored-data-key): tag))
+                if type(new-fields) != dictionary {
+                  assert(false, message: "element '" + name + "': 'synthesize' didn't return a dictionary, but rather " + repr(new-fields) + " (a(n) '" + str(type(new-fields)) + "') instead). Please contact the element author.")
+                }
+                if stored-data-key in new-fields {
+                  _ = new-fields.remove(stored-data-key)
+                }
+                new-fields
+              }
+
+              if labelable and label != none and label != _missing {
+                synthesized-fields.label = label
+              }
+
+              let tag = tag
+              tag.fields = synthesized-fields
+
+              // Store contextual information in synthesize
+              synthesized-fields.insert(stored-data-key, tag)
+
+              if count-needs-fields {
+                count(synthesized-fields)
+
+                // Wrap in additional context so the counter step is detected
+                context {
+                  let body = display(synthesized-fields)
+                  let tag = tag
+                  tag.body = body
+
+                  if custom-ref != none {
+                    // Update with body
+                    let synthesized-fields = synthesized-fields
+                    synthesized-fields.at(stored-data-key) = tag
+
+                    tag.custom-ref = custom-ref(synthesized-fields)
+                  }
+
+                  let tag-metadata = metadata(tag)
+
+                  if reference != none and ref-label != none or outline != none {
+                    // Update with custom-ref
+                    let synthesized-fields = synthesized-fields
+                    synthesized-fields.at(stored-data-key) = tag
+
+                    ref-figure(tag, synthesized-fields, ref-label)
+                  }
+
+                  if labeling {
+                    [#[#[#body#metadata(tag)#lbl-tag]#label#metadata(tag)]#lbl-show]
+                  } else {
+                    [#[#body#metadata(tag)]#lbl-show]
+                  }
+                }
+              } else {
+                let body = display(synthesized-fields)
+                let tag = tag
+                tag.body = body
+
+                if custom-ref != none {
+                  // Update with body
+                  synthesized-fields.at(stored-data-key) = tag
+
+                  tag.custom-ref = custom-ref(synthesized-fields)
+                }
+
+                let tag-metadata = metadata(tag)
+
+                if reference != none and ref-label != none or outline != none {
+                  // Update with custom-ref
+                  synthesized-fields.at(stored-data-key) = tag
+
+                  ref-figure(tag, synthesized-fields, ref-label)
+                }
+
+                if labeling {
+                  [#[#[#body#metadata(tag)#lbl-tag]#label#metadata(tag)]#lbl-show]
+                } else {
+                  [#[#body#metadata(tag)]#lbl-show]
+                }
+              }
+            }
+          } else {
+            let synthesized-fields = if synthesize == none {
+              constructed-fields
+            } else {
+              // Pass contextual information to synthesize
+              // Remove it afterwards to ensure the final tag's 'fields' won't
+              // have its own copy of the tag
+              let new-fields = synthesize(constructed-fields + ((stored-data-key): tag))
+              if type(new-fields) != dictionary {
+                assert(false, message: "element '" + name + "': 'synthesize' didn't return a dictionary, but rather " + repr(new-fields) + " (a(n) '" + str(type(new-fields)) + "') instead). Please contact the element author.")
+              }
+              if stored-data-key in new-fields {
+                _ = new-fields.remove(stored-data-key)
+              }
+              new-fields
+            }
+
+            if labelable and label != none and label != _missing {
+              synthesized-fields.label = label
+            }
+
+            tag.fields = synthesized-fields
+
+            // Store contextual information in synthesize
+            synthesized-fields.insert(stored-data-key, tag)
+
+            if count-needs-fields {
+              count(synthesized-fields)
+
+              // Wrap in additional context so the counter step is detected
+              context {
+                let body = display(synthesized-fields)
+                let tag = tag
+                tag.body = body
+
+                if custom-ref != none {
+                  // Update with body
+                  let synthesized-fields = synthesized-fields
+                  synthesized-fields.at(stored-data-key) = tag
+
+                  tag.custom-ref = custom-ref(synthesized-fields)
+                }
+
+                let tag-metadata = metadata(tag)
+
+                if reference != none and ref-label != none or outline != none {
+                  // Update with custom-ref
+                  let synthesized-fields = synthesized-fields
+                  synthesized-fields.at(stored-data-key) = tag
+
+                  ref-figure(tag, synthesized-fields, ref-label)
+                }
+
+                if labeling {
+                  [#[#[#body#metadata(tag)#lbl-tag]#label#metadata(tag)]#lbl-show]
+                } else {
+                  [#[#body#metadata(tag)]#lbl-show]
+                }
+              }
+            } else {
+              let body = display(synthesized-fields)
+              tag.body = body
+
+              if custom-ref != none {
+                // Update with body
+                synthesized-fields.at(stored-data-key) = tag
+
+                tag.custom-ref = custom-ref(synthesized-fields)
+              }
+
+              let tag-metadata = metadata(tag)
+
+              if reference != none and ref-label != none or outline != none {
+                // Update with custom-ref
+                synthesized-fields.at(stored-data-key) = tag
+
+                ref-figure(tag, synthesized-fields, ref-label)
+              }
+
+              if labeling {
+                [#[#[#body#metadata(tag)#lbl-tag]#label#metadata(tag)]#lbl-show]
+              } else {
+                [#[#body#metadata(tag)]#lbl-show]
+              }
+            }
+          }
+        }
+
+        if data-changed {
+          show lbl-get: set bibliography(title: [#metadata(global-data)#lbl-data-metadata])
+          shown
+        } else {
+          shown
+        }
+      }#lbl-get]
+    }#lbl-outer]
+
+    let tag = [#metadata((
+      data-kind: "element-instance",
+      body: inner,
+      scope: scope,
+      fields: args,
+      func: __elembic_func,
+      default-constructor: default-constructor,
+      name: name,
+      eid: eid,
+      ctx: none,
+      counter: element-counter,
+      reference: reference,
+      custom-ref: none,
+      fields-known: false,
+      valid: true
+    ))#lbl-tag]
+
+    if template != none {
+      inner = template[#inner#tag]
+    }
+
+    [#inner#tag]
+  }
+
+  let final-constructor = if construct != none {
+    {
+      let test-construct = construct(default-constructor)
+      assert(type(test-construct) == function, message: "element.declare: the 'construct' function must receive original constructor and return the new constructor, a new function, not '" + str(type(test-construct)) + "'.")
+    }
+
+    let final-constructor(..args, __elembic_data: none) = {
+      if __elembic_data != none {
+        return if __elembic_data == special-data-values.get-data {
+          (data-kind: "element", ..elem-data, func: final-constructor, default-constructor: default-constructor.with(__elembic_func: final-constructor))
+        } else if __elembic_data == special-data-values.get-where {
+          where(..args)
+        } else {
+          assert(false, message: "element: invalid data key to constructor: " + repr(__elembic_data))
+        }
+      }
+
+      construct(default-constructor.with(__elembic_func: final-constructor))(..args)
+    }
+
+    final-constructor
+  } else {
+    default-constructor
+  }
+
+  final-constructor
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/fields.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/fields.typ
@@ -1,0 +1,406 @@
+#import "data.typ": type-key, custom-type-key
+#import "types/types.typ"
+
+#let field-key = "__elembic_field"
+#let fields-key = "__elembic_fields"
+
+#let current-field-version = 1
+
+#let _missing() = {}
+
+// Specifies an element field's properties.
+#let field(
+  name,
+  type_,
+  doc: none,
+  required: false,
+  named: auto,
+  synthesized: false,
+  default: _missing,
+) = {
+  assert(type(name) == str, message: "field: Field name must be a string, not " + str(type(name)))
+
+  let error-prefix = "field '" + name + "': "
+  assert(doc == none or type(doc) == str, message: error-prefix + "'doc' must be none or a string (add documentation)")
+  assert(type(synthesized) == bool, message: error-prefix + "'synthesized' must be a boolean (true: field is automatically synthesized and cannot be specified or overridden by the user; false: field can be manually specified and overridden by the user)")
+  assert(type(required) == bool, message: error-prefix + "'required' must be a boolean")
+  assert(named == auto or type(named) == bool, message: error-prefix + "'named' must be a boolean or auto")
+  let typeinfo = {
+    let (res, value) = types.validate(type_)
+    assert(res, message: if not res { error-prefix + value } else { "" })
+    value
+  }
+
+  if not required and default == _missing {
+    let (res, value) = types.default(typeinfo)
+    assert(res, message: if not res { error-prefix + value } else { "" })
+
+    default = value
+  }
+
+  default = if required or synthesized {
+    // This value should be ignored in that case
+    auto
+  } else {
+    let (success, value) = types.cast(default, typeinfo)
+    if not success {
+      assert(false, message: error-prefix + value + "\n  hint: given default for field had an incompatible type")
+    }
+
+    value
+  }
+
+  let fold = if not synthesized and "fold" in typeinfo and typeinfo.fold != none {
+    assert(typeinfo.fold == auto or type(typeinfo.fold) == function, message: error-prefix + "type '" + typeinfo.name + "' doesn't appear to have a valid fold field (must be auto or function)")
+    let fold-default = if required {
+      // No field default, use the type's own default to begin folding
+      let (res, value) = types.default(typeinfo)
+      assert(res, message: if not res { error-prefix + value } else { "" })
+
+      value
+    } else {
+      // Use the field default as starting point for folding
+      default
+    }
+
+    (
+      folder: typeinfo.fold,
+      default: fold-default,
+    )
+  } else {
+    none
+  }
+
+  if named == auto {
+    // Pos arg is generally required
+    named = not required
+  }
+
+  if synthesized and (required or not named) {
+    assert(false, message: error-prefix + "synthesized field cannot be required or positional, since it cannot be specified by the user")
+  }
+
+  (
+    (field-key): true,
+    version: current-field-version,
+    name: name,
+    doc: doc,
+    typeinfo: typeinfo,
+    default: default,
+    required: required,
+    synthesized: synthesized,
+    named: named,
+    fold: fold,
+  )
+}
+
+#let parse-fields(fields, allow-unknown-fields: false) = {
+  assert(type(allow-unknown-fields) == bool, message: "element.fields: 'allow-unknown-fields' must be a boolean, not " + str(type(allow-unknown-fields)))
+
+  let required-pos-fields = ()
+  let optional-pos-fields = ()
+  let required-named-fields = ()
+  let optional-named-fields = ()
+  let all-fields = (:)
+  let user-named-fields = (:)
+  let foldable-fields = (:)
+  let user-fields = (:)
+  let synthesized-fields = (:)
+
+  for field in fields {
+    assert(type(field) == dictionary and field.at(field-key, default: none) == true, message: "element.fields: Invalid field received, please use the 'e.fields.field' constructor.")
+    assert(field.named or not field.required or optional-pos-fields == (), message: "element.fields: field '" + field.name + "' cannot be positional and required and appear after other positional but optional fields. Ensure there are only optional fields after the first positional optional field.")
+    assert(field.name not in all-fields, message: "element.fields: duplicate field name '" + field.name + "'")
+
+    if field.required {
+      if field.named {
+        required-named-fields.push(field)
+      } else {
+        required-pos-fields.push(field)
+      }
+    } else if field.named {
+      optional-named-fields.push(field)
+    } else {
+      optional-pos-fields.push(field)
+    }
+
+    if field.fold != none {
+      foldable-fields.insert(field.name, field.fold)
+    }
+
+    if field.synthesized {
+      synthesized-fields.insert(field.name, field)
+    } else {
+      user-fields.insert(field.name, field)
+
+      if field.named {
+        user-named-fields.insert(field.name, field)
+      }
+    }
+
+    all-fields.insert(field.name, field)
+  }
+
+  (
+    (fields-key): true,
+    version: current-field-version,
+    required-pos-fields: required-pos-fields,
+    optional-pos-fields: optional-pos-fields,
+    required-named-fields: required-named-fields,
+    optional-named-fields: optional-named-fields,
+    foldable-fields: foldable-fields,
+    user-named-fields: user-named-fields,
+    user-fields: user-fields,
+    all-fields: all-fields,
+    allow-unknown-fields: allow-unknown-fields,
+  )
+}
+
+// Generates an argument parser function with the given general error
+// prefix (for listing missing fields) and per-field error prefix function
+// (for an invalid field; receives the field name).
+//
+// You can customize 'field-term' to customize what the word "field" is
+// in error messages. It should be either a string or a two-element
+// array with (singular, plural). Setting 'typecheck: false' also fully
+// disables typechecking.
+//
+// Parse arguments into a dictionary of fields and their casted values.
+// By default, include required arguments and error if they are missing.
+// Setting 'include-required' to false will error if they are present
+// instead.
+#let generate-arg-parser(
+  fields: none,
+  general-error-prefix: "",
+  field-error-prefix: _ => "",
+  field-term: "field",
+  typecheck: true,
+) = {
+  assert(type(fields) == dictionary and fields-key in fields, message: "generate-arg-parser: please use 'parse-fields' to generate the fields input.")
+  assert(type(general-error-prefix) == str, message: "generate-arg-parser: 'general-error-prefix' must be a string")
+  assert(type(field-error-prefix) == function, message: "generate-arg-parser: 'field-error-prefix' must be a function receiving field name and returning string")
+  assert(type(typecheck) == bool, message: "generate-arg-parser: 'typecheck' must be a boolean, not " + str(type(typecheck)))
+
+  let (field-singular, field-plural) = if type(field-term) == str {
+    (field-term, field-term + "s")
+  } else if type(field-term) == array and field-term.len() == 2 and field-term.all(term => type(term) == str) {
+    field-term
+  } else {
+    assert(false, message: "generate-arg-parser: 'field-term' must either be a string (plural with 's') or a two-element array of strings (singular, plural).")
+  }
+
+  let (required-pos-fields, optional-pos-fields, required-named-fields, optional-named-fields, all-fields, user-fields, user-named-fields, allow-unknown-fields) = fields
+  let required-pos-fields-amount = required-pos-fields.len()
+  let optional-pos-fields-amount = optional-pos-fields.len()
+  let total-pos-fields-amount = required-pos-fields-amount + optional-pos-fields-amount
+  let all-pos-fields = required-pos-fields + optional-pos-fields
+
+  let has-required-fields = required-pos-fields-amount + required-named-fields.len() != 0
+
+  // If we allow unknown named fields, we still need to check whether a
+  // positional or synthesized field was accidentally specified as a named field.
+  let is-unknown-named-field = if allow-unknown-fields {
+    f => f in all-fields and f not in user-named-fields
+  } else {
+    f => f not in user-named-fields
+  }
+
+  // Disable typechecking anyway if all fields are 'any'
+  //
+  // Have a separate typecheck option so type information can be kept in fields
+  // even if typechecking is undesirable
+  // Note: we don't parse args for synthesized fields, so we can exclude them when
+  // checking whether we will typecheck when parsing args
+  let typecheck = typecheck and user-fields.values().any(f => f.typeinfo.type-kind != "any")
+
+  // Parse args (no typechecking)
+  let parse-args-no-typechecking(args, include-required: true) = {
+    let pos = args.pos()
+
+    if include-required and pos.len() < required-pos-fields-amount {
+      // Plural
+      let term = if required-pos-fields-amount - pos.len() == 1 { field-singular } else { field-plural }
+
+      assert(false, message: general-error-prefix + "missing positional " + term + " " + fields.required-pos-fields.slice(pos.len()).map(f => "'" + f.name + "'").join(", "))
+    }
+
+    if pos.len() > if include-required { total-pos-fields-amount } else { optional-pos-fields-amount } {
+      let expected-arg-amount = if include-required { total-pos-fields-amount } else { optional-pos-fields-amount }
+      let excluding-required-hint = if include-required { "" } else { "\n  hint: only optional fields are accepted here" }
+      assert(false, message: general-error-prefix + "too many positional arguments, expected " + str(expected-arg-amount) + excluding-required-hint)
+    }
+
+    let named-args = args.named()
+    if include-required {
+      if required-named-fields.any(f => f.name not in named-args) {
+        let missing-fields = required-named-fields.filter(f => f.name not in named-args)
+        let term = if missing-fields.len() == 1 { field-singular } else { field-plural }
+
+        assert(false, message: general-error-prefix + "missing required named " + term + " " + missing-fields.map(f => "'" + f.name + "'").join(", "))
+      }
+    } else if required-named-fields.any(f => f.name in named-args) {
+      let field = required-named-fields.find(f => f.name in named-args)
+      assert(false, message: field-error-prefix(field.name) + "this " + field-singular + " cannot be specified here\n  hint: only optional " + field-plural + " are accepted here")
+    }
+
+    // Here we simultaneously check for unknown fields and for positional fields
+    // being wrongly specified as named. If there are no positional fields and
+    // unknown fields are allowed, there is no point in doing this check.
+    if (not allow-unknown-fields or total-pos-fields-amount > 0) and named-args.keys().any(is-unknown-named-field) {
+      let field-name = named-args.keys().find(is-unknown-named-field)
+      let field = all-fields.at(field-name, default: none)
+      let expected-pos-hint = if field == none or field.named { "" } else { "\n  hint: this " + field-singular + " must be specified positionally" }
+      let is-synthesized-hint = if field != none and field.synthesized { "\n  hint: this " + field-singular + " is synthesized and cannot be specified manually" } else { "" }
+
+      assert(false, message: general-error-prefix + "unknown named " + field-singular + " '" + field-name + "'" + expected-pos-hint + is-synthesized-hint)
+    }
+
+    let pos-fields = if include-required { all-pos-fields } else { optional-pos-fields }
+    let i = 0
+    for value in pos {
+      let pos-field = pos-fields.at(i)
+      named-args.insert(pos-field.name, value)
+
+      i += 1
+    }
+
+    named-args
+  }
+
+  // Parse args (with typechecking)
+  let parse-args(args, include-required: true) = {
+    let result = (:)
+
+    let pos = args.pos()
+    if include-required and pos.len() < required-pos-fields-amount {
+      // Plural
+      let term = if required-pos-fields-amount - pos.len() == 1 { field-singular } else { field-plural }
+
+      assert(false, message: general-error-prefix + "missing positional " + term + " " + fields.required-pos-fields.slice(pos.len()).map(f => "'" + f.name + "'").join(", "))
+    }
+
+    let expected-arg-amount = if include-required { total-pos-fields-amount } else { optional-pos-fields-amount }
+
+    if pos.len() > expected-arg-amount {
+      let excluding-required-hint = if include-required { "" } else { "\n  hint: only optional fields are accepted here" }
+      assert(false, message: general-error-prefix + "too many positional arguments, expected " + str(expected-arg-amount) + excluding-required-hint)
+    }
+
+    let named-args = args.named()
+
+    if include-required and required-named-fields.any(f => f.name not in named-args) {
+      let missing-fields = required-named-fields.filter(f => f.name not in named-args)
+      let term = if missing-fields.len() == 1 { field-singular } else { field-plural }
+
+      assert(false, message: general-error-prefix + "missing required named " + term + " " + missing-fields.map(f => "'" + f.name + "'").join(", "))
+    }
+
+    for (field-name, value) in named-args {
+      if allow-unknown-fields and field-name not in all-fields {
+        continue
+      }
+
+      let field = all-fields.at(field-name)
+
+      if field == none or field.synthesized or not field.named {
+        let expected-pos-hint = if field == none or field.named { "" } else { "\n  hint: this " + field-singular + " must be specified positionally" }
+        let is-synthesized-hint = if field != none and field.synthesized { "\n  hint: this " + field-singular + " is synthesized and cannot be specified manually" } else { "" }
+
+        assert(false, message: general-error-prefix + "unknown named " + field-singular + " '" + field-name + "'" + expected-pos-hint + is-synthesized-hint)
+      }
+
+      if not include-required and field.required {
+        assert(false, message: field-error-prefix(field-name) + "this " + field-singular + " cannot be specified here\n  hint: only optional " + field-plural + " are accepted here")
+      }
+
+      let typeinfo = field.typeinfo
+      let kind = typeinfo.type-kind
+
+      // Inlined version of 'types.cast'
+      if kind != "any" {
+        let value-type = type(value)
+        if value-type == dictionary and custom-type-key in value {
+          value-type = value.at(custom-type-key).id
+        }
+        if kind == "literal" and typeinfo.cast == none {
+          if (
+            value != typeinfo.data.value
+            or value-type not in typeinfo.input and "any" not in typeinfo.input
+            or (typeinfo.data.typeinfo.check != none and not (typeinfo.data.typeinfo.check)(value))
+          ) {
+            assert(false, message: field-error-prefix(field-name) + types.generate-cast-error(value, typeinfo))
+          }
+        } else {
+          if (
+            value-type not in typeinfo.input and "any" not in typeinfo.input
+            or typeinfo.check != none and not (typeinfo.check)(value)
+          ) {
+            assert(false, message: field-error-prefix(field-name) + types.generate-cast-error(value, typeinfo))
+          }
+
+          // Only then do we need to replace the given value
+          if typeinfo.cast != none {
+            named-args.insert(field-name, if kind == "native" and typeinfo.data == content {
+              [#value]
+            } else {
+              (typeinfo.cast)(value)
+            })
+          }
+        }
+      }
+    }
+
+    let pos-fields = if include-required { all-pos-fields } else { optional-pos-fields }
+    let i = 0
+    for value in pos {
+      let pos-field = pos-fields.at(i)
+      let typeinfo = pos-field.typeinfo
+      let kind = typeinfo.type-kind
+      let casted = value
+
+      // Inlined version of 'types.cast'
+      if kind != "any" {
+        let value-type = type(value)
+        if value-type == dictionary and custom-type-key in value {
+          value-type = value.at(custom-type-key).id
+        }
+        if kind == "literal" and typeinfo.cast == none {
+          if (
+            value != typeinfo.data.value
+            or value-type not in typeinfo.input and "any" not in typeinfo.input
+            or (typeinfo.data.typeinfo.check != none and not (typeinfo.data.typeinfo.check)(value))
+          ) {
+            assert(false, message: field-error-prefix(pos-field.name) + types.generate-cast-error(value, typeinfo))
+          }
+        } else {
+          if (
+            value-type not in typeinfo.input and "any" not in typeinfo.input
+            or typeinfo.check != none and not (typeinfo.check)(value)
+          ) {
+            assert(false, message: field-error-prefix(pos-field.name) + types.generate-cast-error(value, typeinfo))
+          }
+
+          if typeinfo.cast != none {
+            casted = if kind == "native" and typeinfo.data == content {
+              [#value]
+            } else {
+              (typeinfo.cast)(value)
+            }
+          }
+        }
+      }
+
+      named-args.insert(pos-field.name, casted)
+
+      i += 1
+    }
+
+    named-args
+  }
+
+  if typecheck {
+    parse-args
+  } else {
+    parse-args-no-typechecking
+  }
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/lib.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/lib.typ
@@ -1,0 +1,8 @@
+#import "element.typ": set_, data, apply, revoke, reset, named, style-modes, prepare-get as get, selector, select, ref_ as ref, prepare
+#import "fields.typ": field
+#import "pub/data.typ": *
+#import "pub/element.typ"
+#import "pub/parsing.typ"
+#import "pub/types.typ"
+#import "pub/leaky.typ"
+#import "pub/stateful.typ"

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/data.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/data.typ
@@ -1,0 +1,1 @@
+#import "../data.typ": fields, counter_ as counter, ctx, scope,  func, func-name, eid, tid, repr_ as repr

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/element.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/element.typ
@@ -1,0 +1,2 @@
+// Public re-exports for element-related functions.
+#import "../element.typ": declare

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/leaky.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/leaky.typ
@@ -1,0 +1,2 @@
+// Exports rules defaulting to leaky mode.
+#import "../element.typ": leaky-set as set_, leaky-apply as apply, leaky-revoke as revoke, leaky-reset as reset

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/native.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/native.typ
@@ -1,0 +1,2 @@
+// Public re-exports for native type-related functions and constants.
+#import "../types/native.typ": content_, auto_, none_, float_, function_, int_, array_, dict_, datetime_, duration_, color_, gradient_, str_, type_, bool_, relative_, ratio_, typeinfo, angle_, arguments_, bytes_, tiling, tiling_, version_, fraction_, length_, stroke_

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/parsing.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/parsing.typ
@@ -1,0 +1,1 @@
+#import "../fields.typ": parse-fields, generate-arg-parser

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/stateful.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/stateful.typ
@@ -1,0 +1,8 @@
+// Exports rules defaulting to stateful mode.
+#import "../element.typ": toggle-stateful-mode as toggle, stateful-set as set_, stateful-apply as apply, stateful-revoke as revoke, stateful-reset as reset
+
+// Enable stateful mode.
+#let enable = toggle.with(true)
+
+// Disable stateful mode.
+#let disable = toggle.with(false)

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/types.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/pub/types.typ
@@ -1,0 +1,5 @@
+// Public re-exports for type-related functions and constants.
+#import "../types/base.typ": ok, err, is-ok, any, never, custom-type, typeid, typename, native-elem
+#import "../types/types.typ": option, smart, union, paint, literal, exact, wrap, array_ as array, default, validate as typeinfo, typeof, cast, generate-cast-error
+#import "../types/custom.typ": declare
+#import "native.typ"

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/types/base.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/types/base.typ
@@ -1,0 +1,472 @@
+// The shared fundamentals of the type system.
+#import "../data.typ": data, type-key, custom-type-key, custom-type-data-key, repr_, func-name
+
+#let type-version = 1
+
+// Typeinfo structure:
+// - type-key: kind of type
+// - version: 1
+// - name: type name
+// - input: list of native types / custom types of input
+// - output: list of native types / custom types of output
+// - data: data specific for this type key
+// - check: none (only check inputs) or function x => bool
+// - cast: none (input is unchanged) or function to convert input to output
+// - error: none or function x => string to customize check failure message
+// - default: empty array (no default) or singleton array => default value for this type
+// - fold: none, auto (equivalent to (a, b) => a + b but more efficient) or function (prev, next) => folded value:
+//         determines how to combine two consecutive values of this type in the stylechain
+#let base-typeinfo = (
+  (type-key): true,
+  type-kind: "base",
+  version: type-version,
+  name: "unknown",
+  input: (),
+  output: (),
+  data: none,
+  check: none,
+  cast: none,
+  error: none,
+  default: (),
+  fold: none,
+)
+
+// Top type
+// input and output have "any".
+#let any = (
+  ..base-typeinfo,
+  type-kind: "any",
+  name: "any",
+  input: ("any",),
+  output: ("any",),
+)
+
+// Bottom type
+// input and output are empty.
+#let never = (
+  ..base-typeinfo,
+  type-kind: "never",
+  name: "never",
+  input: (),
+  output: (),
+)
+
+// Any custom type
+#let custom-type = (
+  ..base-typeinfo,
+  (type-key): "custom type",
+  name: "custom type",
+  input: ("custom type",),
+  output: ("custom type",),
+)
+
+#let _sequence = [].func()
+
+#let element(name, eid) = (
+  ..base-typeinfo,
+  type-kind: "element",
+  name: "element '" + name + "'",
+  input: (content,),
+  output: (content,),
+  check: c => c.func() == _sequence and data(c).eid == eid,
+  data: (name: name, eid: eid),
+  error: c => "expected element " + name + ", found " + func-name(c),
+)
+
+#let native-elem(func) = {
+  assert(type(func) == function, message: "types.native-elem: expected native element constructor, got " + str(type(func)))
+
+  (
+    ..base-typeinfo,
+    type-kind: "native-element",
+    name: "native element '" + repr(func) + "'",
+    input: (content,),
+    output: (content,),
+    check: if func == _sequence { c => c.func() == _sequence and data(c).eid == none } else { c => c.func() == func },
+    data: (func: func),
+    error: c => "expected native element " + repr(func) + ", found " + func-name(c),
+  )
+}
+
+// Get the type ID of a value.
+// This is usually 'type(value)', unless value has a custom type.
+// In that case, it has the format '(tid: ..., name: ...)'.
+// This is the format expected by 'input' and 'output' arrays.
+#let typeid(value) = {
+  let value-type = type(value)
+  if value-type == dictionary and custom-type-key in value {
+    value-type = value.at(custom-type-key).id
+  }
+  value-type
+}
+
+// Returns the name of the value's type as a string.
+#let typename(value) = {
+  let value-type = type(value)
+  if value-type == dictionary and custom-type-key in value {
+    let id = value.at(custom-type-key).id
+    if "name" in id {
+      id.name
+    } else {
+      str(id)
+    }
+  } else {
+    str(value-type)
+  }
+}
+
+// Make a unique element or type ID based on prefix and name.
+//
+// Uses a separator and a "bit stuffing" technique to ensure
+// the separator sequence doesn't appear in either of the
+// prefix or the name in the final ID.
+#let id-separator = "_---_"
+#let trimmed-separator = id-separator.trim("_", at: end)
+#let unique-id(kind, prefix, name) = {
+  (
+    kind + "_"
+  ) + prefix.replace(
+    trimmed-separator, trimmed-separator + "-"
+  ) + id-separator + name.replace(
+    trimmed-separator, trimmed-separator + "-"
+  )
+}
+
+// Literal type
+// Only accepted if value is equal to the literal.
+// Input and output are equal to the value.
+//
+// Uses base typeinfo information for information such as casts and whatnot.
+#let literal(value, typeinfo) = {
+  let represented = "'" + if type(value) == str { value } else { repr_(value) } + "'"
+  let value-type = typeid(value)
+
+  let check = if typeinfo.check == none { x => x == value } else { x => x == value and (typeinfo.check)(x) }
+
+  (
+    ..typeinfo,
+    type-kind: "literal",
+    name: "literal " + represented,
+    data: (value: value, typeinfo: typeinfo, represented: represented),
+    check: check,
+    error: _ => "given value wasn't equal to literal " + represented,
+    default: (value,),
+  )
+}
+
+// Union type (one of many)
+// Data is the list of typeinfos.
+// Accepted if the value corresponds to one of the given types.
+// Does not check the validity of typeinfos.
+#let union(typeinfos) = {
+  // Flatten nested unions
+  let typeinfos = typeinfos.map(t => if t.type-kind == "union" { t.data } else { (t,) }).sum(default: ()).dedup()
+  if typeinfos == () {
+    // No inputs accepted...
+    return never
+  }
+  if typeinfos.len() == 1 {
+    // Simplify union if there's nothing else
+    return typeinfos.first()
+  }
+  if typeinfos.any(x => x.type-kind == "any") {
+    // Union with 'any' is just any
+    return any
+  }
+
+  let name = typeinfos.map(t => t.name).join(", ", last: " or ")
+  let input = typeinfos.map(t => t.input).sum(default: ()).dedup()
+  let output = typeinfos.map(t => t.output).sum(default: ()).dedup()
+
+  let has-any-input = "any" in input
+  let has-any-output = "any" in output
+
+  if has-any-input {
+    input = ("any",)
+  }
+
+  if has-any-output {
+    output = ("any",)
+  }
+
+  // Try to optimize checks as much as possible
+  let check = if typeinfos.all(t => t.check == none) {
+    // If there are no checks, just checking inputs is enough
+    none
+  } else {
+    let checked-types = typeinfos.filter(t => t.check != none)
+    let unchecked-inputs = typeinfos.filter(t => t.check == none).map(t => t.input).sum(default: ()).dedup()
+    if input.all(t => t in unchecked-inputs) {
+      // Unchecked types include all possible input types, so some check will always succeed
+      // Note that this check also works for input reduced to just "any". If "any" is an
+      // unchecked input, then checks will never fail.
+      none
+    } else if checked-types.all(t => t.type-kind == "native-element") {
+      // From here onwards, we can assume unchecked-inputs doesn't contain "any",
+      // since it is a subset of input, therefore input would be just ("any",) and
+      // the check above would have had to pass in that case.
+      let all-funcs = checked-types.map(t => t.data.func)
+      let non-seq-funcs = all-funcs.filter(f => f != _sequence)
+      let has-seq = _sequence in all-funcs
+
+      // Check sequence separately, as a sequence can also be a custom element,
+      // so we must tell them apart.
+      if has-seq {
+        if non-seq-funcs == () {
+          x => {
+            let typ = type(x)
+            if typ == dictionary and custom-type-key in x {
+              // Custom type must be checked differently in inputs
+              typ = x.at(custom-type-key).id
+            }
+            typ in unchecked-inputs or typ == content and x.func() == _sequence and data(x).eid == none
+          }
+        } else {
+          x => {
+            let typ = type(x)
+            if typ == dictionary and custom-type-key in x {
+              // Custom type must be checked differently in inputs
+              typ = x.at(custom-type-key).id
+            }
+            typ in unchecked-inputs or typ == content and (x.func() in non-seq-funcs or x.func() == _sequence and data(x).eid == none)
+          }
+        }
+      } else {
+        x => {
+          let typ = type(x)
+          if typ == dictionary and custom-type-key in x {
+            // Custom type must be checked differently in inputs
+            typ = x.at(custom-type-key).id
+          }
+          typ in unchecked-inputs or typ == content and x.func() in non-seq-funcs
+        }
+      }
+    } else if checked-types.all(t => t.type-kind == "element") {
+      let all-eids = checked-types.map(t => t.data.eid)
+
+      x => {
+        let typ = type(x)
+        if typ == dictionary and custom-type-key in x {
+          // Custom type must be checked differently in inputs
+          typ = x.at(custom-type-key).id
+        }
+        typ in unchecked-inputs or typ == content and x.func() == _sequence and data(x).eid in all-eids
+      }
+    } else if checked-types.all(t => t.type-kind == "literal") {
+      let values-inputs-and-checks = checked-types.map(t => (t.data.value, t.input, t.data.typeinfo.check))
+      x => {
+        let typ = type(x)
+        if typ == dictionary and custom-type-key in x {
+          // Custom type must be checked differently in inputs
+          typ = x.at(custom-type-key).id
+        }
+        typ in unchecked-inputs or values-inputs-and-checks.any(((v, i, check)) => x == v and (typ in i or "any" in i) and (check == none or check(x)))
+      }
+    } else {
+      // If any check succeeds and the value has the correct input type, OK
+      let checks-and-inputs = checked-types.map(t => (t.input, t.check))
+      x => {
+        let typ = type(x)
+        if typ == dictionary and custom-type-key in x {
+          // Custom type must be checked differently in inputs
+          typ = x.at(custom-type-key).id
+        }
+        // If one of the types without checks accepts this type as an input then we don't need
+        // to run any checks!
+        typ in unchecked-inputs or checks-and-inputs.any(((inp, check)) => (typ in inp or "any" in inp) and check(x))
+      }
+    }
+  }
+
+  // Try to optimize casts
+  let cast = if typeinfos.all(t => t.cast == none) {
+    none
+  } else {
+    let casting-types = typeinfos.filter(t => t.cast != none)
+    let first-casting-type = casting-types.first()
+    if (
+      // If the casting types are all native, and none of the types before them
+      // accept their "cast-from" types, then we can fast track to a simple check:
+      // if within the 'cast-from' types, then cast, otherwise don't.
+      casting-types != ()
+      and casting-types.all(t => t.type-kind == "native" and t.data in (float, content))
+      and typeinfos.find(t => t.input.any(i => i == "any" or i in first-casting-type.input)) == first-casting-type
+      and (casting-types.len() == 1 or typeinfos.find(t => t.input.any(i => i == "any" or i in casting-types.at(1).input)) == casting-types.at(1))
+    ) {
+      if casting-types.len() >= 2 {  // just float and content
+        x => if type(x) == int { float(x) } else if type(x) in (str, symbol) [#x] else { x }
+      } else if first-casting-type.data == float {  // just float
+        x => if type(x) == int { float(x) } else { x }
+      } else { // just content
+        x => if type(x) in (str, symbol) { [#x] } else { x }
+      }
+    } else {
+      // Generic case
+      x => {
+        let typ = type(x)
+        if typ == dictionary and custom-type-key in x {
+          // Custom type must be checked differently in inputs
+          typ = x.at(custom-type-key).id
+        }
+        let typeinfo = typeinfos.find(t => (typ in t.input or "any" in t.input) and (t.check == none or (t.check)(x)))
+        if typeinfo.cast == none {
+          x
+        } else {
+          (typeinfo.cast)(x)
+        }
+      }
+    }
+  }
+
+  let error = if typeinfos.all(t => t.error == none) {
+    none
+  } else if typeinfos.all(t => t.type-kind == "literal") {
+    let literals = typeinfos.map(t => str(t.data.represented)).join(", ", last: " or ")
+    let message = "given value wasn't equal to literals " + literals
+    x => message
+  } else if typeinfos.all(t => t.type-kind == "native-element") {
+    let funcs = typeinfos.map(t => repr(t.data.func)).join(", ", last: " or ")
+    let head = "expected native elements " + funcs + ", found "
+    x => head + {
+      if type(x) == content { func-name(x) } else { "a(n) " + typename(x) }
+    }
+  } else if typeinfos.all(t => t.type-kind == "element" or t.type-kind == "native-element") {
+    let funcs = typeinfos.map(t => if t.type-kind == "element" { t.data.name } else { repr(t.data.func) + " (native)" }).join(", ", last: " or ")
+    let head = "expected elements " + funcs + ", found "
+    x => head + {
+      if type(x) == content { func-name(x) } else { "a(n) " + typename(x) }
+    }
+  } else {
+    let error-types = typeinfos.filter(t => t.error != none)
+    x => {
+      "all typechecks for union failed" + error-types.map(t => "\n  hint (" + t.name + "): " + (t.error)(x)).sum(default: "")
+    }
+  }
+
+  let is-option = typeinfos.first().type-kind == "native" and typeinfos.first().data == type(none)
+  let is-smart = typeinfos.first().type-kind == "native" and typeinfos.first().data == type(auto)
+
+  let default = if is-option or is-smart {
+    // Default of 'none' for option(...)
+    // Default of 'auto' for smart(...)
+    typeinfos.first().default
+  } else {
+    ()
+  }
+
+  // Match built-in behavior by only folding option(T) or smart(T) if T can fold and the inner isn't explicitly none/auto
+  let fold = if typeinfos.len() == 2 and typeinfos.at(1).fold != none {
+    let other-typeinfo = typeinfos.at(1)
+    let other-fold = other-typeinfo.fold
+    if is-option {
+      if other-fold == auto {
+        (outer, inner) => if inner != none and outer != none { outer + inner } else { inner }
+      } else {
+        (outer, inner) => if inner != none and outer != none { other-fold(outer, inner) } else { inner }
+      }
+    } else if is-smart {
+      if other-fold == auto {
+        (outer, inner) => if inner != auto and outer != auto { outer + inner } else { inner }
+      } else {
+        (outer, inner) => if inner != auto and outer != auto { other-fold(outer, inner) } else { inner }
+      }
+    } else {
+      none
+    }
+  } else {
+    // TODO: We could consider folding an arbitrary union iff the outputs are all disjoint,
+    // so we can easily distinguish the typeinfo for an output based on the type.
+    // Otherwise, can't do much if e.g. an int could be typeinfo A (say, positive integer)
+    // or typeinfo B (say, negative integer) because checks apply to inputs and not outputs
+    // (unless, of course, there is no casting).
+    none
+  }
+
+  (
+    ..base-typeinfo,
+    type-kind: "union",
+    name: name,
+    data: typeinfos,
+    input: input,
+    output: output,
+    check: check,
+    cast: cast,
+    error: error,
+    default: default,
+    fold: fold,
+  )
+}
+
+// A result to indicate success and return a value.
+#let ok(value) = {
+  (true, value)
+}
+
+// A result to indicate failure, with an error value indicating what happened.
+#let err(error) = {
+  (false, error)
+}
+
+// Whether this result was successful.
+#let is-ok(result) = {
+  type(result) == array and result.len() == 2 and result.first() == true
+}
+
+// Wrap a typeinfo with some other data.
+// Mostly unchecked variant of 'types.wrap'.
+#let wrap(typeinfo, overrides) = {
+  (
+    (..typeinfo, type-kind: "wrapped", data: (base: typeinfo, extra: none))
+    + for (key, default) in base-typeinfo {
+      if key == type-key or key == "type-kind" {
+        continue
+      }
+
+      if key in overrides {
+        let override = overrides.at(key)
+        if type(override) == function {
+          override = override(typeinfo.at(key, default: default))
+        }
+
+        if key == "data" {
+          (data: (base: typeinfo, extra: override))
+        } else {
+          ((key): override)
+        }
+      }
+    }
+  )
+}
+
+// A particular collection of types.
+#let collection(name, base, parameters, check: none, cast: none, error: none, ..args) = {
+  if check == none {
+    check = base.check
+  }
+
+  if cast == none {
+    cast = base.cast
+  }
+
+  if check == none and error == none {
+    error = base.error
+  }
+
+  let other-args = args.named()
+  let default = if "default" in other-args {
+    other-args.default
+  } else {
+    base.default
+  }
+
+  (
+    ..base,
+    type-kind: "collection",
+    name: name + if parameters != () { " of " + parameters.map(t => t.name).join(", ", last: " and ") },
+    data: (base: base, parameters: parameters),
+    check: check,
+    cast: cast,
+    error: error,
+    default: default,
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/types/custom.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/types/custom.typ
@@ -1,0 +1,355 @@
+// Custom types!
+#import "../data.typ": special-data-values, custom-type-key, custom-type-data-key, type-key
+#import "base.typ"
+#import "types.typ"
+#import "../fields.typ" as field-internals
+
+#let custom-type-version = 1
+
+// Default folding procedure for custom types.
+// Combines each inner type individually.
+#let auto-fold(foldable-fields) = if foldable-fields == (:) {
+  // No fields to fold, so 'inner' always fully overwrites 'outer'.
+  // In that case, we can just sum inner with outer, adding its fields
+  // on top.
+  auto
+} else {
+  (outer, inner) => {
+    let combined = outer + inner
+
+    for (field-name, fold-data) in foldable-fields {
+      if field-name in inner {
+        let outer = outer.at(field-name, default: fold-data.default)
+        if fold-data.folder == auto {
+          combined.at(field-name) = outer + inner.at(field-name)
+        } else {
+          combined.at(field-name) = (fold-data.folder)(outer, inner.at(field-name))
+        }
+      }
+    }
+
+    combined
+  }
+}
+
+#let declare(
+  name,
+  fields: none,
+  prefix: none,
+  default: none,
+  parse-args: auto,
+  typecheck: true,
+  allow-unknown-fields: false,
+  construct: none,
+  scope: none,
+  casts: none,
+  fold: none,
+) = {
+
+  let fields-hint = if type(fields) == dictionary { "\n  hint: check if you didn't forget to add a trailing comma for a single field: write 'fields: (field,)', not 'fields: (field)'" } else { "" }
+  let casts-hint = if type(casts) == dictionary { "\n  hint: check if you didn't forget to add a trailing comma for a single cast: write 'casts: ((from: ..., with: ...),)', not 'casts: ((from: ..., with: ...))'" } else { "" }
+  assert(type(fields) == array, message: "types.declare: please specify an array of fields, creating each field with the 'field' function." + fields-hint)
+  assert(prefix != none, message: "types.declare: please specify a 'prefix: ...' for your type, to distinguish it from types with the same name. If you are writing a package or template to be used by others, please do not use an empty prefix.")
+  assert(type(prefix) == str, message: "types.declare: the prefix must be a string, not '" + str(type(prefix)) + "'")
+  assert(parse-args == auto or type(parse-args) == function, message: "types.declare: 'parse-args' must be either 'auto' (use built-in parser) or a function (default arg parser, fields: dictionary, typecheck: bool) => (user arguments, include-required: true) => dictionary with parsed fields.")
+  assert(type(typecheck) == bool, message: "types.declare: the 'typecheck' argument must be a boolean (true to enable typechecking in the constructor, false to disable).")
+  assert(type(allow-unknown-fields) == bool, message: "types.declare: the 'allow-unknown-fields' argument must be a boolean.")
+  assert(construct == none or type(construct) == function, message: "types.declare: 'construct' must be 'none' (use default constructor) or a function receiving the original constructor and returning the new constructor.")
+  assert(default == none or type(default) == function, message: "types.declare: 'default' must be none or a function receiving the constructor and returning the default.")
+  assert(scope == none or type(scope) in (dictionary, module), message: "types.declare: 'scope' must be either 'none', a dictionary or a module")
+  assert(
+    casts == none
+    or type(casts) == array and casts.all(
+      d => (
+        type(d) == dictionary
+        and "from" in d
+        and "with" in d
+        and d.keys().all(k => k in ("from", "with", "check"))
+        and type(d.with) == function
+        and ("check" not in d or type(d.check) == function)
+      )
+    ),
+    message: "types.declare: 'casts' must be either 'none' or an array of dictionaries in the form (from: type, check (optional): casted value => bool, with: constructor => casted value => your type)." + casts-hint
+  )
+  assert(fold == none or fold == auto or type(fold) == function, message: "types.declare: 'fold' must be 'none' (no folding), 'auto' (fold each field individually) or a function 'default constructor => auto (same as (a, b) => a + b but more efficient) or function (outer, inner) => combined value'.")
+
+  let tid = base.unique-id("t", prefix, name)
+  let fields = field-internals.parse-fields(fields, allow-unknown-fields: allow-unknown-fields)
+  let (all-fields, user-fields, foldable-fields) = fields
+  let auto-fold = if fold == auto { auto-fold(foldable-fields) } else { none }
+
+  let default-arg-parser = field-internals.generate-arg-parser(
+    fields: fields,
+    general-error-prefix: "type '" + name + "': ",
+    field-error-prefix: field-name => "field '" + field-name + "' of type '" + name + "': ",
+    typecheck: typecheck
+  )
+
+  let parse-args = if parse-args == auto {
+    default-arg-parser
+  } else {
+    let parse-args = parse-args(default-arg-parser, fields: fields, typecheck: typecheck)
+    if type(parse-args) != function {
+      assert(false, message: "types.declare: 'parse-args', when specified as a function, receives the default arg parser alongside `fields: fields dictionary` and `typecheck: bool`, and must return a function (the new arg parser), and not " + base.typename(parse-args))
+    }
+
+    parse-args
+  }
+
+  let default-fields = fields.user-fields.values().map(f => if f.required { (:) } else { ((f.name): f.default) }).sum(default: (:))
+
+  let typeid = (tid: tid, name: name)
+
+  // We will specify default in a bit, once we declare the constructor
+  let typeinfo = (
+    ..base.base-typeinfo,
+    type-kind: "custom",
+    name: name,
+    input: (typeid,),
+    output: (typeid,),
+    data: (
+      id: typeid,
+
+      // Original type before adding casts
+      // or none if this is already the type before casts
+      // (used for 'exact()')
+      pre-casts: none
+    )
+  )
+
+  let type-data = (
+    (custom-type-data-key): true,
+    (custom-type-key): (
+        data-kind: "type-instance",
+        fields: (
+          version: custom-type-version,
+          tid: tid,
+          id: typeid,
+        ),
+        func: declare,
+        default-constructor: declare,
+        tid: "b_custom type",
+        id: "custom type",
+        fields-known: true,
+        valid: true
+    ),
+    version: custom-type-version,
+    name: name,
+    tid: tid,
+    id: typeid,
+    // We will add this here once the constructor is declared
+    typeinfo: none,
+    scope: scope,
+    parse-args: parse-args,
+    default-fields: default-fields,
+    user-fields: user-fields,
+    all-fields: all-fields,
+    fields: fields,
+    typecheck: typecheck,
+    allow-unknown-fields: allow-unknown-fields,
+    default-constructor: none,
+    func: none,
+  )
+
+  let process-casts = if casts == none {
+    none
+  } else {
+    // Trick: We assign cast to each cast-from type and create a union,
+    // and use its generated check/cast functions as our own
+    default-constructor => {
+      let typeinfos = casts.map(cast => {
+        let (res, from) = types.validate(cast.from)
+        if not res {
+          assert(false, message: "types.declare: invalid cast-from type: " + from)
+        }
+
+        let with = (cast.with)(default-constructor)
+        if type(with) != function {
+          assert(
+            false,
+            message: "types.declare: cast 'with' must receive the default constructor and return a function 'casted value => your type'. Received " + base.typename(with)
+          )
+        }
+
+        let cast-check = cast.at("check", default: none)
+        let from-cast = from.cast
+
+        types.wrap(
+          from,
+          check: from-check => if from-check == none {
+            if cast-check == none {
+              none
+            } else if from.cast == none {
+              cast-check
+            } else {
+              value => cast-check(from-cast(value))
+            }
+          } else if cast-check == none {
+            from-check
+          } else if from.cast == none {
+            value => from-check(value) and cast-check(value)
+          } else {
+            value => from-check(value) and cast-check(from-cast(value))
+          },
+
+          output: (typeid,),
+
+          cast: from-cast => if from-cast == none {
+            with
+          } else {
+            value => with(from-cast(value))
+          },
+
+          default: (),
+          fold: none,
+        )
+      })
+
+      // Accept our own typeinfo first and foremost
+      let union = base.union((typeinfo,) + typeinfos)
+
+      assert(
+        union.output == (typeid,) and union.default == () and union.fold == none,
+        message: "types.declare: internal error: cast generated invalid union: " + repr(union)
+      )
+
+      (
+        input: union.input,
+        output: union.output,
+        check: union.check,
+        cast: union.cast,
+        error: if union.error == none {
+          _ => "failed to cast to custom type '" + name + "'"
+        } else {
+          x => (union.error)(x).replace("all typechecks for union failed", "all casts to custom type '" + name + "' failed")
+        },
+        data: typeinfo.data + (pre-casts: typeinfo)
+      )
+    }
+  }
+
+  let default-constructor(..args, __elembic_data: none, __elembic_func: auto) = {
+    if __elembic_func == auto {
+      __elembic_func = default-constructor
+    }
+
+    let default-constructor = default-constructor.with(__elembic_func: __elembic_func)
+    if __elembic_data != none {
+      return if __elembic_data == special-data-values.get-data {
+        let typeinfo = typeinfo + if process-casts != none { process-casts(default-constructor) } else { (:) }
+        if default != none {
+          typeinfo.default = (default(default-constructor),)
+        }
+
+        if auto-fold != none {
+          typeinfo.fold = auto-fold
+        } else if type(fold) == function {
+          let fold = fold(default-constructor)
+          if fold != auto and type(fold) != function {
+            assert(false, message: "types: custom type did not specify a valid fold, must be a function default constructor => value, got " + base.typename(fold))
+          }
+          typeinfo.fold = fold
+        }
+
+        (data-kind: "custom-type-data", ..type-data, typeinfo: typeinfo, func: __elembic_func, default-constructor: default-constructor)
+      } else {
+        assert(false, message: "types: invalid data key to constructor: " + repr(__elembic_data))
+      }
+    }
+
+    let args = parse-args(args, include-required: true)
+
+    let final-fields = default-fields + args
+
+    if foldable-fields != (:) {
+      // Fold received arguments with defaults
+      for (field-name, fold-data) in foldable-fields {
+        if field-name in args {
+          let outer = default-fields.at(field-name, default: fold-data.default)
+          if fold-data.folder == auto {
+            final-fields.at(field-name) = outer + args.at(field-name)
+          } else {
+            final-fields.at(field-name) = (fold-data.folder)(outer, args.at(field-name))
+          }
+        }
+      }
+    }
+
+    final-fields.insert(
+      custom-type-key,
+      (
+        data-kind: "type-instance",
+        fields: final-fields,
+        func: __elembic_func,
+        default-constructor: default-constructor,
+        tid: tid,
+        id: (tid: tid, name: name),
+        scope: scope,
+        fields-known: true,
+        valid: true
+      )
+    )
+
+    final-fields
+  }
+
+  default = if default == none {
+    ()
+  } else {
+    let default = default(default-constructor)
+    assert(
+      type(default) == dictionary and custom-type-key in default and default.at(custom-type-key).id == typeid,
+      message: "types.declare: the 'default' function must return an instance of the new type using the provided constructor, not " + repr(default)
+    )
+
+
+    (default,)
+  }
+
+  fold = if auto-fold != none {
+    auto-fold
+  } else if type(fold) == function {
+    let fold = fold(default-constructor)
+    if fold != auto and type(fold) != function {
+      assert(false, message: "types.declare: a valid fold was not specified, must be a function default constructor => value, got " + base.typename(fold))
+    }
+    fold
+  } else {
+    none
+  }
+
+  if process-casts != none {
+    typeinfo += process-casts(default-constructor)
+  }
+  typeinfo.default = default
+  typeinfo.fold = fold
+  type-data.typeinfo = typeinfo
+
+  let final-constructor = if construct != none {
+    {
+      let test-construct = construct(default-constructor)
+      assert(type(test-construct) == function, message: "types.declare: the 'construct' function must receive the default constructor and return the new constructor, a new function, not '" + str(type(test-construct)) + "'.")
+    }
+
+    let final-constructor(..args, __elembic_data: none) = {
+      if __elembic_data != none {
+        return if __elembic_data == special-data-values.get-data {
+          (data-kind: "custom-type-data", ..type-data, func: final-constructor, default-constructor: default-constructor.with(__elembic_func: final-constructor))
+        } else {
+          assert(false, message: "types: invalid data key to constructor: " + repr(__elembic_data))
+        }
+      }
+
+      construct(default-constructor.with(__elembic_func: final-constructor))(..args)
+    }
+
+    final-constructor
+  } else {
+    default-constructor
+  }
+
+  type-data.default-constructor = default-constructor.with(__elembic_func: final-constructor)
+  type-data.func = final-constructor
+
+  final-constructor
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/types/native.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/types/native.typ
@@ -1,0 +1,341 @@
+// Typst-native types.
+#import "../data.typ": type-key
+#import "base.typ": base-typeinfo, ok, err
+
+// Tiling type (renamed in Typst 0.13.0)
+#let tiling = if sys.version < version(0, 13, 0) { pattern } else { tiling }
+
+#let native-base = (
+  ..base-typeinfo,
+  type-kind: "native",
+)
+
+// Generic typeinfo for a native type.
+// PROPERTY: if type key is native, then output has the native type,
+// and input has a list of native types that can be cast to it.
+#let generic-typeinfo(native-type) = {
+  assert(type(native-type) == type(str), message: "internal error: not a type")
+
+  (
+    ..native-base,
+    name: str(native-type),
+    input: (native-type,),
+    output: (native-type,),
+    data: native-type,
+  )
+}
+
+// Castable types
+
+#let content_ = (
+  ..native-base,
+  name: str(content),
+  input: (content, str, symbol),
+  output: (content,),
+  data: content,
+  cast: x => [#x],
+  default: ([],),
+)
+#let float_ = (
+  ..native-base,
+  name: str(float),
+  input: (float, int),
+  output: (float,),
+  data: float,
+  cast: float,
+  default: (0.0,),
+)
+#let stroke-keys = ("paint", "thickness", "cap", "join", "dash", "miter-limit")
+#let stroke_ = (
+  ..native-base,
+  name: str(stroke),
+  input: (stroke, length, color, gradient, tiling, dictionary),
+  output: (stroke,),
+  data: stroke,
+  cast: stroke,
+  check: v => type(v) != dictionary or v.keys().all(k => k in stroke-keys),
+  default: (stroke(),),
+  // Allow specifying e.g. 4pt in one set rule, red in the other => 4pt + red in the end
+  fold: (outer, inner) => {
+    // Can't sum stroke with stroke, so can't optimize with 'fold: auto' :(
+    stroke(
+      paint: if inner.paint == auto { outer.paint } else { inner.paint },
+      thickness: if inner.thickness == auto { outer.thickness } else { inner.thickness },
+      cap: if inner.cap == auto { outer.cap } else { inner.cap },
+      join: if inner.join == auto { outer.join } else { inner.join },
+      dash: if inner.dash == auto { outer.dash } else { inner.dash },
+      miter-limit: if inner.miter-limit == auto { outer.miter-limit } else { inner.miter-limit },
+    )
+  },
+)
+#let relative_ = (
+  ..native-base,
+  name: str(relative),
+  input: (relative, length, ratio),
+  output: (relative,),
+  data: relative,
+  cast: x => x + 0% + 0pt,
+  default: (0% + 0pt,),
+)
+#let function_ = (
+  ..native-base,
+  name: str(function),
+  // Would add symbol as well, but missing a reliable way to check for callable symbols
+  input: (type, function),
+  output: (type, function,),
+  data: function,
+)
+
+// Folding types (also includes stroke above)
+#let array_ = (
+  ..native-base,
+  name: str(array),
+  input: (array,),
+  output: (array,),
+  data: array,
+  default: ((),),
+
+  // Array fields are added together by default.
+  fold: auto,
+)
+
+#let alignment_ = (
+  ..native-base,
+  name: str(alignment),
+  input: (alignment,),
+  output: (alignment,),
+  data: alignment,
+  fold: (outer, inner) => if inner.axis() == none or outer.axis() == inner.axis() {
+    // If axis A == axis B, we override. For example, left -> right. (No sum)
+    // Same if both are none (2D alignments), in which case inner fully overrides as well (left + top -> center + bottom).
+    // In addition, if inner axis is none (it is a 2D alignment), it overrides in both ways (left -> right + top).
+    inner
+  } else if outer.axis() == none {
+    // Here, we know that inner isn't 2D, so either outer is 2D or both have different axes.
+    // If outer is 2D and inner is 1D, inner replaces its axis in outer, but the other axis is kept.
+    if inner.axis() == "horizontal" {
+      inner + outer.y
+    } else {
+      outer.x + inner
+    }
+  } else {
+    // Both are 1D and have distinct axes, so we just sum.
+    // left and top => left + top
+    // bottom and right => right + bottom
+    inner + outer
+  }
+)
+
+// Simple types (no casting)
+
+#let str_ = (
+  ..native-base,
+  name: str(str),
+  input: (str,),
+  output: (str,),
+  data: str,
+  default: ("",)
+)
+#let bool_ = (
+  ..native-base,
+  name: str(bool),
+  input: (bool,),
+  output: (bool,),
+  data: bool,
+  default: (false,)
+)
+#let dict_ = (
+  ..native-base,
+  name: str(dictionary),
+  input: (dictionary,),
+  output: (dictionary,),
+  data: dictionary,
+  default: ((:),),
+)
+#let int_ = (
+  ..native-base,
+  name: str(int),
+  input: (int,),
+  output: (int,),
+  data: int,
+  default: (0,),
+)
+#let color_ = (
+  ..native-base,
+  name: str(color),
+  input: (color,),
+  output: (color,),
+  data: color,
+)
+#let gradient_ = (
+  ..native-base,
+  name: str(gradient),
+  input: (gradient,),
+  output: (gradient,),
+  data: gradient,
+)
+#let tiling_ = (
+  ..native-base,
+  name: str(tiling),
+  input: (tiling,),
+  output: (tiling,),
+  data: tiling,
+)
+#let datetime_ = (
+  ..native-base,
+  name: str(datetime),
+  input: (datetime,),
+  output: (datetime,),
+  data: datetime,
+)
+#let angle_ = (
+  ..native-base,
+  name: str(angle),
+  input: (angle,),
+  output: (angle,),
+  data: angle,
+  default: (0deg,),
+)
+#let ratio_ = (
+  ..native-base,
+  name: str(ratio),
+  input: (ratio,),
+  output: (ratio,),
+  data: ratio,
+  default: (0%,),
+)
+#let length_ = (
+  ..native-base,
+  name: str(length),
+  input: (length,),
+  output: (length,),
+  data: length,
+  default: (0pt,),
+)
+#let fraction_ = (
+  ..native-base,
+  name: str(fraction),
+  input: (fraction,),
+  output: (fraction,),
+  data: fraction,
+  default: (0fr,),
+)
+#let duration_ = (
+  ..native-base,
+  name: str(duration),
+  input: (duration,),
+  output: (duration,),
+  data: duration,
+  default: (duration(seconds: 0),),
+)
+#let type_ = (
+  ..native-base,
+  name: str(type),
+  input: (type,),
+  output: (type,),
+  data: type,
+)
+#let arguments_ = (
+  ..native-base,
+  name: str(arguments),
+  input: (arguments,),
+  output: (arguments,),
+  data: arguments,
+  default: (arguments(),),
+)
+#let bytes_ = (
+  ..native-base,
+  name: str(bytes),
+  input: (bytes,),
+  output: (bytes,),
+  data: bytes,
+  default: (bytes(()),),
+)
+#let version_ = (
+  ..native-base,
+  name: str(version),
+  input: (version,),
+  output: (version,),
+  data: version,
+  default: (version(0, 0, 0),),
+)
+
+// None / auto
+
+#let none_ = (
+  ..native-base,
+  name: "none",
+  input: (type(none),),
+  output: (type(none),),
+  data: type(none),
+  default: (none,)
+)
+#let auto_ = (
+  ..native-base,
+  name: "auto",
+  input: (type(auto),),
+  output: (type(auto),),
+  data: type(auto),
+  default: (auto,)
+)
+
+// Return the typeinfo for a native type.
+#let typeinfo(t) = {
+  let out = if t == content {
+    content_
+  } else if t == int {
+    int_
+  } else if t == bool {
+    bool_
+  } else if t == float {
+    float_
+  } else if t == type(none) {
+    none_
+  } else if t == type(auto) {
+    auto_
+  } else if t == dictionary {
+    dict_
+  } else if t == array {
+    array_
+  } else if t == str {
+    str_
+  } else if t == color {
+    color_
+  } else if t == gradient {
+    gradient_
+  } else if t == datetime {
+    datetime_
+  } else if t == duration {
+    duration_
+  } else if t == function {
+    function_
+  } else if t == relative {
+    relative_
+  } else if t == stroke {
+    stroke_
+  } else if t == tiling {
+    tiling_
+  } else if t == type {
+    type_
+  } else if t == angle {
+    angle_
+  } else if t == alignment {
+    alignment_
+  } else if t == ratio {
+    ratio_
+  } else if t == length {
+    length_
+  } else if t == fraction {
+    fraction_
+  } else if t == arguments {
+    arguments_
+  } else if t == bytes {
+    bytes_
+  } else if t == version {
+    version_
+  } else {
+    generic-typeinfo(t)
+  }
+
+  (true, out)
+}

--- a/packages/preview/lilaq/0.2.0/src/libs/elembic/types/types.typ
+++ b/packages/preview/lilaq/0.2.0/src/libs/elembic/types/types.typ
@@ -1,0 +1,409 @@
+// The type system used by fields.
+#import "../data.typ": data, special-data-values, type-key, custom-type-key, custom-type-data-key
+#import "base.typ" as base: ok, err
+#import "native.typ"
+
+// The default value for a type.
+#let default(type_) = {
+  if type_.default == () {
+    let prefix = if type_.type-kind in ("native", "union") { type_.type-kind + " " } else { "" }
+    err(prefix + "type '" + type_.name + "' has no known default, please specify an explicit 'default: value' or set 'required: true' for the field")
+  } else {
+    ok(type_.default.first())
+  }
+}
+
+#let sequence_ = [].func()
+#let typeof(value) = {
+  let element-data
+  if type(value) == dictionary and custom-type-key in value {
+    if custom-type-data-key in value {
+      base.custom-type
+    } else {
+      (value.at(custom-type-key).func)(__elembic_data: special-data-values.get-data).typeinfo
+    }
+  } else if type(value) == content and value.func() == sequence_ and {
+    element-data = data(value)
+    element-data.eid != none
+  } {
+    if "name" in element-data and type(element-data.name) == str {
+      base.element(element-data.name, element-data.eid)
+    } else {
+      base.element("unknown-element", element-data.eid)
+    }
+  } else {
+    let (res, typeinfo) = native.typeinfo(type(value))
+    if not res {
+      assert(false, message: "types.typeof: " + typeinfo)
+    }
+
+    typeinfo
+  }
+}
+
+// Literal type
+// Only accepted if value is equal to the literal.
+// Input and output are equal to the value.
+//
+// Uses base typeinfo information for information such as casts and whatnot.
+#let literal(value) = {
+  if value == none {
+    native.none_
+  } else if value == auto {
+    native.auto_
+  } else {
+    base.literal(value, typeof(value))
+  }
+}
+
+// Obtain the typeinfo for a type.
+//
+// Returns ok(typeinfo), or err(error) if there is no corresponding typeinfo.
+#let validate(type_) = {
+  if type(type_) == function {
+    let data = type_(__elembic_data: special-data-values.get-data)
+    let data-kind = data.at("data-kind", default: "unknown")
+    if data-kind == "custom-type-data" {
+      type_ = data.typeinfo
+    } else if data-kind == "element" {
+      type_ = base.element(data.name, data.eid)
+    } else {
+      return (false, "Received invalid type: " + repr(type_) + "\n  hint: use 'types.literal(value)' to indicate only that particular value is valid")
+    }
+  }
+
+  if type(type_) == type {
+    native.typeinfo(type_)
+  } else if type(type_) == dictionary and type-key in type_ {
+    (true, type_)
+  } else if type(type_) == dictionary and custom-type-data-key in type_ {
+    (true, type_.typeinfo)
+  } else if type(type_) == function {
+    (false, "A function is not a valid type. (You can use 'types.literal(func)' to only accept a particular function.)")
+  } else if type_ == none or type_ == auto {
+    // Accept none or auto to mean their types
+    native.typeinfo(type(type_))
+  } else if type(type_) not in (dictionary, array, content) {
+    // Automatically accept literals
+    (true, literal(type_))
+  } else {
+    (false, "Received invalid type: " + repr(type_) + "\n  hint: use 'types.literal(value)' to indicate only that particular value is valid")
+  }
+}
+
+// Error when a value doesn't conform to a certain cast
+#let generate-cast-error(value, typeinfo, hint: none) = {
+  let message = if "any" not in typeinfo.input and base.typeid(value) not in typeinfo.input {
+    if typeinfo.input == () {
+      "type '" + typeinfo.name + "' does not accept any values"
+    } else {
+      (
+        "expected "
+        + typeinfo.input.map(t => if type(t) == dictionary and "name" in t { t.name } else { str(t) }).join(", ", last: " or ")
+        + ", found "
+        + base.typename(value)
+      )
+    }
+  } else if typeinfo.at("error", default: none) != none {
+    (typeinfo.error)(value)
+  } else {
+    "typecheck for " + typeinfo.name + " failed"
+  }
+  let given-hint = if hint == none { "" } else { "\n  hint: " + hint }
+
+  message + given-hint
+}
+
+// Try to accept value via given typeinfo or return error
+// Returns ok(value) a.k.a. (true, value) on success
+// Returns err(value) a.k.a. (false, value) on error
+#let cast(value, typeinfo) = {
+  if type(typeinfo) != dictionary or type-key not in typeinfo {
+    let (res, typeinfo-or-err) = validate(typeinfo)
+    if not res {
+      assert(false, message: "types.cast: " + typeinfo-or-err)
+    }
+    typeinfo = typeinfo-or-err
+  }
+
+  let kind = typeinfo.type-kind
+  if kind == "any" {
+    (true, value)
+  } else {
+    let value-type = type(value)
+    if value-type == dictionary and custom-type-key in value {
+      value-type = value.at(custom-type-key).id
+    }
+
+    if kind == "literal" and typeinfo.cast == none {
+      if value == typeinfo.data.value and (value-type in typeinfo.input or "any" in typeinfo.input) and (typeinfo.data.typeinfo.check == none or (typeinfo.data.typeinfo.check)(value)) {
+        (true, value)
+      } else {
+        (false, generate-cast-error(value, typeinfo))
+      }
+    } else if (
+      value-type not in typeinfo.input and "any" not in typeinfo.input
+      or typeinfo.check != none and not (typeinfo.check)(value)
+    ) {
+      (false, generate-cast-error(value, typeinfo))
+    } else if typeinfo.cast == none {
+      (true, value)
+    } else if kind == "native" and typeinfo.data == content {
+      (true, [#value])
+    } else {
+      (true, (typeinfo.cast)(value))
+    }
+  }
+}
+
+// Expected types for each typeinfo key.
+#let overridable-typeinfo-types = (
+  name: (check: a => type(a) == str, error: "string or function old name => new name"),
+  input: (check: a => type(a) == array and a.all(x => x == "any" or x == "custom type" or type(x) == type or (type(x) == dictionary and "tid" in x)), error: "array of \"any\", \"custom type\", type, or custom type id (tid: ...), or function old input => new input"),
+  output: (check: a => type(a) == array and a.all(x => x == "any" or x == "custom type" or type(x) == type or (type(x) == dictionary and "tid" in x)), error: "array of \"any\", \"custom type\", type, or custom type id (tid: ...), or function old output => new output"),
+  check: (check: a => a == none or type(a) == function, error: "none or function receiving old function and returning a function value => bool"),
+  cast: (check: a => a == none or type(a) == function, error: "none or function receiving old function and returning a function checked input => output"),
+  error: (check: a => a == none or type(a) == function, error: "none or function receiving old function and returning a function checked input => error string"),
+  default: (check: d => d == () or type(d) == array and d.len() == 1, error: "empty array for no default, singleton array for one default, or function old default => new default"),
+  fold: (check: f => f == none or f == auto or type(f) == function, error: "none for no folding, auto to fold with sum (same as (a, b) => a + b), or function receiving old fold and returning either none or auto, or a new function (outer, inner) => combined value"),
+)
+
+// Wrap a type, altering its properties while keeping (or replacing) its input types and checks.
+#let wrap(type_, ..data) = {
+  assert(data.pos() == (), message: "types.wrap: unexpected positional arguments")
+  let (res, typeinfo) = validate(type_)
+  if not res {
+    assert(false, message: "types.wrap: " + typeinfo)
+  }
+
+  let overrides = data.named()
+  for (key, value) in overrides {
+    let (check: validate-value, error: key-error) = overridable-typeinfo-types.at(key, default: (check: none, error: none))
+    if validate-value == none or key-error == none {
+      assert(false, message: "types.wrap: invalid key '" + key + "', must be one of " + overridable-typeinfo-types.keys().join(", ", last: " or "))
+    }
+
+    if type(value) == function {
+      value = value(typeinfo.at(key, default: base.base-typeinfo.at(key)))
+    }
+
+    if type(value) != function and not validate-value(value) {
+      assert(false, message: "types.wrap: invalid value for key '" + key + "', expected " + key-error)
+    }
+  }
+
+  if "any" not in typeinfo.output and "cast" in overrides and "output" not in overrides or "output" in overrides and "any" in overrides.output {
+    // - Collapse "any" + other types into just "any";
+    // - If there is a cast and output is unknown, then set it to any for safety (should we error?)
+    overrides.output = ("any",)
+  }
+
+  if typeinfo.cast != none and "output" in overrides and "cast" not in overrides and "any" not in overrides.output and typeinfo.output.any(o => o not in overrides.output) {
+    // If output was changed to a list which isn't 'any' and isn't a superset of the previous output,
+    // then remove casting as it is no longer safe (might produce something that is invalid)
+    // (TODO: Should we error?)
+    overrides.cast = none
+  }
+
+  if "input" in overrides and "any" in overrides.input {
+    // - Collapse "any" + other types into just "any"
+    overrides.input = ("any",)
+  }
+
+  if "default" not in overrides and typeinfo.default != () and ("check" in overrides or "output" in overrides and "any" not in overrides.output and typeinfo.output.any(o => o not in overrides.output)) {
+    // Not sure if default would fit those criteria anymore:
+    // 1. By overriding the check, it's possible that a type such as positive int (check: int > 0) would no longer
+    // have an acceptable default when changing its check to, say, negative int (check: int < 0).
+    // 2. By overriding the output and removing previous output types, it's possible the default no longer has a valid type (it must be a valid output).
+    overrides.default = ()
+  }
+
+  if ("check" in overrides or "output" in overrides) and "fold" not in overrides {
+    // Folding might not be valid anymore:
+    // 1. By overriding the check, it's possible a fold that, say, adds two numbers, would no longer be valid
+    // if, for example, the new check ensures each number is smaller than 59 (you might add up to that).
+    //    In addition, the fold might now receive parameters that would fail the new check while being cast.
+    // 2. By overriding the output:
+    //    a. and removing old output, it's possible the fold produces invalid output.
+    //    b. and adding new output, it's possible the fold receives parameters of an unexpected type.
+    overrides.fold = none
+  }
+
+  let new-default = overrides.at("default", default: typeinfo.default)
+  let new-output = overrides.at("output", default: typeinfo.output)
+  assert(
+    new-default == ()
+    or "any" in new-output
+    or base.typeid(new-default.first()) in new-output,
+
+    message: "types.wrap: new default (currently " + repr(if new-default == () { none } else { new-default.first() }) + ") must have a type within possible 'output' types of the new type (currently " + if new-output == () { "empty" } else { new-output.map(t => if type(t) == dictionary { t.name } else { str(t) }).join(", ", last: " or ") } + "), since it is itself an output\n  hint: you can either change the default, or update possible output types with 'output: (new, list)' to indicate which native or custom types your wrapped type might end up as after casts (if there are casts)."
+  )
+
+  base.wrap(typeinfo, overrides)
+}
+
+// Specifies that any from a given selection of types is accepted.
+#let union(..args) = {
+  let types = args.pos()
+  assert(types != (), message: "types.union: please specify at least one type")
+
+  let typeinfos = types.map(type_ => {
+    let (res, typeinfo-or-err) = validate(type_)
+    assert(res, message: if not res { "types.union: " + typeinfo-or-err } else { "" })
+
+    typeinfo-or-err
+  })
+
+  base.union(typeinfos)
+}
+
+// An optional type (can be 'none').
+#let option(type_) = union(type(none), type_)
+
+// A type which can be 'auto'.
+#let smart(type_) = union(type(auto), type_)
+
+// Force the type to only accept its outputs (disallow casting).
+// Folding is kept if possible.
+#let exact(type_) = {
+  let (res, type_) = validate(type_)
+  if not res {
+    assert(false, message: "types.exact: " + type_)
+  }
+
+  let key = if type(type_) == dictionary and "type-kind" in type_ { type_.type-kind } else { none }
+  if key == "union" {
+    // exact(union(A, B)) === union(exact(A), exact(B))
+    union(..type_.data.map(exact))
+  } else if type(type_) == type or key == "native" {
+    // exact(float) => can only pass float, not int
+    // exact(stroke) => can only pass stroke, not length, gradient, dict, etc.
+    let native-type = type_.data
+    (
+      ..native.generic-typeinfo(native-type),
+      default: if type_.default != () and type(type_.default.first()) == native-type { type_.default } else { () },
+
+      // Fold is an output => output function. The new output will be just (native-type,),
+      // so if fold previously accepted that native type, it will still accept it, so it
+      // can be kept.
+      fold: if native-type in type_.output { type_.fold } else { none },
+    )
+  } else if key == "literal" {
+    // exact(literal) => literal with base type modified to exact(base type)
+    assert(type(type_.data.value) not in (dictionary, array), message: "types.exact: exact literal types for custom types, dictionaries and arrays are not supported\n  hint: consider customizing the check function to recursively check fields if the performance is acceptable")
+
+    base.literal(type_.data.value, exact(type_.data.typeinfo))
+  } else if key == "any" or key == "never" {
+    // exact(any) => any (same)
+    // exact(never) => never (same)
+    type_
+  } else if key == "custom" {
+    if type_.data.pre-casts == none {
+      type_
+    } else {
+      type_.data.pre-casts
+    }
+  } else {
+    assert(false, message: "types.exact: unsupported type kind " + key + ", supported kinds include native types, literals, custom types, 'any' and 'never'")
+  }
+}
+
+#let array_(type_) = {
+  let (res, param) = validate(type_)
+  if not res {
+    assert(false, message: "types.array: " + param)
+  }
+
+  let kind = param.type-kind
+
+  base.collection(
+    "array",
+    native.array_,
+    (param,),
+    check: if param.check == none and "any" in param.input {
+      none
+    } else if param.input == () {
+      // Propagate 'never'
+      _ => false
+    } else if "any" in param.input {
+      // Only need to run checks
+      a => a.all(x => (param.check)(x))
+    } else {
+      // Some optimizations ahead
+      // The proper code is at the bottom
+      let input = param.input
+      let check = param.check
+      if kind == "native" and param.data == dictionary {
+        a => a.all(x => type(x) == dictionary and custom-type-key not in x)
+      } else if param.input.all(i => type(i) == type) and dictionary not in param.input {
+        // No custom types accepted (the check above excludes '(tid: ..., name: ...)' as well as "any")
+        // If this is a custom type, it will return type(x) = dictionary, so it will fail
+        // (Also excludes "custom type": the type of custom types)
+        // So that suffices
+        if input.len() == 1 {
+          let input = input.first()
+          if check == none {
+            a => a.all(x => type(x) == input)
+          } else {
+            a => a.all(x => type(x) == input and check(x))
+          }
+        } else if input.len() == 2 {
+          let first = input.first()
+          let second = input.at(1)
+          if check == none {
+            a => a.all(x => type(x) == first or type(x) == second)
+          } else {
+            a => a.all(x => (type(x) == first or type(x) == second) and check(x))
+          }
+        } else if check == none {
+          a => a.all(x => type(x) in input)
+        } else {
+          a => a.all(x => type(x) in input and check(x))
+        }
+      } else if param.check == none {
+        a => a.all(x => base.typeid(x) in param.input)
+      } else {
+        a => a.all(x => base.typeid(x) in param.input and check(x))
+      }
+    },
+
+    cast: if param.cast == none {
+      none
+    } else if kind == "native" and param.data == content {
+      a => a.map(x => [#x])
+    } else {
+      a => a.map(param.cast)
+    },
+
+    error: if param.check == none {
+      a => {
+        let (count, message) = a.enumerate().fold((0, ""), ((count, message), (i, element)) => {
+          if "any" not in param.input and base.typeid(element) not in param.input {
+            (count + 1, message + "\n  hint: at position " + str(i) + ": " + generate-cast-error(element, param))
+          } else {
+            (count, message)
+          }
+        })
+
+        let n-elements = if count == 1 { "an element" } else { str(count) + "elements" }
+        n-elements + " in an array of " + param.name + " did not typecheck" + message
+      }
+    } else {
+      a => {
+        let (count, message) = a.enumerate().fold((0, ""), ((count, message), (i, element)) => {
+          if "any" not in param.input and base.typeid(element) not in param.input or not (param.check)(element) {
+            (count + 1, message + "\n  hint: at position " + str(i) + ": " + generate-cast-error(element, param))
+          } else {
+            (count, message)
+          }
+        })
+
+        let n-elements = if count == 1 { "an element" } else { str(count) + "elements" }
+        n-elements + " in an array of " + param.name + " did not typecheck" + message
+      }
+    }
+  )
+}
+
+// Native paint type. Can be used for fills, strokes and so on.
+#let paint = union(color, gradient, native.tiling_)

--- a/packages/preview/lilaq/0.2.0/src/lilaq.typ
+++ b/packages/preview/lilaq/0.2.0/src/lilaq.typ
@@ -1,0 +1,47 @@
+#import "math.typ": *
+
+#import "model/diagram.typ": diagram
+#import "model/axis.typ": axis, xaxis, yaxis
+#import "model/tick.typ": tick, tick-label
+#import "model/spine.typ": spine
+#import "model/title.typ": title
+#import "model/legend.typ": legend
+#import "model/grid.typ": grid
+#import "model/errorbar.typ": errorbar
+#import "model/label.typ": label, xlabel, ylabel
+
+#import "model/mark.typ": mark, marks
+#import "style/styling.typ": style
+#import "style/cycle.typ"
+#import "style/color.typ"
+
+#import "plot/plot.typ": plot
+#import "plot/bar.typ": bar
+#import "plot/hbar.typ": hbar
+#import "plot/stem.typ": stem
+#import "plot/hstem.typ": hstem
+#import "plot/scatter.typ": scatter
+#import "plot/fill-between.typ": fill-between
+#import "plot/colormesh.typ": colormesh
+#import "plot/contour.typ": contour
+#import "plot/boxplot.typ": boxplot
+#import "plot/quiver.typ": quiver
+#import "plot/hlines.typ": hlines
+#import "plot/vlines.typ": vlines
+
+#import "plot/rect.typ": rect
+#import "plot/ellipse.typ": ellipse
+#import "plot/line.typ": line
+#import "plot/path.typ": path
+#import "plot/place.typ": place
+
+
+#import "style/tilings.typ"
+#import "colorbar.typ": colorbar
+#import "place-anchor.typ": place-anchor
+
+
+#import "typing.typ": set-grid, set-label, set-title, set-legend, set-tick, set-tick-label, set-spine, set-diagram, set-errorbar, selector
+
+#import "logic/scale.typ"
+#import "algorithm/ticking.typ": locate-ticks-linear, locate-ticks-log, format-ticks-naive, format-ticks-linear, format-ticks-log

--- a/packages/preview/lilaq/0.2.0/src/loading/txt.typ
+++ b/packages/preview/lilaq/0.2.0/src/loading/txt.typ
@@ -1,0 +1,148 @@
+
+/// Parses a CSV (comma-separated values) string. This function enhances the 
+/// functionality of the built-in Typst function [`csv`](https://typst.app/docs/reference/data-loading/csv/) with features like transforming
+/// values to numerical (or other) types, ignoring comments and selecting only part of 
+/// the data. 
+/// 
+/// Unlike the built-in `csv` function, this function returns the data as a list of 
+/// columns and not as a list of rows. 
+///
+/// -> array | dictionary
+#let load-txt(
+  
+  /// Raw data loaded from a text file via [`read()`](https://typst.app/docs/reference/data-loading/read/). 
+  /// -> str
+  data,
+  
+  /// The delimiter that separates columns in the file. 
+  /// -> str
+  delimiter: ",",
+  
+  /// The characters that indicate the start of a single-line comment.
+  /// -> str
+  comments: "#",
+  
+  /// The number of leading rows to be skipped, including comments. 
+  /// -> int
+  skip-rows: 0,
+  
+  /// Which columns to extract from the file. Expects an array of indices to columns to 
+  /// extract. If `auto`, all columns are extracted. 
+  /// -> auto | array
+  usecols: auto,
+  
+  /// If true, the first line is interpreted as a header naming the individual columns. 
+  /// The result is then returned as a dictionary with the headers. 
+  /// -> bool
+  header: false,
+  
+  /// Optional converter functions or types to use to convert the data entries. This
+  /// can either be a single function or type that is applied to all columns likewise
+  /// or a dictionary with column indices as keys and functions or types as values. 
+  /// Through the (optional) key `rest`, a default converter can be specified to be used 
+  /// for all columns that have no explicit converter assigned. 
+  /// -> function | type | dictionary
+  converters: float
+  
+) = {
+  let rows = data.split("\n")
+    .slice(skip-rows)
+    .filter(row => not (row.starts-with(comments) or row == ""))
+
+  rows = rows.map(row => row.split(delimiter))
+  if rows.len() == 0 { return () }
+
+  let len = rows.first().len()
+  for (i, row) in rows.enumerate() {
+    assert(row.len() == len, message: "All rows need to be of the same length but the row " + repr(row.join(delimiter)) + " does not have " + str(len) + " entries as the other ones. ")
+  }
+  
+  if header {
+    header = rows.at(0).map(str.trim)
+    assert(header.dedup().len() == header.len(), message: "Duplicate entry in header")
+    rows = rows.slice(1)
+  }
+  let cols = array.zip(..rows) 
+  if type(converters) == dictionary {
+    let default-converter = converters.at("rest", default: float)
+    cols = range(cols.len()).map(j => {
+      let converter = converters.at(str(j), default: default-converter)
+      cols.at(j).map(str.trim).map(converter)
+    })
+  } else {
+    assert(type(converters) in (function, type), message: "The converter needs to a function or a type")
+    cols = cols.map(col => col.map(str.trim).map(converters))
+  }
+
+  if header == false {
+    if usecols == auto { return cols }
+    if type(usecols) == int { usecols = (usecols,) }
+    assert(type(usecols) == array, message: "Parameter `usecols` expects an int or an array of ints")
+    return usecols.map(j => cols.at(j))
+  }
+  assert(usecols == auto, message: "Parameter `usecols` can not be used with `header: true`, You can just partially destructure the dictionary. ")
+  return header.zip(cols).to-dict()
+}
+
+#assert.eq(
+   load-txt("1,2,3\n4,5,6"),
+   ((1,4), (2,5), (3,6))
+)
+#assert.eq(
+   load-txt("1, 2 , 3 \n 4, 5, 6"),
+   ((1,4), (2,5), (3,6))
+)
+#assert.eq(
+   load-txt("\n1,2,3\n4,5,6\n\n"),
+   ((1,4), (2,5), (3,6))
+)
+#assert.eq(
+   load-txt("\n1 2 3\n4 5 6", delimiter: " "),
+   ((1,4), (2,5), (3,6))
+)
+#assert.eq(
+   load-txt("1,2,3\n//a\n4,5,6\n//a", comments: "//"),
+   ((1,4), (2,5), (3,6))
+)
+#assert.eq(
+   load-txt("blablabla\n1,2\n3,4\n5,6", skip-rows: 1),
+   ((1,3,5), (2,4,6))
+)
+#assert.eq(
+   load-txt(" n, a, b\n1,2,3\n4,5,6", header: true),
+   (n: (1,4), a: (2,5), b: (3,6))
+)
+#assert.eq(
+   load-txt("1,2,3\n4,5,6", usecols: 1),
+   ((2,5),)
+)
+
+#assert.eq(
+   load-txt("1,2,3\n4,5,6", usecols: (0,2)),
+   ((1,4), (3,6))
+)
+
+
+#assert.eq(
+   load-txt("1,2\n4,5", converters: v => v),
+   (("1","4"), ("2","5"))
+)
+
+
+#assert.eq(
+   load-txt("1,2\n4,5", converters: ("0": v => v)),
+   (("1","4"), (2,5))
+)
+#assert.eq(
+   load-txt("1,2\n4,5", converters: ("1": v => v)),
+   ((1,4), ("2","5"))
+)
+#assert.eq(
+   load-txt("1,2\n4,5", converters: ("0": type, "1": v => v)),
+   ((str, str), ("2","5"))
+)
+
+#assert.eq(
+   load-txt("1,2\n4,5", converters: ("0": float, rest: v => v)),
+   ((1, 4), ("2","5"))
+)

--- a/packages/preview/lilaq/0.2.0/src/logic/limits.typ
+++ b/packages/preview/lilaq/0.2.0/src/logic/limits.typ
@@ -1,0 +1,28 @@
+#import "../math.typ": minmax
+#import "process-coordinates.typ": is-data-coordinates
+
+#let plot-lim(x, err: none) = {
+  if err == none { return minmax(x) }
+  
+  return (
+    calc.min(..array.zip(x, err.m).map(((x, err)) => x - if type(err) == array { err.at(0) } else { err })),
+    calc.max(..array.zip(x, err.p).map(((x, err)) => x + if type(err) == array { err.at(1) } else { err })),
+  )
+}
+
+#let bar-lim(x, base) = {
+  let lim = minmax(x + base)
+  let (base-min, base-max) = minmax(base)
+  if lim.at(0) == base-min { lim.at(0) *= 1fr }
+  if lim.at(1) == base-max { lim.at(1) *= 1fr }
+  return lim
+}
+
+// ignores (relative) lengths and ratios and
+// only accounts for data coordinates (which are
+// given as floats).
+#let compute-primitive-limits(coords) = {
+  let filtered-coords = coords.filter(is-data-coordinates)
+  if filtered-coords.len() == 0 { return none }
+  return (calc.min(..filtered-coords), calc.max(..filtered-coords))
+}

--- a/packages/preview/lilaq/0.2.0/src/logic/process-coordinates.typ
+++ b/packages/preview/lilaq/0.2.0/src/logic/process-coordinates.typ
@@ -1,0 +1,165 @@
+
+/// Takes an array of points as input and filters all points where at least one
+/// coordinate is `calc.nan` to produce
+/// + a filtered copy of the input array
+/// + an array of consecutive "runs", i.e., all connected sequences from the input
+///   separated by points where one or more coordinates take the value `calc.nan`. 
+/// 
+/// -> array
+#let filter-nan-points(
+  
+  /// Input points. The points themselves may have any dimension.
+  /// -> array
+  points, 
+  
+  /// Whether to to split the data into separate runs whenever a coordinate 
+  /// containing a `nan` value is encountered.  
+  /// -> bool
+  generate-runs: false
+  
+) = {
+  if generate-runs {
+    let filtered-points = ()
+    let runs = ((),)
+    for coord in points {
+      if coord.find(float.is-nan) != none { 
+        if runs.last().len() != 0 {
+          runs.push(())
+        }
+        continue 
+      }
+      filtered-points.push(coord)
+      runs.last().push(coord)
+    }
+    return (filtered-points, runs)
+  } else {
+    return points.filter(p => p.find(float.is-nan) == none)
+  }
+}
+
+
+/// Converts an array of points to a step sequence. 
+/// Given $n$ points, the output will have $2n-1$ points and zero points 
+/// if the input has zero points. 
+///
+/// -> array
+#let stepify(
+
+  /// Input points of the form `(x, y)` with `nan` values removed. 
+  /// -> array
+  points, 
+
+  /// Step mode
+  /// - `start`: The interval $(x_{i-1}, x_i]$ takes the value of $x_i$. 
+  /// - `end`: The interval $[x_i, x_{i+1})$ takes the value of $x_i$. 
+  /// - `center`: The value switches half-way between consecutive $x$ positions. 
+  /// -> start | center | end
+  step: start
+
+) = {
+  if points.len() == 0 { return () }
+  let result = ()
+  if step == start {
+    for i in range(points.len() - 1) {
+      result.push(points.at(i))
+      result.push((points.at(i).at(0), points.at(i + 1).at(1)))
+    }
+  } else if step == end {
+    for i in range(points.len() - 1) {
+      result.push(points.at(i))
+      result.push((points.at(i + 1).at(0), points.at(i).at(1)))
+    }
+  } else if step == center {
+    for i in range(points.len() - 1) {
+      result.push(points.at(i))
+      let mid = 0.5 * (points.at(i).at(0) + points.at(i + 1).at(0))
+      result.push((mid, points.at(i).at(1)))
+      result.push((mid, points.at(i + 1).at(1)))
+    }
+  }
+  result.push(points.last())
+  return result
+}
+
+#assert.eq(stepify((), step: start), ())
+#assert.eq(stepify(((0,0),), step: start), ((0,0),))
+#assert.eq(stepify(((0,0), (1,.7)), step: start), ((0,0), (0,.7), (1,.7)))
+#assert.eq(stepify(((0,0), (1,.7), (3,-.1)), step: start), ((0,0), (0,.7), (1,.7), (1,-.1), (3,-.1)))
+
+#assert.eq(stepify((), step: end), ())
+#assert.eq(stepify(((0,0),), step: end), ((0,0),))
+#assert.eq(stepify(((0,0), (1,.7)), step: end), ((0,0), (1,0), (1,.7)))
+#assert.eq(stepify(((0,0), (1,.7), (3,-.1)), step: end), ((0,0), (1,0), (1,.7), (3, .7), (3,-.1)))
+
+#assert.eq(stepify((), step: center), ())
+#assert.eq(stepify(((0,0),), step: center), ((0,0),))
+#assert.eq(stepify(((0,0), (1,.7)), step: center), ((0,0), (0.5,0), (0.5, .7), (1,.7)))
+#assert.eq(stepify(((0,0), (1,.7), (3,-.1)), step: center), ((0,0), (.5,0), (.5, .7), (1,.7), (2, .7), (2, -.1), (3,-.1)))
+
+
+
+/// Transforms a generalized point
+#let transform-point(x, y, transform) = {
+  if type(x) in (int, float) {
+    x = transform(x, 1).at(0)
+  }
+  if type(y) in (int, float) {
+    y = transform(1, y).at(1)
+  }
+  return (x, y)
+}
+#let convert-bezier-curve(points, transform) = {
+  let v = points.at(0)
+  let p = transform-point(..v, transform)
+  let result = (p,)
+  
+  for (x, y) in points.slice(1) {
+    if type(x) in (int, float) {
+      x = transform(x + v.at(0), 1).at(0) - p.at(0)
+    }
+    if type(y) in (int, float) {
+      y = transform(1, y + v.at(1)).at(1) - p.at(1)
+    }
+    result.push((x, y))
+  }
+  return result
+}
+
+// point and size pt -> makes sense
+// point and size data coords -> makes sense
+// point data coords and size pt -> makes sense
+// point data pt and size data coords -> makes no sense
+
+
+#let convert-rect(x, y, width, height, transform) = {
+  // at the end we only want lengths (or relative lengths)!
+  let (x1, y1)  = transform-point(x, y, transform)
+  if type(width) in (int, float) {
+    assert(type(x) in (int, float), message: "Setting the width in terms of data coordinates makes no sense if the origin x coordinate is not in data coordinates")
+    width = transform(x + width, 1).at(0) - transform(x, 1).at(0)
+  }
+  if type(height) in (int, float) {
+    assert(type(y) in (int, float), message: "Setting the height in terms of data coordinates makes no sense if the origin y coordinate is not in data coordinates")
+    height = transform(1, y + height).at(1) - transform(1, y).at(1) 
+  }
+
+  return (x1, width, y1, height)
+}
+
+#let is-data-coordinates(coord) = type(coord) in (int, float)
+#let all-data-coordinates(coords) = {
+  return coords.map(is-data-coordinates).fold(true, (a, b) => a and b)
+}
+
+
+// Convert a vertex for `path`. A vertex may either be a single vertex
+// or a pair/triple of vertices describing a point with handles on a
+// bezier curve. 
+#let convert-vertex(v, transform: it => it) = {
+  if type(v.at(0)) == array {
+    return v.map(p => transform-point(..p, transform))
+  } else {
+    transform-point(..v, transform)
+  }
+}
+

--- a/packages/preview/lilaq/0.2.0/src/logic/sample-colors.typ
+++ b/packages/preview/lilaq/0.2.0/src/logic/sample-colors.typ
@@ -1,0 +1,50 @@
+
+#import "../utility.typ": match-type
+#import "../math.typ" as pmath
+#import "../logic/scale.typ"
+#import "../logic/transform.typ": create-trafo
+
+
+#let sample-colors(
+  values,
+  colormap,
+  norm,
+  min: auto, 
+  max: auto,
+  ignore-nan: false
+) = {
+  if ignore-nan {
+    if min == auto { min = pmath.cmin(values) }
+    if max == auto { max = pmath.cmax(values) }
+  } else {
+    if min == auto { min = calc.min(..values) }
+    if max == auto { max = calc.max(..values) }
+  }
+  if min == max { min -= 1; max += 1}
+
+  let norm-fn = match-type(
+    norm,
+    function: () => norm,
+    string: () => scale.scales.at(norm).transform,
+    dictionary: () => {
+      assert("transform" in norm, message: "The argument `norm` must be a valid scale from the `scales` module")
+      norm.transform
+    },
+    default: () => assert(false, message: "Unsupported type `" + str(type(norm)) + "` for argument `norm`")
+  )
+  
+  let normalize = create-trafo(norm-fn, min, max)
+  assert(type(colormap) in (gradient, array), message: "Invalid type for colormap")
+  if type(colormap) == array {
+    colormap = gradient.linear(..colormap)
+  }
+  let convert-scalar-to-color(x) = {
+    if float.is-nan(x) { return luma(0, 0%) }
+    colormap.sample(normalize(x) * 100%)
+  }
+  (
+    values.map(convert-scalar-to-color), 
+    (norm: norm, min: min, max: max, colormap: colormap)
+  )
+}
+

--- a/packages/preview/lilaq/0.2.0/src/logic/scale.typ
+++ b/packages/preview/lilaq/0.2.0/src/logic/scale.typ
@@ -1,0 +1,142 @@
+/// Scales that can be applied to the displayed data. By default, the 
+/// data is scaled linearly but other scales like `lq.scale.log` and 
+/// `lq.scale.symlog` are available and completely custom scales can
+/// be created with the general `scale` function.  
+
+
+#import "../math.typ": sign
+
+
+/// Constructor for the scale type. Scales are used to transform data coordinates 
+/// into scaled coordinates. Commonly, data is displayed with a linear scale, i.e., 
+/// the entire data is just scaled uniformly. However, in order to visualize large 
+/// ranges, it is often desirable to use logarithmic scaling or other scales that 
+/// improve the readability of the data. 
+#let scale(
+
+  /// Transformation from data coordinates to scaled coordinates.  
+  /// Note that the transformation function does not need to worry about absolute 
+  /// scaling and offset. As an example, the transformation function for the linear 
+  /// scale is just `x => x` and not `x => a * x + b` or similar and the logarithmic 
+  /// scale uses `x => calc.log(x)`. 
+  /// -> function
+  transform,
+
+  /// A precise inverse of the `transform` should be given here to enable the 
+  /// conversion of scaled coordinates back to data coordinates. 
+  /// -> function
+  inverse,
+  
+  /// Name of the scale. Built-in scales are sometimes identified by their name, 
+  /// e.g., when a suitable tick locator needs to be selected automatically. 
+  /// -> str
+  name: "",
+
+  /// An identity value which can be used to find an initial axis range when 
+  /// no limits or plots are given. Scales like logarithmic scales that are 
+  /// only defined for positive values should set this to 1. 
+  /// -> int | float
+  identity: 0, 
+
+  /// Additional data to store in the scale. 
+  /// -> any
+  ..args
+  
+) = (
+  transform: transform,
+  inverse: inverse,
+  name: name,
+  identity: identity,
+  ..args.named()
+)
+
+
+/// Creates a new linear scale. This scale can also be accessed through 
+/// the shorthand `"linear"`. 
+#let linear() = scale(
+  name: "linear",
+  x => x,
+  x => x,
+)
+
+
+/// Creates a new logarithmic scale. This scale can also be accessed through 
+/// the shorthand `"log"`. 
+#let log(
+  
+  /// The base of the logarithm. This info is only used to determine
+  /// the base for ticks. 
+  /// -> float
+  base: 10
+  
+) = scale(
+  name: "log",
+  x => calc.log(x),
+  x => calc.pow(10., x),
+  base: base,
+  identity: 1
+)
+
+
+/// Creates a new symlog scale with a linear scaling in the region 
+/// `[threshold, threshold]` around 0 and a logarithmic scaling beyond that. 
+/// This scale can also be accessed through the shorthand `"symlog"`. 
+#let symlog(
+  
+  /// The base of the logarithm. 
+  /// -> float
+  base: 10, 
+
+  /// The threshold for the linear region. 
+  /// -> float
+  threshold: 2, 
+
+  /// The scaling of the linear region. 
+  /// -> float
+  linscale: 1
+  
+) = {
+  let c = linscale / (1. - 1. / base)
+  let log-base = calc.ln(base)
+  let transform = x => {
+      if x == 0 { return 0. }
+      let abs = calc.abs(x)
+      if abs <= threshold { return x * c }
+      return sign(x) * threshold * (c + calc.ln(abs / threshold) / log-base)
+    }
+  let inv-threshold = transform(threshold)
+  scale(
+    name: "symlog",
+    transform,
+    x => {
+      if x == 0 { return 0. }
+      let abs = calc.abs(x)
+      if abs <= inv-threshold { return x / c }
+      return sign(x) * threshold * calc.pow(base, abs / threshold - c)
+    },
+    
+    threshold: threshold,
+    base: base,
+    linscale: linscale,
+  )
+}
+
+#let check-sym(x) = {
+  let sym = symlog()
+  assert((sym.inverse)((sym.transform)(x)) - x < 1e-15)
+}
+#check-sym(0)
+#check-sym(1)
+#check-sym(1.5)
+#check-sym(2)
+#check-sym(3)
+
+
+
+
+#let scales = (
+  linear: linear(),
+  log: log(base: 10),
+  symlog: symlog(base: 10),
+)
+

--- a/packages/preview/lilaq/0.2.0/src/logic/transform.typ
+++ b/packages/preview/lilaq/0.2.0/src/logic/transform.typ
@@ -1,0 +1,44 @@
+
+/// Creates a data-to-display transformation that maps the interval 
+/// $[x_0, x_1]$ to $[y_0, y_1]$ given some monotonous transformation function 
+/// (e.g., identity or log(x)). 
+/// 
+/// -> function
+#let create-trafo(
+  
+  /// Transformation function that takes one argument. 
+  /// -> function
+  transform, 
+  
+  /// Lower interval bound. 
+  /// -> float
+  x0, 
+  
+  /// Upper interval bound. 
+  /// -> float
+  x1, 
+
+  /// Lower target interval bound. 
+  /// -> float
+  y0: 0, 
+  
+  /// Upper target interval bound. 
+  /// -> float
+  y1: 1
+  
+) = {
+  let a = (y1 - y0) / (transform(x1) - transform(x0))
+  let b = -a * transform(x0) + y0
+  x => a * transform(x) + b
+}
+
+#assert.eq(create-trafo(x => x, -23, 4)(-23), 0)
+#assert.eq(create-trafo(x => x, -23, 4)(4), 1)
+
+#assert.eq(create-trafo(x => x, -23, 4, y0: 1, y1: -1)(-23), 1)
+#assert.eq(create-trafo(x => x, -23, 4, y0: 1, y1: -1)(4), -1)
+
+#assert.eq(create-trafo(x => calc.log(x), 2, 4)(2), 0)
+#assert.eq(create-trafo(x => calc.log(x), 2, 4)(4), 1)
+
+

--- a/packages/preview/lilaq/0.2.0/src/math.typ
+++ b/packages/preview/lilaq/0.2.0/src/math.typ
@@ -1,0 +1,324 @@
+
+#import "vec.typ"
+#import "algorithm/interpolate.typ"
+#import "loading/txt.typ": load-txt
+
+
+
+/// Returns the sign of a number. 
+/// - `0` for $x=0$
+/// - `1` for $x>0$
+/// - `-1` for $x<0$
+/// Note that this is different from the built-in
+/// [`float.signum()`](https://typst.app/docs/reference/foundations/float/#definitions-signum) 
+/// which returns `1.0` for $x=0$. 
+/// -> int
+#let sign(
+  /// The value to determine the sign of. 
+  /// -> int | float
+  value
+) = if value == 0 { 0 } else if value < 0 { -1 } else { 1 }
+
+
+/// Returns the minimum value of an array, ignoring `NaN` values. Returns `none` 
+/// if the array is empty or contains only `NaN` values. 
+/// -> none | float
+#let cmin(
+  /// Values to compute the minimum of. 
+  /// -> array
+  values
+) = {
+  values = values.filter(x => not float.is-nan(x))
+  if values.len() == 0 { return none }
+  return calc.min(..values)
+}
+
+/// Returns the maximum value of an array, ignoring `NaN` values. Returns `none` 
+/// if the array is empty or contains only `NaN` values. 
+/// -> none | float
+#let cmax(
+  /// Values to compute the maximum of. 
+  /// -> array
+  values
+) = {
+  values = values.filter(x => not float.is-nan(x))
+  if values.len() == 0 { return none }
+  return calc.max(..values)
+}
+
+/// Returns the minimum and maximum value of an array, ignoring `NaN` values. 
+/// Returns `(none, none)` if the array is empty or contains only `NaN` values. 
+/// -> array 
+#let minmax(
+  /// Values to compute the minimum and the maximum of. 
+  /// -> array
+  values
+) = {
+  values = values.filter(x => not float.is-nan(x))
+  if values.len() == 0 { return (none, none) }
+  return (calc.min(..values), calc.max(..values))
+}
+
+
+#assert.eq(cmin((1,2,3,4)), 1)
+#assert.eq(cmin((1,2,3,-23.2)), -23.2)
+#assert.eq(cmin((float.nan,2,3,-23.2)), -23.2)
+#assert.eq(cmin((float.nan,)), none)
+#assert.eq(cmax((1,2,3,4)), 4)
+#assert.eq(cmax((-1,-2,-3,-23.2)), -1)
+#assert.eq(cmax((float.nan,2,3,-23.2)), 3)
+#assert.eq(cmax((float.nan,)), none)
+
+#assert.eq(float.is-nan(float.nan), true)
+#assert.eq(float.is-nan(1e123), false)
+#assert.eq(float.is-nan(0), false)
+#assert.eq(float.is-nan(-1232445345345e200000000000000000), false)
+
+
+/// Generates an array of evenly-spaced numbers in the interval `[start, end)` or `[start, end]`. 
+/// -> array
+#let linspace(
+  
+  /// Start of the range.
+  /// -> int | float
+  start, 
+  
+  /// End of the range.
+  /// -> int | float
+  end, 
+  
+  /// Number of evenly-spaced values to produce. 
+  /// -> int
+  num: 50,
+  
+  /// Whether to include the end of the range. If `true`, samples are taken for
+  /// the closed interval `[start, end]`. 
+  /// -> bool
+  include-end: true
+
+) = {
+  assert(num >= 0, message: "linspace: num must be non-negative")
+  if num == 0 { return () }
+  if num == 1 { return (start,) }
+  let k = (end - start) / (num - int(include-end))
+  range(num).map(x => k * x + start)
+}
+
+
+// Special cases: num = 0,1
+#assert.eq(linspace(0, 1, num: 0), ())
+#assert.eq(linspace(0, 1, num: 0, include-end: false), ())
+#assert.eq(linspace(-2.3, 1, num: 1), (-2.3, ))
+#assert.eq(linspace(-2.3, 1, num: 1, include-end: false), (-2.3, ))
+
+// Normal operation
+#assert.eq(linspace(0, 1, num: 2), (0, 1))
+#assert.eq(linspace(0, 1, num: 2, include-end: false), (0, .5))
+#assert.eq(linspace(-3.4, 7, num: 2), (-3.4, 7))
+#assert.eq(linspace(-3, 7, num: 2, include-end: false), (-3, 2))
+#assert.eq(linspace(0, 1, num: 5), (0, .25, .5, .75, 1))
+
+// Inverse range
+#assert.eq(linspace(1, 0, num: 2), (1, 0))
+#assert.eq(linspace(100, 0, num: 2), (100, 0))
+#assert.eq(linspace(100, 0, num: 2, include-end: false), (100, 50))
+
+
+
+
+/// Generates an array of numbers spaced by `step` in the interval `[start, end)`. 
+/// -> array
+#let arange(
+  
+  /// Start of the range. 
+  /// -> int | float
+  start,
+  
+  /// End of the range (excluded). 
+  /// -> int | float
+  end,
+  
+  /// Difference between consecutive values. 
+  /// -> int | float
+  step: 1,
+) = {
+  let num = calc.quo(end - start, step)
+  range(num).map(x => x * step + start)
+}
+
+#let arange1(
+  start, 
+  end, 
+  step: 1,
+) = {
+  let num = calc.quo(calc.abs(end - start), step)
+  range(num).map(x => x * step + start)
+}
+
+
+#assert.eq(arange(0, 1), (0,))
+#assert.eq(arange(0, 2), (0,1))
+#assert.eq(arange(0, 1, step: 0.25), (0,.25, .5, .75))
+#assert.eq(arange(0, 2, step: 0.25), (0,.25, .5, .75, 1, 1.25, 1.5, 1.75))
+
+// Inverse range
+#assert.eq(arange(1, 0), ())
+#assert.eq(arange(41, 0), ())
+#assert.eq(arange(1, 0, step: -1), (1,))
+#assert.eq(arange(0, -4, step: -1), (0, -1, -2, -3))
+#assert.eq(arange(1, 0, step: -0.25), (1,.75, .5, .25))
+
+
+
+
+/// Computes the q-th percentile of the given data. 
+#let percentile(
+
+  /// Array of values. 
+  /// -> array
+  values, 
+
+  /// A percentage between 0% and 100%. 
+  /// -> ratio
+  q, 
+
+  /// Interpolation method. Currently, only `"linear"` is supported. 
+  /// -> "linear"
+  method: "linear"
+  
+) = {
+  assert(method in ("linear",), message: "`percentile`: unknown method \"" + method + "\"")
+
+  
+  return interpolate.linear(values, q / 100% * (values.len() - 1))
+}
+
+/// Creates a rectangular mesh from two input arrays. 
+/// One or more functions are evaluated for each possible pair $(x_i,y_j)$ of
+/// the inputs $\{x_0,...\}$ and $\{y_0,...\}$. 
+/// ```example
+/// #lq.mesh((0, 1), (4, 5), (x, y) => (x + y))
+/// ```
+/// Returns the array `(x, y, ..zs)` where `zs` are two-dimensional arrays 
+/// ```
+/// (
+///   (f(x0, y0), f(x0, y1), ...),
+///   (f(x1, y0), f(x1, y1), ...),
+///   ...
+/// )
+/// ```
+/// for each function that was passed to `mesh()`. 
+/// -> array
+#let mesh(
+
+  /// Array of $x$ coordinates. 
+  /// -> array
+  x, 
+  
+  /// Array of $y$ coordinates. 
+  /// -> array
+  y, 
+
+  /// Bivariate functions that take two numbers `x, y` as inputs. 
+  /// -> function
+  ..transforms
+
+) = {
+  let transforms = transforms.pos()
+  let mesh = transforms.map(transform => y.map(y => x.map(x => transform(x, y))))
+  if transforms.len() == 1 {
+    mesh = mesh.first()
+  }
+  return mesh
+}
+
+#assert.eq(
+  mesh((0, 2), (4, 5), (x, y) => (x + y/10)),
+  ((0.4, 2.4), (0.5, 2.5))
+)
+
+#assert.eq(
+  mesh((0, 2), (4, 5), (x, y) => (x + y/10), (x, y) => (x - y)),
+  (
+    ((0.4, 2.4), (0.5, 2.5)),
+    ((-4, -2), (-5, -3)),
+  )
+)
+
+
+
+
+/// Performs integer (floored) division and returns `(quotient, remainder)` while 
+/// guaranteeing that `quotient * divisor + remainder = divident`. Note that using 
+/// `calc.quo` and `calc.rem` does not give this guarantee. 
+/// -> array
+#let divmod(
+  /// The dividend of the quotient. 
+  /// -> int | float
+  dividend, 
+  
+  /// The divisor of the quotient. 
+  /// -> int | float
+  divisor
+) = {
+  let q = calc.quo(dividend, divisor)
+  return (q, dividend - q * divisor)
+}
+
+#assert.eq(divmod(5, 2), (2, 1))
+#assert.eq(divmod(5, .5), (10, 0))
+#assert.eq(divmod(5.25, .5), (10, 0.25))
+#assert.eq(divmod(5.25, -.5), (-11, -0.25))
+#assert.eq(divmod(5.25, -.5), (-11, -0.25))
+#assert.eq(divmod(-5.25, .5), (-11, 0.25))
+#assert.eq(divmod(-5.25, -.5), (10, -0.25))
+#assert.eq(divmod(2, 1), (2, 0))
+#assert.eq(divmod(-2, 1), (-2, 0))
+#assert.eq(divmod(1, .2), (5, 0))
+#assert.eq(divmod(5, .2), (25, 0))
+
+
+#{
+  let check(x, d) = {
+    let quo = calc.div-euclid(x, d)
+    let rem = calc.rem(x, d)
+    let (quo, rem) = divmod(x, d)
+    assert.eq(quo*d + rem, x)
+  }
+  check(5, -.2)
+  check(2, 1)
+  check(-2, 1)
+  check(1, .2)
+  check(-5, .2)
+  check(-5, -.2)
+  check(115, 22)
+  check(115, .22)
+  check(1e30, 1e20)
+}
+
+
+
+
+/// Decomposes a floating point number into the scientific notation. 
+/// $ x = a\cdot 10^n $
+/// where $a \in [0.1, 1)$ and $n \in \mathbb{Z}$. Returns an array `(a, n)`. 
+/// -> array
+#let decompose-floating-point(
+  /// Number to decompose. 
+  /// -> float
+  value
+) = {
+  let n = int(calc.floor(calc.log(base: 10, value))) + 1
+  let a = value / calc.pow(10., n) 
+  return (a, n)
+}
+
+
+/// Computes $10^x$ for the given number $x$, guaranteeing floating point
+/// computation, even when the input is an `int`. 
+/// -> float
+#let pow10(
+  /// The exponent to which to raise the number 10. 
+  /// -> int | float
+  value
+) = calc.pow(10., value)

--- a/packages/preview/lilaq/0.2.0/src/model/axis.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/axis.typ
@@ -1,0 +1,777 @@
+#import "../logic/scale.typ" as lqscale
+#import "../utility.typ": place-in-out, match, match-type, if-auto
+#import "../algorithm/ticking.typ"
+#import "../bounds.typ": *
+#import "../assertations.typ"
+#import "../model/label.typ": xlabel, ylabel, label as lq-label
+#import "../process-styles.typ": update-stroke, merge-strokes
+#import "../libs/elembic/lib.typ" as e
+
+#import "tick.typ": tick as lq-tick, tick-label as lq-tick-label
+#import "spine.typ": spine
+
+#import "@preview/zero:0.3.3"
+#import "@preview/tiptoe:0.3.0"
+
+
+
+/// An axis for a diagram. Visually, an axis consists of a _spine_ along the axis 
+/// direction, a collection of ticks/subticks and an axis label. 
+/// 
+/// By default, a @diagram features two axes: an `x` and a `y` axis which can be 
+/// configured directly through @diagram.xaxis and @diagram.yaxis. However, it is 
+/// also possible to add more axes, please refer to the 
+/// #link("tutorials/axis")[axis tutorial] for more details. 
+/// 
+/// The built-in tick formatters use the Typst package
+/// #link("https://typst.app/universe/package/zero")[Zero] for displaying
+/// numbers. This makes it possible to define a consistent number format 
+/// throughout the entire document, including tables, in-text quantities,
+/// and figures. 
+#let axis(
+
+  /// Sets the scale of the axis. This may be a @scale object or the name of 
+  /// one of the built-in scales `"linear"`, `"log"`, `"symlog"`.
+  /// -> lq.scale | str 
+  scale: "linear", 
+
+  /// Data limits of the axis. This can be used to fix the minimum and/or maximum value
+  /// displayed along this axis. This parameter expects `auto` or a tuple `(min, max)` 
+  /// where `min` and `max` can also be `auto`. If a limit is `auto`, it will be 
+  /// automatically computed from all plots associated with this axis and @diagram.margin 
+  /// will be applied. If the minimum is larger than the maximum, the scale is inverted
+  /// and if `min` and `max` coincide, the range will be automatically increased. 
+  /// -> auto | array
+  lim: auto,
+
+  /// Label for the axis. Use a @label object for more options. 
+  /// -> content | lq.label
+  label: none,
+
+  /// The kind of the axis. 
+  /// -> "x" | "y"
+  kind: "x", 
+
+  /// Where to place this axis. This can be 
+  /// - one of the sides of the diagram (`top` or `bottom` for $x$-axes, 
+  ///   `left` or `right` for $y$-axes), 
+  /// - a `float` coordinate value on the other axis,
+  /// - a `length` or `relative`,
+  /// - or a combination of the first and third option through a dictionary 
+  ///   with the keys `align` and `offset`. 
+  /// 
+  /// More on axis placement can be found in the 
+  /// #link("tutorials/axis#placement-and-mirrors")[axis tutorial]. 
+  /// -> auto | alignment | float | relative | dictionary
+  position: auto, 
+
+  /// How to stroke the spine of the axis. If not `auto`, this is forwarded to 
+  /// @spine.stroke. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// Whether to mirror the axis, i.e., whether to show the axis ticks also on 
+  /// the side opposite of the one specified with @axis.position. When set to 
+  /// `auto`, mirroring is only activated when `position: auto`. More control
+  /// is granted through a dictionary with the possible keys `ticks` and 
+  /// `tick-labels` to individually activate or deactivate those. 
+  /// 
+  /// More on axis mirrors can be found in the 
+  /// #link("tutorials/axis#placement-and-mirrors")[axis tutorial]. 
+  /// -> auto | bool | dictionary
+  mirror: auto,
+
+  /// Specifies conversions between the data and the ticks. This can be used to
+  /// configure a secondary axis to display the same data in a different unit, 
+  /// e.g., the main axis displays the velocity of a particle while the 
+  /// secondary axis displays the associated energy. In this case, one would 
+  /// pick `functions: (x => m*x*x, y => calc.sqrt(y/m))` with some constant
+  /// `m`. Note that the first function computes the "forward" direction while
+  /// the second function computes the "backward" direction. The user needs to 
+  /// ensure that the two functions are really inverses of each other. 
+  /// By default, this parameter resolves to the identity. 
+  /// -> auto | array
+  functions: auto,
+
+  /// The tick locator for the (major) ticks. 
+  /// -> auto | function
+  locate-ticks: auto,
+  
+  /// The formatter for the (major) ticks. 
+  /// -> auto | function
+  format-ticks: auto,
+  
+  /// The tick locator for the subticks. 
+  /// -> auto | function
+  locate-subticks: auto,
+  
+  /// The formatter for the subticks. 
+  /// -> auto | none | function
+  format-subticks: none,
+
+  /// An array of extra ticks to display. The ticks can be positions given as `float` or `lq.tick` objects. 
+  /// TODO: not implemented yet
+  /// -> array
+  extra-ticks: none, 
+
+  /// The formatter for the extra ticks. 
+  format-extra-ticks: none,
+
+  /// Arguments to pass to the tick locator. 
+  /// -> dictionary
+  tick-args: (:),
+
+  /// Arguments to pass to the subtick locator. 
+  /// -> dictionary
+  subtick-args: (:),
+
+  /// Instead of using the tick locator, specifies the tick locations explicitly and optionally the tick labels. This can be an array with just the tick location or tuples of tick location and label, or a dictionary with the keys `ticks` and `labels`, containing arrays of equal length. When `ticks` is `none`, no ticks are displayed. If it is `auto`, the `tick-locator` is used. 
+  /// -> auto | array | dictionary | none
+  ticks: auto, 
+
+  /// Instead of using the tick locator, specifies the tick positions explicitly and optionally the tick labels.
+  /// -> auto | array | dictionary | none
+  subticks: auto,
+
+  /// Passes the parameter `tick-distance` to the tick locator. The linear tick locator respects this setting and sets the distance between consecutive ticks accordingly. If `tick-args` already contains an entry `tick-distance`, it takes precedence. 
+  /// -> auto | float
+  tick-distance: auto, 
+
+  /// Offset for all ticks on this axis. The offset is subtracted from all ticks and shown at the end of the axis (if it is not 0). An offset can be used to avoid overly long tick labels and to focus on the relative distance between data points. 
+  /// -> auto | float
+  offset: auto,
+
+  /// Exponent for all ticks on this axis. All ticks are divided by $10^\mathrm{exponent}$ and the $10^\mathrm{exponent}$ is shown at the end of the axis (if the exponent is not 0). This setting can be used to avoid overly long tick labels. 
+  /// 
+  /// In combination with logarithmic tick locators, `none` can be used to 
+  /// force writing out all numbers. 
+  /// -> auto | none | float
+  exponent: auto,
+
+  /// Threshold for automatic exponents. 
+  /// -> int
+  auto-exponent-threshold: 3,
+
+  /// If set to `true`, the entire axis is hidden. 
+  /// -> bool
+  hidden: false,
+
+  /// Places an arrow tip on the axis spine. This expects a mark as specified by
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// If not `auto`, this is forwarded to @spine.tip. 
+  /// -> auto | none | tiptoe.mark
+  tip: auto,
+
+  /// Places an arrow tail on the axis spine. This expects a mark as specified by 
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// If not `auto`, this is forwarded to @spine.toe. 
+  /// -> auto | none | tiptoe.mark
+  toe: auto,
+
+  filter: (value, distance) => true,
+
+  /// Plot objects to associate with this axis. This only applies when this is a secondary axis. Automatic limits are then computed according to this axis and transformations of the data coordinates linked to the scaling of this axis. 
+  /// -> any
+  ..plots
+  
+) = {
+  assertations.assert-no-named(plots)
+  plots = plots.pos()
+  if "tick-distance" not in tick-args {
+    tick-args.tick-distance = tick-distance
+  }
+  if type(scale) == str {
+    assert(scale in lqscale.scales, message: "Unknown scale " + scale)
+    scale = lqscale.scales.at(scale)
+  }
+  assert(kind in ("x", "y"), message: "The `kind` of an axis can only be `x` or `y`")
+  let translate = (0pt, 0pt)
+
+
+  if position == auto {
+    if kind == "x" { position = bottom }
+    else if kind == "y" { position = left }
+  } else if type(position) in (int, float, length, relative, ratio) {
+    if kind == "x" { 
+      translate = (0pt, position)
+      position = bottom 
+    }
+    else if kind == "y" { 
+      translate = (position, 0pt)
+      position = left 
+    }
+    if mirror == auto { mirror = none }
+  } else if type(position) == dictionary {
+    assertations.assert-dict-keys(position, mandatory: ("align", "offset"))
+
+    
+    (position, translate) = (position.align, position.offset)
+    if kind == "x" { translate = (0pt, translate) }
+    else if kind == "y" { translate = (translate, 0pt) }
+    if mirror == auto { mirror = none }
+    
+    if kind == "x" {
+      assert(position in (top, bottom), message: "For x-axes, `position` can only be \"top\" or \"bottom\", got " + repr(position))
+    }
+    if kind == "y" {
+      assert(position in (left, right), message: "For y-axes, `position` can only be \"left\" or \"right\", got " + repr(position))
+    }
+  } else if type(position) == alignment {
+    if mirror == auto { mirror = none }
+    
+    if kind == "x" {
+      assert(position in (top, bottom), message: "For x-axes, `position` can only be \"top\" or \"bottom\", got " + repr(position))
+    }
+    if kind == "y" {
+      assert(position in (left, right), message: "For y-axes, `position` can only be \"left\" or \"right\", got " + repr(position))
+    }
+  } else {}
+
+  if ticks != auto {
+    if type(ticks) == dictionary {
+      assert("ticks" in ticks, message: "When passing a dictionary for `ticks`, you need to provide the keys \"ticks\" and optionally \"labels\"")
+      locate-ticks = ticking.locate-ticks-manual.with(..ticks)
+      if "labels" in ticks {
+        format-ticks = ticking.format-ticks-manual.with(labels: ticks.labels) 
+      }
+    } else if type(ticks) == array {
+      if ticks.len() > 0 and type(ticks.first()) == array {
+        let (ticks, labels) = array.zip(..ticks)
+        locate-ticks = ticking.locate-ticks-manual.with(ticks: ticks)
+        format-ticks = ticking.format-ticks-manual.with(labels: labels) 
+      } else {
+        locate-ticks = ticking.locate-ticks-manual.with(ticks: ticks)
+      }
+    } else if ticks == none {
+      locate-ticks = none
+      format-ticks = none
+    } else { assert(false, message: "The parameter `ticks` may either be an array or a dictionary")}
+  }
+  
+  if locate-ticks == auto {
+    locate-ticks = match(
+      scale.name,
+      "linear", () => ticking.locate-ticks-linear,
+      "log", () => ticking.locate-ticks-log.with(base: scale.base),
+      default: () => ticking.locate-ticks-linear,
+    )
+  }
+  if format-ticks == auto {
+    format-ticks = match(
+      scale.name,
+      "linear", () => ticking.format-ticks-linear,
+      "log", () => ticking.format-ticks-log.with(base: scale.base),
+      "symlog", () => ticking.format-ticks-linear,
+      default: () => ticking.format-ticks-naive
+    )
+  }
+  if subticks == none {
+    locate-subticks = none
+  } else if type(subticks) == int {
+    locate-subticks = ticking.locate-subticks-linear.with(num: subticks)
+  } else if subticks != auto {
+    assert(false, message: "Unsupported argument type `" + str(type(subticks)) + "` for parameter `subticks`")
+  }
+  if locate-subticks == auto {
+    locate-subticks = match(
+      scale.name,
+      "linear", () => ticking.locate-subticks-linear,
+      "log", () => ticking.locate-subticks-log.with(base: scale.base),
+      default: none
+    )
+  }
+  let is-independant = plots.len() > 0
+  if functions == auto { functions = (x => x, x => x) }
+  else {
+    assert(type(functions) == array and functions.map(type) == (function, function), message: "The parameter `functions` for `axis()` expects an array of two functions, a forward and an inverse function.")
+    assert(plots.len() == 0, message: "An `axis` can either be created with `functions` or with `..plots` but not both. ")
+    assert(lim == auto, message:  "A dependent `axis` with `functions` is not allowed to have manual axis limits. ")
+  }
+
+  if type(lim) == array {
+    assert.eq(lim.len(), 2, message: "Limit arrays must contain exactly two items")
+    
+  } else if lim == auto { 
+    lim = (auto, auto)
+  } else {
+    assert(false, message: "Unsupported limit specification")
+  }
+
+  if mirror == auto {
+    mirror = (ticks: true)
+  } else if type(mirror) == bool {
+    if mirror { mirror = (ticks: true) }
+    else { mirror = none }
+  } else if type(mirror) == dictionary {
+    for key in mirror.keys() {
+      assert(key in ("ticks", "tick-labels"), message: "When passing a dictionary to `axis.mirror`, only the keys \"ticks\" and \"tick-labels\" are valid, got \"" + key + "\"")
+    }
+  }
+  
+  (
+    type: "axis",
+    scale: scale,
+    lim: lim,
+    functions: (forward: functions.at(0), inv: functions.at(1)),
+    label: label,
+    stroke: stroke,
+    kind: kind,
+    position: position,
+    translate: translate,
+    mirror: mirror,
+      
+    locate-ticks: locate-ticks,
+    format-ticks: format-ticks,
+    locate-subticks: locate-subticks,
+    format-subticks: format-subticks,
+    extra-ticks: extra-ticks,
+    format-extra-ticks: format-extra-ticks,
+
+    filter: filter,
+
+    tick-args: tick-args,
+    subtick-args: subtick-args,
+
+    offset: offset,
+    exponent: exponent,
+    auto-exponent-threshold: auto-exponent-threshold,
+    plots: plots,
+    hidden: hidden,
+    tip: tip,
+    toe: toe,
+  )
+}
+
+#let xaxis = axis.with(kind: "x")
+#let yaxis = axis.with(kind: "y")
+
+
+/// Computes the axis limits of one axis (x or y). For each plot, `xlimits()` 
+/// and `ylimits()` is called. Plots whose limit functions return `none`  
+/// will be ignored. 
+/// If there are no plots or all calls to `xlimits()` and 
+/// `ylimits()` return `none`, the limits are set to `(0,0)`.
+///
+/// Regardless of this, a zero-width range is enlarged by calling 
+/// `next(min, -1)` and `next(max, 1)`. 
+/// Finally lower and upper margins are applied. 
+///
+#let _axis-compute-limits(
+  axis, 
+  lower-margin: 0%, upper-margin: 0%,
+  default-lim: (0, 1),
+  is-independant: auto
+) = {
+  if is-independant == auto {
+    is-independant = axis.plots.len() > 0
+  }
+  let axis-type = match(axis.kind, "x", "x", "y", "y")
+  let (x0, x1) = (none, none)
+  let (tight0, tight1) = (true, true)
+  
+
+  if axis.lim.at(0) != auto { x0 = axis.lim.at(0); tight0 = true }
+  if axis.lim.at(1) != auto { x1 = axis.lim.at(1); tight1 = true }
+  
+  if auto in axis.lim {
+    if is-independant {
+      let plot-limits = axis.plots.map(plot => plot.at(axis-type + "limits")())
+        .filter(x => x != none)
+      if plot-limits.len() == 0 {
+        (x0, x1) = (0, 1)
+        if axis.scale.identity != 0 {
+          (x0, x1) = (axis.scale.identity,) * 2
+        }
+      } else {
+        for (plot-x0, plot-x1) in plot-limits {
+          let tight-bound = (false, false)
+          if type(plot-x0) == fraction { plot-x0 /= 1fr; tight-bound.at(0) = true }
+          if axis.lim.at(0) == auto and (x0 == none or plot-x0 < x0) {
+            x0 = plot-x0
+            tight0 = tight-bound.at(0)
+          }
+          if type(plot-x1) == fraction { plot-x1 /= 1fr; tight-bound.at(1) = true }
+          if axis.lim.at(1) == auto and (x1 == none or plot-x1 > x1) {
+            x1 = plot-x1
+            tight1 = tight-bound.at(1)
+          }
+        }
+      }
+    } else {
+      (x0, x1) = default-lim.map(axis.functions.forward)
+    }
+  }
+  if x0 == x1 {
+    x0 = (axis.scale.inverse)((axis.scale.transform)(x0) - 1)
+    x1 = (axis.scale.inverse)((axis.scale.transform)(x1) + 1)
+  }
+
+
+
+  let k0 = (axis.scale.transform)(x0)
+  let k1 = (axis.scale.transform)(x1)
+  let D = k1 - k0
+
+  if not tight0 {
+    x0 = (axis.scale.inverse)(k0 - D * lower-margin/100%)
+  }
+  if not tight1 {
+    x1 = (axis.scale.inverse)(k1 + D * upper-margin/100%)
+  }
+  
+  return (x0, x1)
+}
+
+
+/// Generates all ticks and subticks as well as their labels for an axis. 
+/// 
+/// -> dictionary
+#let _axis-generate-ticks(
+  /// The axis object. 
+  /// -> lq.axis
+  axis, 
+  
+  /// The length with which the axis will be displayed. This is for example used to determine automatic tick distances. 
+  /// -> length
+  length: 3cm
+) = {
+  let ticks = ()
+  let tick-labels
+  let subticks = (ticks: ())
+  let subtick-labels
+  let (exp, offset) = (axis.exponent, axis.offset)
+
+  let em = measure(line(length: 1em, angle: 0deg)).width
+  axis.tick-args.num-ticks-suggestion = match(
+    axis.kind,
+    "x", length / (3.3 * em),
+    "y", length / (2 * em)
+  )
+  let (x0, x1) = axis.lim
+
+  if x0 != none {
+    if axis.locate-ticks != none {
+      let tick-info = (axis.locate-ticks)(x0, x1, ..axis.tick-args)
+      ticks = tick-info.ticks
+      (tick-labels, exp, offset) = match(
+        axis.format-ticks,
+        none, (none, 0, 0),
+        default: () => (axis.format-ticks)(tick-info, exponent: axis.exponent, offset: axis.offset, auto-exponent-threshold: axis.auto-exponent-threshold),
+      )
+      
+
+      if axis.locate-subticks != none {
+        subticks = (axis.locate-subticks)(x0, x1, ..tick-info, ..axis.subtick-args)
+        subtick-labels = match(
+        axis.format-subticks,
+        none, none,
+        default: () => (axis.format-subticks)(ticks: subticks, exponent: axis.exponent, offset: axis.offset).at(0),
+      )
+      }
+    } 
+  }
+
+  return (
+    ticks: ticks,
+    tick-labels: tick-labels,
+    subticks: subticks.ticks,
+    subtick-labels: subtick-labels,
+    exp: exp,
+    offset: offset
+  )
+}
+
+
+
+
+#let draw-axis(
+  axis,
+  ticking,
+  axis-style,
+  e-get: none
+) = {
+  if axis.hidden { return (none, ()) }
+
+
+  let (ticks, tick-labels, subticks, subtick-labels, exp, offset) = ticking
+  
+  let transform = axis.transform
+
+  let place-tick 
+  let place-exp-or-offset
+  let exp-or-offset-alignment
+  let exp-or-offset-offset
+  
+  if axis.kind == "x" {
+    place-tick = (x, label, position, inset, outset, stroke: axis.stroke) => {
+      if axis.stroke != none {
+        place-in-out(position, 
+          line(length: inset + outset, angle: 90deg, stroke: stroke), 
+          dx: x, dy: outset,
+        )
+      }
+      if label == none { return }
+  
+      place-in-out(position, 
+        place(center + position.inv().y, label), 
+        dx: x, dy: .5em + outset
+      )
+    }
+    place-exp-or-offset = it => place(horizon + right, dx: .5em, dy: 0pt, place(left + horizon, it))
+    exp-or-offset-alignment = (alignment: bottom + right, content-alignment: horizon + left)
+    exp-or-offset-offset = (dx: .5em, dy: 0pt)
+  } else if axis.kind == "y" {
+    place-tick = (y, label, position, inset, outset, stroke: axis.stroke) => {
+      place(position, 
+        line(length: inset + outset, stroke: stroke), 
+        dy: y, dx: -outset
+      )
+      if label == none { return }
+      
+      let size = measure(label)
+      let dx = size.width * 0
+      place-in-out(position, 
+        place(position.inv() + horizon, label), 
+        dx: -dx - .5em + outset, dy: y,
+      )
+    }
+    place-exp-or-offset = it => place(top + center, dx: 0pt, dy: -.5em, place(bottom + center, it))
+    exp-or-offset-alignment = (alignment: top + left, content-alignment: center + bottom)
+    exp-or-offset-offset = (dx: 0pt, dy: -.5em)
+  }
+
+
+
+  let place-ticks(
+    ticks, labels, 
+    position, 
+    display-tick-labels, 
+    sub: false,
+    kind: "x"
+  ) = {
+    if labels == none { labels = (none,) * ticks.len() }
+
+    // let dim = if axis.kind == "x" { "height" } else { "width" }
+    // let content = ticks.zip(labels).map(
+    //   ((tick, label)) => {
+    //     let loc = transform(tick)
+    //     let max = transform(axis.lim.at(if kind == "x" {1} else {0}))
+    //     if not (axis.filter)(tick, calc.min(loc, max - loc)) { return }
+    //     place-tick(loc, if not display-tick-labels {none} else {label}, position, length-coeff*axis-style.inset, length-coeff*axis-style.outset)
+    //   }
+    // ).join()
+    
+    // let max-padding = axis-style.outset
+    // if display-tick-labels {
+    //   let label-space = calc.max(..labels.map(label => measure(label).at(dim)), 0pt)
+    //   max-padding += label-space
+    //   if label-space > 0pt {
+    //     max-padding += .5em
+    //   }
+    // }
+    
+    let align = position.inv()
+    let pad = e-get(lq-tick).pad
+    let factor = if sub { e-get(lq-tick).shorten-sub } else { 1 }
+    let outset = e-get(lq-tick).outset * factor
+    let shorten-sub = e-get(lq-tick).shorten-sub
+    let length = e-get(lq-tick).inset * factor + outset
+    let angle = if align in (top, bottom) { 90deg } else { 0deg }
+  
+    let tick-stroke = merge-strokes(e-get(lq-tick).stroke, axis.stroke, (cap: "butt"), e-get(spine).stroke)
+    if tick-stroke == none {
+      // can happen when spine.stroke is none
+      tick-stroke = 0.5pt
+    }
+
+    let tline = line(length: length, angle: angle, stroke: tick-stroke)
+    let make-tick
+    if align == right {
+      make-tick = (label, loc) => place(dx: -outset, dy: loc, {tline + place(dx: -length - pad, right + horizon, label)})
+    } else if align == left {
+      make-tick = (label, loc) => place(dx: -length + outset, dy: loc, {tline + place(dx: length + pad, left + horizon, label)})
+    } else if align == top {
+      make-tick = (label, loc) => place(dy: -length + outset, dx: loc, {tline + place(dy: length + pad, top + center, label)});
+    } else if align == bottom {
+      make-tick = (label, loc) => place(dy: -outset, dx: loc, {tline + place(dy: -length - pad, bottom + center, label)})
+    }
+
+    let max = transform(axis.lim.at(if kind == "x" { 1 } else { 0 }))
+
+    let content = ticks.zip(labels).map(
+      ((tick, label)) => {
+        let loc = transform(tick)
+        if not (axis.filter)(tick, calc.min(loc, max - loc)) { return }
+        let tick-label = if display-tick-labels { label }
+        if tick-label != none {tick-label = lq-tick-label(tick-label)}
+        make-tick(tick-label, loc)
+      }
+    ).join()
+
+    let max-padding = outset
+    if display-tick-labels {
+      let dim = if axis.kind == "x" { "height" } else { "width" }
+      let label-space = calc.max(..labels.map(label => measure(label).at(dim)), 0pt)
+      max-padding += label-space
+      if label-space > 0pt {
+        max-padding += pad
+      }
+    }
+
+    
+    return (content, max-padding)
+  }
+  
+
+  let the-axis(
+    position: axis.position,
+    translate: (0pt, 0pt),
+    display-ticks: true, 
+    display-tick-labels: true, 
+    display-axis-label: true,
+    kind: "x"
+  ) = {
+    let content = none
+    let max-padding = 0pt
+    let bounds = ()
+    if axis.stroke != none {
+      // later: use set rules here
+      let args = (:)
+      if axis.tip != auto { args.tip = axis.tip }
+      if axis.toe != auto { args.toe = axis.toe }
+      if axis.stroke != auto { args.stroke = axis.stroke }
+      content += place(spine(kind: axis.kind, ..args))
+    }
+
+    if display-ticks {
+      let (c, mp) = place-ticks(ticks, tick-labels, position, display-tick-labels, kind: kind)
+      content += c
+      max-padding = mp
+
+      let (c, mp) = place-ticks(subticks, subtick-labels, position, display-tick-labels, sub: true, kind: kind)
+      content += c
+
+      if axis.extra-ticks != none {
+        for tick in axis.extra-ticks {
+          
+          if type(tick) in (int, float) {
+            tick = lq-tick(tick)
+          } 
+          content += place-tick(transform(tick.value), tick.label, position, tick.inside, tick.outside, stroke: if-auto(tick.stroke, axis.stroke))
+        }
+      }
+    }
+    if display-tick-labels {
+      if type(exp) == int and exp != 0 {
+        let (c, b) = place-with-bounds(
+          {
+            show "X": none
+            zero.num("Xe" + str(exp))
+          },
+          ..exp-or-offset-offset, 
+          ..exp-or-offset-alignment
+        )
+        content += c
+        b = offset-bounds(b, translate)
+        bounds.push(b)
+      }
+      if type(offset) in (int, float) and offset != 0 {
+        let (c, b) = place-with-bounds(
+          zero.num(positive-sign: true, offset), 
+          ..exp-or-offset-offset, 
+          // ..exp-or-offset-alignment
+        )
+        content += c
+        b = offset-bounds(b, translate)
+        bounds.push(b)
+      }
+    }
+    
+    if axis.label != none and display-axis-label {
+      
+      let get-settable-field(element, object, field) = {
+        e.fields(object).at(field, default: e-get(element).at(field))
+      }
+      let label = axis.label
+      if e.eid(label) != e.eid(lq-label) {
+        let constructor = if kind == "x" {xlabel} else {ylabel}
+        label = constructor(label)
+      }
+      let wrapper = if position in (top, bottom) {
+        box.with(width: 100%)
+      } else if position in (left, right) {
+        box.with(height: 100%)
+      }
+
+      let dx = get-settable-field(lq-label, label, "dx")
+      let dy = get-settable-field(lq-label, label, "dy")
+      let pad = get-settable-field(lq-label, label, "pad")
+      if pad == none { pad = 0pt }
+      else { pad += max-padding }
+
+
+      let body = wrapper(label)
+      let size = measure(body)
+
+      let (label, b) = place-with-bounds(body, alignment: position, dx: dx, dy: dy, pad: pad)
+      
+      content += label
+      if kind == "x" {
+        max-padding = size.height + pad
+      } else {
+        max-padding = size.width + pad
+      }
+    }
+    // define box of axis spine
+    content += block(
+      ..if kind == "y"{ (height: 100%, width: 0%) }
+        else{ (width:100%, height: 0pt) },
+      inset: 0pt, outset: 0pt
+    )
+    
+    let main-bounds = create-bounds()
+    if axis.kind == "x" {
+      main-bounds.right = 100%
+      if position == top {
+        main-bounds.top = -max-padding
+        main-bounds.bottom = axis-style.inset
+      } else if position == bottom {
+        main-bounds.bottom = 100% + max-padding
+        main-bounds.top = 100% - axis-style.inset
+      }
+    } else {
+      main-bounds.bottom = 100%
+      if position == left {
+        main-bounds.left = -max-padding
+        main-bounds.right = axis-style.inset
+      } else if position == right {
+        main-bounds.right = 100% + max-padding
+        main-bounds.left = 100% - axis-style.inset
+      }
+    }
+    main-bounds = offset-bounds(main-bounds, translate)
+    bounds.push(main-bounds)
+    return (content, bounds)
+  }
+
+  let (axis-content, bounds) = the-axis(kind: axis.kind, translate: axis.translate)
+  let content = place(axis.position, axis-content, dx: axis.translate.at(0), dy: axis.translate.at(1))
+  let em = measure(line(length: 1em, angle: 0deg)).width
+  
+  // let a = measure(lq-tick-label(box(width: 1em))).width
+  // content += repr(a) + " " + repr(1em.to-absolute())
+  if axis.mirror != none {
+    let (mirror-axis-content, mirror-axis-bounds) = the-axis(
+      kind: axis.kind,
+      position: axis.position.inv(),
+      translate: axis.translate,
+      display-ticks: axis.mirror.at("ticks", default: false),
+      display-tick-labels: axis.mirror.at("tick-labels", default: false),
+      display-axis-label: axis.mirror.at("label", default: false),
+    )
+    content += place(axis.position.inv(), mirror-axis-content)
+    bounds += mirror-axis-bounds
+  }
+  
+  return (content, bounds)
+}

--- a/packages/preview/lilaq/0.2.0/src/model/diagram.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/diagram.typ
@@ -1,0 +1,487 @@
+
+#import "../process-styles.typ": update-stroke, process-margin, process-grid-arg
+#import "../assertations.typ"
+#import "../logic/scale.typ"
+#import "../logic/transform.typ": create-trafo
+#import "legend.typ": legend as lq-legend, _place-legend-with-bounds
+#import "grid.typ": grid as lq-grid
+
+#import "axis.typ": axis, draw-axis, _axis-compute-limits, _axis-generate-ticks
+#import "../algorithm/ticking.typ"
+#import "../bounds.typ": *
+#import "title.typ": title as lq-title
+#import "label.typ": label as lq-label
+#import "../utility.typ": if-auto
+
+#let debug = false
+#import "../style/styling.typ": init as cycle-init, style, process-cycles-arg
+#import "../style/map.typ": petroff10
+#import "../libs/elembic/lib.typ" as e
+
+
+
+/// Creates a new diagram. 
+/// 
+/// -> lq.diagram
+#let diagram(
+  
+  /// The width of the diagram area. 
+  /// -> length
+  width: 6cm,
+  
+  /// The height of the diagram area. 
+  /// -> length
+  height: 4cm,
+
+  /// The title for the diagram. Use a @title object for more options. 
+  /// -> lq.title | str | content | none
+  title: none,
+
+  /// Options to pass to the legend constructor. If set to `none`, no legend is
+  /// shown.
+  /// -> none | dictionary
+  legend: (:),
+
+  /// Data limits along the $x$-axis. Expects `auto` or a tuple `(min, max)` 
+  /// where `min` and `max` may individually be `auto`. Also see @axis.lim. 
+  /// -> auto | array
+  xlim: auto,
+  
+  /// Data limits along the $y$-axis. Expects `auto` or a tuple `(min, max)` 
+  /// where `min` and `max` may individually be `auto`. Also see @axis.lim. 
+  /// -> auto | array
+  ylim: auto,
+
+  /// Label for the $x$-axis. Use a @label object for more options. 
+  /// -> lq.label | content
+  xlabel: none,
+
+  /// Label for the $y$-axis. Use a @label object for more options. 
+  /// -> lq.label | content
+  ylabel: none,
+
+  /// Options to apply to the grid. A `stroke`, `color`, or `length` argument 
+  /// directly sets the grid stroke while a `dictionary` with the possible keys
+  /// `stroke`, `stroke-sub`, and `z-index` gives more fine-grained control. 
+  /// Setting this parameter to `none` removes the grid entirely. 
+  /// See @grid for more details. 
+  /// -> auto | none | dictionary | stroke | color | length
+  grid: auto,
+
+  /// Sets the scale of the $x$-axis. This may be a @scale object or the name
+  /// of one of the built-in scales `"linear"`, `"log"`, `"symlog"`.
+  /// -> str | lq.scale
+  xscale: "linear",
+  
+  /// Sets the scale of the $y$-axis. This may be a @scale object or the name
+  /// of one of the built-in scales `"linear"`, `"log"`, `"symlog"`.
+  /// -> str | lq.scale
+  yscale: "linear",
+
+  /// Configures the $x$-axis through a dictionary of arguments to pass to the 
+  /// constructor of the axis. See @axis for available options. 
+  /// -> none | dictionary
+  xaxis: (:),
+  
+  /// Configures the $y$-axis through a dictionary of arguments to pass to the
+  /// constructor of the axis. See @axis for available options. 
+  /// -> none | dictionary
+  yaxis: (:),
+
+  /// Configures the automatic margins of the diagram around the data. If set 
+  /// to `0%`, the outer-most data points align tightly with the edges of the 
+  /// diagram (as long as the axis limits are left at `auto`). Otherwise, the
+  /// margins are computed in percent of the covered range along an axis (in
+  /// scaled coordinates). 
+  /// 
+  /// The margins can be set individually for each side by passing a dictionary
+  /// with the possible keys
+  /// - `left`, `right`, `top`, `bottom` for addressing individual sides,
+  /// - `x`, `y` for left/right and top/bottom combined sides, and
+  /// - `rest` for all sides not specified by any of the above. 
+  /// 
+  /// -> ratio | dictionary
+  margin: 6%,
+  
+  /// Style cycle to use for this diagram. Check out the 
+  /// #link("tutorials/cycles")[cycles tutorial] for more information. 
+  /// The elements of a style cycles should either be 
+  /// - all functions as described in the tutorial, or
+  /// - all of type `color` in which case the color sequence is automatically
+  ///   converted to a style cycle, or
+  /// - all of type `dictionary` with possible keys `color`, `stroke`, and 
+  ///   `mark`. 
+  ///   
+  /// -> array
+  cycle: petroff10,
+
+  /// How to fill the data area. 
+  /// -> none | color | gradient | tiling 
+  fill: none,
+
+  /// Plot objects like @plot, @bar, @scatter, @contour etc. and additional 
+  /// @axis objects. 
+  /// -> any
+  ..children
+
+) = {}
+
+
+
+#let draw-diagram(it) = {
+  set math.equation(numbering: none)
+  set curve(stroke: .7pt)
+  set line(stroke: .7pt)
+
+  let plots = ()
+  let (xplots, yplots) = ((), ()) // solely used for computing limits
+  let axes = ()
+
+  for child in it.children {
+    if type(child) == dictionary {
+      if child.at("type", default: "") == "axis" { // an axis
+        axes.push(child)
+        // plots += child.plots
+        let axes-id = axes.len() - 1
+        let axes-plots = child.plots.map(plot => (axes-id, plot))
+        if child.plots.len() > 0 {
+          plots += axes-plots 
+          if child.kind == "x" {
+            yplots += child.plots
+          } else {
+            xplots += child.plots
+          }
+        } else {
+          xplots += child.plots
+          yplots += child.plots
+        }
+      } else { // just a regular plot
+        yplots.push(child)
+        xplots.push(child)
+        plots.push(child)
+      }
+    }
+  }
+  if it.xaxis == none { it.xaxis = (hidden: true) }
+  if it.yaxis == none { it.yaxis = (hidden: true) }
+  if type(it.xaxis) == dictionary {
+    it.xaxis = axis(kind: "x", label: it.xlabel, scale: it.xscale, lim: it.xlim, ..it.xaxis)
+  }
+  it.xaxis.plots = xplots
+  if type(it.yaxis) == dictionary {
+    it.yaxis = axis(kind: "y", label: it.ylabel, scale: it.yscale, lim: it.ylim, ..it.yaxis)
+  }
+  it.yaxis.plots = yplots
+
+
+  let margin = process-margin(it.margin)
+
+  it.xaxis.lim = _axis-compute-limits(it.xaxis, lower-margin: margin.left, upper-margin: margin.right, is-independant: true)
+  it.yaxis.lim = _axis-compute-limits(it.yaxis, lower-margin: margin.bottom, upper-margin: margin.top, is-independant: true)
+
+  
+  let normalized-x-trafo = create-trafo(it.xaxis.scale.transform, ..it.xaxis.lim)
+  let normalized-y-trafo = create-trafo(it.yaxis.scale.transform, ..it.yaxis.lim)
+
+  it.xaxis.normalized-scale-trafo = normalized-x-trafo
+  it.yaxis.normalized-scale-trafo = normalized-y-trafo
+  it.xaxis.transform = x => normalized-x-trafo(x) * it.width
+  it.yaxis.transform = y => it.height * (1 - normalized-y-trafo(y))
+  
+  let transform(x, y) = (
+    it.width * normalized-x-trafo(x), 
+    it.height * (1 - normalized-y-trafo(y))
+  )
+
+  
+  let maybe-transform(x, y) = {
+    if type(x) in (int, float) { x = (it.xaxis.transform)(x) }
+    if type(y) in (int, float) { y = (it.yaxis.transform)(y) - it.height }
+    return (x, y)
+  }
+  it.yaxis.translate = maybe-transform(..it.yaxis.translate)
+  it.xaxis.translate = maybe-transform(..it.xaxis.translate)
+
+  let axes-transforms = (none,) * axes.len()
+  
+  for i in range(axes.len()) {
+    let axis = axes.at(i)
+    let model-axis = if axis.kind == "x" { it.xaxis } else { it.yaxis }
+    let has-auto-lim = axis.lim == auto
+    let has-auto-lim = false
+    let axes-margin = if axis.kind == "x" { 
+      (lower-margin: margin.left, upper-margin: margin.right)
+    } else {
+      (lower-margin: margin.bottom, upper-margin: margin.top)
+    }
+    axes.at(i).lim = _axis-compute-limits(axis, default-lim: model-axis.lim, ..axes-margin)
+
+    if axis.plots.len() > 0 {
+      let other-axis = if axis.kind == "x" {it.yaxis} else {it.xaxis}
+      let transform
+      let scale-trafo = create-trafo(axis.scale.transform, ..axes.at(i).lim)
+      if axis.kind == "x" {
+        let normalized-x-trafo = scale-trafo
+        transform = (x, y) => (normalized-x-trafo(x) * it.width, it.height * (1 - normalized-y-trafo(y)))
+        axes.at(i).transform = x => normalized-x-trafo(x) * it.width
+      } else {
+        let normalized-y-trafo = scale-trafo
+        transform = (x, y) => (normalized-x-trafo(x) * it.width, it.height * (1 - normalized-y-trafo(y)))
+        axes.at(i).transform = y => (1 - normalized-y-trafo(y)) * it.height
+      }
+      axes-transforms.at(i) = transform
+    } else {
+      axes.at(i).transform = if has-auto-lim {model-axis.transform} else {
+        let trafo = x => (model-axis.normalized-scale-trafo)((axis.functions.inv)(x))
+        if axis.kind == "y" {
+          y => it.height * (1 - trafo(y))
+        } else {
+          x => it.width * trafo(x)
+        }
+      }
+    }
+  }
+
+  
+  
+  e.get(e-get => {
+  
+  let axis-info = (
+    x: (ticking: _axis-generate-ticks(it.xaxis, length: it.width)), 
+    y: (ticking: _axis-generate-ticks(it.yaxis, length: it.height)), 
+    rest: ((:),) * axes.len()
+  )
+    
+
+  let bounds = (left: 0pt, right: it.width, top: 0pt, bottom: it.height)
+  
+
+
+    
+  let diagram = box(
+    width: it.width, height: it.height, 
+    inset: 0pt, stroke: none, fill: it.fill,
+    {
+    set align(top + left) // sometimes alignment is messed up
+
+
+    let update-bounds = update-bounds.with(width: it.width, height: it.height)
+    
+
+    let artists = ()
+    artists.push((
+      content: {
+        let x-transform = tick => transform(tick, 1).at(0)
+        let y-transform = tick => transform(1, tick).at(1)
+        lq-grid(
+          axis-info.x.ticking.subticks.map(x-transform),
+          true,
+          kind: "x",
+          ..process-grid-arg(it.grid)
+        )
+        lq-grid(
+          axis-info.y.ticking.subticks.map(y-transform),
+          true,
+          kind: "y",
+          ..process-grid-arg(it.grid)
+        )
+        lq-grid(
+          axis-info.x.ticking.ticks.map(x-transform),
+          false,
+          kind: "x",
+          ..process-grid-arg(it.grid)
+        )
+        lq-grid(
+          axis-info.y.ticking.ticks.map(y-transform),
+          false,
+          kind: "y",
+          ..process-grid-arg(it.grid)
+        )
+      }, z: e-get(lq-grid).z-index
+    ))
+
+    let legend-entries = ()
+
+    let cycle = process-cycles-arg(it.cycle)
+
+    for (i, plot) in plots.enumerate() {
+      let cycle-style = cycle.at(calc.rem(i, cycle.len()))
+      let plotted-plot = {
+        show: cycle-init
+        show: cycle-style
+        if type(plot) == array {
+          let axis-id = plot.at(0)
+          plot = plot.at(1)
+          let transform = axes-transforms.at(axis-id)
+          (plot.plot)(plot, transform)
+        } else {
+          (plot.plot)(plot, transform)
+        }
+        if "legend" in plot and plot.label != none {
+          plot.make-legend = true
+          let legend-trafo(x, y) = {
+            (x * 100%, (1 - y) * 100%)
+          }
+          let handle = {
+            show: cycle-init
+            show: cycle-style
+            (plot.plot)(plot, legend-trafo)
+          }
+          legend-entries.push((
+            box(width: 2em, height: .7em, handle),
+            plot.label
+          ))
+        }
+      }
+      if plot.at("clip", default: true) { 
+        plotted-plot = place(box(width: it.width, height: it.height, clip: true, plotted-plot))
+      }
+      artists.push((content: plotted-plot, z: plot.at("z-index", default: 2)))
+    }
+
+
+    let show-bounds(bounds, clr: red) = {
+      place(dx: bounds.left, dy: bounds.top, rect(width: bounds.right - bounds.left, height: bounds.bottom - bounds.top, fill: clr))
+    }
+    if not debug {
+      show-bounds = (args, clr: red) => none
+    }
+
+    let minor-axis-style = (
+      inset: 2pt,
+      outset: 0pt,
+      type: "minor"
+    )
+    let major-axis-style = (
+      inset: 4pt,
+      outset: 0pt,
+      type: "major"
+    )
+    let get-axis-args(axis) = {
+      if axis.kind == "x" { 
+        (length: it.width)
+      } else {
+        (length: it.height)
+      }
+    }
+    let (xaxis-, max-xtick-size) = draw-axis(it.xaxis, axis-info.x.ticking, major-axis-style, e-get: e-get)
+    artists.push((content: xaxis-, z: 20))
+
+    let (yaxis-, max-ytick-size) = draw-axis(it.yaxis, axis-info.y.ticking, major-axis-style, e-get: e-get)
+    artists.push((content: yaxis-, z: 20))
+ 
+    if type(max-ytick-size) == array {
+      for b in max-ytick-size {
+        bounds = update-bounds(bounds, b)
+        show-bounds(b, clr: rgb("#22AA2222"))
+      }
+      for b in max-xtick-size {
+        bounds = update-bounds(bounds, b)
+        show-bounds(b, clr: rgb("#AAAA2222"))
+      }
+    } else {
+      padding.left = max-ytick-size
+      padding.bottom = max-xtick-size
+    }
+
+    for axis in axes {
+      let ticking = _axis-generate-ticks(axis, ..get-axis-args(axis))
+      let (axis-, axis-bounds) = draw-axis(axis, ticking, major-axis-style, e-get: e-get)
+      artists.push((content: axis-, z: 20))
+
+      
+      for b in axis-bounds {
+        bounds = update-bounds(bounds, b)
+        show-bounds(b, clr: rgb("#2222AA22"))
+      }
+    }
+    
+    let get-settable-field(element, object, field) = {
+      e.fields(object).at(field, default: e-get(element).at(field))
+    }
+
+    if it.title != none {
+      let title = it.title
+      if e.eid(title) != e.eid(lq-title) {
+        title = lq-title(title)
+      }
+
+      let position = get-settable-field(lq-title, title, "position")
+      let dx = get-settable-field(lq-title, title, "dx")
+      let dy = get-settable-field(lq-title, title, "dy")
+      let pad = get-settable-field(lq-title, title, "pad")
+
+      let wrapper = if position in (top, bottom) {
+        box.with(width: it.width)
+      } else if position in (left, right) {
+        box.with(height: it.height)
+      }
+
+      let body = wrapper(title)
+      
+      let (title, b) = place-with-bounds(body, alignment: position, dx: dx, dy: dy, pad: pad)
+      
+      artists.push((content: title, z: 20))
+      bounds = update-bounds(bounds, b)
+    }
+
+    
+    if it.legend != none and legend-entries.len() > 0 {
+      let (legend-content, legend-bounds) = _place-legend-with-bounds(it.legend, legend-entries, e-get)
+
+      artists.push((content: legend-content, z: e-get(lq-legend).z-index))
+
+      bounds = update-bounds(bounds, legend-bounds)
+    }
+
+    artists.sorted(key: artist => artist.z).map(artist => artist.content).join()
+  })
+  bounds.bottom -= it.height
+  bounds.right -= it.width
+  bounds.left *= -1
+  bounds.top *= -1
+  box(box(inset: bounds, diagram, stroke: if debug {.1pt} else {0pt}), baseline: bounds.bottom)
+})
+}
+
+#let folding-dict = e.types.wrap(dictionary, fold: old-fold => (a, b) => a + b)
+
+#let diagram = e.element.declare(
+  "diagram",
+  prefix: "lilaq",
+
+  display: draw-diagram, 
+
+  fields: (
+    e.field("children", e.types.any, required: true),
+    e.field("width", length, default: 6cm),
+    e.field("height", length, default: 4cm),
+    e.field("title", e.types.union(none, str, content, lq-title), default: none),
+    e.field("legend", e.types.option(dictionary), default: (:)),
+    e.field("xlim", e.types.union(auto, array), default: auto),
+    e.field("ylim", e.types.union(auto, array), default: auto),
+    e.field("xlabel", e.types.union(lq-label, str, content, none), default: none),
+    e.field("ylabel", e.types.union(lq-label, str, content, none), default: none),
+    e.field("grid", e.types.union(auto, none, dictionary, stroke, color, length), default: auto),
+    e.field("xscale", e.types.union(str, dictionary), default: "linear"),
+    e.field("yscale", e.types.union(str, dictionary), default: "linear"),
+    e.field("xaxis", e.types.option(folding-dict), default: (:)),
+    e.field("yaxis", e.types.option(folding-dict), default: (:)),
+    e.field("margin", e.types.union(ratio, dictionary), default: 6%),
+    e.field("cycle", e.types.wrap(e.types.array(e.types.union(function, color, dictionary)), fold: none), default: petroff10),
+    e.field("fill", e.types.option(e.types.paint), default: none),
+  ),
+
+  parse-args: (default-parser, fields: none, typecheck: none) => (args, include-required: false) => {
+    let args = if include-required {
+      let values = args.pos()
+      arguments(values, ..args.named())
+    } else if args.pos() == () {
+      args
+    } else {
+      assert(false, message: "element 'diagram': unexpected positional arguments\n  hint: these can only be passed to the constructor")
+    }
+
+    default-parser(args, include-required: include-required)
+  },
+)

--- a/packages/preview/lilaq/0.2.0/src/model/errorbar.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/errorbar.typ
@@ -1,0 +1,94 @@
+
+#import "../libs/elembic/lib.typ" as e
+
+
+/// An error bar object for a plot. This type allows for quick configuration and 
+/// complete restyling of error bars. For drawing plots with error bars, 
+/// use @plot. 
+/// 
+/// ```example
+/// #lq.diagram(
+///   lq.plot(
+///     (1, 2, 3, 4),
+///     (1, 2, 1.5, 2.1),
+///     xerr: .2,
+///     yerr: (.2, .1, .2, .2),
+///   )
+/// )
+/// ```
+/// 
+/// The default styling can be changed through set rules
+/// ```example
+/// #show: lq.set-errorbar(stroke: 1pt + red, cap: none)
+/// 
+/// #lq.diagram(
+///   lq.plot(
+///     (1, 2, 3, 4),
+///     (1, 2, 1.5, 2.1),
+///     xerr: .2,
+///     yerr: (.2, .1, .2, .2),
+///   )
+/// )
+/// ```
+#let errorbar(
+
+  /// The kind of error bar: horizontal (`"x"`) or vertical (`"y"`). 
+  /// -> "x" | "y"
+  kind: "x",
+
+  /// The length of the cap. If set to `none`, no cap is drawn. 
+  /// -> none | length
+  cap: 3pt,
+
+  /// How to stroke the error bar. If set to `auto`, the stroke is inherited 
+  /// the plot. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// How to stroke the cap. If set to `auto`, the stroke is inherited 
+  /// from @errorbar.stroke. 
+  /// -> auto | stroke
+  cap-stroke: auto,
+  
+) = {}
+
+
+
+#let errorbar = e.element.declare(
+  "errorbar",
+  prefix: "lilaq",
+
+  display: it => {
+    set curve(stroke: it.stroke) if it.stroke != auto
+
+    if it.kind == "x" {
+      place(horizon, curve(curve.line((100%, 0pt))))
+    } else {
+      place(center + horizon, curve(curve.line((0pt, 100%))))
+    }
+  
+    if it.cap != none {
+      set curve(stroke: it.cap-stroke) if it.cap-stroke != auto
+
+      if it.kind == "x" {
+        let cap = curve(curve.line((0pt, it.cap)))
+        place(left + horizon, cap)
+        place(right + horizon, cap)
+      } else {
+        let cap = curve(curve.line((it.cap, 0pt)))
+        place(center + top, cap)
+        place(center + bottom, cap)
+      }
+    }
+  },
+
+  labelable: false,
+
+  fields: (
+    e.field("kind", str, default: "x"),
+    e.field("stroke", e.types.smart(stroke), default: auto),
+    e.field("cap", e.types.option(length), default: 2.5pt),
+    e.field("cap-stroke", e.types.smart(stroke), default: auto),
+  )
+)
+

--- a/packages/preview/lilaq/0.2.0/src/model/grid.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/grid.typ
@@ -1,0 +1,115 @@
+#import "../libs/elembic/lib.typ" as e
+
+
+/// An axis grid for highlighting tick positions in the diagram area. The 
+/// grid lines are determined from the ticks located by the tick locators
+/// of the main $x$ and $y$ axes for vertical and horizontal grid lines, 
+/// respectively. 
+/// 
+/// One way to set up the grid stroke is with a style rule. The stroke 
+/// for the grid lines at the main ticks is controlled by @grid.stroke
+/// ```example
+/// #show: lq.set-grid(stroke: teal)
+/// 
+/// #lq.diagram(
+/// 
+/// )
+/// ```
+/// and the stroke of the subticks by @grid.stroke-sub:
+/// ```example
+/// #show: lq.set-grid(stroke-sub: 0.5pt + luma(90%))
+/// 
+/// #lq.diagram(
+/// 
+/// )
+/// ```
+/// 
+/// Through the parameter @diagram.grid, the look of the grid can also be 
+/// controlled directly for an individual diagram. 
+/// ```example
+/// #lq.diagram(
+///   grid: (stroke: black, stroke-sub: 0.25pt)
+/// )
+/// ```
+/// 
+/// Aside from `#show: lq.set-grid(stroke: none)`, the grid can be turned off 
+/// entirely with the short-hand `grid: none`. 
+/// ```example
+/// #lq.diagram(
+///   grid: none
+/// )
+/// ```
+#let grid(
+
+  /// A list of tick positions as absolute length coordinates within the 
+  /// diagram frame. This is automatically filled by @diagram with the ticks 
+  /// resulting from the axes' tick locators. 
+  /// -> array
+  ticks,
+
+  /// Whether the ticks passed to @grid.ticks are subticks. 
+  /// -> bool
+  sub,
+
+  /// The axis kind: horizontal (`"x"`) or vertical (`"y"`). 
+  /// -> "x" | "y"
+  kind: "x",
+
+  /// How to stroke grid lines. 
+  /// -> none | stroke
+  stroke: 0.5pt + luma(80%),
+
+  /// How to stroke grid lines for subticks. If `auto`, the style is inherited
+  /// from @grid.stroke. 
+  /// -> auto | none | stroke
+  stroke-sub: none,
+
+  /// Determines the $z$ position of the grid in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 0,
+  
+) = {}
+
+
+// A stroke type that can also be auto or none and that still
+// folds correctly. During folding auto and none override an 
+// existing stroke fully. 
+#let auto-none-stroke = e.types.wrap(
+  e.types.smart(e.types.option(stroke)),
+  fold: old-fold => (outer, inner) => if inner in (none, auto) or outer in (none, auto) { inner } else { (e.types.native.stroke_.fold)(outer, inner) }
+)
+
+
+#let grid = e.element.declare(
+  "grid",
+  prefix: "lilaq",
+
+  display: it => {
+
+    let stroke = if it.sub { it.stroke-sub } else { it.stroke }
+    if stroke == none { return }
+
+    let line
+    if it.kind == "x" {
+      line = tick => place(
+        std.line(start: (tick, 0%), end: (tick, 100%), stroke: stroke)
+      )
+    } else if it.kind == "y" {
+      line = tick => place(
+        std.line(start: (0%, tick), end: (100%, tick), stroke: stroke)
+      )
+    }
+
+    it.ticks.map(line).join()
+  },
+
+  fields: (
+    e.field("ticks", array, required: true),
+    e.field("sub", bool, required: true),
+    e.field("kind", str, default: "x"),
+    e.field("stroke", e.types.option(stroke), default: 0.5pt + luma(80%)),
+    e.field("stroke-sub", auto-none-stroke, default: none),
+    e.field("z-index", float, default: 0),
+  ),
+)

--- a/packages/preview/lilaq/0.2.0/src/model/label.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/label.typ
@@ -1,0 +1,73 @@
+
+
+/// A label for a diagram axis. 
+#let label(
+  
+  /// Content to show in the label. 
+  /// -> any
+  body,
+
+  /// The kind of axis that the label is attached to.
+  /// -> "x" | "y"
+  kind: "x",
+
+  /// Horizontal offset. 
+  /// -> length
+  dx: 0pt,
+
+  /// Vertical offset. 
+  /// -> length
+  dy: 0pt,
+
+  /// Padding between the axis (and its ticks and labels) and the label. 
+  /// When this is set to `none`, the label is drawn directly on the axis
+  /// (ignoring the ticks).
+  /// -> none | length
+  pad: 0.75em,
+
+  /// Angle at which the label is drawn. The label of a `y` axis is often 
+  /// drawn at `-90deg`. 
+  /// -> angle
+  angle: 0deg
+  
+) = {
+  (
+    body: body,
+    dx: dx,
+    dy: dy,
+    pad: pad,
+    angle: angle
+  )
+}
+
+
+
+#import "../libs/elembic/lib.typ" as e
+
+#let label = e.element.declare(
+  "label",
+  prefix: "lilaq",
+
+  display: it => rotate(it.angle, it.body, reflow: true),
+
+  fields: (
+    e.field("body", content, required: true),
+    e.field("dx", relative, default: 0pt),
+    e.field("dy", relative, default: 0pt),
+    e.field(
+      "kind", 
+      e.types.union(
+        e.types.literal("x"), 
+        e.types.literal("y")
+      ), 
+      default: "x"
+    ),
+    e.field("pad", e.types.option(length), default: .7em),
+    e.field("angle", angle, default: 0deg),
+  )
+)
+
+
+
+#let xlabel = label
+#let ylabel = label.with(angle: -90deg)

--- a/packages/preview/lilaq/0.2.0/src/model/legend.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/legend.typ
@@ -1,0 +1,163 @@
+#import "../process-styles.typ": twod-ify-alignment
+#import "../bounds.typ": place-with-bounds
+#import "../assertations.typ"
+#import "../libs/elembic/lib.typ" as e
+
+/// A diagram legend listing all labeled plots. 
+/// 
+/// Also refer to the 
+/// #link("tutorials/legend")[legend tutorial] for more details. 
+#let legend(
+
+  /// The items to place in the legend. Items are tuples of a 
+  /// plot preview image and the corresponding label. This field is 
+  /// filled automatically by @diagram. 
+  /// -> array
+  ..children,
+
+  /// How to fill the background of the legend. 
+  /// -> none | color | gradient | tiling
+  fill: white.transparentize(20%),
+
+  /// Determines the padding of the entire legend within its box. 
+  /// -> relative
+  inset: 0.3em,
+
+  /// How to stroke the outer border of the legend. 
+  /// -> none | stroke 
+  stroke: 0.5pt + gray,
+
+  /// The radius of the outer border of the legend. 
+  /// -> relative | dictionary
+  radius: 1.5pt,
+
+  /// Where to place the legend in the diagram. This can be an alignment
+  /// or a position `(x, y)` where `x` and `y` are relative lengths, i.e., 
+  /// they can be
+  /// - lengths like `20pt` or `2em`,
+  /// - ratios like `50%` (measuring in the data area),
+  /// - or a combination thereof. 
+  /// 
+  /// To place the legend outside the diagram, say to the right, use a 
+  /// combination of `position: left + horizon` and `dx: 100%`. Positioning 
+  /// of the legend is treated more in-depth in the
+  /// #link("tutorials/legend#positioning")[legend tutorial].
+  /// -> alignment | array
+  position: top + right,
+
+  /// In the case that @legend.position is an `alignment`, `pad` determines 
+  /// how much to pad the legend from the outer edge of the data area 
+  /// of the diagram. 
+  /// -> length
+  pad: 2pt, 
+
+  /// The horizontal displacement of the legend from the position specified 
+  /// through @legend.position. 
+  /// -> relative
+  dx: 0pt,
+
+  /// The vertical displacement of the legend from the position specified 
+  /// through @legend.position. 
+  /// -> relative
+  dy: 0pt,
+
+  /// Specifies the $z$ position of the legend in the order of rendered
+  /// diagram objects. 
+  /// -> int | float
+  z-index: 25,
+
+) = {}
+
+#let legend = e.element.declare(
+  "legend",
+  prefix: "lilaq",
+
+  display: it => box(
+    stroke: it.stroke,
+    inset: it.inset,
+    fill: it.fill,
+    radius: it.radius,
+    table(..it.children.join())
+  ),
+
+  fields: (
+    e.field("children", e.types.array(e.types.any), required: true),
+    e.field("fill", e.types.option(e.types.paint), default: white.transparentize(20%)),
+    e.field("inset", relative, default: 0.3em),
+    e.field("stroke", e.types.option(stroke), default: 0.5pt + gray),
+    e.field("radius", e.types.union(relative, dictionary), default: 1.5pt),
+    
+    e.field("position", e.types.union(alignment, array), default: top + right),
+    e.field("pad", length, default: 2pt),
+    e.field("dx", relative, default: 0pt),
+    e.field("dy", relative, default: 0pt),
+    e.field("z-index", float, default: 6),
+  ),
+
+  parse-args: (default-parser, fields: none, typecheck: none) => (args, include-required: false) => {
+    let args = if include-required {
+      let values = args.pos()
+      arguments(values, ..args.named())
+    } else if args.pos() == () {
+      args
+    } else {
+      assert(false, message: "element 'legend': unexpected positional arguments\n  hint: these can only be passed to the constructor")
+    }
+
+    default-parser(args, include-required: include-required)
+  },
+)
+
+
+#let _place-legend-with-bounds(
+
+  /// -> true | dictionary
+  my-legend, 
+
+  /// -> array(array)
+  legend-entries,
+
+  e-get
+
+) = {
+  let get-settable-field(element, object, field) = {
+    e.fields(object).at(field, default: e-get(element).at(field))
+  }
+
+  if my-legend == true { my-legend = (:)}
+  my-legend = legend(..legend-entries, ..my-legend)
+
+  let pos = get-settable-field(legend, my-legend, "position")
+  let dx = get-settable-field(legend, my-legend, "dx")
+  let dy = get-settable-field(legend, my-legend, "dy")
+  let pad = get-settable-field(legend, my-legend, "pad")
+
+  let alignment = top + left
+  let content-alignment = "inside"
+
+  if type(pos) == std.alignment {
+    alignment = pos
+  } else if type(pos) == array {
+    assert.eq(pos.len(), 2, message: "`legend.position` needs to be a pair of coordinates, got " + repr(pos))
+    dx += pos.at(0)
+    dy += pos.at(1)
+    pad = 0pt
+  } 
+
+  place-with-bounds(
+    alignment: alignment, 
+    content-alignment: content-alignment, 
+    dx: dx, dy: dy, pad: pad,
+    wrap-in-box: true,
+    {
+      set table(
+        columns: 2, 
+        stroke: none, 
+        inset: 2pt, 
+        align: horizon + left
+      )
+      set table.cell(breakable: false)
+      my-legend
+    }
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/model/mark.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/mark.typ
@@ -1,0 +1,190 @@
+#import "@preview/tiptoe:0.3.0": arc
+
+
+/// A mark for a plot. Refer to the #link("tutorials/marks")[mark tutorial] for
+/// a list of available mark shapes and more details. 
+#let mark(
+
+  /// The size of the mark. The built-in mark shapes are tuned to match in 
+  /// optical size, see #link("tutorials/marks#sizing")[mark sizing]. 
+  /// -> length
+  size: 4pt,
+
+  /// How to fill the mark. If set to `auto`, the fill is inherited from the
+  /// plot. 
+  /// -> auto | none | color | gradient | tiling
+  fill: auto,
+
+  /// How to stroke the mark. If set to `auto`, the stroke is inherited from the
+  /// plot.
+  /// -> stroke
+  stroke: 0.7pt,
+
+  /// The shape of the mark. This can be a string identifying one of the 
+  /// built-in marks (check out the tutorial) or a function that takes a mark 
+  /// and produces content. 
+  /// -> str | function
+  shape: "."
+
+) = {}
+
+#let mark = grid
+
+
+
+#let circle = mark => {
+  let radius = mark.size / 2
+  move(
+    dx: -radius, 
+    dy: -radius, 
+    std.ellipse(width: radius*2, height: radius*2, fill: mark.fill, stroke: mark.stroke)
+  )
+}
+
+
+#let small-circle = mark => {
+  let radius = mark.size / 4
+  move(
+    dx: -radius, 
+    dy: -radius, 
+    std.ellipse(width: radius*2, height: radius*2, fill: mark.fill, stroke: mark.stroke)
+  )
+}
+
+
+#let point = mark => {
+  let radius = .5pt
+  move(
+    dx: -radius, 
+    dy: -radius, 
+    std.circle(radius: radius, fill: mark.fill, stroke: mark.stroke)
+  )
+}
+
+
+#let square = mark => {
+  let s = mark.size * 0.85
+  move(
+    dx: -s / 2, 
+    dy: -s / 2, 
+    rect(width: s, height: s, fill: mark.fill, stroke: mark.stroke)
+  )
+}
+
+
+#let cross = mark => {
+  let s = mark.size / calc.sqrt(8) * 1.2
+  place(line(start: (-s, -s), end: (s, s), stroke: mark.stroke))
+  line(start: (s, -s), end: (-s, s), stroke: mark.stroke)
+}
+
+
+// #let plus = mark => {
+//   let s = mark.size / 2 * 1.2
+//   place(line(start: (0pt, -s), end: (0pt, s), stroke: mark.stroke))
+//   line(start: (s, 0pt), end: (-s, 0pt), stroke: mark.stroke)
+// }
+
+
+#let polygon = (mark, n: 5, angle: 0deg) => { 
+  // The last term serves for equalizing the apparent size of polygons with different n. 
+  let radius = mark.size / 2 * calc.sqrt(1 + 4 / (n*n))
+  let dy = (0, .13, 0, .03, 0, .02).at(n - 2, default: 0) * radius
+  let poly = std.polygon(
+    stroke: mark.stroke, fill: mark.fill,
+    ..range(n).map(i => {
+      let phi = i * 360deg / n
+      (
+        radius * calc.sin(phi),
+        -radius * calc.cos(phi) + dy
+      )
+    })
+  )
+  if angle != 0deg {
+    poly = rotate(angle, origin: left + top, poly)
+  }
+  poly
+}
+
+
+#let star = (mark, n: 5, angle: 0deg, inset: 60%) => { 
+  let radius = mark.size / 2 * 1.15
+  
+  std.polygon(
+    stroke: mark.stroke, 
+    fill: mark.fill,
+    ..range(n * 2).map(i => {
+      let r = if calc.even(i) { radius } else { radius * (100% - inset) }
+      let phi = i * 360deg / n / 2 + angle
+      (
+        r * calc.sin(phi),
+        -r * calc.cos(phi)
+      )
+    })
+  )
+}
+
+
+#let asterisk = star.with(inset: 100%)
+
+
+#let moon = (mark, angle: 0deg) => {
+  let radius = mark.size / 2
+  
+  arc(
+    radius: radius, 
+    fill: mark.fill, 
+    closed: "segment", 
+    arc: 180deg, 
+    stroke: 0pt, 
+    angle: angle
+  )
+  move(
+    dx: -radius, 
+    dy: -radius, 
+    std.circle(radius: radius, fill: none, stroke: mark.stroke)
+  )
+}
+
+
+#let text-mark = (mark, body: emoji.heart) => place(
+  center + horizon,
+  body
+)
+
+
+
+#let marks = (
+  ".": small-circle,
+  ",": point,
+  "*": asterisk,
+  "asterisk": asterisk,
+  "x": cross,
+  "+": asterisk.with(n: 4),
+  "|": polygon.with(n: 2),
+  "-": polygon.with(n: 2, angle: 90deg),
+  "a3": asterisk.with(n: 3),
+  "a4": asterisk.with(n: 4),
+  "a5": asterisk.with(n: 5),
+  "a6": asterisk.with(n: 6),
+  "<": polygon.with(n: 3, angle: -90deg),
+  ">": polygon.with(n: 3, angle: 90deg),
+  "^": polygon.with(n: 3),
+  "v": polygon.with(n: 3, angle: 180deg),
+  "o": circle,
+  "s": square,
+  "polygon": polygon,
+  "d": polygon.with(n: 4),
+  "p5": polygon.with(n: 5),
+  "p6": polygon.with(n: 6),
+  "p7": polygon.with(n: 7),
+  "p8": polygon.with(n: 8),
+  "star": star,
+  "s3": star.with(n: 3, inset: 70%),
+  "s4": star.with(n: 4),
+  "s5": star.with(n: 5),
+  "s6": star.with(n: 6),
+  "moon": moon,
+  "text": text-mark,
+  "none": mark => none
+)

--- a/packages/preview/lilaq/0.2.0/src/model/spine.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/spine.typ
@@ -1,0 +1,52 @@
+#import "../libs/elembic/lib.typ" as e
+#import "@preview/tiptoe:0.3.0"
+
+
+/// The spine of a diagram axis (the line drawn along the axis). 
+#let spine(
+  
+  /// How to stroke the spine of the axis. 
+  /// -> none | stroke
+  stroke: (thickness: 0.5pt, cap: "square"),
+
+  /// Places an arrow tip on the axis spine. This expects a mark as specified by
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  tip: none,
+
+  /// Places an arrow tail on the axis spine. This expects a mark as specified by 
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  toe: none
+
+) = {}
+
+
+
+
+#let spine = e.element.declare(
+  "spine",
+  prefix: "lilaq",
+
+  display: it => {
+    if it.stroke == none { return }
+    let line
+    if it.kind == "x" {
+      line = tiptoe.line.with(tip: it.tip, toe: it.toe)
+    } else if it.kind == "y"{
+      line = tiptoe.line.with(angle: 90deg, tip: it.toe, toe: it.tip)
+    }
+    line(length: 100%, stroke: it.stroke)
+  },
+
+  fields: (
+    e.field("stroke", e.types.option(stroke), default: (thickness: 0.5pt, cap: "square")),
+    e.field(
+      "kind", 
+      e.types.union(e.types.literal("x"), e.types.literal("y")), 
+      default: "x"
+    ),
+    e.field("tip", e.types.option(function), default: none),
+    e.field("toe", e.types.option(function), default: none),
+  )
+)

--- a/packages/preview/lilaq/0.2.0/src/model/tick.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/tick.typ
@@ -1,0 +1,138 @@
+
+#import "../process-styles.typ": twod-ify-alignment
+#import "../libs/elembic/lib.typ" as e
+#import "spine.typ": spine
+
+
+/// A tick or subtick on a diagram axis. A tick consists of a tick mark on the axis and
+/// a tick label, usually a number denoting the coordinate value. 
+#let tick(
+  
+  /// Position of the tick in data coordinates. 
+  /// -> float
+  value, 
+
+  /// The content for the tick label. 
+  /// -> any
+  label: none,
+
+  /// Whether this is a subtick. 
+  /// -> bool
+  sub: false,
+
+  /// How to stroke the tick mark. If set to `auto`, the stroke is inherited 
+  /// the axis spine. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// How much to shorten sub ticks compared to regular ticks. 
+  /// -> float
+  shorten-sub: 0.5,
+
+  /// Where to align the tick. For example, if set to `right`, the tick label is
+  /// shown to the left of the tick, aligning at its right side. Ticks on a 
+  /// $y$-axis on the left side of the diagram will typically be aligned on the
+  /// right. 
+  /// -> left | top | right | bottom
+  align: right,
+
+  /// The padding to add between the tick and the tick label. 
+  /// -> length
+  pad: 0.5em,
+  
+  /// The length of the tick on the inside of the axis. Here, the tick label
+  /// is considered to be on the _outside_. For example, if @tick.align is set
+  /// to `right`, the inset determines the tick length to the right of the 
+  /// axis spine. 
+  /// -> length
+  inset: 4pt,
+
+  /// Length of the tick on the outside of the axis, see @tick.inset. For
+  /// example, if @tick.align is set to `right`, the inset determines the tick
+  /// length to the left of the axis spine. 
+  /// -> length
+  outset: 0pt
+  
+) = {}
+
+
+
+#let tick = e.element.declare(
+  "tick",
+  prefix: "lilaq",
+
+  display: it => e.get(e-get => {
+    let angle = if it.align in (top, bottom) { 90deg } else { 0deg }
+    let factor = if it.sub { it.shorten-sub } else { 1 }
+    let length = (it.inset + it.outset) * factor
+    
+    let stroke = it.stroke
+    if stroke == auto { 
+      stroke = e-get(spine).stroke 
+    }
+
+    box(inset: (repr(it.align): it.pad + it.outset * factor), {
+      place(
+        twod-ify-alignment(it.align), 
+        pad(
+          ..(repr(it.align): -it.pad - length),
+          line(length: length, angle: angle, stroke: stroke)
+        )
+      )
+      it.label
+    })
+  }),
+
+  labelable: false,
+
+  fields: (
+    e.field("value", float, required: true),
+    e.field("sub", bool, default: false),
+    e.field("label", e.types.any, default: none),
+    e.field("align", e.types.wrap(alignment, fold: none), default: right),
+    e.field("stroke", e.types.smart(stroke), default: auto),
+    e.field("shorten-sub", float, default: 0.5),
+    e.field("pad", length, default: 0.5em),
+    e.field("inset", length, default: 3pt),
+    e.field("outset", length, default: 0pt),
+  )
+)
+
+
+#tick(34, label: [34])
+#tick(34, label: [34], align: left)
+#tick(34, label: [34], align: top)
+#tick(34, label: [34], align: bottom)
+
+#tick(34, label: [34], inset: 2pt)
+#tick(34, label: [34], align: left, inset: 2pt)
+#tick(34, label: [34], align: top, inset: 2pt)
+#tick(34, label: [34], align: bottom, inset: 2pt)
+
+
+
+
+/// A tick label, usually a number denoting the coordinate value. 
+/// This type exists prominently to enable `show` rules on tick labels. 
+#let tick-label(
+
+  /// Content to show in the label. 
+  /// -> content
+  body
+
+) = {}
+
+
+
+#let tick-label = e.element.declare(
+  "tick-label",
+  prefix: "lilaq",
+
+  display: it => {
+    it.body
+  },
+
+  fields: (
+    e.field("body", content, required: true),
+  )
+)

--- a/packages/preview/lilaq/0.2.0/src/model/title.typ
+++ b/packages/preview/lilaq/0.2.0/src/model/title.typ
@@ -1,0 +1,57 @@
+#import "../libs/elembic/lib.typ" as e
+
+
+/// A title for a diagram. Titles can be placed at the top (default),
+/// left, right, or bottom of a diagram. 
+#let title(
+
+  /// The content to show in the title. 
+  /// -> any
+  body,
+
+  /// Position of the title in the diagram. 
+  /// -> left | top | right | bottom
+  position: top,
+
+  /// Horizontal offset. 
+  /// -> length
+  dx: 0pt,
+
+  /// Vertical offset. 
+  /// -> length
+  dy: 0pt,
+
+  /// Padding between the axes and the title. 
+  /// -> length
+  pad: 0.5em,
+  
+) = {
+  assert(
+    position in (top, bottom, left, right), 
+    message: "`position` needs to be one of \"top\", \"left\", \"bottom\", and \"right\""
+  )
+
+  (
+    body: body,
+    position: position,
+    dx: dx,
+    dy: dy,
+    pad: pad
+  )
+}
+
+
+#let title = e.element.declare(
+  "title",
+  prefix: "lilaq",
+
+  display: it => it.body,
+
+  fields: (
+    e.field("body", content, required: true),
+    e.field("position", alignment, default: top),
+    e.field("dx", length, default: 0pt),
+    e.field("dy", length, default: 0pt),
+    e.field("pad", length, default: 0.5em),
+  )
+)

--- a/packages/preview/lilaq/0.2.0/src/place-anchor.typ
+++ b/packages/preview/lilaq/0.2.0/src/place-anchor.typ
@@ -1,0 +1,15 @@
+
+#let place-anchor(x, y, name) = {
+  (
+    label: none,
+    plot: (plot, transform) => {
+      let (x, y) = transform(x, y)
+      place(
+        dx: x, dy: y, [#box()#label(name)]
+      )
+    },
+    xlimits: () => none,
+    ylimits: () => none,
+    legend-handle: (..) => none
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/bar.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/bar.typ
@@ -1,0 +1,287 @@
+#import "../assertations.typ"
+#import "../logic/limits.typ": bar-lim
+#import "../process-styles.typ": merge-fills
+#import "../utility.typ": match-type, match
+
+#import "../logic/process-coordinates.typ": filter-nan-points, stepify
+#import "../math.typ": vec, minmax
+#import "../style/styling.typ": prepare-path
+
+
+#let render-bar(
+  plot, 
+  transform, 
+  orientation: "vertical"
+) = {
+  
+  let offset-coeff = plot.offset-coeff
+    
+  let get-bar-range = match-type(
+    plot.width,
+    int: () => i => (
+        plot.width * offset-coeff, plot.width * (1 + offset-coeff),
+      ),
+    float: () => i => (
+        plot.width * offset-coeff, plot.width * (1 + offset-coeff),
+      ),
+    array: () => i => (
+        plot.width.at(i) * offset-coeff, plot.width.at(i) * (1 + offset-coeff),
+      ),
+  )
+
+
+  show: prepare-path.with(
+    fill: if type(plot.style.fill) != array { plot.style.fill},
+    stroke: plot.style.stroke,
+    element: rect
+  )
+
+
+  let colored-rect = {
+    if type(plot.style.fill) == array {
+      (i, width: 0pt, height: 0pt) => rect(
+        width: width, height: height, fill: plot.style.fill.at(i)
+      )
+    } else {
+      (i, width: 0pt, height: 0pt) => rect(width: width, height: height)
+    }
+  }
+
+
+  if "make-legend" in plot {
+    colored-rect(0, width: 100%, height: 100%)
+  } else {
+
+    if orientation == "vertical" {
+    
+      for i in range(plot.x.len()) {
+        let y = plot.y.at(i)
+        if float.is-nan(y) { continue }
+        
+        let (x1, x2) = get-bar-range(i)
+        let x = plot.x.at(i)
+        
+        let (xx1, y0) = transform(x + x1, plot.base.at(i, default: plot.base.first()))
+        let (xx2, yy) = transform(x + x2, y)
+
+        place(dx: xx1, dy: yy, colored-rect(i, width: xx2 - xx1, height: y0 - yy))
+      }
+
+    } else if orientation == "horizontal" {
+
+      for i in range(plot.y.len()) {
+        let x = plot.x.at(i)
+        if float.is-nan(x) { continue }
+        
+        let (y1, y2) = get-bar-range(i)
+        let y = plot.y.at(i)
+        
+        let (x0, yy1) = transform(plot.base.at(i, default: plot.base.first()), y + y1)
+        let (xx, yy2) = transform(x, y + y2)
+        
+        place(dx: x0, dy: yy2, colored-rect(i, width: xx - x0, height: yy1 - yy2))
+      }
+
+    }
+
+  }
+}
+
+
+
+/// Creates a bar plot from the given data. 
+/// 
+/// ```example
+/// #lq.diagram(
+///   xaxis: (subticks: none),
+///   lq.bar(
+///     (1, 2, 3, 4, 5, 6), 
+///     (1, 2, 3, 2, 5, 3), 
+///   )
+/// )
+/// ```
+/// 
+/// 
+/// The example below demonstrates how to use custom tick labels by passing 
+/// an array of `(location, label)` tuples to @axis.ticks. 
+/// ```example
+/// #lq.diagram(
+///   xaxis: (
+///     ticks: ("Apples", "Bananas", "Kiwis", "Mangos", "Papayas")
+///       .map(rotate.with(-45deg, reflow: true))
+///       .enumerate(),
+///     subticks: none,
+///   ),
+///   lq.bar(
+///     range(5),
+///     (5, 3, 4, 2, 1)
+///   )
+/// )
+/// ```
+#let bar(
+  
+  /// An array of $x$ coordinates specifying the bar positions. 
+  /// -> array
+  x, 
+  
+  /// An array of $y$ coordinates specifying the bar heights. The number of
+  /// $x$ and $y$ coordinates must match. 
+  /// -> array
+  y, 
+
+  /// How to fill the bars. This can be a single value applied to all bars or
+  /// an array with the same length as the coordinate arrays.
+  /// -> none | color | gradient | tiling | array
+  fill: auto,
+
+  /// How to stroke the bars. All values allowed by the built-in `rect`
+  /// function are also allowed here, see 
+  /// [`std.rect#stroke`](https://typst.app/docs/reference/visualize/rect/#parameters-stroke). 
+  /// In particular, note that by passing a dictionary, the individual sides
+  ///  of the bars can be stroked independently. 
+  /// -> auto | none | color | length | stroke | gradient | tiling | dictionary
+  stroke: none,
+
+  /// Alignment of the bars at the $x$ values. 
+  /// #details[
+  ///   Demonstration of the different alignment modes. 
+  ///   ```example
+  ///   #lq.diagram(
+  ///     xaxis: (subticks: none),
+  ///     lq.bar(
+  ///       (1,2,3,4,5), (1,2,3,4,5), 
+  ///       width: 0.2, fill: red, 
+  ///       align: left, label: "left"
+  ///     ),
+  ///     lq.bar(
+  ///       (1,2,3,4,5), (5,4,3,2,1), 
+  ///       width: 0.2, fill: blue, 
+  ///       align: right, label: "right"
+  ///     ),
+  ///     lq.bar(
+  ///       (1,2,3,4,5), (2.5,) * 5, 
+  ///       width: 0.2, fill: rgb("#AAEEAA99"),
+  ///       align: center, label: "center"
+  ///     ),
+  ///   )
+  ///   ```
+  /// ]
+  /// -> left | center | right
+  align: center,
+
+  /// Width of the bars in data coordinates. The width can be set either to a
+  /// constant for all bars or per-bar by passing an array with 
+  /// the same length as the coordinate arrays. 
+  /// #details[
+  ///   Example for a bar plot with varying bar widths.
+  ///   ```example
+  ///   #lq.diagram(
+  ///     lq.bar(
+  ///       (1, 2, 3, 4, 5), 
+  ///       (1, 2, 3, 2, 5), 
+  ///       width: (1, 0.5, 1, 0.5, 1), 
+  ///       fill: orange, 
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> int | float | array
+  width: 0.8,
+
+  /// An offset to apply to all $x$ coordinates. This is equivalent to replacing
+  /// the array passed to @bar.x with `x.map(x => x + offset)`. Using an offset
+  /// can be useful to avoid overlaps when plotting multiple bar plots into one
+  /// diagram. 
+  /// -> int | float
+  offset: 0,
+
+
+  /// Defines the $y$ coordinate of the baseline of the bars. This can either  
+  /// be a constant value applied to all bars or it can be set per-bar by
+  /// passing an array with the same length as the coordinate arrays. 
+  /// #details[
+  ///   Bar plot with varying base. 
+  ///   ```example
+  ///   #lq.diagram(
+  ///     xaxis: (subticks: none),
+  ///     lq.bar(
+  ///       (1, 2, 3, 4, 5), 
+  ///       (1, 2, 3, 0, 5), 
+  ///       base: (0, 1, 2, -1, 0), 
+  ///       fill: white, 
+  ///       stroke: 0.7pt
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> int | float | array
+  base: 0,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-matching-data-dimensions(
+    x, y, width: width, base: base, fill: fill, fn-name: "bar"
+  )
+
+  if offset != 0 {
+    x = x.map(x => x + offset)
+  }
+  
+  if type(base) != array {
+    base = (base,)
+  }
+  
+  let offset-coeff = match(
+    align,
+    left, 0, 
+    center, -0.5, 
+    right, -1
+  )
+
+  let simple-lims() = vec.add(
+    minmax(x), 
+    (offset-coeff*width, (1 + offset-coeff) * width)
+  )
+  
+  let xlim = match-type(
+    width,
+    int: simple-lims,
+    float: simple-lims,
+    array: () => (
+      calc.min(..x.zip(width).map(((x, w)) => x + offset-coeff * w)),
+      calc.max(..x.zip(width).map(((x, w)) => x + (1 + offset-coeff) * w)),
+    )
+  )
+
+  (
+    x: x,
+    y: y,
+    width: width,
+    offset-coeff: offset-coeff,
+    label: label,
+    base: base,
+    style: (
+      align: align,
+      stroke: stroke,
+      fill: fill
+    ),
+    plot: render-bar,
+    xlimits: () => xlim,
+    ylimits: () => bar-lim(y, base),
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/boxplot.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/boxplot.typ
@@ -1,0 +1,303 @@
+#import "../assertations.typ"
+#import "../utility.typ": match
+#import "../algorithm/boxplot.typ": *
+#import "../utility.typ"
+#import "../style/styling.typ": mark, prepare-mark
+
+#let render-boxplot(plot, transform) = {
+
+  
+  if "make-legend" in plot {
+    return std.line(length: 100%, stroke: plot.style.stroke)
+  }
+
+
+  let style = plot.style
+
+  let box-thickness = utility.if-auto(stroke(style.stroke).thickness, 1pt)
+  
+  for (i, statistics) in plot.statistics.enumerate() {
+
+    let x1 = plot.width.at(i) * -0.5
+    let x2 = plot.width.at(i) * 0.5
+    let x = plot.x.at(i)
+
+    
+    
+    let (xx1, q1) = transform(x + x1, statistics.q1)
+    let (xx2, q3) = transform(x + x2, statistics.q3)
+    let (middle, median) = transform(x, statistics.median)
+    let (_, whisker-low) = transform(x, statistics.whisker-low)
+    let (_, whisker-high) = transform(x, statistics.whisker-high)
+    let (xm1, _) = transform(x - style.cap-length / 2, statistics.q1)
+    let (xm2, _) = transform(x + style.cap-length / 2, statistics.q1)
+
+    
+    place(line(
+      start: (middle, q1), 
+      end: (middle, whisker-low), 
+      stroke: style.whisker
+    ))
+    place(line(
+      start: (middle, q3), 
+      end: (middle, whisker-high), 
+      stroke: style.whisker
+    ))
+    place(line(
+      start: (xm1, whisker-low), 
+      end: (xm2, whisker-low), 
+      stroke: style.cap
+    ))
+    place(line(
+      start: (xm1, whisker-high), 
+      end: (xm2, whisker-high), 
+      stroke: style.cap
+    ))
+
+    place(
+      dx: xx1, dy: q1,
+      rect(
+        height: q3 - q1, width: xx2 - xx1, 
+        fill: style.fill, stroke: style.stroke
+      )
+    )
+    
+    place(line(
+      start: (xx1 + box-thickness / 2, median), 
+      end: (xx2 - box-thickness / 2, median), 
+      stroke: style.median
+    ))
+    
+    if style.mean != none {
+      let (_, mean) = transform(x, statistics.mean)
+
+      if type(style.mean) in (str, function) {
+        show: prepare-mark.with(
+          func: plot.style.mean,
+          size: plot.style.mark-size,
+          fill: plot.style.outlier-fill
+        )
+        set mark(stroke: plot.style.outlier-stroke)
+        place(dx: middle, dy: mean, mark())
+
+      } else {
+        place(line(
+          start: (xx1 + box-thickness/2, mean), 
+          end: (xx2 - box-thickness/2, mean), 
+          stroke: style.mean
+        ))
+      }
+    }
+    if plot.style.mark != none {
+      
+      show: prepare-mark.with(
+        func: plot.style.mark,
+        size: plot.style.mark-size,
+        fill: plot.style.outlier-fill
+      )
+      set mark(stroke: plot.style.outlier-stroke)
+      for outlier in statistics.outliers {
+        let (_, y) = transform(x + x1, outlier)
+        place(dx: middle, dy: y, mark())
+      }
+    }
+    
+  }
+}
+
+/// Computes and visualizes one or more boxplots from datasets. 
+/// 
+/// In the following example, boxplots are generated for four different 
+/// datasets. The default boxplot visualizes the first and third quartil as 
+/// well as the median of the data with a box and shows traditional whiskers 
+/// and outliers. 
+/// ```example
+/// #lq.diagram(
+///   lq.boxplot(
+///     stroke: blue.darken(50%), 
+///     (1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 19),
+///     range(1, 30),
+///     (1, 28, 25, 30),
+///     (1, 2, 3, 4, 5, 6, 32),
+///   )
+/// )
+/// ```
+/// 
+/// By default, the mean value is not shown but it can be visualized by setting
+/// the @boxplot.mean parameter to a mark or line stroke. 
+/// ```example
+/// #lq.diagram(
+///   lq.boxplot((1, 3, 10), mean: "."),
+///   lq.boxplot((1, 3, 10), mean: green, x: 2),
+/// )
+/// ```
+/// 
+/// Boxplots can be richly customized as demonstrated below. 
+/// ```example
+/// #lq.diagram(
+///   lq.boxplot(
+///     (1, 3, 10), 
+///     stroke: luma(30%), 
+///     fill: yellow, 
+///     median: red
+///   ),
+///   lq.boxplot(
+///     (1.5, 3, 9), 
+///     x: 2, 
+///     whisker: blue, 
+///     cap: red, 
+///     cap-length: 0.7, 
+///     median: green
+///   ),
+///   lq.boxplot(
+///     lq.linspace(5.3, 6.2) + (2, 3, 7, 9.5), 
+///     x: 3, 
+///     outliers: "x"
+///    ),
+///   lq.boxplot(
+///     lq.linspace(5.3, 6.2) + (2, 3, 7, 9.5), 
+///     x: 4, 
+///     outliers: none
+///   ),
+/// )
+/// ```
+#let boxplot(
+
+  /// One or more data arrays to generate a boxplot from. 
+  /// -> array
+  ..data,
+
+  /// The $x$ coordinate(s) to draw the boxplots at. If set to `auto`, boxplots will 
+  /// be created at integer positions starting with 1. 
+  /// -> auto | int | float | array
+  x: auto,
+
+  /// The position of the whiskers. The length of the whiskers is at most 
+  /// `whisker-pos * (q3 - q1)` where `q1` and `q3` are the first and third quartils. 
+  /// However, the whiskers always end at an actual data point, so the length can be 
+  /// less then that. The default value of 1.5 is a very common convention established 
+  /// by John Tukey in _Exploratory data analysis_ (1977).
+  /// -> int | float
+  whisker-pos: 1.5,
+
+  /// The width of the boxplots in $x$ data coordinates. This can be a constant width
+  /// applied to all boxplots or an array of widths matching the number of data sets. 
+  /// -> int | float | array
+  width: 0.5,
+
+  /// How to fill the boxes. 
+  /// -> none | color | gradient | tiling
+  fill: none,
+
+  /// How to stroke the boxplot in general. Also see @boxplot.whisker, @boxplot.cap. 
+  /// -> length | color | stroke | gradient | tiling | dictionary
+  stroke: 1pt + black,
+
+  /// How to stroke the line that indicates the median of the data. 
+  /// -> length | color | stroke | gradient | tiling | dictionary
+  median: 1pt + orange,
+
+  /// Whether and how to display the mean value. The mean value can be 
+  /// visualized with a mark (see @plot.mark) or a line like the median. 
+  /// -> none | lq.mark | str | stroke 
+  mean: none,
+
+  /// How to stroke the whiskers. If set to `auto`, the stroke is inherited from 
+  /// @boxplot.stroke. 
+  /// -> auto | length | color | stroke | gradient | tiling | dictionary
+  whisker: auto,
+
+  /// How to stroke the caps of the whiskers. If set to `auto`, the stroke is inherited 
+  /// from @boxplot.stroke.   
+  /// -> auto | length | color | stroke | gradient | tiling | dictionary
+  cap: auto,
+
+  /// The length of the whisker caps in $x$ data coordinates. 
+  /// -> int | float
+  cap-length: 0.25,
+
+  /// Whether and how to display outliers. See @plot.mark. 
+  /// -> none | lq.mark | str 
+  outliers: "o",
+
+  /// The size of the marks used to visualize outliers. 
+  /// -> length
+  outlier-size: 5pt,
+  
+  /// How to fill outlier marks. 
+  /// -> none | auto | color
+  outlier-fill: none,
+  
+  /// How to stroke outlier marks. 
+  /// -> stroke
+  outlier-stroke: black,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-no-named(data)
+  data = data.pos()
+  let num-boxplots = data.len()
+  
+  if type(x) in (int, float) { x = (x,) }
+  if x == auto { x = range(1, num-boxplots + 1) }
+  assert(
+    x.len() == num-boxplots, 
+    message: "The number of x coordinates does not match the number of data arrays"
+  )
+  
+  if type(width) in (int, float) { width = (width,) * num-boxplots }
+  assert(
+    width.len() == num-boxplots, 
+    message: "The number of widths does not match the number of data arrays"
+  )
+  
+  if whisker == auto { whisker = utility.if-none(stroke, std.stroke()) }
+  if cap == auto { cap = utility.if-none(stroke, std.stroke()) }
+  
+  let statistics = data.map(boxplot-statistics.with(whiskers: whisker-pos))
+  let outlier-values = ()
+  if outliers != none {
+    outlier-values = statistics.map(boxplot => boxplot.outliers).flatten()
+  }
+  let ymax = calc.max(..statistics.map(x => x.whisker-high), ..outlier-values)
+  let ymin = calc.min(..statistics.map(x => x.whisker-low), ..outlier-values)
+  let xmin = x.at(0) - width.at(0)
+  let xmax = x.at(-1) + width.at(-1)
+  (
+    x: x,
+    statistics: statistics,
+    label: label,
+    width: width,
+    style: (
+      fill: fill,
+      stroke: stroke,
+      cap: cap,
+      cap-length: cap-length,
+      whisker: whisker,
+      median: median,
+      mean: mean,
+      mark: if outliers != none { outliers },
+      mark-size: outlier-size,
+      outlier-fill: outlier-fill,
+      outlier-stroke: outlier-stroke,
+    ),
+    plot: render-boxplot,
+    xlimits: () => (xmin, xmax),
+    ylimits: () => (ymin, ymax),
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/colormesh.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/colormesh.typ
@@ -1,0 +1,235 @@
+#import "../assertations.typ"
+#import "../math.typ": sign, mesh
+#import "../logic/sample-colors.typ": sample-colors
+
+#let are-dimensions-all-equal(data) = {
+  if data.len() <= 1 { return true }
+  let x0 = data.first()
+  return data.slice(1).all(x => calc.abs(1 - x/x0) < 1e-8)
+}
+
+#assert(are-dimensions-all-equal((1, 1, 1)))
+#assert(not are-dimensions-all-equal((1, 1, 2)))
+#assert(not are-dimensions-all-equal((1, 1, 1.0001)))
+#assert(are-dimensions-all-equal((1, 1, 1.000000001)))
+
+
+
+#let render-colormesh(plot, transform) = {
+  if "make-legend" in plot {
+    return box(width: 100%, height: 100%, fill: plot.color.at(0))
+  }
+
+  let get-extents(a) = {
+    a.zip(a.slice(1)).map(((a, a1)) => a1 - a)
+  }
+
+  let get-size(i, a) = {
+    if i < a.len() - 1 { 
+      let diff = a.at(i + 1) - a.at(i)
+      if i > 0 {
+        (a.at(i) - a.at(i - 1), diff)
+      } else {
+        (diff, diff)
+      }
+    }
+    else { 
+      let diff = a.at(-1) - a.at(-2)
+      (diff, diff)
+    }
+  }
+
+  let widths = get-extents(plot.x)
+  let heights = get-extents(plot.y)
+
+  if are-dimensions-all-equal(widths) and are-dimensions-all-equal(heights) {
+    let (x0, xn) = (plot.x.at(0), plot.x.at(-1))
+    let (y0, yn) = (plot.y.at(0), plot.y.at(-1))
+
+    let w = widths.at(0)
+    let h = heights.at(0)
+    let (x1, y1) = transform(x0 - w / 2, y0 - h / 2)
+    let (x2, y2) = transform(xn + w / 2, yn + h / 2)
+    let scale-x = 100%
+    let scale-y = -100%
+    if x1 > x2 { 
+      (x1, x2) = (x2, x1)
+      scale-x *= -1
+    }
+    if y1 < y2 { 
+      (y1, y2) = (y2, y1)
+      scale-y *= -1
+    }
+
+    let img = image(
+      bytes(plot.color.map(c => rgb(c).components().map(x => int(x / 100% * 255))).join()),
+      format: (
+        encoding: "rgba8",
+        width: plot.x.len(),
+        height: plot.y.len(),
+      ),
+      scaling: plot.interpolation,
+      width: x2 - x1,
+      fit: "stretch",
+      height: y1 - y2
+    )
+    place(
+      dx: x1, dy: y2, 
+      scale(x: scale-x, y: scale-y, img)
+    )
+
+  } else {
+    assert(
+      plot.interpolation == "pixelated", 
+      message: "For non-evenly-spaced color meshes, currently only the interpolation option \"pixelated\" is supported. "
+    )
+
+    for i in range(plot.x.len()) {
+      for j in range(plot.y.len()) {
+        let x = plot.x.at(i)
+        let y = plot.y.at(j)
+        
+        let (w1, w2) = get-size(i, plot.x)
+        let (h1, h2) = get-size(j, plot.y)
+        let (x1, y1) = transform(x - w1 / 2, y + h2 / 2)
+        let (x2, y2) = transform(x + w2 / 2, y - h1 / 2)
+        let fill = plot.color.at(i + j * plot.x.len())
+        let width = x2 - x1
+        let height = y2 - y1
+        place(
+          dx: x1, dy: y1, 
+          rect(width: width * 1.01, height: height * 1.01, fill: fill)
+        )
+      }
+    }
+
+  }
+}
+
+
+/// Plots a rectangular color mesh, e.g., a heatmap. 
+/// ```example
+/// #lq.diagram(
+///   width: 4cm, height: 4cm,
+///   lq.colormesh(
+///     lq.linspace(-4, 4, num: 10),
+///     lq.linspace(-4, 4, num: 10),
+///     (x, y) => x * y, 
+///     map: color.map.magma
+///   )
+/// )
+/// ```
+/// 
+/// When the input `x` and `y` coordinate arrays are both evenly spaced, an 
+/// image is drawn instead of individual rectangles. This reduces the file size
+/// and improves rendering in most cases. When either array is not evenly
+/// spaced, the entire color mesh is drawn with individual rectangles. 
+/// 
+#let colormesh(
+  
+  /// A one-dimensional array of $x$ data coordinates. 
+  /// -> array
+  x, 
+  
+  /// A one-dimensional array of $y$ data coordinates. 
+  /// -> array
+  y, 
+
+  /// Specifies the $z$ coordinates (height) for all combinations of $x$ and $y$ 
+  /// coordinates. This can either be a 
+  /// - two-dimensional $m×n$-array where $m$ is the length of @colormesh.y 
+  ///   and $n$ is the length of @colormesh.x (for each $y$ value, a row of $x$
+  ///   values), 
+  /// - or a function that takes an `x` and a `y` value and returns a 
+  ///   corresponding `z` coordinate. 
+  /// Also see the function @mesh that can be used to create such meshes. 
+  /// -> array | function
+  z,
+  
+  /// A color map in the form of a gradient or an array of colors to sample from. 
+  /// -> array | gradient
+  map: color.map.viridis,
+
+  /// Sets the data value that corresponds to the first color of the color map.
+  /// If set to `auto`, it defaults to the minimum $z$ value.
+  /// -> auto | int | float
+  min: auto,
+
+  /// Sets the data value that corresponds to the last color of the color map.
+  /// If set to `auto`, it defaults to the maximum $z$ value.
+  /// -> auto | int | float
+  max: auto,
+
+  /// The normalization method used to scale $z$ coordinates to the range 
+  /// $[0,1]$ before mapping them to colors using the color map. This can be a 
+  /// @scale, a string that is the identifier of a built-in scale or a function 
+  /// that takes one argument (for example the argument `x => calc.log(x)` 
+  /// would be equivalent to passing `"log"`). Note that the function does not 
+  /// actually need to map the values to the interval $[0,1]$. Instead it 
+  /// describes a scaling that is applied before the data set is _linearly_ 
+  /// scaled to the interval $[0,1]$. 
+  /// -> lq.scale | str | function
+  norm: "linear",
+
+  /// Whether to apply smoothing or leave the color mesh pixelated. This is 
+  /// currently only supported when @colormesh.x and @colormesh.y are evenly 
+  /// spaced. 
+  /// -> "pixelated" | "smooth"
+  interpolation: "pixelated",
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2
+
+) = {
+
+  if type(z) == function {
+    z = mesh(x, y, z)
+  }
+
+  assert.eq(
+    y.len(), z.len(), 
+    message: "`colormesh`: The number of `y` coordinates and the number of rows in `z` must match. Found " + str(y.len()) + " != " + str(z.len())
+  )
+  assert(
+    type(z) == array and type(z.first()) == array, 
+    message: "`colormesh`: `z` expects a 2D array"
+  )
+  assert.eq(
+    x.len(), z.first().len(), 
+    message: "`colormesh`: The number of `x` coordinates and the row length in `z` must match. Found " + str(x.len()) + " != " + str(z.first().len())
+  )
+
+  let color = z.flatten()
+
+  let cinfo
+  if type(color.at(0, default: 0)) in (int, float) {
+    (color, cinfo) = sample-colors(color, map, norm, ignore-nan: true, min: min, max: max)
+  }
+  
+  (
+    cinfo: cinfo,
+    x: x,
+    y: y,
+    z: z,
+    label: label,
+    color: color,
+    plot: render-colormesh,
+    interpolation: interpolation,
+    xlimits: () => (
+      1fr * (x.at(0) - 0.5 * (x.at(1) - x.at(0))), 
+      1fr * (x.at(-1) + 0.5 * (x.at(-1) - x.at(-2)))
+    ),
+    ylimits: () => (
+      1fr * (y.at(0) - 0.5 * (y.at(1) - y.at(0))), 
+      1fr * (y.at(-1) + 0.5 * (y.at(-1) - y.at(-2)))
+    ),
+    legend: true,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/contour.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/contour.typ
@@ -1,0 +1,220 @@
+#import "../assertations.typ"
+#import "../algorithm/contour.typ": *
+#import "../logic/sample-colors.typ": sample-colors
+#import "../math.typ": minmax, mesh
+
+#let render-contour(plot, transform) = {
+  if "make-legend" in plot {
+    return std.line(length: 100%, stroke: plot.line-colors.first())
+  }
+
+    
+  if plot.fill { 
+  
+    let (xmin, xmax) = minmax(plot.x)
+    let (ymin, ymax) = minmax(plot.y)
+    let canvas-rect = ((xmax, ymax), (xmax, ymin), (xmin, ymin), (xmin, ymax), (xmax, ymax)) // right-turning curve
+    // assert.eq(compute-polygon-orientation(..canvas-rect), right)
+    
+    for (i, contour) in plot.contours.enumerate() {
+      set curve(stroke: none, fill: plot.line-colors.at(i))
+
+      let to-closed-curve(contour) = {
+        if contour.len() == 0 { return () }
+        contour = contour.map(p => transform(..p))
+        return (
+          curve.move(contour.first()),
+          ..contour.slice(1).map(curve.line),
+          curve.close(),
+        )
+      }
+      if i == 0 {
+        contour = (canvas-rect,)
+      }
+      if contour.len() == 0 { continue }
+      if compute-polygon-orientation(..contour.first()) == left {
+        contour = (canvas-rect,) + contour
+      }
+      place(curve(
+        ..contour.map(to-closed-curve).join()
+      ))
+    }
+
+  } else {
+      
+    for (i, contour) in plot.contours.enumerate() {
+      set curve(stroke: plot.line-colors.at(i))
+      set curve(stroke: plot.stroke)
+      for path in contour {
+        path = path.map(p => transform(..p))
+        place(std.curve(
+          curve.move(path.first()),
+          ..path.slice(1).map(curve.line)
+        ))
+      }
+    }
+    
+  }
+}
+
+
+/// Creates a contour plot for a 3-dimensional mesh. Given a set of `levels`, 
+/// a number of cuts through the mesh are computed automatically and displayed
+/// as contour lines. Contour plots can be either just stroked
+/// 
+/// ```example
+/// #lq.diagram(
+///   width: 4cm, height: 4cm,
+///   lq.contour(
+///     lq.linspace(-5, 5, num: 12),
+///     lq.linspace(-5, 5, num: 12),
+///     (x, y) => x * y, 
+///     map: color.map.icefire,
+///   )
+/// )
+/// ```
+/// or filled per-level. 
+/// ```example
+/// #lq.diagram(
+///   width: 4cm, height: 4cm,
+///   lq.contour(
+///     lq.linspace(-5, 5, num: 12),
+///     lq.linspace(-5, 5, num: 12),
+///     (x, y) => x * y, 
+///     map: color.map.icefire,
+///     fill: true
+///   )
+/// )
+/// ```
+#let contour(
+
+  /// A one-dimensional array of $x$ data coordinates. 
+  /// -> array
+  x, 
+  
+  /// A one-dimensional array of $y$ data coordinates. 
+  /// -> array
+  y, 
+
+  /// Specifies the $z$ coordinates (height) for all combinations of $x$ and $y$ 
+  /// coordinates. This can either be a 
+  /// - two-dimensional $m×n$-array where $m$ is the length of @colormesh.y 
+  ///   and $n$ is the length of @colormesh.x (for each $y$ value, a row of $x$
+  ///   values), 
+  /// - or a function that takes an `x` and a `y` value and returns a 
+  ///   corresponding `z` coordinate. 
+  /// Also see the function @mesh that can be used to create such meshes. 
+  /// -> array | function
+  z,
+
+  /// Specifies the levels to compute contours for. If this is an integer, an 
+  /// according number of levels is automatically selected evenly from a ticking 
+  /// pattern. TODO: unclear. 
+  /// The desired levels can also be selected manually by passing an array of ($z$) 
+  /// coordinates. 
+  /// -> int | array
+  levels: 10,
+
+  /// Whether to fill the contour levels. 
+  /// -> bool
+  fill: false,
+
+  /// How to stroke the contours in the cases that `fill: false`. If this
+  /// argument specifies a color, the coloring from the @contour.map is
+  /// overridden. 
+  /// -> stroke
+  stroke: 0.7pt,
+  
+  /// A color map in form of a gradient or an array of colors to sample from. 
+  /// -> array | gradient
+  map: color.map.viridis,
+
+  /// Sets the data value that corresponds to the first color of the color map. If set 
+  /// to `auto`, it defaults to the minimum $z$ value.
+  /// -> auto | int | float
+  min: auto,
+
+  /// Sets the data value that corresponds to the last color of the color map. If set 
+  /// to `auto`, it defaults to the maximum $z$ value.
+  /// -> auto | int | float
+  max: auto,
+
+  /// The normalization method used to scale $z$ coordinates to the range 
+  /// $[0,1]$ before mapping them to colors using the color map. This can be a 
+  /// @scale, a string that is the identifier of a built-in scale or a function 
+  /// that takes one argument. See @colormesh.norm. 
+  /// -> lq.scale | str | function
+  norm: "linear",
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2
+
+) = {
+  if type(z) == function {
+    z = mesh(x, y, z)
+
+  }
+  assert.eq(
+    y.len(), z.len(), 
+    message: "`colormesh`: The number of `y` coordinates and the number of rows in `z` must match. Found " + str(y.len()) + " != " + str(z.len())
+  )
+  assert(
+    type(z) == array and type(z.first()) == array, 
+    message: "`colormesh`: `z` expects a 2D array"
+  )
+  assert.eq(
+    x.len(), z.first().len(), 
+    message: "`colormesh`: The number of `x` coordinates and the row length in `z` must match. Found " + str(x.len()) + " != " + str(z.first().len())
+  )
+  
+  let z-flat = z.flatten()
+  let (z0, z1) = (calc.min(..z-flat), calc.max(..z-flat))
+  if z0 == z1 { z0 -= 1; z1 += 1}
+
+  if type(levels) == int {
+    import "../algorithm/ticking.typ"
+    let range = ticking.locate-ticks-linear(z0, z1, num-ticks-suggestion: levels)
+    levels = range.ticks
+  }
+  
+  if min == auto { min = calc.min(..z-flat) }
+  if max == auto { max = calc.max(..z-flat) }
+  let (color, cinfo) = sample-colors(levels, map, norm, min: min, max: max)
+
+
+  let contours = generate-contours(x, y, z, levels, z-range: z1 - z0)
+
+  if fill {
+
+    let boundaries = (xmin: x.first(), xmax: x.last(), ymin: y.first(), ymax: y.last())
+
+    contours = contours.map(paths => {
+      paths.map(close-path-at-boundaries.with(boundaries: boundaries)).filter(x => x != none)
+    })
+  }
+  
+  
+  (
+    cinfo: cinfo,
+    x: x,
+    y: y,
+    z: z,
+    levels: levels,
+    line-colors: color,
+    contours: contours,
+    fill: fill,
+    stroke: stroke,
+    label: label,
+    plot: render-contour,
+    xlimits: () => (x.at(0)*1fr, x.at(-1)*1fr),
+    ylimits: () => (y.at(0)*1fr, y.at(-1)*1fr),
+    legend: true,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/ellipse.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/ellipse.typ
@@ -1,0 +1,113 @@
+#import "../assertations.typ"
+#import "../logic/limits.typ": compute-primitive-limits
+#import "../logic/process-coordinates.typ": all-data-coordinates, convert-rect
+
+
+/// Plots an ellipse or circle with origin `(x, y)`. The origin coordinates as well
+/// as width and height can either be given as 
+/// - data coordinates (`int` or `float`),
+/// - or absolute coordinates from the top left corner of the data area (`length`),
+/// - or in percent relative to the data area (`ratio`),
+/// - or a combination of the latter two (`relative`).  
+/// 
+/// Note that coordinate types can also be mixed (e.g., a length for `x` and a scalar for `y`).
+/// 
+/// 
+/// For example in order to access the center, you can write `(50%, 50%)`. 
+/// 
+/// 
+/// ```example
+/// #lq.diagram(
+///   width: 3cm, height: 3cm,
+///   lq.ellipse(2, 2, width: 10, height: 4, fill: yellow),
+///   lq.ellipse(10, 4, width: 4, height: 4, fill: red),
+///   lq.ellipse(50%, 50%, width: 45%, height: 45%, stroke: blue)
+/// )
+/// ```
+/// 
+#let ellipse(
+  
+  /// The x coordinate of the origin.
+  /// -> float | relative 
+  x, 
+
+  /// The y coordinate of the origin.
+  /// -> float | relative 
+  y,
+
+  /// The width of the ellipse. 
+  /// -> auto | float | relative
+  width: auto,
+
+  /// The height of the ellipse. 
+  /// -> auto | float | relative
+  height: auto, 
+
+  /// How to fill the ellipse.  
+  /// -> none | color | gradient | tiling
+  fill: none,
+
+  /// How to stroke the ellipse.
+  /// -> auto | none | stroke
+  stroke: auto,
+
+  /// How much to pad the content of the ellipse. See the built-in [`std.ellipse#inset`](https://typst.app/docs/reference/visualize/ellipse/#parameters-inset).
+  /// -> relative | dictionary
+  inset: 5pt,
+
+  /// How much to expand the ellipse beyond its defined size.
+  /// See the built-in [`std.ellipse#outset`](https://typst.app/docs/reference/visualize/ellipse/#parameters-outset).
+  /// -> relative | dictionary
+  outset: 0pt,
+
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram 
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+
+  /// An optional body to place inside the ellipse. If `width` and/or `height` are set to `auto`, they will adapt to the content. 
+  /// -> any
+  ..body
+
+) = {
+  assertations.assert-no-named(body, fn: "ellipse")
+  (
+    x: x, 
+    y: y,
+    plot: (plot, transform) => { 
+      if "make-legend" in plot {
+        return std.ellipse(
+          width: 100%, height: 100%, 
+          fill: fill, stroke: stroke
+        )
+      }
+
+      let (x1, width, y1, height) = convert-rect(x, y, width, height, transform)
+      place(dx: x1, dy: y1, 
+        std.ellipse(
+          width: width, 
+          height: height, 
+          fill: fill, 
+          stroke: stroke, 
+          inset: inset, 
+          outset: outset,
+          body.pos().at(0, default: none)
+        )
+      )
+    },
+    xlimits: compute-primitive-limits.with((x, if all-data-coordinates((x, width)) { x + width } else { x })),
+    ylimits: compute-primitive-limits.with((y, if all-data-coordinates((y, height)) { y + height } else { y })),
+    label: label,
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/fill-between.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/fill-between.typ
@@ -1,0 +1,121 @@
+#import "../assertations.typ"
+#import "../process-styles.typ": merge-strokes, merge-fills
+#import "../logic/process-coordinates.typ": filter-nan-points, stepify
+#import "../math.typ": minmax
+#import "../style/styling.typ": prepare-path
+
+#let render-fill-between(plot, transform) = {
+  
+  let y2 = if plot.y2 == none { (0,)*plot.x.len() } else { plot.y2 }
+  
+  let (points, runs) = filter-nan-points(plot.x.zip(plot.y1, y2), generate-runs: true)
+
+  show: prepare-path.with(
+    fill: plot.style.fill,
+    stroke: plot.style.stroke,
+    element: polygon
+  )
+  
+  if "make-legend" in plot {
+    polygon((0%, 0%), (0%, 100%), (100%, 100%), (100%, 0%))
+  } else {
+      for run in runs {
+      let there = run.map(x => x.slice(0,2))
+      let back = run.map(x => (x.at(0), x.at(2)))
+      if plot.style.step != none {
+        there = stepify(there, step: plot.style.step)
+        back = stepify(back, step: plot.style.step)
+      }
+      
+
+    else {
+        place(polygon(
+          ..((there + back.rev()).map(p => transform(..p))))
+        )
+      }
+    }
+  }
+}
+
+
+/// Fills the area between two graphs. 
+/// 
+/// ```example
+/// #let xs = lq.linspace(-1, 2)
+/// #lq.diagram(
+///   lq.fill-between(
+///     xs, 
+///     xs.map(calc.sin),
+///     y2: xs.map(calc.cos),
+///   )
+/// )
+/// ```
+/// or the area between one graph and the $x$-axis:
+/// ```example
+/// #let xs = lq.linspace(0, 3, num: 80)
+/// #lq.diagram(
+///   lq.fill-between(
+///     label: [Maxwell-distribution],
+///     xs, 
+///     xs.map(x => x*x*calc.exp(-x*x*1.3)),
+///   )
+/// )
+/// ```
+#let fill-between(
+
+  /// An array of $x$ data coordinates. Data coordinates need to be of type `int` or `float`. 
+  /// -> array
+  x, 
+
+  
+  /// An array of $y$ data coordinates. The number of $x$ and $y$ coordinates must match. 
+  /// -> array
+  y1, 
+
+  
+  /// An second array of $y$ data coordinates. If this is `none`, the area between the coordinates `y1` and the $x$-axis is filled. 
+  /// -> none | array
+  y2: none,
+
+  /// How to stroke the area. 
+  /// -> none | stroke
+  stroke: none,
+
+  /// How to fill the area. 
+  /// -> none | color | gradient | tiling
+  fill: auto,
+  
+  /// Step mode for plotting the lines. See @plot.step. 
+  /// -> none | start | end | center
+  step: none,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram 
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  
+  assertations.assert-matching-data-dimensions(x, x, y1: y1, y2: y2, fn-name: "fill-between")
+  
+  (
+    x: x,
+    y1: y1,
+    y2: y2,
+    label: label,
+    style: (
+      fill: fill,
+      stroke: stroke,
+      step: step,
+    ),
+    plot: render-fill-between,
+    xlimits: () => minmax(x),
+    ylimits: () => minmax(y1 + y2 + if y2 == none {(0,)}),
+    legend: true,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/hbar.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/hbar.typ
@@ -1,0 +1,183 @@
+#import "bar.typ": *
+
+
+/// Creates a horizontal bar plot from the given data. 
+/// 
+/// ```example
+/// #lq.diagram(
+///   yaxis: (subticks: none),
+///   lq.hbar(
+///     (1, 2, 3, 2, 5, 3), 
+///     (1, 2, 3, 4, 5, 6), 
+///   )
+/// )
+/// ```
+/// 
+/// Also see @bar. 
+#let hbar(
+  
+  /// An array of $x$ coordinates specifying the bar lengths. 
+  /// -> array
+  x, 
+  
+  /// An array of $y$ coordinates specifying the bar positions. The number of 
+  /// $x$ and $y$ coordinates must match. 
+  /// -> array
+  y, 
+
+  /// How to fill the bars. This can be a single value applied to all bars or
+  /// an array with the same length as the coordinate arrays.
+  /// -> none | color | gradient | tiling | array
+  fill: auto,
+
+  /// How to stroke the bars. All values allowed by the built-in `rect`
+  /// function are also allowed here, see 
+  /// [`std.rect#stroke`](https://typst.app/docs/reference/visualize/rect/#parameters-stroke). 
+  /// In particular, note that by passing a dictionary, the individual sides
+  ///  of the bars can be stroked independently. 
+  /// -> auto | none | color | length | stroke | gradient | tiling | dictionary
+  stroke: none,
+
+  /// Alignment of the bars at the $y$ values. 
+  /// #details[
+  ///   Demonstration of the different alignment modes. 
+  ///   ```example
+  ///   #lq.diagram(
+  ///     yaxis: (subticks: none),
+  ///     lq.hbar(
+  ///       (1,2,3,4,5), (1,2,3,4,5), 
+  ///       width: 0.2, fill: red, 
+  ///       align: top, label: "top"
+  ///     ),
+  ///     lq.hbar(
+  ///       (5,4,3,2,1), (1,2,3,4,5), 
+  ///       width: 0.2, fill: blue, 
+  ///       align: bottom, label: "bottom"
+  ///     ),
+  ///     lq.hbar(
+  ///       (2.5,) * 5, (1,2,3,4,5), 
+  ///       width: 0.2, fill: rgb("#AAEEAA99"),
+  ///       align: center, label: "center"
+  ///     ),
+  ///   )
+  ///   ```
+  /// ]
+  /// -> top | center | bottom
+  align: center,
+
+  /// Width of the bars in data coordinates. The width can be set either to a
+  /// constant for all bars or per-bar by passing an array with 
+  /// the same length as the coordinate arrays. 
+  /// #details[
+  ///   Example for a bar plot with varying bar widths.
+  ///   ```example
+  ///   #lq.diagram(
+  ///     lq.hbar(
+  ///       (1, 2, 3, 2, 5), 
+  ///       (1, 2, 3, 4, 5), 
+  ///       width: (1, 0.5, 1, 0.5, 1), 
+  ///       fill: orange, 
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> int | float | array
+  width: 0.8,
+
+  /// An offset to apply to all $y$ coordinates. This is equivalent to replacing
+  /// the array passed to @bar.y with `y.map(y => y + offset)`. Using an offset
+  /// can be useful to avoid overlaps when plotting multiple bar plots into one
+  /// diagram. 
+  /// -> int | float
+  offset: 0,
+
+
+  /// Defines the $x$ coordinate of the baseline of the bars. This can either  
+  /// be a constant value applied to all bars or it can be set per-bar by
+  /// passing an array with the same length as the coordinate arrays. 
+  /// #details[
+  ///   Bar plot with varying base. 
+  ///   ```example
+  ///   #lq.diagram(
+  ///     yaxis: (subticks: none),
+  ///     lq.hbar(
+  ///       (1, 2, 3, 0, 5), 
+  ///       (1, 2, 3, 4, 5), 
+  ///       base: (0, 1, 2, -1, 0), 
+  ///       fill: white, 
+  ///       stroke: 0.7pt
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> int | float | array
+  base: 0,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram 
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-matching-data-dimensions(
+    x, y, width: width, base: base, fn-name: "hbar"
+  )
+
+  if offset != 0 {
+    y = y.map(y => y + offset)
+  }
+  
+  if type(base) != array {
+    base = (base,)
+  }
+  
+  let offset-coeff = match(
+    align,
+    top, 0,
+    center, -0.5, 
+    bottom, -1
+  )
+
+  let simple-lims() = vec.add(
+    minmax(y), 
+    (offset-coeff*width, (1 + offset-coeff) * width)
+  )
+  
+  let ylim = match-type(
+    width,
+    int: simple-lims,
+    float: simple-lims,
+    array: () => (
+      calc.min(..y.zip(width).map(((y, w)) => y + offset-coeff * w)),
+      calc.max(..y.zip(width).map(((y, w)) => y + (1 + offset-coeff) * w)),
+    )
+  )
+
+  (
+    x: x,
+    y: y,
+    width: width,
+    offset-coeff: offset-coeff,
+    label: label,
+    base: base,
+    style: (
+      align: align,
+      stroke: stroke,
+      fill: fill
+    ),
+    plot: render-bar.with(orientation: "horizontal"),
+    xlimits: () => bar-lim(x, base),
+    ylimits: () => ylim,
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/hlines.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/hlines.typ
@@ -1,0 +1,102 @@
+#import "../process-styles.typ": merge-strokes
+#import "../math.typ": minmax
+
+
+#let render-hlines(plot, transform) = {
+  let min = plot.min
+  let max = plot.max
+
+  if "make-legend" in plot {
+    return std.line(length: 100%, stroke: plot.style.line)
+  }
+
+  if min == auto { min = 0% }
+  else {
+    (min, _) = transform(min, 1)
+  }
+  if max == auto { max = 100% }
+  else {
+    (max, _) = transform(max, 1)
+  }
+
+  for y in plot.y {
+    let (_, yy) = transform(1, y)
+    place(line(start: (min, yy), end: (max, yy), stroke: plot.style.line))
+  }
+}
+
+
+
+/// Draws a set of horizontal lines into the diagram.
+/// 
+/// By default, the lines are indefinite and span the entire width of the
+/// diagram, independent of the limits, however, through `min` and `max`, 
+/// beginning and end of the line can be fixed to an $x$ coordinate, 
+/// respectively. 
+/// ```example
+/// #lq.diagram(
+///   xlim: (0, 7),
+///   lq.hlines(1, 1.1, line: teal, label: "Indefinite"),
+///   lq.hlines(2, line: blue, min: 2, label: "Fixed start"),
+///   lq.hlines(3, line: purple, max: 2, label: "Fixed end"),
+///   lq.hlines(4, line: red, min: 1, max: 3, label: "Fixed"),
+/// ) 
+/// ```
+#let hlines(
+
+  /// The $y$ coordinate(s) of one or more horizontal lines to draw. 
+  /// -> int | float
+  ..y, 
+
+  /// The beginning of the line as an $x$ coordinate. If set to `auto`, the line will 
+  /// always start at the left edge of the diagram. 
+  /// -> auto | int | float
+  min: auto,
+  
+  /// The end of the line as an $x$ coordinate. If set to `auto`, the line will 
+  /// always end at the right edge of the diagram. 
+  /// -> auto | int | float
+  max: auto,
+
+  /// How to stroke the lines. 
+  /// -> stroke
+  line: black,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  y = y.pos()
+
+  line = merge-strokes(line)
+
+  let xlimits = none
+  if min != auto {
+    xlimits = (min, min)
+  }
+  if max != auto {
+    xlimits = (if min == auto { max } else { min }, max)
+  }
+
+  (
+    y: y,
+    label: label,
+    min: min, 
+    max: max,
+    style: (
+      line: line,
+    ),
+    plot: render-hlines,
+    xlimits: () => xlimits,
+    ylimits: () => minmax(y),
+    legend: true,
+    z-index: z-index
+  )
+}
+

--- a/packages/preview/lilaq/0.2.0/src/plot/hstem.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/hstem.typ
@@ -1,0 +1,148 @@
+#import "../assertations.typ"
+#import "../logic/limits.typ": bar-lim
+#import "../process-styles.typ": merge-strokes, merge-fills
+#import "../logic/process-coordinates.typ": filter-nan-points
+#import "../math.typ": minmax
+#import "../utility.typ": if-auto
+#import "../style/styling.typ": mark, prepare-mark, prepare-line
+
+
+
+#let render-hstem(plot, transform) = {
+  let marker = mark()
+  set line(stroke: plot.style.stroke)
+
+  let (ymin, ymax) = (plot.ylimits)()
+  
+  if "make-legend" in plot {
+    ymin = 0
+    ymax = 1
+    plot.x = (.75,)
+    plot.y = (.5,)
+    plot.base = .25
+  }
+  
+  let (x0, y1) = transform(plot.base, ymin)
+  let (x0, y2) = transform(plot.base, ymax)
+
+  
+
+  
+  show: prepare-mark.with(
+    func: plot.style.mark, 
+    color: merge-fills(plot.style.color),
+    size: plot.style.mark-size
+  )
+  show: prepare-line.with(
+    stroke: merge-strokes(plot.style.stroke, plot.style.color)
+  )
+
+  let points = filter-nan-points(plot.x.zip(plot.y)).map(p => transform(..p))
+
+  points.map(((x, y)) => place(line(start: (x0, y), end: (x, y)))).join()
+  
+  if plot.style.base-stroke != none {
+    set line(stroke: (cap: "square"))
+    place(line(
+      start: (x0, y1), 
+      end: (x0, y2), 
+      stroke: plot.style.base-stroke
+    ))
+  }
+  
+  points.map(((x, y)) => place(dx: x, dy: y, marker)).join()
+}
+
+
+/// Creates a horizontal stem plot. 
+/// ```example
+/// #let ys = lq.linspace(0, 10, num: 20)
+///   
+/// #lq.diagram( 
+///   lq.hstem(
+///     ys.map(calc.cos), 
+///     ys, 
+///     color: orange, 
+///     mark: "d",
+///     base-stroke: black,
+///   )
+/// ) 
+/// ```
+///
+/// Also see @stem for vertical stem plots. 
+#let hstem(
+
+  /// An array of $x$ coordinates. 
+  /// -> array
+  x, 
+  
+  /// An array of $y$ coordinates. The number of $x$ and $y$ coordinates 
+  /// must match. 
+  /// -> array
+  y, 
+
+  /// Combined color for line and marks. See also the parameters @hstem.line 
+  /// and @hstem.mark-color which take precedence over `color`, if set. 
+  /// -> auto | color
+  color: auto,
+  
+  /// The line style to use for this plot (takes precedence over @hstem.color). 
+  /// -> auto | stroke
+  stroke: auto, 
+  
+  /// The mark to use to mark data points. See @plot.mark. 
+  /// -> auto | lq.mark | str
+  mark: auto, 
+  
+  /// Size of the marks. 
+  /// -> length
+  mark-size: 5pt,
+  
+  /// Color of the marks (takes precedence over @hstem.color). 
+  /// -> auto | color
+  mark-color: auto,
+  
+  /// Defines the $x$ coordinate of the base line.
+  /// -> int | float
+  base: 0,
+
+  /// How to stroke the base line. 
+  /// -> stroke
+  base-stroke: red,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-matching-data-dimensions(x, y, fn-name: "hstem")
+  (
+    x: x,
+    y: y,
+    base: base,
+    label: label,
+    style: (
+      color: color,
+      mark: mark,
+      mark-size: mark-size,
+      mark-color: merge-fills(mark-color, color),
+      stroke: merge-strokes(stroke, color),
+      base-stroke: base-stroke
+    ),
+    plot: render-hstem,
+    xlimits: () => bar-lim(x, (base,)),
+    ylimits: () => minmax(y),
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/line.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/line.typ
@@ -1,0 +1,119 @@
+#import "../logic/process-coordinates.typ": convert-vertex
+#import "../logic/limits.typ": compute-primitive-limits
+#import "@preview/tiptoe:0.3.0"
+
+
+/// Draws a line into the data area. 
+/// ```example
+/// #lq.diagram(
+///   width: 3cm, height: 3cm,
+///   lq.line((1, 2), (5, 4))
+/// )
+/// ```
+/// The coordinates can also be given relative to the data area 
+/// (`0%` means at the very left/top and `100%` at the very right/bottom)
+/// ```example
+/// #lq.diagram(
+///   width: 3cm, height: 3cm,
+///   lq.line((0%, 0%), (100%, 100%))
+/// )
+/// ```
+/// or mixed between relative, absolute and data values. 
+/// ```example
+/// #lq.diagram(
+///   width: 3cm, height: 3cm,
+///   lq.line(
+///     stroke: (paint: blue, dash: "dashed"),
+///     (1, 100%), (4, 10pt)
+///   )
+/// )
+/// ```
+/// 
+/// Arrow tips and tails can be added to a line through the arguments `tip` and `toe`. 
+/// This is supported via the Typst package 
+/// #link("https://typst.app/universe/package/tiptoe")[tiptoe].
+/// ```example
+/// #import "@preview/tiptoe:0.3.0"
+/// #let xs = lq.arange(-5, 6)
+/// 
+/// #lq.diagram(
+///   lq.plot(xs, xs.map(x => x*x)),
+///   lq.line(
+///     tip: tiptoe.stealth,
+///     toe: tiptoe.bar,
+///     (0, 10), (4, 16)
+///   )
+/// )
+/// ```
+/// 
+#let line(
+
+  /// The start point of the line. Coordinates can be given as
+  /// - data coordinates (`int` or `float`),
+  /// - or absolute coordinates from the top left corner of the data area 
+  ///   (`length`),
+  /// - or in percent relative to the data area (`ratio`),
+  /// - or a combination of the latter two (`relative`).  
+  /// -> array
+  start, 
+
+  /// The end point of the line, see @line.start. 
+  /// -> array
+  end,
+
+  /// How to stroke the line. 
+  /// -> stroke
+  stroke: stroke(),
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+
+  /// Places an arrow tip on the line. This expects a mark as specified by
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  tip: none,
+  
+  /// Places an arrow tail on the line. This expects a mark as specified by 
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  toe: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram objects. 
+  /// See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+
+) = {
+  let vertices = (start, end)
+  (
+    plot: (plot, transform) => { 
+      if "make-legend" in plot {
+        return std.line(length: 100%, stroke: stroke)
+      }
+
+      let (start, end) = vertices.map(convert-vertex.with(transform: transform))
+      if tip == none and toe == none {
+        return place(std.line(
+          stroke: stroke,
+          start: start, end: end
+        ))
+      }
+      place(tiptoe.line(
+        stroke: stroke,
+        start: start, end: end,
+        tip: tip, toe: toe
+      ))
+    },
+    xlimits: compute-primitive-limits.with(vertices.map(x => x.at(0))),
+    ylimits: compute-primitive-limits.with(vertices.map(x => x.at(1))),
+    label: label,
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/path.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/path.typ
@@ -1,0 +1,204 @@
+#import "../assertations.typ"
+#import "../logic/limits.typ": compute-primitive-limits
+#import "../logic/process-coordinates.typ": convert-bezier-curve, transform-point
+#import "../math.typ": vec
+#import "@preview/tiptoe:0.3.0"
+
+
+
+
+#let path-to-curve(
+  ..vertices,
+  closed: false
+) = {
+  vertices = vertices.pos()
+  if vertices.len() == 0 { return }
+
+  let is-vertex(v) = type(v) == array and type(v.first()) != array
+  let extract-vertex(v) = {
+    if is-vertex(v) { v }
+    else { v.first() }
+  }
+  
+  let curve-elements = ()
+  let start-in = none
+  let out = none
+  for vertex in vertices {
+    let v = extract-vertex(vertex)
+    
+    if is-vertex(vertex) {
+      if out == none {
+        curve-elements.push((v,))
+      } else {
+        curve-elements.push((out, none, v))
+        out = none
+      }
+    } else {
+      if vertex.len() == 2 {
+        vertex.push(vec.multiply(vertex.at(1), -1))
+        // now its definitely a "cubic"!
+      }
+      if curve-elements.len() == 0 {
+        curve-elements.push((v,))
+        start-in = vec.add(v, vertex.at(1))
+      } else if out == none {
+        curve-elements.push((auto, vec.add(v, vertex.at(1)), v))
+        out = auto
+      } else {
+        curve-elements.push((out, vec.add(v, vertex.at(1)), v))
+      }
+      out = vec.add(v, vertex.at(2))
+    }
+  }
+
+  let to-curve-element(x) = {
+    if x.len() == 1 { curve.line(..x) }
+    else if x.len() == 2 { curve.quad(..x) }
+    else if x.len() == 3 { curve.cubic(..x) }
+  }
+  curve-elements = curve-elements.map(to-curve-element)
+  let start = extract-vertex(vertices.first())
+  if closed {
+    if out != none or start-in != none {
+      curve-elements.push(curve.cubic(out, start-in, start))
+    }
+    curve-elements.push(curve.close(mode: "straight"))
+  }
+  
+  (
+    curve.move(start),
+    ..curve-elements,
+  )
+}
+
+
+/// Draws a path into the data area. Each vertex may be given as data coordinates, 
+/// as percentage relative to the data area or in absolute lengths (see @rect). 
+///
+/// ```example
+/// #lq.diagram(
+///   height: 3.8cm,
+///   width: 4cm, 
+///   lq.path(
+///     ((0, 1), (0, -1)),
+///     ((.5, 1), (0, 1)),
+///     ((0,-1), (0, 1), (0, 1)),
+///     ((-.5, 1), (0, -1)),
+///     ((0, 1), (0, 1)),
+///     stroke: red + 2pt
+///   )
+/// )
+/// ```
+/// 
+#let path(
+
+  /// Vertices and curve elements. See the Typst built-in `path` function. 
+  /// -> array
+  ..vertices,
+
+  /// How to fill the path.  
+  /// -> none | color | gradient | tiling
+  fill: none,
+
+  /// How to stroke the path.
+  /// -> auto | none | stroke
+  stroke: auto,
+
+  /// Whether to close the path. 
+  /// -> bool
+  closed: false,
+
+  /// Places an arrow tip on the curve. This expects a mark as specified by
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  tip: none,
+  
+  /// Places an arrow tail on the curve. This expects a mark as specified by 
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  toe: none,
+
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram objects. 
+  /// See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+
+) = {
+  assertations.assert-no-named(vertices, fn: "path")
+
+  let sub(p, q) = (p.at(0) - q.at(0), p.at(1) - q.at(1))
+  let add(p, q) = (p.at(0) + q.at(0), p.at(1) + q.at(1))
+
+  vertices = vertices.pos()
+  let all-points = vertices.enumerate().map(((i, v)) => {
+    if type(v.at(0)) != array { return (v,) }
+    if v.len() == 3 { 
+      return (v.at(0),) + v.slice(1).map(c => {
+         if not c.map(type).all(x => x in (int, float)) { return v.at(0) }
+        add(v.at(0), c)
+      }) 
+    } 
+    let vs = (v.at(0),)
+    if i != 0 and v.at(1).map(type).all(x => x in (int, float)){
+      vs.push(add(v.at(0), v.at(1)))
+    }
+    if i != vertices.len() - 1 {
+      // vs.push(sub(v.at(0), v.at(1)))
+    }
+    return vs
+  }).join()
+  // vertices = all-points  
+  // let all-points = vertices
+  (
+    vertices: vertices,
+    plot: (plot, transform) => { 
+      if "make-legend" in plot {
+        return std.rect(
+          width: 100%, height: 100%, 
+          fill: fill, stroke: stroke
+        )
+      }
+
+      let new-vertices = vertices.map(v => {
+        if type(v.at(0)) != array { return transform-point(..v, transform) }
+        return convert-bezier-curve(v, transform)
+        let p = transform-point(..v.at(0), transform)
+        let cs = v.slice(1).map(c => {
+          let cabs = add(v.at(0), c)
+          let cabs = c
+          sub(transform-point(..cabs, transform), p)
+        })
+        (p,) + cs
+      })
+      let segments = path-to-curve(
+        closed: closed,
+        ..new-vertices
+      )
+      let curve = std.curve
+      if tip != none or toe != none {
+        curve = tiptoe.curve.with(tip: tip, toe: toe)
+      }
+
+      place(
+        curve(
+          ..segments, 
+          fill: fill, stroke: stroke, 
+        )
+      )
+    },
+    xlimits: compute-primitive-limits.with(all-points.map(x => x.at(0))),
+    ylimits: compute-primitive-limits.with(all-points.map(x => x.at(1))),
+    label: label,
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/place.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/place.typ
@@ -1,0 +1,98 @@
+#import "../process-styles.typ": twod-ify-alignment
+#import "../logic/process-coordinates.typ": transform-point
+
+
+/// Places any type of content in the data area. The coordinates of the origin
+/// can be given as data coordinates, as percentage relative to the data area
+/// or in absolute lengths (see @rect). 
+/// 
+/// ```example
+/// #lq.diagram(
+///   lq.place(0.5, 0.5)[Hello],
+///   lq.place(0%, 0.3, align: left)[
+///     Text placed at `x: 0%` and `y: 0.3`
+///   ]
+/// )
+/// ```
+/// 
+/// Unlike other plotting commands, @place is not clipped to the data area by
+/// default and the z-index is higher, making the placed content appear 
+/// on top of most other diagram objects. 
+/// 
+/// ```example
+/// #lq.diagram(
+///   lq.plot((1, 2, 3), (1, 2.1, 3)),
+///   lq.place(
+///     10%, 0%, 
+///     align: left,
+///     box(fill: yellow, inset: 2pt)[
+///       Here comes the plot🎶 ↓
+///     ]
+///   )
+/// )
+/// ```
+/// Clipping can be activated via @place.clip and the z-index can be changed
+/// through @place.z-index.  
+/// 
+/// 
+/// With @place, a smaller plot can also be placed within another plot. 
+/// 
+/// ```example
+/// #let xs = lq.linspace(-5, 5, num: 20)
+/// 
+/// #lq.diagram(
+///   lq.plot((1,2,3), (1,2,3)),
+///   lq.place(25%, 50%,
+///     lq.diagram(
+///       title: [mini],
+///       fill: white,
+///       width: 40pt, height: 30pt, 
+///       lq.plot(xs, xs.map(x => x*x))
+///     )
+///   )
+/// )
+/// ```
+/// 
+#let place(
+
+  /// The $x$ coordinate of the origin.
+  /// -> float | relative 
+  x, 
+
+  /// The $y$ coordinate of the origin.
+  /// -> float | relative 
+  y,
+
+  /// The content to place in the data area. 
+  /// -> any
+  body,
+
+  /// How to align the content at the origin coordinates. 
+  /// -> alignment
+  align: center + horizon,
+
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: false,
+  
+  /// Determines the $z$ position of the content in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 21,
+
+) = {
+  (
+    plot: (plot, transform) => { 
+      let (px, py) = transform-point(x, y, transform)
+      std.place(
+        dx: px, dy: py,
+        std.place(twod-ify-alignment(align), body),
+      )
+    },
+    xlimits: () => none,
+    ylimits: () => none,
+    label: none,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/plot.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/plot.typ
@@ -1,0 +1,444 @@
+#import "../logic/limits.typ": plot-lim
+#import "../process-styles.typ": merge-strokes, merge-fills
+#import "../assertations.typ"
+#import "../logic/process-coordinates.typ": filter-nan-points, stepify
+#import "../utility.typ": if-auto
+#import "../style/styling.typ": mark, prepare-mark, prepare-path
+#import "../model/errorbar.typ": errorbar
+
+#let get-errorbar-stroke(base-stroke) = {
+  if base-stroke == auto { return stroke() }
+  if base-stroke == none { return stroke() }
+  return stroke()
+  return stroke(thickness: base-stroke.thickness, paint: base-stroke.paint)
+}
+
+// Process error inputs of the form as documented in @plot.xerr. 
+#let process-errors(err, n /* basically x.len() */, kind: "x") = {
+
+  if type(err) in (int, float) {
+    err = (p: (err,) * n, m: (err,) * n)
+
+  } else if type(err) == dictionary {
+    assert(
+      "m" in err and "p" in err,
+      message: "Error bar dictionaries must contain both \"p\" and \"m\""
+    )
+    if err.keys().len() != 2 {
+      let key = err.keys().filter(x => x not in ("m", "p")).first()
+      assert(
+        false,
+        message: "Errorbar dictionary contains unexpected key \"" + key + "\", expected \"p\" and \"m\""
+      )
+    }
+
+    if type(err.m) in (int, float) {
+      err.m = (err.m,) * n
+    } else if type(err.m) == array {
+      assert(
+        err.m.len() == n,
+        message: "The length of `" + kind + "err.m` does not match the number of data points"
+      )
+    } else {
+      assert(false, message: "`" + kind + "err.m` expects a float or an array")
+    }
+    if type(err.p) in (int, float) {
+      err.p = (err.p,) * n
+    } else if type(err.p) == array {
+      assert(
+        err.p.len() == n,
+        message: "The length of `" + kind + "err.p` does not match the number of data points"
+      )
+    } else {
+      assert(false, message: "`" + kind + "err.p` expects a float or an array")
+    }
+
+  } else if type(err) == array {
+    assert(
+      err.len() == n, 
+      message: "The length of `" + kind + "err` (" + str(err.len()) + ") does not match the number of data points"
+    )
+
+    err = err.map(e => {
+      if type(e) in (int, float) { (p: e, m: e) }
+      else if type(e) == dictionary { 
+        assert("p" in e and "m" in e, message: "Errorbar dictionaries must contain both \"m\" and \"p\"")
+        e
+      }
+      else { assert(false, message: "Expected a single uncertainty or a dictionary, found " + repr(e))}
+    })
+    err = (p: err.map(e => e.p), m: err.map(e => e.m))
+
+  } else {
+    assert(
+      false, 
+      message: "`" + kind + "err` expects a float, an array, or a dictionary with the keys \"p\" and \"m\"."
+    )
+
+  }
+  err
+}
+
+
+#let render-plot(plot, transform) = {
+  let (points, runs) = filter-nan-points(plot.x.zip(plot.y), generate-runs: true)
+
+  if "make-legend" in plot {
+    runs = (((0, 0.5), (1, 0.5)),)
+    points = ((0.5, 0.5),)
+    if plot.yerr != none { plot.yerr = (p: (.5,), m: (.5,),) }
+    if plot.xerr != none { plot.xerr = (p: (.25,), m: (.25,)) }
+  }
+
+
+
+  let line = merge-strokes(plot.style.stroke, plot.style.color)
+  if line != none {
+    show: prepare-path.with(
+      stroke: line,
+      element: curve
+    )
+
+    for run in runs {
+      if run.len() == 0 { continue }
+      if plot.style.step != none { run = stepify(run, step: plot.style.step )}
+      run = run.map(p => transform(..p))
+      place(curve(
+        curve.move(run.first()),
+        ..run.slice(1).map(curve.line)
+      ))
+    }
+  }
+
+  
+
+  let get-upper-lower(value, error) = {
+    if type(error) in (float, int) { 
+      return (value - error, value + error)
+    }
+    if type(error) == array { 
+      assert.eq(error.len(), 2, message: "Individual errors need to be numbers or pairs of numbers, encountered array of length " + str(error.len()))
+      return (value - error.at(0), value + error.at(1))
+    }
+    assert(false, "Invalid type \'" + str(type(err)) + "\' for error")
+  }
+
+
+  let errorbar-stroke = prepare-path.with(
+    stroke: merge-strokes(
+      ..((dash: "solid"), plot.style.stroke, plot.style.color).filter(x => x != none)
+    )
+  )
+
+
+  let filter = {
+    let every = plot.mark.every
+    if every == 1 { none }
+    else if type(every) == int {
+      let n = plot.x.len()
+      arr => range(calc.quo(n, every)).map(i => arr.at(i * every))
+    } else if type(every) == dictionary {
+      assertations.assert-dict-keys(every, mandatory: ("n",), optional: ("start", "end"))
+      let size = plot.x.len()
+      let start = every.at("start", default: 0)
+      let end = every.at("end", default: size + 1)
+      if end < 0 { end = size + end }
+      assert(start >= 0 and start < size, message: "Invalid start index " + str(start))
+
+      arr => range(calc.quo(end - start, every.n))
+      .map(i => arr.at(i * every.n + start))
+    } else if type(every) == array {
+      arr => every.map(i => arr.at(i))
+    }
+  }
+
+  if filter != none { points = filter(points) }
+  
+
+  if plot.xerr != none {
+    show: errorbar-stroke
+
+    let (p, m) = plot.xerr
+    if filter != none { 
+      p = filter(p)
+      m = filter(m)
+    }
+    
+    points.zip(p, m).map((((x, y), p, m)) => {
+      let (p0, p1) = (transform(x - m, y), transform(x + p, y))
+
+      place(
+        dx: p0.at(0),
+        dy: p0.at(1),
+        box(width: p1.at(0) - p0.at(0), errorbar(kind: "x"))
+      )
+      
+    }).join()
+  }
+  
+  if plot.yerr != none {
+    show: errorbar-stroke
+    
+    let (p, m) = plot.yerr
+    if filter != none { 
+      p = filter(p)
+      m = filter(m)
+    }
+
+    points.zip(p, m).map((((x, y), p, m)) => {
+      let (p0, p1) = (transform(x, y - m), transform(x, y + p))
+
+      place(
+        dx: p0.at(0),
+        dy: p1.at(1),
+        box(height: p0.at(1) - p1.at(1), errorbar(kind: "y"))
+      )
+      
+    }).join()
+  }
+  
+
+  
+  show: prepare-mark.with(
+    func: plot.mark.mark, 
+    color: merge-fills(plot.style.color),
+    fill: plot.mark.fill,
+    size: plot.mark.size
+  )
+  
+  let marker = mark()
+  let transformed-points = points.map(p => transform(..p))
+  transformed-points.map(((x, y)) => place(dx: x, dy: y, marker)).join()
+
+}
+
+
+
+
+/// Standard plotting method for 2d data with lines and/or marks and optional  
+/// error bars. Points where the $x$ or $y$ coordinate is `nan` are skipped. 
+/// 
+/// ```example
+/// #let x = lq.linspace(0, 10)
+/// 
+/// #lq.diagram(
+///   lq.plot(x, x.map(x => calc.sin(x)))
+/// )
+/// ```
+/// 
+/// By default, the line and mark style is determined by the current @diagram.cycle. 
+/// However, they can be configured per plot with the options @plot.color, @plot.mark,
+/// and @plot.stroke. 
+/// 
+/// This function is also intended for creating plots with error bars. 
+/// Those can be styled through @errorbar. 
+/// 
+/// ```example
+/// #lq.diagram(
+///   lq.plot(
+///     range(8), (3, 6, 2, 6, 5, 9, 0, 4),
+///     yerr: (1, 1, .7, .8, .2, .6, .5, 1),
+///     stroke: none, 
+///     mark: "star",
+///     mark-size: 6pt
+///   )
+/// )
+/// ```
+#let plot(
+  
+  /// An array of $x$ data coordinates. Data coordinates need to be of type `int` or `float`. 
+  /// -> array
+  x, 
+  
+  /// An array of $y$ data coordinates. The number of $x$ and $y$ coordinates must match. 
+  /// -> array
+  y, 
+  
+  /// Optional errors/uncertainties for $x$ coordinates. Symmetric errors can
+  /// be specified as a
+  /// - a constant (e.g., `xerr: 1.5`) or
+  /// - an array with the same length as @plot.x for individual errors per 
+  ///   data point (e.g., `xerr: (0.5, 1, 1.5)`). 
+  /// 
+  /// Asymmetric errors can be given as
+  /// - a dictionary with the keys `p` (plus) and `m` (minus) with either a 
+  ///   constant value or arrays with the same length as @plot.x (e.g., 
+  ///   `xerr: (p: 1, m: 2)`) or
+  /// - an array of dictionaries per data point, each filled with single `p` 
+  ///   and `m` values (e.g., `xerr: ((p: 1, m: 2), (p: 2, m: 3))`). 
+  /// 
+  /// The look of the error bars can be controlled through @errorbar. 
+  /// -> none | array | dictionary
+  xerr: none,
+  
+  /// Optional errors/uncertainties for $y$ coordinates. See @plot.xerr. 
+  /// 
+  /// The look of the error bars can be controlled through @errorbar. 
+  /// -> none | array
+  yerr: none,
+  
+  /// Combined color for line and marks. See also the parameters @plot.stroke and 
+  /// @plot.mark-fill which take precedence over `color`, if set. 
+  /// -> auto | color
+  color: auto,
+  
+  /// The line style to use for this plot (takes precedence over @plot.color). 
+  /// -> auto | stroke
+  stroke: auto, 
+  
+  /// The mark to use to mark data points. This may either be a mark (such as 
+  /// `lq.mark.x`) or a registered mark string, see @mark. 
+  /// -> auto | lq.mark | string
+  mark: auto, 
+  
+  /// Size of the marks. For variable-size mark plots, use the plot type @scatter. 
+  /// -> auto | length
+  mark-size: auto,
+  
+  /// Color of the marks (takes precedence over @plot.color). 
+  /// TODO: this parameter should eventually be removed. Instead one
+  /// would be able to set mark color and stroke through
+  /// ```
+  /// #lq.diagram(
+  ///  plot(..), // normal plot
+  ///  {
+  ///    set mark(fill: red, stroke: black)
+  ///    plot(..)
+  ///  }
+  ///)
+  /// ```
+  /// This again reduces the API. `mark.size` however is common enough to deserve 
+  /// its own parameter. 
+  /// -> auto | color
+  mark-color: auto,
+  
+  /// Step mode for plotting the lines. 
+  /// - `none`: Consecutive data points are connected with a straight line. 
+  /// - `start`: The interval $(x_{i-1}, x_i]$ takes the value of $x_i$. 
+  /// - `center`: The value switches half-way between consecutive $x$ positions. 
+  /// - `end`: The interval $[x_i, x_{i+1})$ takes the value of $x_i$. 
+  ///
+  /// #details[
+  ///   ```example
+  ///   #import lilaq
+  ///
+  ///   #lq.diagram(
+  ///     lq.plot(
+  ///       range(8), (3,6,2,6,5,9,0,4),
+  ///       step: center
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> none | start | end | center
+  step: none,
+
+  /// Specifies the interval of marks to plot. This can be used to skip
+  /// marks while still drawing lines between all points.
+  /// - `none`: All marks are plotted.
+  /// - `int`: Every $n$-th mark is plotted.
+  /// - `array`: All marks with the given indices are plotted.
+  /// - `dict`: A dictionary with the keys `n`, `start` (start index), and 
+  ///   `end` (end index, negative indices count from the end) can be used 
+  ///   to specify a range of marks to plot.
+  /// 
+  /// #details[
+  ///   ```example
+  ///   #lq.diagram(
+  ///     lq.plot(
+  ///       range(20),
+  ///       range(20).map(x => x*x),
+  ///       every: 4
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> none | int | array | dict
+  every: none,
+  
+  /// The legend label for this plot. If not given, the plot will not appear in the 
+  /// legend. 
+  /// -> any
+  label: none,
+  
+  /// Whether to clip the plot to the data area. This is usually a good idea for plots 
+  /// with lines but it does also clip part of marks that lie right on an axis. 
+  /// #details[
+  ///   Comparison between clipped and non-clipped plot. 
+  ///   ```example
+  ///   #lq.diagram(
+  ///     margin: 0%,
+  ///     lq.plot(
+  ///       (1, 2, 3), (2.5, 1.9, 1.5), 
+  ///       mark: "o", 
+  ///     ),
+  ///     lq.plot(
+  ///       (1, 2, 3), (1, 2.1, 3), 
+  ///       mark: "o", 
+  ///       clip: false
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> bool
+  clip: true,
+  
+  /// Specifies the $z$ position of this plot in the order of rendered diagram 
+  /// objects. This makes it also possible to render plots in front of the axes 
+  /// which have a z-index of `2.1`. 
+  /// #details[
+  ///   In this example, the points are listed before the bars in the legend but 
+  ///   they are still drawn in front of the bars. 
+  ///   ```example
+  ///   #lq.diagram(
+  ///     legend: (position: bottom),
+  ///     lq.plot(
+  ///       (1, 2, 3, 4), (2, 3, 4, 5),
+  ///       mark-size: 10pt,
+  ///       z-index: 2.01,
+  ///       label: [Points],
+  ///     ),
+  ///     lq.bar(
+  ///       (1, 2, 3, 4), (2, 3, 4, 5),
+  ///       label: [Bars],
+  ///     )
+  ///   )
+  ///   ```
+  /// ]
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-matching-data-dimensions(x, y, fn-name: "plot")
+  
+  assert(step in (none, start, end, center))
+
+  if xerr != none { xerr = process-errors(xerr, x.len(), kind: "x") }
+  if yerr != none { yerr = process-errors(yerr, x.len(), kind: "y") }
+
+
+  (
+    x: x,
+    y: y,
+    xerr: xerr,
+    yerr: yerr,
+    label: label,
+    mark: (
+      mark: mark,
+      fill: mark-color,
+      size: mark-size,
+      every: every
+    ),
+    style: (
+      stroke: stroke,
+      color: color,
+      step: step
+    ),
+    plot: render-plot,
+    xlimits: () => plot-lim(x, err: xerr),
+    ylimits: () => plot-lim(y, err: yerr),
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/quiver.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/quiver.typ
@@ -1,0 +1,296 @@
+#import "../assertations.typ"
+#import "../logic/sample-colors.typ": sample-colors
+#import "../process-styles.typ": merge-strokes
+#import "../math.typ": vec, mesh
+#import "../utility.typ": if-auto, match, match-type
+#import "../style/styling.typ": style
+
+#import "@preview/tiptoe:0.3.0"
+
+
+
+#let render-quiver(plot, transform) = context {
+
+
+  let arrow = plot.style.arrow
+  let get-arrow-stroke = plot.style.get-arrow-stroke
+
+  if "make-legend" in plot {
+    return arrow(
+      length: 100%, 
+      stroke: get-arrow-stroke(0, 1)
+    )
+  }
+
+  let pivot = match(plot.style.pivot,
+    center, () => dir => dir.map(x => -x*0.5),
+    start, () => dir => (0, 0),
+    end, () => dir => dir.map(x => -x),
+    default: () => assert(false, message: "The argument `pivot` of `quiver` needs to be one of 'start', 'center', or 'end'")
+  )
+
+
+  for i in range(plot.x.len()) {
+    for j in range(plot.y.len()) {
+      let dir = plot.directions.at(j).at(i)
+      if dir.any(float.is-nan) { continue }
+      
+      let x = plot.x.at(i)
+      let y = plot.y.at(j)
+      dir = vec.multiply(dir, plot.scale)
+      let length = calc.sqrt(dir.map(x => x*x).sum())
+      let start = vec.add((x, y), pivot(dir))
+      let end = vec.add(start, dir)
+
+      let stroke = get-arrow-stroke(i + j*plot.x.len(), length)
+      
+      if length == 0 {
+        let (x, y) = transform(..start)
+        let radius = plot.style.thickness / 2 
+        place(
+          dx: x - radius, dy: y - radius,
+          circle(radius: radius, fill: stroke.paint)
+        )
+        continue
+      }
+
+      place(
+        arrow(
+          start: transform(..start), 
+          end: transform(..end), 
+          stroke: stroke
+        )
+      )
+    }
+  }
+}
+
+/// Creates a quiver plot for visualizing vector fields over a rectangular 
+/// coordinate grid. 
+/// 
+/// The `quiver` function takes an array of $x$- and $y$-coordinates as well as
+/// a two-dimensional array of vector directions or a mapper from `(x, y)` 
+/// pairs to direction vectors. 
+/// ```example
+/// #lq.diagram(
+///   lq.quiver(
+///     lq.arange(-2, 3),
+///     lq.arange(-2, 3),
+///     (x, y) => (x + y, y - x)
+///   )
+///  )
+/// ```
+/// By default, arrow lengths and strokes are scaled automatically to 
+/// compensate for the density of a quiver plot. 
+/// 
+/// On top, the arrows can easily be color-coded, similar to @colormesh, 
+/// see @quiver.color. 
+#let quiver(
+
+  /// A one-dimensional array of $x$ data coordinates. 
+  /// -> array
+  x, 
+  
+  /// A one-dimensional array of $y$ data coordinates. 
+  /// -> array
+  y, 
+
+  /// Direction vectors for the arrows. 
+  /// This can either be a two-dimensional array of dimensions $m×n$ 
+  /// where $m$ is the length of @quiver.x and $n$ is the length of @quiver.y, 
+  /// or a function that takes an `x` and a `y` value and returns a 
+  /// corresponding 2-dimensional vector. Masking is possible through `nan` values. 
+  /// -> array | function
+  directions,
+
+  /// How to stroke the arrows. This parameter takes precedence over 
+  /// @quiver.color. If the stroke thickness is left at `auto`, small
+  /// arrows will be drawn with a thinner line style. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// Scales the length of the arrows uniformly. If set to `auto`, the length 
+  /// is heuristically computed from the density of the coordinate grid. 
+  /// -> auto | int | float
+  scale: auto, 
+
+  /// With which part the arrows should point onto the grid coordinates, e.g., 
+  /// when set to `end`, the tip (end) of the arrow will point to the 
+  /// respective coordinates. 
+  /// 
+  /// #details[
+  ///   ```example
+  ///   #let x = lq.arange(-2, 3)
+  ///   #let y = lq.arange(-2, 3)
+  ///   #let (directions) = lq.mesh(x, y, (x, y) => (x + y, y - x))
+  /// 
+  ///   #let quiver-diagram = lq.diagram.with(
+  ///     xaxis: (tick-distance: 1),
+  ///     xlim: (-3, 3),
+  ///     ylim: (-3, 3),
+  ///     width: 4cm
+  ///   )
+  /// 
+  ///   #quiver-diagram(
+  ///     title: [`pivot: end`],
+  ///     lq.quiver(x, y, directions, pivot: end),
+  ///   )
+  ///   #quiver-diagram(
+  ///     title: [`pivot: center` (default)],
+  ///     lq.quiver(x, y, directions, pivot: center),
+  ///   )
+  ///   #quiver-diagram(
+  ///     title: [`pivot: start`],
+  ///     lq.quiver(x, y, directions, pivot: start),
+  ///   )
+  ///   ```
+  /// ]
+  /// -> start | center | end
+  pivot: end,  
+
+  /// Determines the arrow tip to use. This expects a mark as specified by
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  tip: tiptoe.stealth.with(length: 400%),
+  
+  /// Determines the arrow tail to use. This expects a mark as specified by 
+  /// the #link("https://typst.app/universe/package/tiptoe")[tiptoe package]. 
+  /// -> none | tiptoe.mark
+  toe: none,
+
+  /// How to color the arrows. This can be a single color or a two-dimensional
+  /// array with the same dimensions as @quiver or a function that receives 
+  /// `(x, y)` pairs from the given `x` and `y` coordinates and returns a 
+  /// scalar/color. 
+  /// #details[
+  ///   In this example, we make a color-coding by taking the `x` value of the
+  ///   direction vectors. 
+  ///   ```example
+  ///   #let x = lq.arange(-2, 3)
+  ///   #let y = lq.arange(-2, 3)
+  ///   #let (directions) = lq.mesh(x, y, (x, y) => (x + y, y - x))
+  /// 
+  ///   #lq.diagram(
+  ///     lq.quiver(
+  ///       x, y, 
+  ///       directions,
+  ///       color: directions.map(d => d.map(d => d.at(0)))
+  ///     ),
+  ///   )
+  ///   ```
+  /// ]
+  /// -> color | array | function
+  color: black,
+  
+  /// A color map in form of a gradient or an array of colors to sample from. 
+  /// -> array | gradient
+  map: color.map.viridis,
+
+  /// Sets the data value that corresponds to the first color of the color map. 
+  /// If set to `auto`, it defaults to the minimum color value.
+  /// -> auto | int | float
+  min: auto,
+
+  /// Sets the data value that corresponds to the last color of the color map. 
+  /// If set to `auto`, it defaults to the maximum color value.
+  /// -> auto | int | float
+  max: auto,
+
+  /// The normalization method used to scale @quiver.color scalars to the range 
+  /// $[0,1]$ before mapping them to colors using the color map. This can be a 
+  /// @scale, a string that is the identifier of a built-in scale or a function 
+  /// that takes one argument. 
+  /// -> lq.scale | str | function
+  norm: "linear",
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram 
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2
+  
+) = {
+  
+  if type(directions) == function {
+    directions = mesh(x, y, directions)
+  }
+  
+  if type(color) == function {
+    color = mesh(x, y, color)
+  }
+  
+  if type(color) == array { 
+    assert(type(color.first()) == array, message: "The argument `color` for `quiver` either needs to be a single value or a 2D array")
+    let color-flat = color.flatten()
+    assert(x.len() * y.len() == color-flat.len(), message: "The number of elements in `color` does not match the grid for `quiver()`")
+    
+    if type(color-flat.at(0, default: 0)) in (int, float) {
+      let cinfo
+      (color, cinfo) = sample-colors(color-flat, map, norm, ignore-nan: true, min: min, max: max)
+    }
+  }
+
+  if scale == auto {
+    let lengths = directions.join().map(a => calc.sqrt(a.map(b => b*b).sum()))
+    lengths = lengths.filter(x => not float.is-nan(x))
+    
+    let n = lengths.len()
+    let average = lengths.sum() / n
+    let compensation = calc.max(4., calc.pow(n, .6) * .6)
+    
+    scale = 1 / (0.54 * average * compensation)
+  }
+
+  if stroke != auto { stroke = std.stroke(stroke) }
+  
+  let thickness = match-type(
+    stroke,
+    stroke: () => if-auto(stroke.thickness, 1pt),
+    auto-type: 1pt
+  )
+
+
+  let get-stroke = {
+    if stroke != auto and stroke.thickness != auto { 
+    let p = stroke
+      (color, length) => merge-strokes(stroke, color) 
+    } else {
+    (color, length) => merge-strokes(
+      1pt*calc.clamp(4 * length, .2, 1), 
+      stroke, color
+    )
+    }
+  }
+
+  
+  let get-arrow-stroke = match-type(
+    color,
+    panic: true,
+    color: () => (i, len) => get-stroke(color, len),
+    array: () => (i, len) => get-stroke(color.at(i), len),
+  )
+  let arrow = tiptoe.line.with(tip: tip, toe: toe)
+  
+  (
+    x: x,
+    y: y,
+    directions: directions,
+    scale: scale,
+    label: label,
+    style: (
+      thickness: thickness,
+      pivot: pivot, 
+      color: color,
+      arrow: arrow,
+      get-arrow-stroke: get-arrow-stroke
+    ),
+    plot: render-quiver,
+    xlimits: () => (x.at(0), x.at(-1)),
+    ylimits: () => (y.at(0), y.at(-1)),
+    legend: true,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/rect.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/rect.typ
@@ -1,0 +1,118 @@
+#import "../assertations.typ"
+#import "../logic/limits.typ": compute-primitive-limits
+#import "../logic/process-coordinates.typ": all-data-coordinates, convert-rect
+
+
+/// Plots a rectangle or square with origin `(x, y)`. The origin coordinates as well
+/// as width and height can either be given as 
+/// - data coordinates (`int` or `float`),
+/// - or absolute coordinates from the top left corner of the data area (`length`),
+/// - or in percent relative to the data area (`ratio`),
+/// - or a combination of the latter two (`relative`).  
+/// 
+/// Note that coordinate types can also be mixed (e.g., a length for `x` and a scalar for `y`).
+/// 
+/// For example in order to access the center, you can write `(50%, 50%)`. 
+/// 
+/// ```example
+/// #lq.diagram(
+///   width: 3cm, height: 3cm,
+///   lq.rect(2, 2, width: 10, height: 4, fill: yellow),
+///   lq.rect(10, 4, width: 4, height: 4, fill: red),
+///   lq.rect(50%, 50%, width: 45%, height: 45%, stroke: blue)
+/// )
+/// ```
+/// 
+#let rect(
+  
+  /// The x coordinate of the origin.
+  /// -> float | relative 
+  x, 
+
+  /// The y coordinate of the origin.
+  /// -> float | relative 
+  y,
+
+  /// The rectangle's width. 
+  /// -> auto | float | relative
+  width: auto,
+
+  /// The rectangle's height. 
+  /// -> auto | float | relative
+  height: auto, 
+
+  /// How to fill the rectangle.  
+  /// -> none | color | gradient | tiling
+  fill: none,
+
+  /// How to stroke the rectangle.
+  /// -> auto | none | stroke
+  stroke: auto,
+
+  /// The corner rounding radius of the rectangle.  
+  /// -> relative
+  radius: 0pt,
+
+  /// How much to pad the content of the rectangle. See the built-in [`std.rect#inset`](https://typst.app/docs/reference/visualize/rect/#parameters-inset).
+  /// -> relative | dictionary
+  inset: 5pt,
+
+  /// How much to expand the rectangle beyond its defined size.
+  /// See the built-in [`std.rect#outset`](https://typst.app/docs/reference/visualize/rect/#parameters-outset).
+  /// -> relative | dictionary
+  outset: 0pt,
+
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram objects. 
+  /// See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+
+  /// An optional body to place inside the rectangle. 
+  /// -> any
+  ..body
+
+) = {
+  assertations.assert-no-named(body, fn: "rect")
+  
+  let body = body.pos().at(0, default: none)
+
+  (
+    x: x, 
+    y: y,
+    plot: (plot, transform) => { 
+      if "make-legend" in plot {
+        return std.rect(
+          width: 100%, height: 100%, 
+          fill: fill, stroke: stroke, radius: radius
+        )
+      }
+      let (x1, width, y1, height) = convert-rect(x, y, width, height, transform)
+      place(dx: x1, dy: y1, 
+        std.rect(
+          width: width, 
+          height: height, 
+          fill: fill, 
+          stroke: stroke,
+          radius: radius, 
+          inset: inset, 
+          outset: outset,
+          body
+        )
+      )
+    },
+    xlimits: compute-primitive-limits.with((x, if all-data-coordinates((x, width)) { x + width } else { x })),
+    ylimits: compute-primitive-limits.with((y, if all-data-coordinates((y, height)) { y + height } else { y })),
+    label: label,
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/plot/scatter.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/scatter.typ
@@ -1,0 +1,203 @@
+#import "../process-styles.typ": merge-strokes
+#import "../assertations.typ"
+#import "../logic/process-coordinates.typ": filter-nan-points
+#import "../logic/sample-colors.typ": sample-colors
+#import "../math.typ": minmax
+#import "../style/styling.typ": mark, prepare-mark, _auto
+#import "../utility.typ": if-auto, match-type
+
+
+
+#let render-scatter(plot, transform) = {
+  
+  let get-mark-size = match-type(
+    plot.size,
+    length: () => i => plot.size,
+    array: () => i => plot.size.at(i),
+    auto-type: () => i => auto,
+    panic: true
+  )
+  
+  let get-mark-color = match-type(
+    plot.color,
+    color: () => i => plot.color,
+    array: () => i => plot.color.at(i),
+    auto-type: () => i => _auto,
+    panic: true,
+  )
+  let get-alpha = match-type(
+    plot.alpha,
+    ratio: () => i => plot.alpha,
+    array: () => i => plot.alpha.at(i),
+    panic: true,
+  )
+  
+  let points = filter-nan-points(plot.x.zip(plot.y))
+  if "make-legend" in plot {
+    points = ((0.5,.5),)
+  }
+
+  
+  
+  show: prepare-mark.with(
+    func: plot.style.mark, 
+  )
+  set mark(stroke: plot.style.stroke)
+
+  for (i, p) in points.enumerate() {
+    let p = transform(..p)
+    
+    let size = get-mark-size(i)
+    let mark-color = get-mark-color(i)
+    
+    let options = (
+      fill: mark-color.transparentize(100% - get-alpha(i))
+    )
+    if size != auto { options.inset = size }
+    if plot.style.stroke != none { options.stroke = merge-strokes(plot.style.stroke, mark-color) }
+    
+    place(dx: p.at(0), dy: p.at(1), mark(..options))
+  }
+}
+
+
+
+
+/// Produces a scatter plot from the given coordinates. The mark size and 
+/// color can be set per point (this discerns @scatter from @plot). 
+/// 
+/// ```example
+/// #import "@preview/suiji:0.3.0"
+/// #let rng = suiji.gen-rng(33)
+/// #let (rng, x) = suiji.uniform(rng, size: 20)
+/// #let (rng, y) = suiji.uniform(rng, size: 20)
+/// #let (rng, colors) = suiji.uniform(rng, size: 20)
+/// #let (rng, sizes) = suiji.uniform(rng, size: 20)
+/// 
+/// #lq.diagram(
+///   lq.scatter(
+///     x, y, 
+///     size: sizes.map(size => 200 * size), 
+///     color: colors, 
+///     map: color.map.magma
+///   )
+/// )
+/// ```
+#let scatter(
+  
+  /// An array of $x$ coordinates. 
+  /// -> array
+  x, 
+  
+  /// An array of $y$ coordinates. The number of $x$ and $y$ coordinates must match. 
+  /// -> array
+  y, 
+  
+  /// Mark sizes as `float` values. The area of the marks will scale proportionally 
+  /// with these numbers while the actual mark size (width) will scale with 
+  /// $\sqrt(\mathrm{size})$.
+  /// -> auto | array
+  size: auto, 
+
+  /// Mark colors. The element may either be of type `color` (then the argument
+  /// @scatter.map will be ignored) or of type `float`. In the case of the 
+  /// latter, the colors will be determined by normalizing the values and passing 
+  /// them through the `map`.
+  /// -> auto | color | array
+  color: auto,
+
+  /// A color map in form of a gradient or an array of colors to sample from when 
+  /// @scatter.color is given as `float` values.  
+  /// -> array | gradient
+  map: color.map.viridis,
+
+  /// Sets the data value that corresponds to the first color of the color map. If set 
+  /// to `auto`, it defaults to the minimum value of @scatter.color.
+  /// -> auto | int | float
+  min: auto,
+
+  /// Sets the data value that corresponds to the last color of the color map. If set 
+  /// to `auto`, it defaults to the maximum value of @scatter.color.
+  /// -> auto | int | float
+  max: auto,
+
+  /// The normalization method used to scale $z$ coordinates to the range 
+  /// $[0,1]$ before mapping them to colors using the color map. This can be a 
+  /// @scale, a string that is the identifier of a built-in scale or a function 
+  /// that takes one argument (for example the argument `x => calc.log(x)` 
+  /// would be equivalent to passing `"log"`). Note that the function does not 
+  /// actually need to map the values to the interval $[0,1]$. Instead it 
+  /// describes a scaling that is applied before the data set is _linearly_ 
+  /// scaled to the interval $[0,1]$. 
+  /// -> lq.scale | str | function
+  norm: "linear",
+
+  /// The mark to use to mark data points. See @plot.mark. 
+  /// -> auto | lq.mark | string
+  mark: auto, 
+
+  /// Mark stroke. TODO: need to get rid of it
+  /// -> stroke
+  stroke: 1pt,
+
+  /// The fill opacity. TODO: maybe get rid of it, there is already color. 
+  /// -> ratio | array
+  alpha: 100%,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-matching-data-dimensions(x, y, fn-name: "scatter")
+  
+  
+  if type(size) == array { 
+    assert.eq(x.len(), size.len(), message: "Input dimensions for x (" + str(x.len()) + ") and size (" + str(size.len()) + ") don't match")
+    let size-type = type(size.at(0, default: 0))
+    if size-type in (int, float) {
+      size = size.map(x => calc.sqrt(x) * 1pt)
+    }
+  }
+  let cinfo
+  if type(color) == array { 
+    assert.eq(x.len(), color.len(), message: "Input dimensions for coordinates (" + str(x.len()) + ") and color (" + str(color.len()) + ") don't match")
+    
+    if type(color.at(0, default: 0)) in (int, float) {
+      if type(map) == array {
+        map = gradient.linear(..map)
+      }
+      (color, cinfo) = sample-colors(color, map, norm, ignore-nan: false, min: min, max: max)
+    }
+  }
+  (
+    cinfo: cinfo,
+    x: x,
+    y: y,
+    size: size,
+    color: color, 
+    alpha: alpha,
+    label: label,
+    style: (
+      mark: mark,
+      stroke: stroke,
+      map: map,
+    ),
+    plot: render-scatter,
+    xlimits: () => minmax(x),
+    ylimits: () => minmax(y),
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}
+

--- a/packages/preview/lilaq/0.2.0/src/plot/stem.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/stem.typ
@@ -1,0 +1,157 @@
+#import "../assertations.typ"
+#import "../logic/limits.typ": bar-lim
+#import "../process-styles.typ":  merge-strokes, merge-fills
+#import "../logic/process-coordinates.typ": filter-nan-points
+#import "../math.typ": minmax
+#import "../utility.typ": if-auto
+#import "../style/styling.typ": mark, prepare-mark, prepare-line
+
+#let render-stem(plot, transform) = {
+  let marker = plot.style.mark
+  let marker = mark()
+  
+  
+  let (xmin, xmax) = (plot.xlimits)()
+  
+  if "make-legend" in plot {
+    xmin = 0
+    xmax = 1
+    plot.x = (.5,)
+    plot.y = (.8,)
+    plot.base = 0
+  }
+  
+  let (x1, y0) = transform(xmin, plot.base)
+  let (x2, y0) = transform(xmax, plot.base)
+  let points = filter-nan-points(plot.x.zip(plot.y)).map(p => transform(..p))
+
+  show: prepare-mark.with(
+    func: plot.style.mark, 
+    color: merge-fills(plot.style.color),
+    size: plot.style.mark-size
+  )
+  
+    
+  {
+    
+    
+    show: prepare-line.with(
+      stroke: merge-strokes(plot.style.stroke, plot.style.color)
+    )
+    
+    
+
+    points.map(((x, y)) => place(line(start: (x, y0), end: (x, y)))).join()
+    
+  }
+
+  if plot.style.base-stroke != none {
+    set line(stroke: (cap: "square"))
+    place(line(
+      start: (x1, y0), 
+      end: (x2, y0), 
+      stroke: plot.style.base-stroke
+    ))
+  }
+  
+  points.map(((x, y)) => place(dx: x, dy: y, marker)).join()
+}
+
+
+
+
+/// Creates a vertical stem plot. 
+/// 
+/// ```example
+/// #let xs = lq.linspace(0, 10, num: 30)
+///   
+/// #lq.diagram(
+///   lq.stem(
+///     xs, 
+///     xs.map(calc.cos), 
+///     color: orange, 
+///     mark: "d",
+///     base: -0.25,
+///     base-stroke: black,
+///   )
+/// )
+/// ```
+///
+/// Also see @hstem for horizontal stem plots. 
+#let stem(
+
+  /// An array of $x$ coordinates. 
+  /// -> array
+  x, 
+  
+  /// An array of $y$ coordinates. The number of $x$ and $y$ coordinates 
+  /// must match. 
+  /// -> array
+  y, 
+
+  /// Combined color for line and marks. See also the parameters @stem.line 
+  /// and @stem.mark-color which take precedence over `color`, if set. 
+  /// -> auto | color
+  color: auto,
+  
+  /// The line style to use for this plot (takes precedence over @stem.color). 
+  /// -> auto | stroke
+  stroke: auto, 
+  
+  /// The mark to use to mark data points. See @plot.mark. 
+  /// -> lq.mark | str
+  mark: auto, 
+  
+  /// Size of the marks. 
+  /// -> length
+  mark-size: 5pt,
+  
+  /// Color of the marks (takes precedence over @stem.color). 
+  /// -> auto | color
+  mark-color: auto,
+  
+  /// Defines the $y$ coordinate of the base line.
+  /// -> int | float
+  base: 0,
+
+  /// How to stroke the base line. 
+  /// -> stroke
+  base-stroke: red,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Whether to clip the plot to the data area. See @plot.clip. 
+  /// -> bool
+  clip: true,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects. See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  assertations.assert-matching-data-dimensions(x, y, fn-name: "stem")
+  (
+    x: x,
+    y: y,
+    base: base,
+    label: label,
+    style: (
+      mark: mark,
+      color: color,
+      mark-size: mark-size,
+      mark-color: merge-fills(mark-color, color),
+      stroke: merge-strokes(stroke, color),
+      base-stroke: base-stroke
+    ),
+    plot: render-stem,
+    xlimits: () => minmax(x),
+    ylimits: () => bar-lim(y, (base,)),
+    legend: true,
+    clip: clip,
+    z-index: z-index
+  )
+}
+

--- a/packages/preview/lilaq/0.2.0/src/plot/vlines.typ
+++ b/packages/preview/lilaq/0.2.0/src/plot/vlines.typ
@@ -1,0 +1,99 @@
+
+#import "../process-styles.typ": merge-strokes
+#import "../math.typ": minmax
+
+
+
+
+#let render-vlines(plot, transform) = {
+  let min = plot.min
+  let max = plot.max
+
+  if "make-legend" in plot {
+    return std.line(length: 100%, stroke: plot.style.line)
+  }
+
+  if min == auto { min = 100% }
+  else {
+    (_, min) = transform(1, min)
+  }
+  if max == auto { max = 0% }
+  else {
+    (_, max) = transform(1, max)
+  }
+
+  for x in plot.x {
+    let (xx, _) = transform(x, 1)
+    place(line(start: (xx, min), end: (xx, max), stroke: plot.style.line))
+  }
+}
+
+
+
+/// Draws a set of vertical lines into the diagram. 
+/// ```example
+/// #lq.diagram(
+///   ylim: (0, 7),
+///   lq.vlines(1, 1.1, line: teal, label: "Indefinite"),
+///   lq.vlines(2, line: blue, min: 2, label: "Fixed start"),
+///   lq.vlines(3, line: purple, max: 2, label: "Fixed end"),
+///   lq.vlines(4, line: red, min: 1, max: 3, label: "Fixed"),
+/// )
+/// ```
+#let vlines(
+
+  /// The $x$ coordinate(s) of one or more vertical lines to draw. 
+  /// -> int | float
+  ..x, 
+
+  /// The beginning of the line as $y$ coordinate. If set to `auto`, the line will 
+  /// always start at the bottom of the diagram. 
+  /// -> auto | int | float
+  min: auto,
+  
+  /// The end of the line as $y$ coordinate. If set to `auto`, the line will 
+  /// always end at the top of the diagram. 
+  /// -> auto | int | float
+  max: auto,
+
+  /// How to stroke the lines. 
+  /// -> stroke
+  line: black,
+  
+  /// The legend label for this plot. See @plot.label. 
+  /// -> content
+  label: none,
+  
+  /// Determines the $z$ position of this plot in the order of rendered diagram
+  /// objects.  See @plot.z-index.  
+  /// -> int | float
+  z-index: 2,
+  
+) = {
+  x = x.pos()
+
+  line = merge-strokes(line)
+
+  let ylimits = none
+  if min != auto {
+    ylimits = (min, min)
+  }
+  if max != auto {
+    ylimits = (if min == auto { max } else { min }, max)
+  }
+
+  (
+    x: x,
+    min: min, 
+    max: max,
+    label: label,
+    style: (
+      line: line,
+    ),
+    plot: render-vlines,
+    xlimits: () => minmax(x),
+    ylimits: () => ylimits,
+    legend: true,
+    z-index: z-index
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/process-styles.typ
+++ b/packages/preview/lilaq/0.2.0/src/process-styles.typ
@@ -1,0 +1,158 @@
+/// Updates the first stroke with the second, i.e., returns the second stroke but all 
+/// fields that are auto are inherited from the first stroke. 
+/// If the second stroke is none, returns none. 
+#let update-stroke(stroke1, stroke2) = {
+  let if-not-auto(a, b) = if b == auto {a} else {b}
+  if stroke2 == none { return none }
+  if stroke1 == none { stroke1 = stroke() }
+  let s1 = stroke(stroke1)
+  let s2 = stroke(stroke2)
+  let paint = if-not-auto(s1.paint, s2.paint)
+  let thickness = if-not-auto(s1.thickness, s2.thickness)
+  let cap = if-not-auto(s1.cap, s2.cap)
+  let join = if-not-auto(s1.join, s2.join)
+  let dash = if-not-auto(s1.dash, s2.dash)
+  let miter-limit = if-not-auto(s1.miter-limit, s2.miter-limit)
+  return stroke(paint: paint, thickness: thickness, cap: cap, join: join, dash: dash, miter-limit: miter-limit)
+}
+
+
+
+
+/// Merge a series of fills sorted by descending priority. Fills exclude each other, 
+/// so the first fill that is not auto is returned. If all fills are
+/// `auto`, then `auto` is returned. 
+///
+/// -> auto | none | color | gradient | tiling
+#let merge-fills(
+  
+  /// The fills to merge. 
+  /// -> none | color | gradient | tiling
+  ..fills
+  
+) = {
+  let fills = fills.pos()
+  let pos = fills.position(x => x != auto)
+  if pos == none { return auto }
+  return fills.at(pos)
+}
+
+
+
+/// Merge a series of strokes sorted by descending priority.
+///
+/// -> stroke
+#let merge-strokes(
+  
+  /// The strokes to merge. 
+  /// -> none | auto | stroke | length | color | gradient | tiling | dictionary
+  ..strokes
+  
+) = {
+  let strokes = strokes.pos().filter(x => x != auto).rev()
+  return strokes.fold(stroke(), update-stroke)
+}
+
+
+
+#assert.eq(merge-fills(red, blue), red)
+#assert.eq(merge-fills(red, blue, green), red)
+#assert.eq(merge-fills(auto, blue, green), blue)
+#assert.eq(merge-fills(auto, auto, auto, black, red), black)
+#assert.eq(merge-fills(auto), auto)
+#assert.eq(merge-fills(none), none)
+
+
+#assert.eq(merge-strokes(auto), stroke())
+#assert.eq(merge-strokes(none), none)
+#assert.eq(merge-strokes(1pt), stroke(1pt))
+#assert.eq(merge-strokes(1pt, black), 1pt + black)
+#assert.eq(merge-strokes(auto, red), stroke(red))
+#assert.eq(merge-strokes(red, auto), stroke(red))
+#assert.eq(merge-strokes(red, stroke(dash: "dotted"), 4pt, 10pt), stroke(paint: red, dash: "dotted", thickness: 4pt))
+#assert.eq(merge-strokes(stroke(), 1pt, tiling("1"), red, auto, stroke()), 1pt + tiling("1"))
+#assert.eq(merge-strokes(none, stroke(), 1pt, tiling("1"), red, auto, stroke()), none)
+#assert.eq(merge-strokes(1pt, none, tiling("1"), red, auto, stroke()), stroke(1pt))
+
+
+
+/// Brings a margin argument into "normal" form, which is a dictionary with the 
+/// (all obligatory) keys `left`, `right`, `top`, and `bottom`. 
+/// The input can either be a single `ratio` or a dictionary
+/// with the possible keys
+///   - `left`, `right`, `top`, and `bottom`,
+///   - `x` and `y` for combined `left`/`right` and `top`/`bottom`, respectively,
+///   - and `rest` for all otherwise unspecified values. 
+///
+/// -> dictionary
+#let process-margin(
+  
+  /// The margin argument to process. 
+  /// -> ratio | dictionary
+  margin
+  
+) = {
+  if type(margin) == ratio {
+    (left: margin, right: margin, top: margin, bottom: margin)
+  } else if type(margin) == dictionary {
+    let rest = margin.at("rest", default: 5%)
+    if not "left" in margin { margin.left = margin.at("x", default: rest) }
+    if not "right" in margin { margin.right = margin.at("x", default: rest) }
+    if not "top" in margin { margin.top = margin.at("y", default: rest) }
+    if not "bottom" in margin { margin.bottom = margin.at("y", default: rest) }
+    margin
+  } else {
+    assert(false, message: "The type `" + str(type(margin)) + "` is not valid for margin arguments. ")
+  }
+}
+
+
+/// Makes a 2D alignment out of a 2D or 1D alignment. If the input is already a 2D 
+/// alignment, it is returned unchanged. Else, it is complemented with the respective 
+/// defaults for vertical and horizontal alignment. 
+///
+/// -> alignment
+#let twod-ify-alignment(
+  
+  /// Alignment to 2D-ify. 
+  /// -> alignment
+  alignment, 
+  
+  /// Default vertical alignment to apply if the input provides just a horizontal alignment. 
+  /// -> alignment
+  vertical: horizon, 
+
+  /// Default horizontal alignment to apply if the input provides just a vertical alignment. 
+  /// -> alignment
+  horizontal: center
+  
+) = {
+  if alignment.axis() == none { return alignment }
+  if alignment.axis() == "vertical" {
+    return alignment + horizontal
+  }
+  return alignment + vertical
+}
+
+#assert.eq(twod-ify-alignment(top + right), top + right)
+#assert.eq(twod-ify-alignment(top + left), top + left)
+#assert.eq(twod-ify-alignment(top), top + center)
+#assert.eq(twod-ify-alignment(bottom), bottom + center)
+#assert.eq(twod-ify-alignment(horizon), horizon + center)
+#assert.eq(twod-ify-alignment(left), left + horizon)
+#assert.eq(twod-ify-alignment(right), right + horizon)
+#assert.eq(twod-ify-alignment(center), center + horizon)
+#assert.eq(twod-ify-alignment(center + bottom), center + bottom)
+#assert.eq(twod-ify-alignment(right, vertical: bottom), right + bottom)
+#assert.eq(twod-ify-alignment(top, horizontal: right), top + right)
+
+
+#let process-grid-arg(grid) = {
+  if grid == none { return (stroke: none, stroke-sub: none) }
+  if grid == auto { return (:) }
+  if type(grid) == dictionary { return grid }
+  if type(grid) in (color, stroke, length) {
+    return (stroke: grid)
+  }
+}
+

--- a/packages/preview/lilaq/0.2.0/src/style/color.typ
+++ b/packages/preview/lilaq/0.2.0/src/style/color.typ
@@ -1,0 +1,1 @@
+#import "map.typ"

--- a/packages/preview/lilaq/0.2.0/src/style/cycle.typ
+++ b/packages/preview/lilaq/0.2.0/src/style/cycle.typ
@@ -1,0 +1,69 @@
+
+/// Creates a new style cycle on a given element with the specified properties.
+/// 
+/// The following example shows how to create a new style cycle with colors 
+/// alternating between `red`, `blue`, and `green`. 
+/// ```typ
+/// let cycle = lq.cycle.generic(lq.style, fill: (red, blue, green))
+/// ```
+#let generic(element, ..properties) = {
+  properties = properties.named()
+  let keys = properties.keys()
+  let values = array.zip(..properties.values())
+
+  values.map(value => it => { 
+    set element(..array.zip(keys, value).to-dict()); it 
+  })
+} 
+
+#let generic-color(..properties) = {
+  generic(style, ..properties)
+}
+
+
+
+/// Folds plotting style cycles with ascending precedence, i.e., settings from
+/// the last cycle may override settings from the preceding cycles. 
+#let fold(
+
+  /// The cycles to fold element-wise. 
+  /// -> array
+  ..cycles, 
+
+  /// How to fold cycles of different lengths. The options are:
+  /// - `"strict"`: Cycles must have the same length.
+  /// - `"shortest"`: Cycles are folded up to the last element of the shortest
+  ///   cycle.
+  /// - `"longest"`: Cycles that are too short are extended with empty elements
+  ///   to the length of longest cycle before folding them. 
+  /// - `"repeat"`: Cycles that are too short are repeated to the length of the
+  ///   longest cycle before folding them.
+  ///  
+  /// -> "shortest" | "longest" | "repeat" | "strict"
+  mode: "longest"
+
+) = {
+  cycles = cycles.pos().rev()
+
+  if mode == "strict" {
+    let lengths = cycles.map(cycle => cycle.len())
+    if lengths.dedup().len() > 1 {
+      assert(false, message: "Cycles must have the same length in strict mode")
+    }
+
+  } else if mode == "longest" {
+    let max-length = calc.max(..cycles.map(cycle => cycle.len()))
+    cycles = cycles.map(cycle => cycle + (it => it,) * (max-length - cycle.len()))
+
+  } else if mode == "repeat" {
+    let max-length = calc.max(..cycles.map(cycle => cycle.len()))
+    cycles = cycles.map(cycle => {
+      if cycle.len() == max-length { return cycle }
+      (cycle * calc.ceil(max-length / cycle.len())).slice(0, max-length)
+    })
+  }
+
+  array.zip(..cycles).map(sets => 
+    it => sets.fold(it, (it, cycle) => cycle(it))
+  )
+}

--- a/packages/preview/lilaq/0.2.0/src/style/map.typ
+++ b/packages/preview/lilaq/0.2.0/src/style/map.typ
@@ -1,0 +1,205 @@
+
+
+
+#let petroff6 = (
+  rgb(87, 144, 252),
+  rgb(248, 156, 32),
+  rgb(228, 37, 54),
+  rgb(150, 74, 139),
+  rgb(156, 156, 161),
+  rgb(122, 33, 221)
+)
+
+#let petroff8 = (
+  rgb(24, 69, 251),
+  rgb(255, 94, 2),
+  rgb(201, 31, 22),
+  rgb(200, 73, 169),
+  rgb(173, 173, 125),
+  rgb(134, 200, 221),
+  rgb(87, 141, 255),
+  rgb(101, 99, 100)
+)
+
+#let petroff10 = (
+  rgb(63, 144, 218),
+  rgb(255, 169, 14),
+  rgb(189, 31, 1),
+  rgb(148, 164, 162),
+  rgb(131, 45, 182),
+  rgb(169, 107, 89),
+  rgb(231, 99, 0),
+  rgb(185, 172, 112),
+  rgb(113, 117, 129),
+  rgb(146, 218, 221)
+)
+
+#let live2 = (
+  rgb("#048A81"),
+  rgb("#935FA7"),
+  rgb("#FF4D4D"),
+  rgb("#A0BD42"),
+  rgb("#ED8E40"),
+  rgb("#3277b4"),
+  rgb("#ed5ce8"),
+  rgb("#9fb0c1"),
+  rgb("#a05713"),
+)
+
+#let matplotlib = (
+  rgb("#1f77b4"),
+  rgb("#ff7f0e"),
+  rgb("#2ca02c"),
+  rgb("#d62728"),
+  rgb("#9467bd"),
+  rgb("#8c564b"),
+  rgb("#e377c2"),
+  rgb("#7f7f7f"),
+  rgb("#bcbd22"),
+  rgb("#17becf")
+)
+
+#let matplotlib20 = (
+  rgb("#1f77b4"),
+  rgb("#aec7e8"),
+  rgb("#ff7f0e"),
+  rgb("#ffbb78"),
+  rgb("#2ca02c"),
+  rgb("#98df8a"),
+  rgb("#d62728"),
+  rgb("#ff9896"),
+  rgb("#9467bd"),
+  rgb("#c5b0d5"),
+  rgb("#8c564b"),
+  rgb("#c49c94"),
+  rgb("#e377c2"),
+  rgb("#f7b6d2"),
+  rgb("#7f7f7f"),
+  rgb("#c7c7c7"),
+  rgb("#bcbd22"),
+  rgb("#dbdb8d"),
+  rgb("#17becf"),
+  rgb("#9edae5")
+)
+
+
+// ColorBrewer Maps
+
+#let yellow-green-blue = (
+  rgb("#ffffd9"),
+  rgb("#edf8b1"),
+  rgb("#c7e9b4"),
+  rgb("#7fcdbb"),
+  rgb("#41b6c4"),
+  rgb("#1d91c0"),
+  rgb("#225ea8"),
+  rgb("#253494"),
+  rgb("#081d58")
+)
+
+#let pink-purple = (
+  rgb("#fff7f3"),
+  rgb("#fde0dd"),
+  rgb("#fcc5c0"),
+  rgb("#fa9fb5"),
+  rgb("#f768a1"),
+  rgb("#dd3497"),
+  rgb("#ae017e"),
+  rgb("#7a0177"),
+  rgb("#49006a"),
+)
+
+#let purple-blue-green = (
+  rgb("#fff7fb"),
+  rgb("#ece2f0"),
+  rgb("#d0d1e6"),
+  rgb("#a6bddb"),
+  rgb("#67a9cf"),
+  rgb("#3690c0"),
+  rgb("#02818a"),
+  rgb("#016c59"),
+  rgb("#014636"),
+)
+
+#let white-blue = (
+  rgb("#fff7fb"),
+  rgb("#ece7f2"),
+  rgb("#d0d1e6"),
+  rgb("#a6bddb"),
+  rgb("#74a9cf"),
+  rgb("#3690c0"),
+  rgb("#0570b0"),
+  rgb("#045a8d"),
+  rgb("#023858")
+)
+
+
+#let red-white-blue = (
+  rgb("#67001f"),
+  rgb("#b2182b"),
+  rgb("#d6604d"),
+  rgb("#f4a582"),
+  rgb("#fddbc7"),
+  rgb("#f7f7f7"),
+  rgb("#d1e5f0"),
+  rgb("#92c5de"),
+  rgb("#4393c3"),
+  rgb("#2166ac"),
+  rgb("#053061")
+)
+
+#let red-yellow-blue = (
+  rgb("#a50026"),
+  rgb("#d73027"),
+  rgb("#f46d43"),
+  rgb("#fdae61"),
+  rgb("#fee090"),
+  rgb("#ffffbf"),
+  rgb("#e0f3f8"),
+  rgb("#abd9e9"),
+  rgb("#74add1"),
+  rgb("#4575b4"),
+  rgb("#313695"),
+)
+
+#let red-gray = (
+  rgb("#67001f"),
+  rgb("#b2182b"),
+  rgb("#d6604d"),
+  rgb("#f4a582"),
+  rgb("#fddbc7"),
+  rgb("#ffffff"),
+  rgb("#e0e0e0"),
+  rgb("#bababa"),
+  rgb("#878787"),
+  rgb("#4d4d4d"),
+  rgb("#1a1a1a"),
+)
+
+#let orange-purple = (
+  rgb("#7f3b08"),
+  rgb("#b35806"),
+  rgb("#e08214"),
+  rgb("#fdb863"),
+  rgb("#fee0b6"),
+  rgb("#f7f7f7"),
+  rgb("#d8daeb"),
+  rgb("#b2abd2"),
+  rgb("#8073ac"),
+  rgb("#542788"),
+  rgb("#2d004b"),
+)
+
+#let purple-green = (
+  rgb("#40004b"),
+  rgb("#762a83"),
+  rgb("#9970ab"),
+  rgb("#c2a5cf"),
+  rgb("#e7d4e8"),
+  rgb("#f7f7f7"),
+  rgb("#d9f0d3"),
+  rgb("#a6dba0"),
+  rgb("#5aae61"),
+  rgb("#1b7837"),
+  rgb("#00441b"),
+)

--- a/packages/preview/lilaq/0.2.0/src/style/styling.typ
+++ b/packages/preview/lilaq/0.2.0/src/style/styling.typ
@@ -1,0 +1,285 @@
+
+#import "../assertations.typ"
+#import "../process-styles.typ": merge-strokes, merge-fills
+#import "../utility.typ": if-none
+#import "../model/mark.typ": mark, marks
+
+#import "map.typ": petroff10
+#import "cycle.typ": generic
+
+
+#let _auto = rgb("#0000A1AA")
+
+#let style = std.circle
+
+#let process-stroke(stroke, color) = {
+  if stroke == none { return none }
+  if stroke.paint == _auto {
+    std.stroke(paint: color, thickness: stroke.thickness, cap: stroke.cap, join: stroke.join, dash: stroke.dash, miter-limit: stroke.miter-limit)
+  } else { 
+    stroke
+  }
+}
+
+
+
+#let init(body) = {
+    
+  show mark: it => {
+    let color = style.fill
+    (it.align)((
+      size: it.inset.length, 
+      fill: if it.fill == _auto { color } else { it.fill }, 
+      stroke: process-stroke(it.stroke, color),
+      color: color
+    ))
+  }
+  
+  
+  set style(fill: black)
+  set mark(fill: _auto, stroke: _auto + .7pt, align: marks.at("."), inset: 4pt)
+  body
+}
+
+
+
+
+#let prepare-path(body, stroke: auto, fill: none, element: curve) = context {
+  
+  set element(stroke: merge-strokes(style.stroke, style.fill), fill: merge-fills(fill, style.fill))
+  set element(stroke: stroke) if stroke != auto
+  body
+}
+
+#let prepare-line(body, stroke: auto) = context {
+  set line(stroke: merge-strokes(style.stroke, style.fill))
+  set line(stroke: stroke) if stroke != auto
+  body
+}
+
+#let resolve-mark(mark) = {
+  if mark == none { 
+    mark = "none" 
+  }
+
+  if type(mark) == str { 
+    if mark not in marks {
+      assert(false, message: "Unknown mark \"" + mark + "\"")
+    }
+    marks.at(mark) 
+  } else if type(mark) == function or mark == auto {
+    mark
+  } else {
+    assert(false, message: "Invalid mark " + repr(mark))
+  }
+}
+
+
+
+#let process-cycles-arg(cycle) = {
+  assert(cycle.len() > 0, message: "The style cycle for the diagram must not be empty")
+  if type(cycle.first()) == color {
+    generic(style, fill: cycle)
+  } else if type(cycle.first()) == dictionary {
+    cycle.map(c => {
+      assertations.assert-dict-keys(c, optional: ("color", "stroke", "mark"))
+      
+      it => {
+        set style(fill: c.color) if "color" in c
+        set style(stroke: c.stroke) if "stroke" in c
+        set mark(align: resolve-mark(c.mark)) if "mark" in c
+        it
+      }
+    })
+  } else {
+    cycle
+  }
+}
+
+
+
+
+#let prepare-mark(
+  body, 
+  color: auto, 
+  stroke: auto, 
+  func: auto,
+  fill: auto,
+  size: auto
+) = {
+  set style(fill: color) if color != auto
+  func = resolve-mark(func)
+  set mark(align: func) if func != auto
+  set mark(fill: fill) if fill != auto
+  set mark(inset: size) if size != auto
+  body
+}
+
+
+
+
+
+
+#show raw.where(block: true): block.with(fill: luma(95%), inset: 1em)
+#show raw.where(block: false): box.with(fill: luma(95%), outset: (y: .3em), inset: (x: .3em,), radius: .2em)
+
+#show: init
+
+
+
+
+
+== Mark sizes 
+Marks are deliberately designed to match in optical size for the same size setting. This results in the `mark.size` not giving a precise definition of the width or radius of some marks. The optical size is subjective and is influenced by a combination of the area and the dimensions of a mark. 
+
+Adjustments made:
+- The square is a bit smaller to better match the optical size of the circle. 
+- The polygons with low $n$ are drawn with a larger circumference
+- Stars are drawn a bit larger to compensate their lack of area. 
+- ... and some more. 
+- The circle mark has (at least when the stroke is set to `none`) the exact radius as given through `mark.size`
+In addition, polygons with 3, 5, and 7 sides are lowered by a fraction to improve the optical center. 
+
+
+
+
+#{
+
+  
+  let config = (size: 20pt, fill: blue, stroke: blue + 1pt)
+  marks.pairs().map(((name, mark)) => box({
+    table(
+      text(.8em, raw(name)),
+      box(
+        width: config.size*1.5, height: config.size*1.5,
+        
+        stroke: 1pt + gray,
+        {
+          set line(stroke: .5pt + gray)
+          place(line(start: (0%, 50%), length: config.size*1.5))
+          place(line(start: (50%, 0%), angle: 90deg, length: config.size*1.5))
+          place(mark(config), dx: 50%, dy: 50%)
+        }
+      )
+    )
+  })).join()
+}
+
+
+== Implementation notes and ramble
+
+Marks are essential for visualizing data. The configuration and selection of marks is therefore of greatest importance and requires a well-thought-out solution. 
+
+Things to consider:
+- Marks need a mechanism to inherit their color (both fill and stroke) from the current line style by default, so the user needs to set the color only once for both line and marks. At the same time, marks also need an option to specify their color separately. 
+- Marks need to be configurable in cycle styles (style sets that determine how consecutive calls to plot functions will be styled by default). 
+- Some default marks have a configurable parameter such as the angle or the number of spikes. 
+- It should be easy to create a custom mark shape. Marks should be just functions that get passed information about the color and stroke to be used for the mark. 
+
+For these reasons, `mark` should be a type defined as the following:
+
+#show "#type": text.with(red)
+```typc
+#type mark {
+  /// How to fill the mark. 
+  fill: auto | color | gradient | tiling = auto,
+  
+  /// How to stroke the mark. 
+  stroke: none | stroke = 1pt,
+
+  /// The size of the mark. 
+  size: length = 4pt
+  
+  /// Mark function or known mark name. 
+  mark: str | function = "o"
+}
+```
+The mark functions receive a dictionary with `size`, `fill`, and `stroke` which they can use to create the content of the mark, e.g., 
+```typ
+#let circle = mark => {
+  circle(radius: mark.size / 2, fill: mark.fill, stroke: mark.stroke)
+}
+```
+Alternatively, `mark` could always be contextual content (`any`), e.g, 
+```typ
+#let circle = context {
+  std.circle(radius: mark.size/2, fill: mark.fill, stroke: mark.stroke)
+}
+
+#show mark: it => {
+  let color = style.fill
+  set mark(
+    inset: it.inset.length, 
+    fill: if it.fill == auto { color } else { it.fill }, 
+    stroke: process-stroke(mark.stroke, color),
+  )
+  it.mark
+}
+```
+This might be yet a bit cleaner. #highlight[Actually, it's muuuuuch worse in performance. Moreover the first version can be optimized to compute many marks at once. ]
+
+
+Possible behaviors for filled marks:
+- Are by default filled *and* stroked with `color` and a `1pt` outline. 
+- Stroke and fill color can be set manually to vary from the line `color`. Setting `fill` to `none` results in an unfilled mark. 
+or
+- Are by default *only* filled
+- If `stroke: auto`, they show no stroke. 
+
+// #[
+    
+//   #set mark(align: circle)
+//   #mark()~
+//   #set style(fill: red)
+//   #mark()~
+//   #set mark(fill: orange)
+//   #mark()~
+//   #mark(fill: green)~
+//   #set mark(fill: none, stroke: .5pt)
+//   #mark()~
+//   #set mark(fill: _auto, stroke: blue)
+//   #mark()~
+// ]
+
+
+Possible behaviors for (only) stroked marks:
+- Can only be stroked
+- Are by default stroked with `color` and `1pt`. 
+- The stroke can be set manually
+or
+- If `stroke: auto` or `stroke.fill: auto` they inherit the color 
+  - firstly from `mark.fill`
+  - secondly from `style.fill`
+
+Currently, we have the first (and probably better) behavior for both. 
+// #let mymark = context {
+//   std.circle(radius: mark.inset.length/2, fill: mark.fill, stroke: mark.stroke)
+// }
+
+// #set style(fill: green)
+// #range(42000).map(x => mark()).join()
+// #range(4200).map(x => {
+//   set mark(inset: calc.sqrt(x) *.1pt, fill: green)
+//   box(mymark)}
+// ).join()
+// #range(4000).map(x => place(circle()((size: calc.sqrt(x) *.2pt, fill: green, stroke:blue)))).join()
+
+
+// #[
+    
+//   #set mark(align: cross)
+//   #mark()~
+//   #set style(fill: red)
+//   #mark()~
+//   #set mark(fill: orange)
+//   #mark()~
+//   #set mark(stroke: 1.5pt)
+//   #set mark(stroke: (cap: "round"), inset: 10pt)
+//   #mark()~
+//   #set mark(stroke: green)
+//   #mark(stroke: 2pt)~
+  
+// ]
+
+
+

--- a/packages/preview/lilaq/0.2.0/src/style/tilings.typ
+++ b/packages/preview/lilaq/0.2.0/src/style/tilings.typ
@@ -1,0 +1,30 @@
+#import "../process-styles.typ": merge-strokes
+
+
+
+#let crosses(
+  size: 30pt, stroke: 1pt
+) = tiling(size: (size, size))[
+  #place(line(start: (0%, 0%), end: (100%, 100%), stroke: stroke))
+  #place(line(start: (0%, 100%), end: (100%, 0%), stroke: stroke))
+]
+
+#let diag(
+  stroke: 3pt,
+  angle: 45deg,
+  gap: 1cm
+) = {
+  let m = calc.tan(angle)
+  let width = 90pt
+  let height = m * width
+  
+  
+  tiling(size: (width, height), {
+    stroke = merge-strokes(stroke, std.stroke(cap: "square"))
+
+    place(line(start: (0%, 0%), end: (100%, 100%), stroke: stroke))
+    place(line(start: (90%, -10%), end: (110%, 10%), stroke: stroke))
+    place(line(start: (-10%, 90%), end: (10%, 110%), stroke: stroke))
+  })
+
+}

--- a/packages/preview/lilaq/0.2.0/src/typing.typ
+++ b/packages/preview/lilaq/0.2.0/src/typing.typ
@@ -1,0 +1,20 @@
+#import "libs/elembic/lib.typ" as e: selector
+#import "model/grid.typ": grid
+#import "model/label.typ": label
+#import "model/title.typ": title
+#import "model/legend.typ": legend
+#import "model/tick.typ": tick, tick-label
+#import "model/spine.typ": spine
+#import "model/diagram.typ": diagram
+#import "model/errorbar.typ": errorbar
+
+#let set_ = e.set_
+#let set-grid = e.set_.with(grid)
+#let set-title = e.set_.with(title)
+#let set-label = e.set_.with(label)
+#let set-legend = e.set_.with(legend)
+#let set-tick = e.set_.with(tick)
+#let set-tick-label = e.set_.with(tick-label)
+#let set-spine = e.set_.with(spine)
+#let set-diagram = e.set_.with(diagram)
+#let set-errorbar = e.set_.with(errorbar)

--- a/packages/preview/lilaq/0.2.0/src/utility.typ
+++ b/packages/preview/lilaq/0.2.0/src/utility.typ
@@ -1,0 +1,73 @@
+
+
+#let place-in-out(
+  alignment,
+  content,
+  dx: 0pt, dy: 0pt,
+) = {
+  if alignment.y == top { dy *= -1 }
+  if alignment.x == right { dx *= -1 }
+  place(alignment, content, dx: dx, dy: dy)
+}
+
+
+
+#let if-auto(value, default) = if value == auto { default } else { value }
+#let if-none(value, default) = if value == none { default } else { value }
+
+#let match-type(value, ..args) = {
+  let value-type = str(type(value))
+  args = args.named()
+  let get-output(output) = {
+      if type(output) == function { return output() }
+      else { return output }
+    }
+  for (key, output) in args {
+    if key == "auto-type" { key = "auto" }
+    if key == "none-type" { key = "none" }
+    if value-type == key { 
+      return get-output(output)
+    }
+  }
+  if "default" in args { return get-output(args.default) }
+  panic("The provided value matches none of the given types. Found " + str(value-type))
+}
+
+#let match(value, ..args) = {
+  let pos-args = args.pos()
+  let get-output(output) = {
+      if type(output) == function { return output() }
+      else { return output }
+    }
+  assert(calc.even(pos-args.len()))
+  let i = 0
+  while i < pos-args.len() {
+    if value == pos-args.at(i) { 
+      return get-output(pos-args.at(i + 1))
+    }
+    i += 2
+  }
+  if "default" in args.named() { return get-output(args.named().default) }
+  panic("The provided value matches none of the given arguments")
+}
+
+
+
+#let _run-func-on-first-loc(func, label-name: "loc-tracker") = {
+  let lbl = label(label-name)
+  [#metadata(label-name)#lbl]
+  locate(loc => {
+    let use-loc = query(selector(lbl).before(loc), loc).last().location()
+    func(use-loc)
+  })
+}
+
+/// Place content at a specific location on the page relative to the top left corner
+/// of the page, regardless of margins, current container, etc.
+/// -> content
+#let absolute-place(dx: 0em, dy: 0em, content) = {
+  _run-func-on-first-loc(loc => {
+    let pos = loc.position()
+    place(dx: -pos.x + dx, dy: -pos.y + dy, content)
+  })
+}

--- a/packages/preview/lilaq/0.2.0/src/vec.typ
+++ b/packages/preview/lilaq/0.2.0/src/vec.typ
@@ -1,0 +1,66 @@
+
+/// Transforms two vectors $a, b$ of the same length with a function that 
+/// receives pairs $(a_i,b_i)$ for all $i$. 
+#let transform(
+  /// First vector. 
+  /// -> array
+  a, 
+  /// Second vector. 
+  /// -> array
+  b, 
+  /// The function to apply to each item.
+  /// -> function
+  mapper
+) = array.zip(a, b, exact: true).map(mapper)
+
+
+/// Pair-wise adds the elements of two vectors of the same length. 
+#let add(
+  /// First vector. 
+  /// -> array
+  a, 
+  /// Second vector.
+  /// -> array
+  b
+) = transform(a, b, ((x,y)) => x + y)
+
+
+/// Pair-wise subtracts the elements of two vectors of the same length. 
+#let subtract(
+  /// First vector. 
+  /// -> array
+  a, 
+  /// Second vector.
+  /// -> array
+  b
+) = transform(a, b, ((x,y)) => x - y)
+
+
+/// Multiplies all entries of a vector with a scalar. 
+#let multiply(
+  /// Vector.
+  /// -> array
+  a, 
+  /// Scalar. 
+  /// -> int | float
+  c
+) = a.map(x => x * c)
+
+
+/// Computes the inner product of two vectors. 
+#let inner(
+  /// First vector. 
+  /// -> array
+  a, 
+  /// Second vector.
+  /// -> array
+  b
+) = transform(a, b, ((x,y)) => x * y).sum()
+
+
+
+
+#assert.eq(add((1,2,3), (4,5,6)), (5,7,9))
+#assert.eq(subtract((1,2,3), (4,5,6)), (-3,-3,-3))
+#assert.eq(multiply((1,2,3), 2), (2,4,6))
+#assert.eq(inner((1,2,3), (4,5,6)), 32)

--- a/packages/preview/lilaq/0.2.0/typst.toml
+++ b/packages/preview/lilaq/0.2.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lilaq"
+version = "0.2.0"
+entrypoint = "src/lilaq.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Scientific data visualization."
+compiler = "0.13.0"
+
+repository = "https://github.com/lilaq-project/lilaq"
+keywords = ["plotting", "diagram", "axis", "matplotlib", "tikz", "pgfplots", "graph", "visualisation", "chart"]
+categories = ["visualization"]
+exclude = ["/docs/*", "/tests/*"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] an update for a package

With this release, important improvements are made to the defaults, prominently including a new default color cycle.  



Instead of a somewhat arbitrary color cycle, Lilaq now uses a thoroughly researched, highly optimized color sequence that is friendly to people with color deficiencies. This map is a result of the work of M. A. Petroff (https://arxiv.org/abs/2107.02270). 
On top, Lilaq ships a small set of color sequences, available under `lq.color.map`. 

<img src="https://github.com/user-attachments/assets/2edbf6ba-68da-4b81-b8c8-359149c9b578" width=50%>

Moreover, the default axis thickness and tick length have been reduced, resulting in a better harmony with text surrounding a diagram figure. 

The mark shapes of Lilaq are carefully designed to match in optical size, so they look good together in one plot without further adaptation. This release makes some fine adjustments to the mark sizes. Furthermore, some marks have been added and a few ones renamed (see below). 

The most important fixes in this release concern a bug that made it impossible to replace the default style cycle and an issue when first-line-indent was applied to all paragraphs. 

The full changelog can be viewed at https://lilaq.org/blog/release-0.2.0. 