### PR TITLE
fix package issue link and description

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Package-specific issue
-    url: https://typst.app/docs/packages
-    about: Please report issues with a specific package on that package's repository. You can find it by clicking the chain icon in the package list.
+    url: https://typst.app/universe/search/
+    about: Please report issues with a specific package on that package's repository. You can find it by searching for the package on Typst Universe and looking for the "Repository" link in the package's "About" section.


### PR DESCRIPTION
When going to https://github.com/typst/packages/issues/new/choose, the "Package-specific issue" link target does not exist and I assume the description also refers to the UI on the old site. This PR updates them.

I chose the search page as the link target, but I think the Universe home page would work too.