### PR TITLE
CI: avoid conflicts when rebasing the PR for linting

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -68,7 +68,7 @@ jobs:
           git fetch origin ${{ github.base_ref }}
           git checkout ${{ github.base_ref }}
           git checkout $pr_head
-          git rebase ${{ github.base_ref }}
+          git rebase ${{ github.base_ref }} -X ours
       - uses: typst/package-check@v0.3.0
         with:
           installation-id: ${{ secrets.GH_INSTALLATION_ID }}


### PR DESCRIPTION
Prefer the changes that were accepted in main over what is in the branch, as the conflict will generally arise from an outdated base: the conflicting changes are simply older versions of the file, and replaying the whole history would eventually give the same result.
