### PR TITLE
oxifmt:0.3.0

### DIFF
--- a/packages/preview/oxifmt/0.3.0/LICENSE
+++ b/packages/preview/oxifmt/0.3.0/LICENSE
@@ -1,0 +1,1 @@
+MIT OR Apache-2.0

--- a/packages/preview/oxifmt/0.3.0/LICENSE-APACHE
+++ b/packages/preview/oxifmt/0.3.0/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 PgBiel
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/preview/oxifmt/0.3.0/LICENSE-MIT
+++ b/packages/preview/oxifmt/0.3.0/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PgBiel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/oxifmt/0.3.0/README.md
+++ b/packages/preview/oxifmt/0.3.0/README.md
@@ -1,0 +1,302 @@
+# typst-oxifmt (v0.3.0)
+
+A Typst library that brings convenient string formatting and interpolation through the `strfmt` function. Its syntax is taken directly from Rust's `format!` syntax, so feel free to read its page for more information (https://doc.rust-lang.org/std/fmt/); however, this README should have enough information and examples for all expected uses of the library. Only a few things aren't supported from the Rust syntax, such as the `p` (pointer) format type, or the `.*` precision specifier. Check out the ["Examples" section](#examples) for more.
+
+A few extras (beyond the Rust-like syntax) will be added over time, though (feel free to drop suggestions at the repository: https://github.com/PgBiel/typst-oxifmt). The first "extra" so far is the `fmt-decimal-separator: "string"` parameter, which lets you customize the decimal separator for decimal numbers (floats) inserted into strings. E.g. `strfmt("Result: {}", 5.8, fmt-decimal-separator: ",")` will return the string `"Result: 5,8"` (comma instead of dot). We also provide thousands separator support with `fmt-thousands-separator: "_"` for example. See more at ["Custom options"](#custom-options).
+
+**Compatible with:** [Typst](https://github.com/typst/typst) v0.7.0+
+
+## Quick examples
+
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+// "User John has 10 apples."
+#strfmt("User {} has {} apples.", "John", 10)
+
+// "if exp > 100 { true }"
+#strfmt("if {var} > {num} {{ true }}", var: "exp", num: 100)
+
+// "1.10e2 meters"
+#strfmt("{:.2e} meters", 110.0)
+
+// "20_000 players have more than +002,300 points."
+#strfmt(
+  "{} players have more than {:+08.3} points.",
+  20000,
+  2.3,
+  fmt-decimal-separator: ",",
+  fmt-thousands-separator: "_"
+)
+
+// "The byte value is 0x8C or 10001100"
+#strfmt("The byte value is {:#02X} or {0:08b}", 140)
+```
+
+## Table of Contents
+
+- [Usage](#usage)
+    - [Formatting options](#formatting-options)
+    - [Examples](#examples)
+    - [Custom options](#custom-options)
+    - [Grammar](#grammar)
+- [Issues and Contributing](#issues-and-contributing)
+- [Testing](#testing)
+- [Changelog](#changelog)
+- [License](#license)
+
+## Usage
+
+You can use this library through Typst's package manager (for Typst v0.6.0+):
+
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+```
+
+For older Typst versions, download the `oxifmt.typ` file either from Releases or directly from the repository. Then, move it to your project's folder, and write at the top of your Typst file(s):
+
+```typ
+#import "oxifmt.typ": strfmt
+```
+
+Doing the above will give you access to the main function provided by this library (`strfmt`), which accepts a format string, followed by zero or more replacements to insert in that string (according to `{...}` formats inserted in that string), an optional `fmt-decimal-separator` parameter, and returns the formatted string, as described below.
+
+Its syntax is almost identical to Rust's `format!` (as specified here: https://doc.rust-lang.org/std/fmt/). You can escape formats by duplicating braces (`{{` and `}}` become `{` and `}`). Here's an example (see more examples in the file `tests/strfmt-tests.typ`):
+
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("I'm {}. I have {num} cars. I'm {0}. {} is {{cool}}.", "John", "Carl", num: 10)
+#assert.eq(s, "I'm John. I have 10 cars. I'm John. Carl is {cool}.")
+```
+
+Note that `{}` extracts positional arguments after the string sequentially (the first `{}` extracts the first one, the second `{}` extracts the second one, and so on), while `{0}`, `{1}`, etc. will always extract the first, the second etc. positional arguments after the string. Additionally, `{bananas}` will extract the named argument "bananas".
+
+### Formatting options
+
+You can use `{:spec}` to customize your output. See the Rust docs linked above for more info, but a summary is below.
+
+(You may also want to check out the examples at [Examples](#examples).)
+
+- Adding a `?` at the end of `spec` (that is, writing e.g. `{0:?}`) will call `repr()` to stringify your argument, instead of `str()`. Note that this only has an effect if your argument is a string, an integer, a float or a `label()` / `<label>` - for all other types (such as booleans or elements), `repr()` is always called (as `str()` is unsupported for those).
+    - For strings, `?` (and thus `repr()`) has the effect of printing them with double quotes. For floats, this ensures a `.0` appears after it, even if it doesn't have decimal digits. For integers, this doesn't change anything. Finally, for labels, the `<label>` (with `?`) is printed as `<label>` instead of `label`.
+    - **TIP:** Prefer to always use `?` when you're inserting something that isn't a string, number or label, in order to ensure consistent results even if the library eventually changes the non-`?` representation.
+- After the `:`, add e.g. `_<8` to align the string to the left, padding it with as many `_`s as necessary for it to be at least `8` characters long (for example). Replace `<` by `>` for right alignment, or `^` for center alignment. (If the `_` is omitted, it defaults to ' ' (aligns with spaces).)
+    - If you prefer to specify the minimum width (the `8` there) as a separate argument to `strfmt` instead, you can specify `argument$` in place of the width, which will extract it from the integer at `argument`. For example, `_^3$` will center align the output with `_`s, where the minimum width desired is specified by the fourth positional argument (index `3`), as an integer. This means that a call such as `strfmt("{:_^3$}", 1, 2, 3, 4)` would produce `"__1__"`, as `3$` would evaluate to `4` (the value at the fourth positional argument/index `3`). Similarly, `named$` would take the width from the argument with name `named`, if it is an integer (otherwise, error).
+- **For numbers:**
+    - Specify `+` after the `:` to ensure zero or positive numbers are prefixed with `+` before them (instead of having no sign). `-` is also accepted but ignored (negative numbers always specify their sign anyways).
+    - Use something like `:09` to add zeroes to the left of the number until it has at least 9 digits / characters.
+        - The `9` here is also a width, so the same comment from before applies (you can add `$` to take it from an argument to the `strfmt` function).
+    - Use `:.5` to ensure your float is represented with 5 decimal digits of precision (zeroes are added to the right if needed; otherwise, it is rounded, **not truncated**).
+        - Note that floating point inaccuracies can be sometimes observed here, which is an unfortunate current limitation.
+        - Similarly to `width`, the precision can also be specified via an argument with the `$` syntax: `.5$` will take the precision from the integer at argument number 5 (the sixth one), while `.test$` will take it from the argument named `test`.
+    - **Integers only:** Add `x` (lowercase hex) or `X` (uppercase) at the end of the `spec` to convert the number to hexadecimal. Also, `b` will convert it to binary, while `o` will convert to octal.
+        - Specify a hashtag, e.g. `#x` or `#b`, to prepend the corresponding base prefix to the base-converted number, e.g. `0xABC` instead of `ABC`.
+    - Add `e` or `E` at the end of the `spec` to ensure the number is represented in scientific notation (with `e` or `E` as the exponent separator, respectively).
+    - For decimal numbers (floats), you can specify `fmt-decimal-separator: ","` to `strfmt` to have the decimal separator be a comma instead of a dot, for example.
+        - To have this be the default, you can alias `strfmt`, such as using `#let strfmt = strfmt.with(fmt-decimal-separator: ",")`.
+    - You can enable thousands separators for numbers with `fmt-thousands-separator: "_"` to separate with an underscore, for example.
+    - By default, thousands separators are inserted after every third digit from the end of the number. Use `fmt-thousands-count: 2` to change that to every second digit as an example.
+    - Number spec arguments (such as `.5`) are ignored when the argument is not a number, but e.g. a string, even if it looks like a number (such as `"5"`).
+- Note that all spec arguments above **have to be specified in order** - if you mix up the order, it won't work properly!
+    - Check the grammar below for the proper order, but, in summary: fill (character) with align (`<`, `>` or `^`) -> sign (`+` or `-`) -> `#` -> `0` (for 0 left-padding of numbers) -> width (e.g. `8` from `08` or `9` from `-<9`) -> `.precision` -> spec type (`?`, `x`, `X`, `b`, `o`, `e`, `E`)).
+
+Some examples:
+
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s1 = strfmt("{0:?}, {test:+012e}, {1:-<#8x}", "hi", -74, test: 569.4)
+#assert.eq(s1, "\"hi\", +00005.694e2, -0x4a---")
+
+#let s2 = strfmt("{:_>+11.5}", 59.4)
+#assert.eq(s2, "__+59.40000")
+
+#let s3 = strfmt("Dict: {:!<10?}", (a: 5))
+#assert.eq(s3, "Dict: (a: 5)!!!!")
+```
+
+### Examples
+
+- **Inserting labels, text and numbers into strings:**
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("First: {}, Second: {}, Fourth: {3}, Banana: {banana} (brackets: {{escaped}})", 1, 2.1, 3, label("four"), banana: "Banana!!")
+#assert.eq(s, "First: 1, Second: 2.1, Fourth: four, Banana: Banana!! (brackets: {escaped})")
+```
+
+- **Forcing `repr()` with `{:?}`** (which adds quotes around strings, and other things - basically represents a Typst value):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("The value is: {:?} | Also the label is {:?}", "something", label("label"))
+#assert.eq(s, "The value is: \"something\" | Also the label is <label>")
+```
+
+- **Inserting other types than numbers and strings** (for now, they will always use `repr()`, even without `{...:?}`, although that is more explicit):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("Values: {:?}, {1:?}, {stuff:?}", (test: 500), ("a", 5.1), stuff: [a])
+#assert.eq(s, "Values: (test: 500), (\"a\", 5.1), [a]")
+```
+
+- **Padding to a certain width with characters:** Use `{:x<8}`, where `x` is the **character to pad with** (e.g. space or `_`, but can be anything), `<` is the **alignment of the original text** relative to the padding (can be `<` for left aligned (padding goes to the right), `>` for right aligned (padded to its left) and `^` for center aligned (padded at both left and right)), and `8` is the **desired total width** (padding will add enough characters to reach this width; if the replacement string already has this width, no padding will be added):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("Left5 {:-<5}, Right6 {:=>6}, Center10 {centered: ^10?}, Left3 {tleft:_<3}", "xx", 539, tleft: "okay", centered: [a])
+#assert.eq(s, "Left5 xx---, Right6 ===539, Center10     [a]    , Left3 okay")
+// note how 'okay' didn't suffer any padding at all (it already had at least the desired total width).
+```
+
+- **Padding numbers with zeroes to the left:** It's a similar functionality to the above, however you write `{:08}` for 8 characters (for instance) - note that any characters in the number's representation matter for width (including sign, dot and decimal part):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("Left-padded7 numbers: {:07} {:07} {:07} {3:07}", 123, -344, 44224059, 45.32)
+#assert.eq(s, "Left-padded7 numbers: 0000123 -000344 44224059 0045.32")
+```
+
+- **Defining padding-to width using parameters, not literals:** If you want the desired replacement width (the `8` in `{:08}` or `{: ^8}`) to be passed via parameter (instead of being hardcoded into the format string), you can specify `parameter$` in place of the width, e.g. `{:02$}` to take it from the third positional parameter, or `{:a>banana$}` to take it from the parameter named `banana` - note that the chosen parameter **must be an integer** (desired total width):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("Padding depending on parameter: {0:02$} and {0:a>banana$}", 432, 0, 5, banana: 9)
+#assert.eq(s, "Padding depending on parameter: 00432 aaaaaa432")  // widths 5 and 9
+```
+
+- **Displaying `+` on positive numbers:** Just add a `+` at the "beginning", i.e., before the `#0` (if either is there), or after the custom fill and align (if it's there and not `0` - see [Grammar](#grammar) for the exact positioning), like so:
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("Some numbers: {:+} {:+08}; With fill and align: {:_<+8}; Negative (no-op): {neg:+}", 123, 456, 4444, neg: -435)
+#assert.eq(s, "Some numbers: +123 +0000456; With fill and align: +4444___; Negative (no-op): -435")
+
+```
+
+- **Converting numbers to bases 2, 8 and 16:** Use one of the following specifier types (i.e., characters which always go at the very end of the format): `b` (binary), `o` (octal), `x` (lowercase hexadecimal) or `X` (uppercase hexadecimal). You can also add a `#` between `+` and `0` (see the exact position at the [Grammar](#grammar)) to display a **base prefix** before the number (i.e. `0b` for binary, `0o` for octal and `0x` for hexadecimal):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("Bases (10, 2, 8, 16(l), 16(U):) {0} {0:b} {0:o} {0:x} {0:X} | W/ prefixes and modifiers: {0:#b} {0:+#09o} {0:_>+#9X}", 124)
+#assert.eq(s, "Bases (10, 2, 8, 16(l), 16(U):) 124 1111100 174 7c 7C | W/ prefixes and modifiers: 0b1111100 +0o000174 ____+0x7C")
+```
+
+- **Picking float precision (right-extending with zeroes):** Add, at the end of the format (just before the spec type (such as `?`), if there's any), either `.precision` (hardcoded, e.g. `.8` for 8 decimal digits) or `.parameter$` (taking the precision value from the specified parameter, like with `width`):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("{0:.8} {0:.2$} {0:.potato$}", 1.234, 0, 2, potato: 5)
+#assert.eq(s, "1.23400000 1.23 1.23400")
+```
+
+- **Scientific notation:** Use `e` (lowercase) or `E` (uppercase) as specifier types (can be combined with precision):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("{0:e} {0:E} {0:+.9e} | {1:e} | {2:.4E}", 124.2312, 50, -0.02)
+#assert.eq(s, "1.242312e2 1.242312E2 +1.242312000e2 | 5e1 | -2.0000E-2")
+```
+
+### Custom options
+
+Oxifmt has some additional formatting options laid on top of Rust's, listed below with examples:
+
+- **Customizing the decimal separator on floats:** Just specify `fmt-decimal-separator: ","` (comma as an example):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("{0} {0:.6} {0:.5e}", 1.432, fmt-decimal-separator: ",")
+#assert.eq(s, "1,432 1,432000 1,43200e0")
+```
+
+- **Displaying thousands separators on numbers:** Specify `fmt-thousands-separator: "_"` (underscore as an example - the default is `""` which disables the feature):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("{}", 20000, fmt-thousands-separator: "_")
+#assert.eq(s, "20_000")
+```
+
+- **Customizing the distance between thousands separators:** Specify `fmt-thousands-count: 2` (2 as an example - the default is 3):
+```typ
+#import "@preview/oxifmt:0.3.0": strfmt
+
+#let s = strfmt("{}", 20000, fmt-thousands-count: 2, fmt-thousands-separator: "_")
+#assert.eq(s, "2_00_00")
+```
+
+### Grammar
+
+Here's the grammar specification for valid format `spec`s (in `{name:spec}`), which is basically Rust's format:
+
+```
+format_spec := [[fill]align][sign]['#']['0'][width]['.' precision]type
+fill := character
+align := '<' | '^' | '>'
+sign := '+' | '-'
+width := count
+precision := count | '*'
+type := '' | '?' | 'x?' | 'X?' | identifier
+count := parameter | integer
+parameter := argument '$'
+```
+
+Note, however, that precision of type `.*` is not supported yet and will raise an error.
+
+## Issues and Contributing
+
+Please report any issues or send any contributions (through pull requests) to the repository at https://github.com/PgBiel/typst-oxifmt
+
+## Testing
+
+If you wish to contribute, you may clone the repository and test this package with the following commands (from the project root folder):
+
+```sh
+git clone https://github.com/PgBiel/typst-oxifmt
+cd typst-oxifmt/tests
+typst c strfmt-tests.typ --root ..
+```
+
+The tests succeeded if you received no error messages from the last command (please ensure you're using a supported Typst version).
+
+## Changelog
+
+### v0.3.0
+
+- **Breaking change:** Named replacements prefixed with `fmt-` are now an error. Those are reserved for future `oxifmt` options. ([Issue #15](https://github.com/PgBiel/typst-oxifmt/issues/15))
+  - For example, instead of `strfmt("{fmt-x}", fmt-x: 10)`, write `strfmt("{_fmt-x}, _fmt-x: 10")` instead (or some other name with a different prefix).
+- Added thousands separator support, configurable with `strfmt(format, fmt-thousands-count: 3, fmt-thousands-separator: "")`. The first option defines how many digits should appear between each separator, and the second option controls the separator itself (default is empty string, disabling it). ([Issue #5](https://github.com/PgBiel/typst-oxifmt/issues/5))
+  - For example, `strfmt("{}", 2000, fmt-thousands-separator: ",")` displays `"2,000"`.
+  - Within the same example, adding `fmt-thousands-count: 2` would display `20,00` instead.
+  - Numeric systems with irregular thousands separator distances will be supported in a future release.
+- Added support for numeric formatting of [fixed-point `decimal` numbers](https://typst.app/docs/reference/foundations/decimal/). They support the same format specifiers as floats, e.g. `{:e}` for exponential notation, `{:.3}` for a fixed precision and so on. ([Issue #11](https://github.com/PgBiel/typst-oxifmt/issues/11))
+- oxifmt is now dual-licensed as MIT or Apache-2.0 (previously just MIT).
+- Fixed some bugs when formatting `inf` and `NaN`.
+- Fixed a rare case of wrong usage of types in strings in internal code, which could cause oxifmt to generate an error in upcoming Typst v0.14. **It is recommended to upgrade oxifmt to avoid this problem.**
+  - However, this was only triggered when a very rare formatting option was used (dynamic precision specifiers, which have a dollar sign `$`, e.g. `{:.prec$}`), so existing code is unlikely to be affected. Still a good idea to upgrade, though.
+- Fixed exponential notation formatting with very large numbers. Note that they might need rounding to look good (e.g. `strfmt("{:.2e}", number)` instead of just `{:e}`), but they will no longer cause an error. ([Issue #16](https://github.com/PgBiel/typst-oxifmt/issues/16))
+
+### v0.2.1
+
+- Fixed formatting of UTF-8 strings. Before, strings with multi-byte UTF-8 codepoints would cause formatting inconsistencies or even crashes. ([Issue #6](https://github.com/PgBiel/typst-oxifmt/issues/6))
+- Fixed an inconsistency in negative number formatting. Now, it will always print a regular hyphen (e.g. '-2'), which is consistent with Rust's behavior; before, it would occasionally print a minus sign instead (as observed in a comment to [Issue #4](https://github.com/PgBiel/typst-oxifmt/issues/4)).
+- Added compatibility with Typst 0.8.0's new type system.
+
+### v0.2.0
+
+- The package's name is now `oxifmt`!
+- `oxifmt:0.2.0` is now available through Typst's Package Manager! You can now write `#import "@preview/oxifmt:0.2.0": strfmt` to use the library.
+- Greatly improved the README, adding a section for common examples.
+- Fixed negative numbers being formatted with two minus signs.
+- Fixed custom precision of floats not working when they are exact integers.
+
+### v0.1.0
+
+- Initial release, added `strfmt`.
+
+## License
+
+Licensed under MIT or Apache-2.0, at your option.

--- a/packages/preview/oxifmt/0.3.0/oxifmt.typ
+++ b/packages/preview/oxifmt/0.3.0/oxifmt.typ
@@ -1,0 +1,710 @@
+// oxifmt v0.2.1
+
+// For compatibility with pre-0.8.0 Typst types, which were strings
+#let _int-type = type(0)
+#let _float-type = type(5.5)
+#let _str-type = type("")
+#let _label-type = type(<hello>)
+
+#let _minus-sign = "\u{2212}"
+#let using-080 = type(type(5)) != _str-type
+#let using-090 = using-080 and str(-1).codepoints().first() == _minus-sign
+#let using-0110 = using-090 and sys.version >= version(0, 11, 0)
+#let using-0120 = using-090 and sys.version >= version(0, 12, 0)
+
+#let _decimal = if using-0120 { decimal } else { none }
+
+#let _arr-chunks = if using-0110 {
+  array.chunks
+} else {
+  (arr, chunks) => {
+    let i = 0
+    let res = ()
+    for element in arr {
+      if i == 0 {
+        res.push(())
+        i = chunks
+      }
+      res.last().push(element)
+      i -= 1
+    }
+    res
+  }
+}
+
+#let _float-is-nan = if using-0110 {
+  float.is-nan
+} else {
+  x => type(x) == _float-type and "NaN" in repr(x)
+}
+
+#let _float-is-infinite = if using-0110 {
+  float.is-infinite
+} else {
+  x => type(x) == _float-type and "inf" in repr(x)
+}
+
+#let _strfmt_formatparser(s) = {
+  if type(s) != _str-type {
+    panic("String format parsing internal error: String format parser given non-string.")
+  }
+  let result = ()
+  let codepoints = s.codepoints()
+
+  // -- parsing state --
+  let current-fmt-span = none
+  let current-fmt-name = none
+  // if the last character was an unescaped {
+  let last-was-lbracket = false
+  // if the last character was an unescaped }
+  let last-was-rbracket = false
+
+  // -- procedures --
+  let write-format-span(last-i, result, current-fmt-span, current-fmt-name) = {
+    current-fmt-span.at(1) = last-i + 1  // end index
+    result.push((format: (name: current-fmt-name, span: current-fmt-span)))
+    current-fmt-span = none
+    current-fmt-name = none
+    (result, current-fmt-span, current-fmt-name)
+  }
+
+  // -- errors --
+  let excessive-lbracket() = {
+    panic("String format parsing error: Inserted a second, non-escaped { inside a {format specifier}. Did you forget to insert a } somewhere, or to escape the { with {{?")
+  }
+  let excessive-rbracket() = {
+    panic("String format parsing error: Inserted a stray } (doesn't match any { from before). Did you forget to insert a { somewhere, or to escape the } with }}?")
+  }
+  let missing-rbracket() = {
+    panic("String format parsing error: Reached end of string with an open format specifier {, but without a closing }. Did you forget to insert a right bracket, or to escape the { with {{?")
+  }
+
+  // -- parse loop --
+  let last-i = none
+  let i = 0
+  for character in codepoints {
+    if character == "{" {
+      // double l-bracket = escape
+      if last-was-lbracket {
+        last-was-lbracket = false  // escape {{
+        last-was-rbracket = false
+        if current-fmt-span.at(0) == last-i {
+          current-fmt-span = none  // cancel this span
+          current-fmt-name = none
+        }
+        if current-fmt-name != none {
+          // if in the middle of a larger span ({ ... {{ <-):
+          // add the escaped character to the format name
+          current-fmt-name += character
+        } else {
+          // outside a span ({...} {{ <-) => emit an 'escaped' token
+          result.push((escape: (escaped: "{", span: (last-i, i + 1))))
+        }
+
+        last-i = i
+        i += 1  // '{' is ASCII, so 1 byte
+        continue
+      }
+      if last-was-rbracket {
+        // { ... }{ <--- ok, close the previous span
+        (result, current-fmt-span, current-fmt-name) = write-format-span(last-i, result, current-fmt-span, current-fmt-name)
+        last-was-rbracket = false
+      }
+      if current-fmt-span == none {
+        // begin span
+        current-fmt-span = (i, none)
+        current-fmt-name = ""
+      }
+      last-was-lbracket = true
+    } else if character == "}" {
+      last-was-lbracket = false
+      if last-was-rbracket {
+        last-was-rbracket = false  // escape }}
+        if current-fmt-name != none {
+          current-fmt-name += character
+        } else {
+          result.push((escape: (escaped: "}", span: (last-i, i + 1))))
+        }
+
+        last-i = i
+        i += 1  // '}' is ASCII, so 1 byte
+        continue
+      }
+      // delay closing the span to the next iteration
+      // in case this is an escaped }
+      last-was-rbracket = true
+    } else {
+      // { ... {A  <--- non-escaped { inside larger {}
+      if last-was-lbracket and (current-fmt-span != none and current-fmt-span.at(0) != last-i) {
+        excessive-lbracket()
+      }
+      if last-was-rbracket {
+        if current-fmt-span == none {
+          // {...} }A <--- non-escaped } with no matching {
+          excessive-rbracket()
+        } else {
+          // { ... }A <--- ok, close the previous span
+          (result, current-fmt-span, current-fmt-name) = write-format-span(last-i, result, current-fmt-span, current-fmt-name)
+        }
+      }
+      // {abc <--- add character to the format name
+      if current-fmt-name != none {
+        current-fmt-name += character
+      }
+      last-was-lbracket = false
+      last-was-rbracket = false
+    }
+
+    last-i = i
+    i += character.len() // index must be in bytes, and a UTF-8 codepoint can have more than one byte
+  }
+  // { ...
+  if current-fmt-span != none {
+    if last-was-rbracket {
+      // ... } <--- ok, close span
+      (result, current-fmt-span, current-fmt-name) = write-format-span(last-i, result, current-fmt-span, current-fmt-name)
+    } else {
+      // {abcd| <--- string ended with unclosed span
+      missing-rbracket()
+    }
+  }
+
+  result
+}
+
+#let _strfmt_parse-fmt-name(name) = {
+  // {a:b} => separate 'a' from 'b'
+  // (also accepts {a}, {}, {0}, {:...})
+  let (name, ..extras) = name.split(":")
+  let name = if type(name) != _str-type {
+    name
+  } else if name == "" {
+    none
+  } else if name.codepoints().all(x => x == "0" or x == "1" or x == "2" or x == "3" or x == "4" or x == "5" or x == "6" or x == "7" or x == "8" or x == "9") {
+    int(name)
+  } else {
+    name
+  }
+  (name, extras.join())
+}
+
+#let _strfmt_is-numeric-type(obj) = {
+  type(obj) in (_int-type, _float-type, _decimal)
+}
+
+#let _strfmt_stringify(obj) = {
+  if type(obj) == _float-type {
+    if _float-is-infinite(obj) {
+      // Fix 0.12.0 inf string inconsistency
+      if obj < 0 { "-" } else { "" } + "inf"
+    } else {
+      // Fix negative sign not being a hyphen
+      // for consistency with our rich formatting output
+      str(obj).replace("\u{2212}", "-")
+    }
+  } else if type(obj) == _int-type {
+    str(obj).replace("\u{2212}", "-")
+  } else if type(obj) in (_label-type, _str-type, _decimal) {
+    str(obj)
+  } else {
+    repr(obj)
+  }
+}
+
+#let _strfmt_display-radix(num, radix, signed: true, lowercase: false) = {
+  let num = int(num)
+  if type(radix) != _int-type or num == 0 or radix <= 1 {
+    return "0"
+  }
+
+  // Note: only integers are accepted here, so no need to check for decimal signed zero
+  let sign = if num < 0 and signed { "-" } else { "" }
+  let num = calc.abs(num)
+  let radix = calc.min(radix, 16)
+  let digits = if lowercase {
+    ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f")
+  } else {
+    ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F")
+  }
+  let result = ""
+
+  while (num > 0) {
+    let quot = calc.quo(num, radix)
+    let rem = calc.floor(calc.rem(num, radix))
+    let digit = digits.at(rem)
+    result = digit + result
+    num = quot
+  }
+
+  sign + result
+}
+
+#let _strfmt_with-precision(num, precision) = {
+  if precision == none {
+    return _strfmt_stringify(num)
+  }
+  let result = _strfmt_stringify(calc.round(if type(num) == _decimal { num } else { float(num) }, digits: calc.min(50, precision)))
+  let digits-match = result.match(regex("^\\d+\\.(\\d+)$"))
+  let digits-len-diff = 0
+  if digits-match != none and digits-match.captures.len() > 0 {
+    // get the digits capture group; its length will be digit amount
+    let digits = digits-match.captures.first()
+    digits-len-diff = precision - digits.len()
+  } else if "." not in result {  // 5.0 or something
+    // 0 digits! Difference will be exactly 'precision'
+    digits-len-diff = precision
+  }
+
+  // add missing zeroes for precision
+  if digits-len-diff > 0 {
+    if "." not in result {
+      result += "."  // decimal separator missing
+    }
+    result += "0" * digits-len-diff
+  }
+
+  result
+}
+
+#let _strfmt_exp-format(num, exponent-sign: "e", precision: none) = {
+  assert(_strfmt_is-numeric-type(num), message: "String formatter internal error: Cannot convert '" + repr(num) + "' to a number to obtain its scientific notation representation.")
+
+  if type(num) == _decimal {
+    // Normalize signed zero
+    let num = if num == 0 { _decimal("0") } else { num }
+    let (integral, ..fractional) = str(num).split(".")
+    // Normalize decimals with larger scales than is needed
+    let fractional = fractional.sum(default: "").trim("0", at: end)
+    let (integral, fractional, exponent) = if num > -1 and num < 1 and fractional != "" {
+      let first-non-zero = fractional.position("1")
+      if first-non-zero == none { first-non-zero = fractional.position("2") }
+      if first-non-zero == none { first-non-zero = fractional.position("3") }
+      if first-non-zero == none { first-non-zero = fractional.position("4") }
+      if first-non-zero == none { first-non-zero = fractional.position("5") }
+      if first-non-zero == none { first-non-zero = fractional.position("6") }
+      if first-non-zero == none { first-non-zero = fractional.position("7") }
+      if first-non-zero == none { first-non-zero = fractional.position("8") }
+      if first-non-zero == none { first-non-zero = fractional.position("9") }
+      assert(first-non-zero != none, message: "String formatter internal error: expected non-zero fractional digit")
+
+      // Integral part is zero
+      // Convert 0.00012345 -> 1.2345
+      // Position of first non-zero is the amount of zeroes - 1
+      // (e.g. above, position of 1 is 3 => 3 zeroes,
+      // so exponent is -3 - 1 = -4)
+      (
+        fractional.at(first-non-zero),
+        fractional.slice(first-non-zero + 1),
+        -first-non-zero - 1
+      )
+    } else {
+      // Number has non-zero integral part, or is zero
+      // Convert 12345.6789 -> 1.23456789
+      // Exponent is integral digits - 1
+      (
+        integral.at(0),
+        integral.slice(1) + fractional,
+        integral.len() - 1
+      )
+    }
+    return (
+      // mantissa
+      integral + if fractional != "" { "." + fractional } else { "" },
+      exponent-sign + _strfmt_stringify(exponent)
+    )
+  }
+
+  let f = float(num)
+  let exponent = if f == 0 { 1 } else { calc.floor(calc.log(calc.abs(f), base: 10)) }
+  let mantissa = f / calc.pow(10.0, exponent)
+  let mantissa = _strfmt_with-precision(mantissa, precision)
+
+  (mantissa, exponent-sign + _strfmt_stringify(exponent))
+}
+
+// Parses {format:specslikethis}.
+// Rust's format spec grammar:
+/*
+format_spec := [[fill]align][sign]['#']['0'][width]['.' precision]type
+fill := character
+align := '<' | '^' | '>'
+sign := '+' | '-'
+width := count
+precision := count | '*'
+type := '' | '?' | 'x?' | 'X?' | identifier
+count := parameter | integer
+parameter := argument '$'
+*/
+#let _generate-replacement(
+  fullname, extras, replacement,
+  pos-replacements: (), named-replacements: (:),
+  fmt-decimal-separator: auto,
+  fmt-thousands-count: 3,
+  fmt-thousands-separator: ""
+) = {
+  if extras == none {
+    let is-numeric = _strfmt_is-numeric-type(replacement)
+
+    if is-numeric {
+      let is-nan = type(replacement) == _float-type and _float-is-nan(replacement)
+      let is-inf = type(replacement) == _float-type and _float-is-infinite(replacement)
+      let string-replacement = _strfmt_stringify(calc.abs(replacement))
+      let sign = if (
+        not is-nan and replacement < 0
+        or replacement == 0 and type(replacement) == _decimal and (
+          // Preserve signed zero decimal
+          "-" in str(replacement) or _minus-sign in str(replacement)
+        )
+      ) {
+        "-"
+      } else {
+        ""
+      }
+      let (integral, ..fractional) = string-replacement.split(".")
+      if fmt-thousands-separator != "" and not is-nan and not is-inf {
+        integral = _arr-chunks(integral.codepoints().rev(), fmt-thousands-count)
+          .join(fmt-thousands-separator.codepoints().rev())
+          .rev()
+          .join()
+      }
+
+      if fractional.len() > 0 {
+        let decimal-separator = if fmt-decimal-separator not in (auto, none) { _strfmt_stringify(fmt-decimal-separator) } else { "." }
+        return sign + integral + decimal-separator + fractional.first()
+      } else {
+        return sign + integral
+      }
+    } else {
+      return _strfmt_stringify(replacement)
+    }
+  }
+  let extras = _strfmt_stringify(extras)
+  // note: usage of [\s\S] in regex to include all characters, incl. newline
+  // (dot format ignores newline)
+  let extra-parts = extras.match(
+    //           fill      align    sign   #   0     width(from param)      width      precision(from param)    precision  spectype
+    regex("^(?:([\\s\\S])?([<^>]))?([+-])?(#)?(0)?(?:(?:(\\d+)|([^.$]+))\$|(\\d+))?(?:\\.(?:(?:(\\d+)|([^$]+))\$|(\\d+|\*)))?([^\\s]*)\\s*$")
+  )
+  if extra-parts == none {
+    panic("String formatter error: Invalid format spec '" + extras + "', from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}'. Try escaping the braces { } with {{ }} if you wanted to insert literal braces.")
+  }
+
+  let (fill, align, sign, hashtag, zero, width-posarg, width-namedarg, width-lit, precision-posarg, precision-namedarg, precision-lit, spectype) = extra-parts.captures
+
+  // 'count' type parameters in the spec (width, precision) can be either a literal number (123),
+  // a number referring to a positional argument (123$), or some text referring to a named argument (abc$).
+  // The final $ is mandatory for the last two cases.
+  let parse-count(lit, pos, named, spec-part-name: "unknown") = {
+    if lit != none {
+      int(lit)
+    } else if pos != none {
+      let i = int(pos)
+      assert(
+        pos-replacements.len() > 0,
+        message: "String formatter error: Attempted to use positional argument " + str(i) + " for " + spec-part-name + ", but no positional arguments were given (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}')."
+      )
+      assert(
+        i >= 0 and i < pos-replacements.len(),
+        message: "String formatter error: Attempted to use positional argument " + str(i) + " for " + spec-part-name + ", but there is no argument at that position (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}'). Please note that positional arguments start at position 0, and are specified in order after the format string in the 'strfmt' call."
+      )
+      let arg = pos-replacements.at(i)
+      assert(
+        type(arg) == _int-type,
+        message: "String formatter error: Attempted to use positional argument " + str(i) + " for " + spec-part-name + ", but it was a(n) '" + str(type(arg)) + "', not an integer (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}')."
+      )
+
+      int(arg)
+    } else if named != none {
+      assert(
+        named-replacements.len() > 0,
+        message: "String formatter error: Attempted to use named argument '" + named + "' for " + spec-part-name + ", but no named arguments were given (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}')."
+      )
+      assert(
+        named in named-replacements,
+        message: "String formatter error: Attempted to use named argument '" + named + "' for " + spec-part-name + ", but there is no argument associated to that name (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}'). Ensure you pass that argument in the 'strfmt' call, e.g. strfmt(\"string {:.myarg$}\", 5.823, myarg: 10)."
+      )
+      let arg = named-replacements.at(named)
+      assert(
+        type(arg) == _int-type,
+        message: "String formatter error: Attempted to use named argument '" + named + "' for " + spec-part-name + ", but it was a(n) '" + str(type(arg)) + "', not an integer (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}')."
+      )
+
+      int(arg)
+    } else {
+      none
+    }
+  }
+
+  if precision-lit == "*" {
+    panic("String formatter error: Precision specification of type `.*` is not supported yet (from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}'). Try specifying your desired precision directly on the format spec, e.g. `.5`, or through some argument, e.g. `.name$` to take it from the 'name' named argument.")
+  }
+
+  let align = if align == "" {
+    none
+  } else if align == "<" {
+    left
+  } else if align == ">" {
+    right
+  } else if align == "^" {
+    center
+  } else if align != none {
+    panic("String formatter error: Invalid alignment in the format spec: '" + align + "' (must be either '<', '^' or '>').")
+  }
+  let width = parse-count(width-lit, width-posarg, width-namedarg, spec-part-name: "width")
+  let width = if width == none { 0 } else { int(width) }
+  let precision = parse-count(precision-lit, precision-posarg, precision-namedarg, spec-part-name: "precision")
+  let hashtag = hashtag == "#"
+  let zero = zero == "0"
+  let hashtag-prefix = ""
+
+  let valid-specs = ("", "?", "b", "x", "X", "o", "x?", "X?", "e", "E")
+  let spec-error() = {
+    panic(
+      "String formatter error: Unknown spec type '" + spectype + "', from '{" + fullname.replace("{", "{{").replace("}", "}}") + "}'. Valid options include: '" + valid-specs.join("', '") + "'. Maybe you specified some invalid formatting spec syntax (after the ':'), which can also prompt this error. Check the oxifmt docs for more information.")
+  }
+  if spectype not in valid-specs {
+    spec-error()
+  }
+
+  if _strfmt_is-numeric-type(replacement) {
+    let is-nan = type(replacement) == _float-type and _float-is-nan(replacement)
+    let is-inf = type(replacement) == _float-type and _float-is-infinite(replacement)
+    if zero {
+      // disable fill, we will be prefixing with zeroes if necessary
+      fill = none
+    } else if fill == none {
+      fill = " "
+      zero = false
+    }
+    // default number alignment to right
+    if align == none {
+      align = right
+    }
+
+    if replacement == 0 and type(replacement) == _decimal {
+      // Preserve signed zero.
+      if "-" in str(replacement) or _minus-sign in str(replacement) {
+        sign = "-"
+      } else if sign == "+" {
+        sign = "+"
+      } else {
+        sign = ""
+      }
+    } else if sign == "+" and not is-nan and replacement >= 0 {
+      // if + is specified, + will appear before all numbers >= 0.
+      sign = "+"
+    } else if not is-nan and replacement < 0 {
+      sign = "-"
+    } else {
+      sign = ""
+    }
+
+    // we'll add the sign back later!
+    replacement = calc.abs(replacement)
+
+    // Separate integral from fractional parts
+    // We'll recompose them later
+    let integral = ""
+    let fractional = ()
+    let exponent-suffix = ""
+
+    if spectype in ("e", "E") and not is-nan and not is-inf {
+      let exponent-sign = if spectype == "E" { "E" } else { "e" }
+      let (mantissa, exponent) = _strfmt_exp-format(calc.abs(replacement), exponent-sign: exponent-sign, precision: precision)
+      (integral, ..fractional) = mantissa.split(".")
+      exponent-suffix = exponent
+    } else if type(replacement) != _int-type and precision != none and not is-nan and not is-inf {
+      let new-replacement = _strfmt_with-precision(replacement, precision)
+      (integral, ..fractional) = new-replacement.split(".")
+    } else if type(replacement) == _int-type and spectype in ("x", "X", "b", "o", "x?", "X?") {
+      let radix-map = (x: 16, X: 16, "x?": 16, "X?": 16, b: 2, o: 8)
+      let radix = radix-map.at(spectype)
+      let lowercase = spectype.starts-with("x")
+      integral = _strfmt_stringify(_strfmt_display-radix(replacement, radix, lowercase: lowercase, signed: false))
+      if hashtag {
+        let hashtag-prefix-map = ("16": "0x", "2": "0b", "8": "0o")
+        hashtag-prefix = hashtag-prefix-map.at(str(radix))
+      }
+    } else {
+      precision = none
+      let new-replacement = if spectype.ends-with("?") {
+        let repr-res = repr(replacement)
+        if using-090 and not using-0110 and type(replacement) == _float-type and "." not in repr-res {
+          // Workaround for repr inconsistency in Typst 0.9.0 and 0.10.0
+          repr-res + ".0"
+        } else {
+          repr-res
+        }
+      } else {
+        _strfmt_stringify(replacement)
+      }
+      (integral, ..fractional) = new-replacement.split(".")
+    }
+
+    let decimal-separator = if fmt-decimal-separator not in (auto, none) { _strfmt_stringify(fmt-decimal-separator) } else { "." }
+    let replaced-fractional = if fractional.len() > 0 { decimal-separator + fractional.join(decimal-separator) } else { "" }
+    let exponent-suffix = exponent-suffix.replace(".", decimal-separator)
+
+    if zero {
+      let width-diff = width - (integral.len() + replaced-fractional.codepoints().len() + sign.len() + hashtag-prefix.len() + exponent-suffix.codepoints().len())
+      if width-diff > 0 {  // prefix with the appropriate amount of zeroes
+        integral = ("0" * width-diff) + integral
+      }
+    }
+
+    // Format with thousands AFTER zeroes, but BEFORE applying textual prefixes
+    if fmt-thousands-separator != "" and not is-nan and not is-inf {
+      integral = _arr-chunks(integral.codepoints().rev(), fmt-thousands-count)
+        .join(fmt-thousands-separator.codepoints().rev())
+        .rev()
+        .join()
+    }
+
+    replacement = integral + replaced-fractional + exponent-suffix
+  } else {
+    sign = ""
+    hashtag-prefix = ""
+    hashtag = false
+    zero = false
+    replacement = if spectype.ends-with("?") {
+      repr(replacement)
+    } else {
+      _strfmt_stringify(replacement)
+    }
+    if fill == none {
+      fill = " "
+    }
+    if align == none {
+      align = left
+    }
+    if precision != none and replacement.len() > precision {
+      replacement = replacement.slice(0, precision)
+    }
+  }
+
+  // use number prefixes parsed above
+  replacement = sign + hashtag-prefix + replacement
+
+  if fill != none {
+    // perform fill/width adjustments: "x" ---> "  x" if width is 4
+    let width-diff = width - replacement.codepoints().len()  // number prefixes are also considered for width
+    if width-diff > 0 {
+      if align == left {
+        replacement = replacement + (fill * width-diff)
+      } else if align == right {
+        replacement = (fill * width-diff) + replacement
+      } else if align == center {
+        let width-fill = fill * (calc.ceil(float(width-diff) / 2))
+        replacement = width-fill + replacement + width-fill
+      }
+    }
+  }
+
+  replacement
+}
+
+#let strfmt(
+  format,
+  ..replacements,
+  fmt-decimal-separator: auto,
+  fmt-thousands-count: 3,
+  fmt-thousands-separator: "",
+) = {
+  if format == "" { return "" }
+  let formats = _strfmt_formatparser(format)
+  let num-replacements = replacements.pos()
+  let named-replacements = replacements.named()
+  let unnamed-format-index = 0
+
+  if fmt-decimal-separator != auto and type(fmt-decimal-separator) != _str-type {
+    assert(
+      false,
+      message: "String formatter error: 'fmt-decimal-separator' must be a string or 'auto', got '" + str(type(fmt-decimal-separator)) + "' instead."
+    )
+  }
+
+  if type(fmt-thousands-count) != _int-type {
+    assert(
+      false,
+      message: "String formatter error: 'fmt-thousands-count' must be an integer, got '" + str(type(fmt-thousands-count)) + "' instead."
+    )
+  }
+
+  if fmt-thousands-count <= 0 {
+    assert(
+      false,
+      message: "String formatter error: 'fmt-thousands-count' must be a positive integer, got " + str(fmt-thousands-count) + " instead."
+    )
+  }
+
+  if type(fmt-thousands-separator) != _str-type {
+    assert(
+      false,
+      message: "String formatter error: 'fmt-thousands-separator' must be a string (or empty string, \"\", to disable), got '" + str(type(fmt-thousands-separator)) + "' instead."
+    )
+  }
+
+  for (name, _) in named-replacements {
+    if name.starts-with("fmt-") {
+      assert(false, message: "String formatter error: unknown format option '" + name + "'. Keys prefixed with 'fmt-' are reserved for future oxifmt options. Please use a different key name.")
+    }
+  }
+
+  let parts = ()
+  let last-span-end = 0
+  for f in formats {
+    let replace-by = none
+    let replace-span = none
+    if "escape" in f {
+      replace-by = f.escape.escaped
+      replace-span = f.escape.span
+    } else if "format" in f {
+      let f = f.format
+      let (name, extras) = _strfmt_parse-fmt-name(f.name)
+      if name == none {
+        let fmt-index = unnamed-format-index
+        let amount-pos-replacements = num-replacements.len()
+        if amount-pos-replacements == 0 {
+          panic("String formatter error: Specified a {} (or similar) format to extract positional replacements, but none were given. Try specifying them sequentially after the format string, e.g. strfmt(\"{}, {}\", 5, 1+1) would become \"5, 2\".")
+        }
+        if amount-pos-replacements <= fmt-index {
+          let were-was = if amount-pos-replacements == 1 { "was" } else { "were" }
+          panic("String formatter error: Specified more {} (or similar) formats than positional replacements (only " + str(amount-pos-replacements) + " of them " + were-was + " given!). Please specify the missing positional arguments sequentially after the format string in the 'strfmt' call.")
+        }
+        replace-by = num-replacements.at(fmt-index)
+        unnamed-format-index += 1
+      } else if type(name) == _int-type {
+        let fmt-index = name
+        let amount-pos-replacements = num-replacements.len()
+        if amount-pos-replacements == 0 {
+          panic("String formatter error: format key '" + str(name) + "' would attempt to get a positional replacement, but none were given after the string. Try specifying positional replacements after the format string in the 'strfmt' call, e.g. strfmt(\"{1}, {0}\", 2, 3) would become \"3, 2\".")
+        }
+        if amount-pos-replacements <= fmt-index {
+          let were-was = if amount-pos-replacements == 1 { "was" } else { "were" }
+          panic("String formatter error: format key '" + str(name) + "', from '{" + f.name.replace("{", "{{").replace("}", "}}") + "}', is not a valid positional replacement position (only " + str(amount-pos-replacements) + " of them " + were-was + " given). Note that the first position is 0. For example, strfmt(\"{1}, {0}\", 2, 3) would become \"3, 2\".")
+        }
+        replace-by = num-replacements.at(fmt-index)
+      } else {  // named replacement
+        if name not in named-replacements {
+          panic("String formatter error: format key '" + name + "', from '{" + f.name.replace("{", "{{").replace("}", "}}") + "}', does not match any given named replacement. Try specifying it after the format string, e.g. like so: strfmt(\"Test: {myarg}\", myarg: 1 + 1) would become \"Test: 2\".")
+        }
+        replace-by = named-replacements.at(name)
+      }
+      replace-by = _generate-replacement(f.name, extras, replace-by, pos-replacements: num-replacements, named-replacements: named-replacements, fmt-decimal-separator: fmt-decimal-separator, fmt-thousands-count: fmt-thousands-count, fmt-thousands-separator: fmt-thousands-separator)
+      replace-span = f.span
+    } else {
+      panic("String formatter error: Internal error (unexpected format received).")
+    }
+    // {...}ABCABCABC{...}  <--- push ABCABCABC to parts
+    parts.push(format.slice(last-span-end, replace-span.at(0)))
+    // push the replacement string instead of the {...} at the end
+    parts.push(replace-by)
+    last-span-end = replace-span.at(1)
+  }
+  if last-span-end < format.len() {
+    parts.push(format.slice(last-span-end, format.len()))
+  }
+
+  // join all the string parts (constant parts + formatted parts + escaped parts)
+  parts.join()
+}

--- a/packages/preview/oxifmt/0.3.0/typst.toml
+++ b/packages/preview/oxifmt/0.3.0/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "oxifmt"
+version = "0.3.0"
+authors = ["PgBiel <https://github.com/PgBiel>"]
+license = "MIT OR Apache-2.0"
+description = "Convenient Rust-like string formatting in Typst"
+entrypoint = "oxifmt.typ"
+repository = "https://github.com/PgBiel/typst-oxifmt"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Added thousands separators with `fmt-thousands-separator: ","` (for example) and support for numeric formatting of fixed-point `decimal`. Fixed some type checking code incompatible with Typst 0.14.0 (edge case and no existing packages appear to trigger it from a quick search, so not too critical).

**Breaking change:** Format specifiers can no longer start with `fmt-`, as that prefix is reserved for oxifmt's own options.

Also updated license to MIT OR Apache-2.0 (previously MIT only).
