### PR TITLE
callisto:0.2.2

### DIFF
--- a/packages/preview/callisto/0.2.2/README.md
+++ b/packages/preview/callisto/0.2.2/README.md
@@ -12,8 +12,8 @@ A Typst package for reading from Jupyter notebooks. It currently addresses the f
 
 The examples below illustrate the basic functionality. For more information see
 
--  the [tutorial](docs/Tutorial.md),
--  the [function reference](docs/Reference.md).
+-  the [tutorial](https://github.com/knuesel/callisto/blob/release-0.2/docs/Tutorial.md),
+-  the [function reference](https://github.com/knuesel/callisto/blob/release-0.2/docs/Reference.md).
 
 ```typst
 #import "@preview/callisto:0.2.2"
@@ -111,7 +111,7 @@ The API is centered on the following main functions:
 
 - `outputs`: takes a cell specification and returns cell outputs of the desired type (result, displays, errors, streams).
 
-The function parameters are described in detail in the [function reference](docs/Reference.md).
+The function parameters are described in detail in the [function reference](https://github.com/knuesel/callisto/blob/release-0.2/docs/Reference.md).
 
 The cell specification can be a cell index, execution count, tag, ID, metadata label, user-defined cell field or filter function. Code cells can start with header lines of the form `#| key: value`. When a notebook is processed, header lines are used to define corresponding fields in the cell metadata, and are removed from the cell source.
 


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

A small doc fix for Readme links: previously I used links relative to other pages, but I see they get converted to "raw content" links on Typst Universe. Now I use absolute links to the GitHub repo instead, so that Markdown
 files are shown properly.