### PR TITLE
update readme package version in typst universe

### DIFF
--- a/packages/preview/wrap-it/0.1.1/README.md
+++ b/packages/preview/wrap-it/0.1.1/README.md
@@ -20,9 +20,7 @@ documentation](https://github.com/ntjess/wrap-it/blob/main/docs/manual.pdf)</u><
 The easiest method is to import `wrap-it: wrap-content` from the
 `@preview` package:
 
-``` typ
-#import "@preview/wrap-it:0.1.0": wrap-content
-```
+`#import "@preview/wrap-it:0.1.1": wrap-content`
 
 # Sample use:
 


### PR DESCRIPTION
https://github.com/ntjess/wrap-it/issues/11 and https://github.com/ntjess/wrap-it/issues/9 both correctly note there is a typo in the Typst Universe readme about current `wrap-it` version. This patch only ensures the universe docs are up-to-date, so hopefully will be OK to submit without creating a version bump