### PR TITLE
Deprecate `prooftrees` package, and maybe the name?

### DIFF
--- a/packages/preview/prooftrees/0.1.0/README.md
+++ b/packages/preview/prooftrees/0.1.0/README.md
@@ -1,3 +1,13 @@
+# Prooftrees [DEPRECATED]
+
+Deprecated in favour of [curryst](https://github.com/pauladam94/curryst). 
+This package is no longer maintained and lacks many of the features of `curryst`.
+
+
+# Old Description
+
+---
+
 # Prooftrees
 
 This package is for constructing proof trees in the style of natural deduction or the sequent calculus, for `typst` `0.7.0`. Please do open issues for bugs etc :)

--- a/packages/preview/prooftrees/0.1.0/typst.toml
+++ b/packages/preview/prooftrees/0.1.0/typst.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 entrypoint = "src/prooftrees.typ"
 authors = ["david-davies <https://github.com/david-davies>"]
 license = "MIT"
-description = "Proof trees for natural deduction and type theories"
+description = "[Deprecated in favour of `curryst`; this package is no longer maintained.] Proof trees for natural deduction and type theories"
 repository = "https://github.com/david-davies/typst-prooftree"
 exclude = ["examples/"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Explain what the package does and why it's useful.

`prooftrees` is no longer maintained, and users should be forwarded to `curryst` instead.

Another point:
Since I first submitted the package, a new naming guideline for packages asks that packages not have the 'obvious' or 'canonical' names for their functionality.
I believe this package breaks that guideline, as new users will likely unwittingly find `prooftrees` before the other more useful (and maintained) libraries.

I'm not sure what the best solution to this would be.

Thanks,
David

