### PR TITLE
eeaabb:0.1.0

### DIFF
--- a/packages/preview/eeaabb/0.1.0/LICENSE.md
+++ b/packages/preview/eeaabb/0.1.0/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2025 Jeremy Gao and Y.D.X.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/eeaabb/0.1.0/README.md
+++ b/packages/preview/eeaabb/0.1.0/README.md
@@ -1,0 +1,53 @@
+
+![eeaabb](https://raw.githubusercontent.com/WenSimEHRP/eeaabb/refs/heads/main/title.png)
+
+Visual debug helpers for Typst to extract element axis-aligned bounding boxes (AABB).
+
+## Exports
+
+- `eeaabb(content, unit: length.pt, precision: 3)` – Box the whole content with width & height labels.
+- `ccaabb(content, unit: length.pt, precision: 3)` – Box each character separately.
+- `debug-font(...)` - Test a font's x-height, cap height, bounds, etc.
+  See <https://forum.typst.app/t/a-snippet-to-debug-font-by-visualize-baseline-cap-height-etc/4597> for details.
+
+Parameters:
+
+- `unit` conversion function for lengths.
+  - default: `length.pt`. Available options: `length.{cm,mm,inches,pt}`
+- `precision` decimal places (default `3`).
+
+## Example
+
+```typst
+#import "@preview/eeaabb:0.1.0": ccaabb, eeaabb
+
+// Explicit calls
+#eeaabb(block[Hello World])\
+#ccaabb(text(size: 2em)[Kerning?])
+
+// Calling via a show rule
+#[
+  #set text(top-edge: "bounds")
+  #show: eeaabb
+  #show: ccaabb
+  Asogi Genshin\
+  亜双義\u{3000}玄真
+]
+
+// Calling via a show rule, this time with some extra touches
+#[
+  #set text(top-edge: "bounds")
+  #show: eeaabb.with(unit: length.mm, precision: 4)
+  #show: ccaabb.with(unit: length.mm, precision: 4)
+  Asogi Kazuma\
+  亜双義\u{3000}一真
+]
+```
+
+```typst
+#import "@preview/eeaabb:0.1.0": debug-font
+#show: debug-font
+
+// test your font here
+The quick brown fox jumps over a lazy dog.
+```

--- a/packages/preview/eeaabb/0.1.0/aabb.typ
+++ b/packages/preview/eeaabb/0.1.0/aabb.typ
@@ -1,0 +1,107 @@
+#import "@preview/oxifmt:1.0.0": strfmt
+#let heights = state("heights", ())
+#let widths = state("widths", ())
+
+///
+/// Internal helper: measure a piece of content and draw an AABB rectangle
+/// with width/height numeric labels (side effects: appends to `widths` & `heights`).
+///
+/// - unit (fn length -> length): Conversion function applied to measured pt value (default passed in by caller, usually length.pt).
+/// - precision (int): Fractional digits to keep when formatting the number.
+/// - c (content): Any content node to be measured & wrapped.
+/// -> content: A boxed version of `c` with overlay labels; original flow preserved.
+#let _aabb_internal(
+  unit,
+  precision,
+  placements: (
+    top + left,
+    bottom + left,
+    top + left,
+    top + left,
+  ),
+  c,
+) = context {
+  let size = measure(c)
+  widths.update(it => it + (size.width,))
+  heights.update(it => it + (size.height,))
+  let hstuff = text(
+    bottom-edge: "baseline",
+    top-edge: "cap-height",
+    fill: color.mix(red, green),
+    raw(strfmt("{:." + str(precision) + "}", unit(size.height))),
+  )
+  let wstuff = text(
+    bottom-edge: "baseline",
+    top-edge: "cap-height",
+    fill: color.mix(green, blue),
+    raw(strfmt("{:." + str(precision) + "}", unit(size.width))),
+  )
+  let hstuffs = measure(hstuff)
+  let wstuffs = measure(wstuff)
+  box(..size, stroke: .2pt + gray, {
+    c
+    place(placements.at(0), dy: -.1pt, place(
+      placements.at(1),
+      box(
+        stroke: (left: .2pt + gray),
+        fill: white.transparentize(60%),
+        scale(
+          reflow: true,
+          x: calc.min(size.width / wstuffs.width * 100%, 20%),
+          y: 20%,
+          wstuff,
+        ),
+      ),
+    ))
+    place(placements.at(3), dx: .1pt, dy: .1pt, place(
+      placements.at(3),
+      rotate(-90deg, reflow: true, box(
+        fill: white.transparentize(60%),
+        scale(
+          x: calc.min(size.height / hstuffs.width * 100%, 20%),
+          y: 20%,
+          reflow: true,
+          hstuff,
+        ),
+      )),
+    ))
+  })
+}
+
+///
+/// Character-by-character AABB visualization.
+/// For each codepoint in the textual representation of the argument, draws an
+/// individual measurement rectangle with labels. Good for inspecting glyph advance,
+/// kerning and vertical metrics.
+///
+/// - c (content/text): Source whose `.text` will be iterated per character.
+/// - unit (fn length -> length): Unit conversion (e.g. length.pt, length.mm).
+/// - precision (int): Decimal places for numbers (default 3).
+/// -> content: Original content returned after side-effectful rendering.
+#let ccaabb(c, unit: length.pt, precision: 3) = {
+  show regex(".+"): it => context {
+    for c in it.text {
+      _aabb_internal(unit, precision, c)
+    }
+  }
+  c
+}
+
+///
+/// Element-level AABB visualization.
+/// Wraps the whole content block in a single measurement rectangle with width &
+/// height labels. Non-destructive (returns original content) while drawing overlay.
+///
+/// - c (content): Content to visualize.
+/// - unit (fn length -> length): Unit conversion (default length.pt).
+/// - precision (int): Decimal places (default 3).
+/// -> content: Original content after drawing the overlay.
+#let eeaabb(c, unit: length.pt, precision: 3) = {
+  show: _aabb_internal.with(unit, precision, placements: (
+    bottom + right,
+    top + right,
+    bottom + right,
+    bottom + right,
+  ))
+  c
+}

--- a/packages/preview/eeaabb/0.1.0/debug-font.typ
+++ b/packages/preview/eeaabb/0.1.0/debug-font.typ
@@ -1,0 +1,125 @@
+/// Visualize the conceptual frame around an example text.
+///
+/// https://typst.app/docs/reference/text/text/#parameters-top-edge
+/// https://typst.app/docs/reference/text/text/#parameters-bottom-edge
+/// https://forum.typst.app/t/a-snippet-to-debug-font-by-visualize-baseline-cap-height-etc/4597/
+#let debug-font(
+  models: (
+    (top-edge: "bounds"),
+    (top-edge: "ascender"),
+    (top-edge: "cap-height"),
+    (top-edge: "x-height"),
+    // Usually, top and bottom baselines are identical
+    // However, it's not true for most math equations.
+    // You can specify both of them, and they will collapse into one or display separately, depending whether they are identical.
+    (top-edge: "baseline"),
+    (bottom-edge: "baseline"),
+    (bottom-edge: "descender"),
+    (bottom-edge: "bounds"),
+  ),
+  palette: (aqua, fuchsia, green, yellow, fuchsia, aqua, yellow),
+  example-body,
+) = context {
+  // Measure the distance between top and bottom baselines
+  // Usually, the two baselines are identical, and `d == 0`.
+  // However, it's not true for most math equations.
+  let d = measure(text(
+    top-edge: "baseline",
+    bottom-edge: "baseline",
+    example-body,
+  )).height
+
+  // Measure heights and sort increasingly
+  // A list of (edge name, signed height relative to the bottom baseline)
+  let edge-heights = models
+    .map(raw-m => {
+      // Fill with defaults
+      let m = (top-edge: "baseline", bottom-edge: "baseline", ..raw-m)
+
+      // Measure the height of the example
+      let h = measure(text(..m, example-body)).height
+
+      // Calculate the sign of the height
+      if m.top-edge != "baseline" and m.bottom-edge == "baseline" {
+        (m.top-edge, h)
+      } else if m.top-edge == "baseline" and m.bottom-edge != "baseline" {
+        (m.bottom-edge, d - h)
+      } else {
+        assert(m.top-edge == m.bottom-edge and m.bottom-edge == "baseline")
+        assert.eq(
+          h,
+          d,
+          message: "Measuring the distance between top and bottom baselines twice gives inconsistent results. How did you achieve that?",
+        )
+        if d == 0pt {
+          ("baseline", h)
+        } else {
+          let key = raw-m.keys().first()
+          (
+            "baseline (" + key + ")",
+            if key == "top-edge" { h } else { h - d },
+          )
+        }
+      }
+    })
+    .sorted(key: ((e, h)) => h)
+    .dedup() // Collapse two baselines into one, if they are identical
+
+
+  // Check there are enough colors
+  assert(
+    edge-heights.len() - 1 <= palette.len(),
+    message: "There are too few colors in `palette` to fill between all edge lines in `models`. Please set more colors.",
+  )
+
+  // Make sure `place(bottom, dy: …)` is relative to the baseline
+  set text(bottom-edge: "baseline")
+
+  box({
+    // Draw stripes
+    let heights = edge-heights.map(((e, h)) => h)
+    for (h-low, h-high, fill) in heights
+      .slice(0, -1)
+      .zip(heights.slice(1), palette) {
+      place(bottom, dy: -h-low, box(
+        height: h-high - h-low,
+        fill: fill,
+        hide(example-body),
+      ))
+    }
+
+    // Write the example
+    example-body
+  })
+
+  // Write annotations
+  box({
+    let last-h = none
+    let long-arrow = false
+    for (edge, h) in edge-heights {
+      // if too narrow, change the arrow size
+      if last-h != none and calc.abs(h - last-h) < 0.2em.to-absolute() {
+        long-arrow = not long-arrow
+      } else {
+        long-arrow = false
+      }
+      let arrow-size = if long-arrow { 6em } else { 1em }
+
+      place(
+        bottom,
+        dy: -h + 0.3em / 2,
+        text(
+          0.3em,
+          bottom-edge: "descender",
+          text(
+            black.transparentize(50%),
+            $stretch(arrow.l, size: #arrow-size)$,
+          )
+            + edge,
+        ),
+      )
+
+      last-h = h
+    }
+  })
+}

--- a/packages/preview/eeaabb/0.1.0/lib.typ
+++ b/packages/preview/eeaabb/0.1.0/lib.typ
@@ -1,0 +1,2 @@
+#import "debug-font.typ": debug-font
+#import "aabb.typ": ccaabb, eeaabb, heights, widths

--- a/packages/preview/eeaabb/0.1.0/typst.toml
+++ b/packages/preview/eeaabb/0.1.0/typst.toml
@@ -1,0 +1,7 @@
+[package]
+name = "eeaabb"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Jeremy Gao <@wensimehrp>", "Y.D.X. <@YDX-2147483647>"]
+license = "MIT"
+description = "Extract element AABBs and inspect sizes"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Explain what the package does and why it's useful.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [ ] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
