### PR TITLE
Link to the docs in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,12 +19,12 @@ These things need to be checked for a new submission to be merged. If you're jus
 -->
 
 I have read and followed the submission guidelines and, in particular, I
-- [ ] selected a name that isn't the most obvious or canonical name for what the package does
-- [ ] added a `typst.toml` file with all required keys
-- [ ] added a `README.md` with documentation for my package
-- [ ] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
+- [ ] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
+- [ ] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
+- [ ] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
+- [ ] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
 - [ ] tested my package locally on my system and it worked
-- [ ] `exclude`d PDFs or README images, if any, but not the LICENSE
+- [ ] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
 
 <!--
 The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.


### PR DESCRIPTION
This links to the relevant parts of the docs inside the PR template, so people don't have to search for (or guess) what we're referring to in the bullet points.