### PR TITLE
latex-lookalike: fix import path of example to use @preview namespace

### DIFF
--- a/packages/preview/latex-lookalike/0.1.0/example/example.typ
+++ b/packages/preview/latex-lookalike/0.1.0/example/example.typ
@@ -1,4 +1,4 @@
-#import "@local/latex-lookalike:0.1.0"
+#import "@preview/latex-lookalike:0.1.0"
 
 #set heading(numbering: "1.1")
 


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

This is just a small fix to use the `@preview` namespace instead of the `@local` namespace for the `latex-lookalike` example document.

Ref: https://github.com/typst/packages/pull/2584