### PR TITLE
Use correct units for information about file and image

### DIFF
--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -404,7 +404,7 @@ fn process_thumbnail(
     // Get file size.
     let file_size = fs::metadata(&original_path)?.len() as usize;
     if file_size > 3 * 1024 * 1024 {
-        bail!("thumbnail must be smaller than 3MB");
+        bail!("thumbnail must be smaller than 3 MiB");
     }
 
     let mut image = image::open(&original_path)?;
@@ -412,7 +412,7 @@ fn process_thumbnail(
     // Ensure that the image has at least a certain minimum size.
     let longest_edge = image.width().max(image.height());
     if longest_edge < 1080 {
-        bail!("each thumbnail's longest edge must be at least 1080px long");
+        bail!("each thumbnail's longest edge must be at least 1080 px long");
     }
 
     // We produce a full-size and a miniature thumbnail.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -175,10 +175,10 @@ Required for submissions to this repository:
 - `thumbnail`: A path relative to the package's root that points to a PNG or
   lossless WebP thumbnail for the template. The thumbnail must depict one of the
   pages of the template **as initialized.** The longer edge of the image must be
-  at least 1080px in length. Its file size must not exceed 3MB. Exporting a PNG
-  at 250 DPI resolution is usually a good way to generate a thumbnail. You can
-  use the following command for that: `typst compile -f png --pages 1 --ppi 250
-  main.typ thumbnail.png`. You are encouraged to use [oxipng] to reduce the
+  at least 1080 px in length. Its file size must not exceed 3 MiB. Exporting a
+  PNG at 250 PPI resolution is usually a good way to generate a thumbnail. You
+  can use the following command for that: `typst compile -f png --pages 1 --ppi
+  250 main.typ thumbnail.png`. You are encouraged to use [oxipng] to reduce the
   thumbnail's file size. The thumbnail will automatically be excluded from the
   package files and must not be referenced anywhere in the package.
 


### PR DESCRIPTION
DPI is for printers, not digital images. MB is multiple of 10, which code uses
multiple of 2, which is MiB. There must be a single whitespace between quantity
number and unit of measurement.

After RTFM, I refreshed my memory and PPI in the CLI and this docs is
incorrect. PPI refers to physical size, not digital. As such, if you keep the
image size (in pixels), PPI will not change its appearance when viewed
digitally. So providing `--ppi` is confusing and imprecise. Moreover, the
default is 144 PPI, which will not translate `set page` pt to px like I would
assume. For that, you would have to use `--ppi 72`. Compiler instead must just
set some EXIF image tag that describes the set PPI. As for image size, perhaps
a `--scale` ratio or `--width` px flag should be added, to easily get the right
image size depending on how you configure your `set page` or your requirements.
