### PR TITLE
dashy-todo:0.1.1

### DIFF
--- a/packages/preview/dashy-todo/0.1.1/LICENSE
+++ b/packages/preview/dashy-todo/0.1.1/LICENSE
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright 2024-2025 Otto-AA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/dashy-todo/0.1.1/README.md
+++ b/packages/preview/dashy-todo/0.1.1/README.md
@@ -1,0 +1,50 @@
+# Dashy TODO
+
+Create simple TODO comments, which are displayed at the sides of the page.
+
+I suggest to also take a look at the [drafting package](https://typst.app/universe/package/drafting), which is a more feature-complete annotation library, but also suitable for simple TODO comments.
+
+![Screenshot](example.svg)
+
+## Usage
+
+The package provides a `todo(message, position: auto | left | right)` method. Call it anywhere you need a todo message.
+
+```typst
+#import "@preview/dashy-todo:0.1.1": todo
+
+// It automatically goes to the closer side (left or right)
+A todo on the left #todo[On the left].
+
+// You can specify a position if you want to (auto, left, right or "inline")
+#todo(position: right)[Also right]
+
+// You can add arbitrary content
+#todo[We need to fix the $lim_(x -> oo)$ equation. See #link("https://example.com")[example.com]]
+
+// And you can create an outline for the TODOs
+#outline(title: "TODOs", target: figure.where(kind: "todo"))
+```
+
+## Styling
+
+You can change the border color with any [stroke](https://typst.app/docs/reference/visualize/stroke/) type:
+
+```
+#todo(stroke: blue)[This is in blue!]
+
+#let blue-todo = todo.with(stroke: blue)
+#blue-todo[This is also in blue!]
+```
+
+You can modify the text by wrapping it, e.g.:
+
+```
+#let small-todo = (..args) => text(size: 0.6em)[#todo(..args)]
+
+#small-todo[This will be in fine print]
+```
+
+## Contributing
+
+See https://github.com/Otto-AA/dashy-todo/blob/main/CONTRIBUTING.md.

--- a/packages/preview/dashy-todo/0.1.1/example.svg
+++ b/packages/preview/dashy-todo/0.1.1/example.svg
@@ -1,0 +1,1738 @@
+<svg class="typst-doc" viewBox="0 0 453.54330708661416 340.15748031496065" width="453.54330708661416pt" height="340.15748031496065pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <path class="typst-shape" fill="#ffffff" fill-rule="nonzero" d="M 0 0 L 0 340.15747 L 453.5433 340.15747 L 453.5433 0 Z "/>
+    <g>
+        <g transform="translate(90.70866141732283 40.4949381327334)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 9.933)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#gFEB94A1E3ADB595B05DF90D09979543F" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g4903813593648E111167B975CD6AD3BA" x="11.3036" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDE5888032A667C61E0F2A9F956287985" x="19.096" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g64A1F39F0DBD9BF68AB01E1009879DA9" x="25.671799999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g63EA10F98C28BA150F4CE2DE65B750A4" x="35.2044" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g295DFB81A5E395C1DFE0CF122DF08D85" x="47.647600000000004" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6D73600544136687ECCA2FDBD828407D" x="57.6114" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gFEB94A1E3ADB595B05DF90D09979543F" x="68.85340000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6D73600544136687ECCA2FDBD828407D" x="80.15700000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDE5888032A667C61E0F2A9F956287985" x="91.39900000000002" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 65.9159381327334)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="6.512" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="14.233999999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="21.944999999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="29.666999999999994" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="36.706999999999994" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="41.733999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="45.73799999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="53.404999999999994" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="58.431999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="64.273" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="67.749" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="73.29299999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="81.98299999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="87.00999999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="90.48599999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="93.46699999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="98.17499999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="103.20199999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="106.10599999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gED11A2FABFE2E5A685ACE8A9144B017E" x="109.00999999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="117.42499999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="123.21099999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="128.755" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="133.045" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="136.02599999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="139.50199999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="142.48299999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="148.027" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="153.98899999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="158.98299999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="167.29899999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="172.843" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="181.55499999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="185.03099999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="190.94899999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="198.61599999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="203.32399999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="206.22799999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="211.772" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="216.06199999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="220.97899999999998" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(315.77966141732287 65.9159381327334)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-315.77966141732287 -65.9159381327334)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(362.8346456692913 60.4159381327334)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(-0 -0)">
+                                                            <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 11.638 L 82.708664 11.638 L 82.708664 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(0 0)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(2.2 9.438)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="7.7219999999999995" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="16.434" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="19.91" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="25.828" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="33.495000000000005" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="37.587" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g7F5F86196ADADB0032CB2049EB771F59" x="40.568000000000005" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="46.068000000000005" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="51.986000000000004" fill="#000000" fill-rule="nonzero"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 22.788)">
+                                                <g class="typst-group">
+                                                    <g/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(315.77966141732287 65.9159381327334)">
+                                    <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 5.5 "/>
+                                </g>
+                                <g transform="translate(315.77966141732287 71.4159381327334)">
+                                    <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 51.054985 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(315.77966141732287 65.9159381327334)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="7.04" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="10.021" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="15.587000000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="23.254" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="26.73" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 80.30393813273339)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="3.476" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="9.394" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="17.061" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="25.751" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="30.668000000000003" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="34.144000000000005" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="40.062000000000005" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="45.68300000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="53.99900000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="58.70700000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="63.73400000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="66.638" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="69.542" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(162.67066141732283 80.30393813273339)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-162.67066141732283 -80.30393813273339)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 74.80393813273339)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(-0 -0)">
+                                                            <path class="typst-shape" fill="none" stroke="#0074d9" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 11.638 L 82.708664 11.638 L 82.708664 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(0 0)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(2.2 9.438)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="7.7219999999999995" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="16.434" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="19.91" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="25.828" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="33.495000000000005" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="36.399" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gAFF10F80711561B34177BDAF77CC0EC4" x="41.316" fill="#000000" fill-rule="nonzero"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 22.788)">
+                                                <g class="typst-group">
+                                                    <g/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(162.67066141732283 80.30393813273339)">
+                                    <path class="typst-shape" fill="none" stroke="#0074d9" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 5.5 "/>
+                                </g>
+                                <g transform="translate(162.67066141732283 85.80393813273339)">
+                                    <path class="typst-shape" fill="none" stroke="#0074d9" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L -75.962 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(162.67066141732283 80.30393813273339)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g48E25B73E0A9EDA398E65EF73A37635E" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE06C4B72531F49CBE9DB12FC3B2B6B4" x="6.0169999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="12.177" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="15.158" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="21.384" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="26.950000000000003" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="32.571000000000005" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="37.48800000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="41.778000000000006" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1295BAC9495BE95B0AA9CA96F2C2AB56" x="47.74000000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="50.68800000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gC23C47A73633CA682D6E6C5BB47A559" x="56.91400000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="63.07400000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g9EB1D08A7B1324D48AADD79859AC05BD" x="66.55000000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gED11A2FABFE2E5A685ACE8A9144B017E" x="71.72000000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="77.29700000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="82.84100000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="91.432" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="96.14" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="101.167" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="109.879" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="118.569" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="123.596" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="129.558" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="135.399" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="140.426" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="143.32999999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gED11A2FABFE2E5A685ACE8A9144B017E" x="146.23399999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="154.64899999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g9BA8B627FB15C42338CB980C362A00D2" x="160.11599999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="165.49499999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="170.41199999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="174.504" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="178.596" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="181.577" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="187.143" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 94.6919381327334)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="2.9810000000000003" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="6.457000000000001" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 101.84193813273339)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-0 -0)">
+                        <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 15.238 L 272.12598 15.238 L 272.12598 0 Z "/>
+                    </g>
+                    <g transform="translate(4 11.238000000000001)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g48F357F36910BC90E94F31A287082659" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="5.544" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="11.088" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="19.679" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="24.386999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="29.413999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="38.126" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="43.153" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="46.057" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="50.347" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="58.641" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="64.35" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="67.25399999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="72.28099999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="76.98899999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="84.65599999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="88.13199999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="94.05" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="98.967" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="110.407" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="113.38799999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="122.1" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="127.127" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="135.839" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="138.82" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="144.78199999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="147.68599999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="150.66699999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="156.62899999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6243475FABEC8A0579537E4EA4C95CD7" x="164.29599999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="169.82899999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="175.29599999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="180.68599999999995" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(362.8346456692913 117.07993813273342)">
+            <g class="typst-group">
+                <g/>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 137.5179381327334)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g48F357F36910BC90E94F31A287082659" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="5.544" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="11.088" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="19.679" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="24.386999999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="29.413999999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="38.126" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="43.153" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="48.719" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="57.035000000000004" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="61.743" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="67.584" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="71.87400000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="75.35000000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="80.894" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="92.334" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="97.042" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="102.586" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="108.548" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="112.024" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="116.941" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="122.903" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="126.379" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(219.50766141732282 137.5179381327334)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-219.50766141732282 -137.5179381327334)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(362.8346456692913 132.0179381327334)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(-0 -0)">
+                                                            <path class="typst-shape" fill="none" stroke="#2ecc40" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 2" d="M 0 0 L 0 55.077 L 82.708664 55.077 L 82.708664 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(0 0)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(2.2 9.438)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#gA68DA6B3B3D238AE928C954AEAD7F96A" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="9.581" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="17.248" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="23.21" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="28.204" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="33.198" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="41.514" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="44.99" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gC23C47A73633CA682D6E6C5BB47A559" x="53.284" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="59.444" fill="#000000" fill-rule="nonzero"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(2.2 16.588)">
+                                                                        <g class="typst-group">
+                                                                            <g>
+                                                                                <g transform="translate(0 7.513000000000001)">
+                                                                                    <g class="typst-text" transform="scale(1, -1)">
+                                                                                        <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                                        <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="3.476" fill="#000000" fill-rule="nonzero"/>
+                                                                                        <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="9.394" fill="#000000" fill-rule="nonzero"/>
+                                                                                    </g>
+                                                                                </g>
+                                                                                <g transform="translate(17.061000000000003 7.513000000000001)">
+                                                                                    <g class="typst-text" transform="scale(1, -1)">
+                                                                                        <use xlink:href="#g974A285F6CE2EF207BE5DE97B66461CA" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                                        <use xlink:href="#g58D62D4C1CABAD108A850FB1F742AC89" x="3.0580000000000003" fill="#000000" fill-rule="nonzero"/>
+                                                                                        <use xlink:href="#g83B8E421B35ADFEF9620EAF15AAE496A" x="6.1160000000000005" fill="#000000" fill-rule="nonzero"/>
+                                                                                    </g>
+                                                                                </g>
+                                                                                <g transform="translate(32.34 10.23)">
+                                                                                    <g class="typst-text" transform="scale(1, -1)">
+                                                                                        <use xlink:href="#g82C9138B1F990639C9D4AF197D33953B" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                                    </g>
+                                                                                </g>
+                                                                                <g transform="translate(37.329600000000006 10.23)">
+                                                                                    <g class="typst-text" transform="scale(1, -1)">
+                                                                                        <use xlink:href="#gC58233CC6A8C89B5BA6C36DC8CD01DC1" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                                    </g>
+                                                                                </g>
+                                                                                <g transform="translate(45.0296 10.23)">
+                                                                                    <g class="typst-text" transform="scale(1, -1)">
+                                                                                        <use xlink:href="#gA845BF5A6E6958A52079EDE8CD31C40A" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                                    </g>
+                                                                                </g>
+                                                                            </g>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(2.2 38.489)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g89FD5B500F3A7CF8EB197275F181B2CD" x="4.994000000000001" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="10.527000000000001" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="16.368000000000002" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="21.395000000000003" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="24.871000000000002" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="27.852000000000004" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="33.396" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="39.358000000000004" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gAE16D62B0766FCB252798197B2E66D5D" x="44.528000000000006" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="49.86300000000001" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="54.857000000000006" fill="#000000" fill-rule="nonzero"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(2.2 52.877)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="4.84" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="10.23" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="15.257000000000001" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="23.947000000000003" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="29.656000000000002" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="32.56" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="37.367000000000004" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="39.787000000000006" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="44.495000000000005" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="50.039" fill="#000000" fill-rule="nonzero"/>
+                                                                        </g>
+                                                                    </g>
+                                                                    <g transform="translate(2.2 53.735)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.44" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 23.947 0 "/>
+                                                                    </g>
+                                                                    <g transform="translate(28.776000000000003 53.735)">
+                                                                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.44" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 32.153 0 "/>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 66.22700000000002)">
+                                                <g class="typst-group">
+                                                    <g/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(219.50766141732282 137.5179381327334)">
+                                    <path class="typst-shape" fill="none" stroke="#2ecc40" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 2" d="M 0 0 L 0 5.5 "/>
+                                </g>
+                                <g transform="translate(219.50766141732282 143.0179381327334)">
+                                    <path class="typst-shape" fill="none" stroke="#2ecc40" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 2" d="M 0 0 L 147.32698 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 157.95593813273342)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gA68DA6B3B3D238AE928C954AEAD7F96A" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="9.581" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="17.248" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="21.956" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="26.983" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="35.695" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="40.722" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="43.626000000000005" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="47.916000000000004" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="56.21" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="60.918" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="66.462" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="72.424" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="75.9" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="79.90400000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="85.44800000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="91.102" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="94.578" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="100.49600000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="108.16300000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="111.63900000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="116.47900000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="121.86900000000001" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(218.80366141732281 157.95593813273342)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(-218.80366141732281 -157.95593813273342)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 154.65593813273344)">
+                                    <g class="typst-group">
+                                        <g>
+                                            <g transform="translate(4 4)">
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g transform="translate(-0 -0)">
+                                                            <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 6.9828 L 82.708664 6.9828 L 82.708664 0 Z "/>
+                                                        </g>
+                                                        <g transform="translate(0 0)">
+                                                            <g class="typst-group">
+                                                                <g>
+                                                                    <g transform="translate(1.3199999999999998 5.662799999999999)">
+                                                                        <g class="typst-text" transform="scale(1, -1)">
+                                                                            <use xlink:href="#g4AA98C76A3CD9D099D3A2BA331297E03" x="0" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gE0064DA460A3F923796CBC34360CE325" x="3.9401999999999995" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gD915A41BD839830DDF95593AB4587147" x="7.491" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g813EA6BAE404C14A9B381CCCD713CECC" x="9.2796" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gF8C22B8E9428DE19ED5E76D0B6F94D79" x="13.5036" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gD915A41BD839830DDF95593AB4587147" x="18.433799999999998" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gE178D7F47461E6A52FD78FD9F0543213" x="20.222399999999997" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gE178D7F47461E6A52FD78FD9F0543213" x="21.964799999999997" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g37A521866C3DDB88EADD371B6489FA" x="25.357199999999995" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gF165E978833A3682C842FC6D491F1148" x="28.676999999999996" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gD915A41BD839830DDF95593AB4587147" x="33.27719999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gFF67C7F08C47ECAA5515ACD903E6A3E3" x="35.065799999999996" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g3508090D5DB08745FDAC16BE13B23CF0" x="40.29299999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gFF67C7F08C47ECAA5515ACD903E6A3E3" x="43.98899999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gF165E978833A3682C842FC6D491F1148" x="47.56619999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gF2C65265520F47D93ECEB2A9CD8CD2B" x="52.16639999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gC15FD23282FB7CA5B3EE5FAD299A288" x="55.59179999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gD915A41BD839830DDF95593AB4587147" x="58.04699999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#gFF67C7F08C47ECAA5515ACD903E6A3E3" x="59.83559999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                            <use xlink:href="#g9959320E8E7A94EFAC8C7F4415EB4833" x="63.41279999999999" fill="#000000" fill-rule="nonzero"/>
+                                                                        </g>
+                                                                    </g>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                            <g transform="translate(4 15.272799999999998)">
+                                                <g class="typst-group">
+                                                    <g/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                                <g transform="translate(218.80366141732281 157.95593813273342)">
+                                    <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L 0 3.3 "/>
+                                </g>
+                                <g transform="translate(218.80366141732281 161.2559381327334)">
+                                    <path class="typst-shape" fill="none" stroke="#ff851b" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" d="M 0 0 L -132.095 0 "/>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(218.80366141732281 157.95593813273342)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="4.29" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD05C8665D544229CD7C233365E808FE" x="7.271000000000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="11.935" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="19.602" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE06C4B72531F49CBE9DB12FC3B2B6B4" x="22.583000000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2A9009985370E4784889D5A432B8A008" x="28.743000000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="36.872" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2A9009985370E4784889D5A432B8A008" x="44.539" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="52.756" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="56.848" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="61.875" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="70.334" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="73.315" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2601149520DEB11192D8871B69705481" x="79.541" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="82.52199999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="91.234" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(317.81466141732284 157.95593813273342)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g8C05BBC574D5FE4CFE5913B9029DB694" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g23110B8D3E178F349F41AF3F1139706F" x="5.298046875000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g3BCE8E5AFB034A1CFA0F275699E216B3" x="10.596093750000001" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8C05BBC574D5FE4CFE5913B9029DB694" x="15.894140625000002" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(339.0068489173228 157.95593813273342)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="7.457999999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="12.485" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="15.389" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="18.293" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 178.39393813273338)">
+            <g class="typst-text" transform="scale(1, -1)">
+                <use xlink:href="#g1D73A7A3000FC25AB5C09DB0E511C1F1" x="0" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="7.645" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="13.607" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gC23C47A73633CA682D6E6C5BB47A559" x="21.923000000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="28.083000000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="34.045" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="39.072" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="41.976" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gED11A2FABFE2E5A685ACE8A9144B017E" x="44.879999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g9EB1D08A7B1324D48AADD79859AC05BD" x="49.895999999999994" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gED11A2FABFE2E5A685ACE8A9144B017E" x="55.065999999999995" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="60.642999999999994" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="66.187" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="74.77799999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="79.48599999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="84.51299999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="93.225" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="97.93299999999999" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="101.937" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="106.854" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="111.881" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="115.357" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="123.024" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="130.801" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="134.277" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g6243475FABEC8A0579537E4EA4C95CD7" x="139.30399999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="144.72699999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="147.63099999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="155.29799999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gBE06C4B72531F49CBE9DB12FC3B2B6B4" x="160.84199999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="167.00199999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="172.02899999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="174.93299999999996" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gED11A2FABFE2E5A685ACE8A9144B017E" x="180.58699999999996" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="186.16399999999996" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="191.70799999999997" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="197.54899999999998" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="204.391" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="210.903" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="218.625" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="226.336" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="234.05800000000002" fill="#000000" fill-rule="nonzero"/>
+                <use xlink:href="#g62E645D0BABB53DB5C64FC1234E3D1C" x="238.348" fill="#000000" fill-rule="nonzero"/>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 198.19393813273336)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 9.933)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g295DFB81A5E395C1DFE0CF122DF08D85" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6D73600544136687ECCA2FDBD828407D" x="9.9638" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gFEB94A1E3ADB595B05DF90D09979543F" x="21.2058" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6D73600544136687ECCA2FDBD828407D" x="32.5094" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gDE5888032A667C61E0F2A9F956287985" x="43.7514" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 216.37693813273336)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="6.512" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="14.233999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="21.944999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g52F53110020E971308997FA33FA7F046" x="32.416999999999994" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(43.032000000000004 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="7.7219999999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="16.434" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="19.91" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="25.828" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="33.495000000000005" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="37.587" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g7F5F86196ADADB0032CB2049EB771F59" x="40.568000000000005" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="46.068000000000005" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="51.986000000000004" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(101.24400000000001 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(4.1178713910761156 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(8.235742782152231 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(12.353614173228346 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(16.471485564304462 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(20.589356955380577 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(24.707228346456695 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(28.825099737532813 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(32.94297112860893 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(37.060842519685046 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(41.17871391076116 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(45.29658530183728 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(49.4144566929134 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(53.53232808398951 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(57.650199475065634 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(61.76807086614175 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(65.88594225721786 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(70.00381364829397 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(74.12168503937008 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(78.23955643044619 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(82.3574278215223 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(86.4752992125984 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(90.59317060367452 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(94.71104199475063 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(98.82891338582674 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(102.94678477690285 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(107.06465616797895 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(111.18252755905506 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(115.30039895013117 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(119.41827034120729 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(123.5361417322834 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(127.6540131233595 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(131.77188451443564 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(135.88975590551175 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(140.00762729658788 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(144.125498687664 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(148.24337007874013 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(152.36124146981624 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(156.47911286089237 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(160.5969842519685 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(264.26098425196847 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g52F53110020E971308997FA33FA7F046" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 230.76493813273333)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="6.512" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="14.233999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="21.944999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g8133231E88A02C601D4A13E78DD5AB79" x="32.416999999999994" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(43.032000000000004 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="7.7219999999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="16.434" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="19.91" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="25.828" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="33.495000000000005" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="36.399" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gAFF10F80711561B34177BDAF77CC0EC4" x="41.316" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(93.65400000000001 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(4.102121567121183 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(8.204243134242367 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(12.306364701363547 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(16.408486268484733 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(20.510607835605914 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(24.612729402727098 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(28.714850969848282 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(32.816972536969466 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(36.91909410409065 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(41.02121567121183 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(45.123337238333015 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(49.225458805454195 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(53.32758037257538 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(57.429701939696564 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(61.53182350681775 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(65.63394507393893 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(69.7360666410601 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(73.83818820818128 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(77.94030977530245 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(82.04243134242363 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(86.14455290954481 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(90.24667447666599 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(94.34879604378716 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(98.45091761090833 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(102.55303917802952 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(106.6551607451507 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(110.75728231227187 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(114.85940387939304 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(118.96152544651422 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(123.0636470136354 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(127.16576858075658 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(131.26789014787778 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(135.37001171499895 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(139.47213328212013 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(143.5742548492413 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(147.67637641636247 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(151.77849798348365 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(155.88061955060482 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(159.982741117726 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(164.08486268484717 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(168.18698425196837 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(264.26098425196847 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g52F53110020E971308997FA33FA7F046" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 245.15293813273334)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="6.512" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="14.233999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="21.944999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6E676F4AC4E0A6739716B2650049D122" x="32.416999999999994" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(43.032000000000004 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g48F357F36910BC90E94F31A287082659" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="5.544" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="11.088" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="19.679" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="24.386999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="29.413999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="38.126" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="43.153" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="46.057" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="50.347" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="58.641" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="64.35" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="67.25399999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="72.28099999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="76.98899999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="84.65599999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="88.13199999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="94.05" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="98.967" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="110.407" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="113.38799999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="122.1" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="127.127" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="135.839" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="138.82" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="144.78199999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="147.68599999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="150.66699999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="156.62899999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6243475FABEC8A0579537E4EA4C95CD7" x="164.29599999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="169.82899999999995" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="175.29599999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="180.68599999999995" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(228.88799999999998 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(4.119123031496069 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(8.238246062992138 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(12.357369094488206 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(16.476492125984276 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(20.595615157480346 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(24.714738188976412 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(28.833861220472482 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(32.95298425196855 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(264.2609842519685 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g52F53110020E971308997FA33FA7F046" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 259.54093813273334)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="6.512" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="14.233999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="21.944999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g3D755F22EA44077C36D6DAB39CE77D75" x="32.416999999999994" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(43.032000000000004 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#gA68DA6B3B3D238AE928C954AEAD7F96A" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="9.581" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="17.248" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="23.21" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="28.204" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE6F033D381DE263D17F3D282D6F4539" x="33.198" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="41.514" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="44.99" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC23C47A73633CA682D6E6C5BB47A559" x="53.284" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="59.444" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="67.584" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="71.06" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="76.97800000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="87.39500000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g89FD5B500F3A7CF8EB197275F181B2CD" x="92.38900000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gD81BBE63D3896E389D965841F55FD823" x="97.92200000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="103.763" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="108.79" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="112.266" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="115.247" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="120.791" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="126.753" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gAE16D62B0766FCB252798197B2E66D5D" x="131.923" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="137.258" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="142.252" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="149.919" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gACA8C8372E397B2A6390FB0ABD8B454F" x="154.75900000000001" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B8E9BF6DE9807F61775E11A6D0CAB0D" x="160.149" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="165.176" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="173.86599999999999" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="179.575" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="182.47899999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="187.28599999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gE5375F7960F3BFC8B71B32E6E573207A" x="189.70599999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g56D1BA11FCB90BD281F2B56DA5344C18" x="194.41399999999996" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g85670A81F105DEDF150C249F023CD5C5" x="199.95799999999997" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(254.43000000000006 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(7.410984251968473 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(264.2609842519685 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g52F53110020E971308997FA33FA7F046" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g transform="translate(90.70866141732283 273.9289381327333)">
+            <g class="typst-group">
+                <g>
+                    <g transform="translate(0 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="6.512" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g3ACBDEFEE62D886C68713244CC221B65" x="14.233999999999998" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1ACC4969B3C6B01DA31AF0AEF7B25079" x="21.944999999999997" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g59FDDD5E0FE4FB61395B3BF25C03A511" x="32.416999999999994" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(43.032000000000004 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g767A293D1BC7743CA9408AC17A782327" x="0" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g84F7D56C26B4F026CB730340333F3592" x="6.567" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="12.485" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g670F26D21C61EF57D19F8F107A62B0CA" x="15.466" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2A9009985370E4784889D5A432B8A008" x="22.506" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="30.723" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="33.704" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g77BC2A2BD0F2C981307857FA0DC1A2C2" x="36.608000000000004" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g6243475FABEC8A0579537E4EA4C95CD7" x="42.262" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="47.795" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="55.462" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="58.443000000000005" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gC23C47A73633CA682D6E6C5BB47A559" x="67.155" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="73.315" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#gBE0D1B008B2A7A3ED176E6F0B57CEAEE" x="79.277" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g5C1EAF09AC09CDE799FC6A983FC1D9F7" x="86.944" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g8030D7A0BE4B4880ADF7A940D8D531F4" x="92.653" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2601149520DEB11192D8871B69705481" x="96.745" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" x="99.726" fill="#000000" fill-rule="nonzero"/>
+                            <use xlink:href="#g1B62498D59215C22335138D632626DDB" x="105.688" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                    <g transform="translate(154.946 0)">
+                        <g class="typst-group">
+                            <g>
+                                <g transform="translate(0 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(4.111345548152634 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(8.222691096305269 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(12.334036644457905 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(16.445382192610538 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(20.556727740763172 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(24.668073288915807 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(28.77941883706844 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(32.890764385221075 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(37.00210993337371 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(41.113455481526344 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(45.22480102967898 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(49.33614657783161 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(53.44749212598425 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(57.55883767413688 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(61.670183222289516 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(65.78152877044215 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(69.89287431859479 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(74.00421986674742 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(78.11556541490006 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(82.22691096305269 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(86.33825651120533 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(90.44960205935796 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(94.5609476075106 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(98.67229315566323 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(102.78363870381585 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                                <g transform="translate(106.8949842519685 7.238)">
+                                    <g class="typst-text" transform="scale(1, -1)">
+                                        <use xlink:href="#g4DA78131B4AE5A2575D972CF0C2113FB" x="0" fill="#000000" fill-rule="nonzero"/>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                    <g transform="translate(264.2609842519685 7.238)">
+                        <g class="typst-text" transform="scale(1, -1)">
+                            <use xlink:href="#g52F53110020E971308997FA33FA7F046" x="2.75" fill="#000000" fill-rule="nonzero"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <defs id="glyph">
+        <symbol id="gFEB94A1E3ADB595B05DF90D09979543F" overflow="visible">
+            <path d="M 2.849 0 C 3.465 0 4.7278 -0.0308 5.3438 -0.0308 C 6.699 -0.0308 8.2236 0.308 9.317 1.2628 C 10.0562 1.9096 10.5644 3.1878 10.5644 4.7585998 C 10.5644 7.6075997 8.7164 9.9484 4.928 9.9484 C 4.1118 9.9484 3.465 9.933 2.849 9.933 C 2.233 9.933 0.4774 9.963799 0.4774 9.963799 C 0.3234 9.8714 0.3234 9.5326 0.4774 9.4402 C 1.3244 9.394 1.7556 9.3324 1.7556 8.0542 L 1.7556 1.8788 C 1.7556 0.6006 1.3244 0.539 0.4774 0.4928 C 0.3234 0.40039998 0.3234 0.0616 0.4774 -0.0308 C 0.4774 -0.0308 2.233 0 2.849 0 Z M 3.9115999 1.8326 L 3.9115999 8.1466 C 3.9115999 8.9936 4.312 9.3015995 4.8664 9.3015995 C 7.9002 9.3015995 8.239 6.699 8.239 4.3736 C 8.239 1.5708 6.5604 0.616 5.39 0.616 C 4.312 0.616 3.9115999 0.80079997 3.9115999 1.8326 Z "/>
+        </symbol>
+        <symbol id="g4903813593648E111167B975CD6AD3BA" overflow="visible">
+            <path d="M 4.5429997 0.7546 C 4.6507998 0.1232 5.0666 -0.154 5.7441998 -0.154 C 6.5912 -0.154 7.1918 0.1694 7.7616 0.7084 C 7.7308 0.8932 7.6692 1.0164 7.4844 1.1396 C 7.2842 0.9856 7.1302 0.924 6.8375998 0.924 C 6.4988 0.924 6.4063997 1.2012 6.4063997 1.9557999 L 6.4372 4.1734 C 6.4372 6.391 5.0666 6.8375998 3.8037999 6.8375998 C 2.6796 6.8375998 0.9548 6.1908 0.9548 5.1744 C 0.9548 4.7432 1.1396 4.4044 1.7402 4.4044 C 2.2946 4.4044 2.695 4.7432 2.695 5.1128 C 2.695 5.1898 2.6796 5.2822 2.6642 5.3746 C 2.6334 5.5285997 2.6026 5.6826 2.6334 5.8366 C 2.6488 6.006 2.772 6.1908 3.2802 6.1908 C 3.927 6.1908 4.466 5.9136 4.466 3.9578 L 3.4342 3.6344 C 1.8172 3.1262 0.6776 2.6796 0.6776 1.4629999 C 0.6776 0.40039998 1.2628 -0.154 2.6026 -0.154 C 3.0492 -0.154 3.9424 0.3388 4.4506 0.7392 Z M 4.466 3.3572 L 4.466 1.3244 C 4.081 1.0164 3.696 0.77 3.4187999 0.77 C 2.7566 0.77 2.5256 1.2166 2.5256 1.694 C 2.5256 2.2638 2.5718 2.7412 3.6652 3.0954 Z "/>
+        </symbol>
+        <symbol id="gDE5888032A667C61E0F2A9F956287985" overflow="visible">
+            <path d="M 0.7392 2.2484 C 0.80079997 1.4938 0.8778 0.77 1.001 0.1848 C 1.2936 0.0924 2.2792 -0.154 3.1416 -0.154 C 4.3274 -0.154 5.8058 0.4928 5.8058 1.8326 C 5.8058 2.3562 5.6826 2.772 5.3284 3.157 C 4.8972 3.6498 4.2504 4.0348 3.542 4.3428 C 2.9259999 4.6046 2.7104 5.0974 2.7104 5.544 C 2.7104 5.8982 3.003 6.1908 3.4496 6.1908 C 3.9886 6.1908 4.5122 5.698 4.8972 4.7585998 C 5.1744 4.7124 5.3438 4.7278 5.4978 4.8356 C 5.4978 5.39 5.4362 5.9752 5.2976 6.468 C 4.8048 6.6836 4.4198 6.8375998 3.5728 6.8375998 C 2.7566 6.8375998 1.9866 6.5296 1.4938 6.0368 C 1.1396 5.6826 0.9702 5.2514 0.9702 4.8356 C 0.9702 4.3736 1.155 4.004 1.4476 3.6806 C 1.925 3.157 2.772 2.618 3.234 2.4024 C 3.85 2.1252 4.0194 1.5708 4.0194 1.2012 C 4.0194 0.7084 3.5266 0.4466 3.1108 0.4466 C 2.4178 0.4466 1.6786 1.155 1.3552 2.2792 C 1.1087999 2.3253999 0.9856 2.31 0.7392 2.2484 Z "/>
+        </symbol>
+        <symbol id="g64A1F39F0DBD9BF68AB01E1009879DA9" overflow="visible">
+            <path d="M 8.1312 1.9712 L 8.1312 4.3736 C 8.1312 6.0676 7.4074 6.8375998 6.083 6.8375998 C 5.5132 6.8375998 4.4198 6.2678 3.542 5.7288 L 3.542 8.9782 C 3.542 9.9792 3.5882 10.549 3.5882 10.549 C 3.5882 10.6876 3.4804 10.7492 3.3418 10.7492 C 2.772 10.5644 1.54 10.3949995 0.4466 10.3488 C 0.40039998 10.164 0.4158 9.9946 0.4928 9.856 C 1.4629999 9.779 1.54 9.7636 1.54 8.701 L 1.54 1.9557999 C 1.54 0.6776 1.2936 0.539 0.3542 0.4928 C 0.2618 0.40039998 0.2618 0.0616 0.3542 -0.0308 C 1.001 -0.0154 1.694 0 2.541 0 C 3.2802 0 3.7576 -0.0154 4.4198 -0.0308 C 4.5122 0.0616 4.5122 0.40039998 4.4198 0.4928 C 3.773 0.539 3.542 0.6776 3.542 1.9557999 L 3.542 5.1128 C 4.1888 5.5132 4.697 5.698 4.9742 5.698 C 5.5902 5.698 6.1292 5.4208 6.1292 4.5429997 L 6.1292 1.9712 C 6.1292 0.6776 5.8828 0.539 5.2514 0.4928 C 5.159 0.40039998 5.159 0.0616 5.2514 -0.0308 C 5.8982 -0.0154 6.391 0 7.1302 0 C 7.9772 0 8.6548 -0.0154 9.317 -0.0308 C 9.4094 0.0616 9.4094 0.40039998 9.317 0.4928 C 8.3776 0.539 8.1312 0.6776 8.1312 1.9712 Z "/>
+        </symbol>
+        <symbol id="g63EA10F98C28BA150F4CE2DE65B750A4" overflow="visible">
+            <path d="M 3.7268 -2.5872 C 3.9732 -2.156 4.2042 -1.6015999 4.389 -1.1396 C 5.621 1.8326 6.3756 3.4958 7.1918 5.2206 C 7.4074 5.6672 7.8694 6.1446 8.4392 6.1908 C 8.5316 6.2832 8.5316 6.6219997 8.4392 6.7144 C 8.0542 6.699 7.777 6.6836 7.3458 6.6836 C 6.8068 6.6836 6.2832 6.699 5.7134 6.7144 C 5.621 6.6219997 5.621 6.2832 5.7134 6.1908 C 6.2062 6.1446 6.699 6.0676 6.4526 5.5132 L 4.8664 1.9557999 C 4.8664 1.9404 4.8664 1.9404 4.851 1.925 C 4.851 1.9404 4.851 1.9557999 4.8356 1.9866 L 3.4034 5.2052 C 3.388 5.2206 3.388 5.236 3.388 5.2514 C 3.1108 5.8519998 3.003 6.1138 3.9115999 6.1908 C 4.004 6.2832 4.004 6.6219997 3.9115999 6.7144 C 3.3418 6.699 2.4178 6.6836 1.8634 6.6836 C 1.3398 6.6836 0.462 6.699 0.154 6.7144 C 0.0616 6.6219997 0.0616 6.2832 0.154 6.1908 C 0.8316 6.1292 0.9548 6.0214 1.3706 5.0512 L 3.3572 0.4928 C 3.4034 0.4158 3.465 0.3542 3.5112 0.2926 C 3.7114 0.0154 3.8808 -0.2156 3.7884 -0.4312 L 3.4187999 -1.2782 C 3.2186 -1.7556 3.0338 -2.0328 2.6026 -2.0328 C 2.3253999 -2.0328 2.2792 -1.9712 2.0636 -1.9712 C 1.4784 -1.9712 1.1396 -2.3716 1.1396 -2.6796 C 1.1396 -2.8798 1.1858 -3.1262 1.3244 -3.2956 C 1.4629999 -3.465 1.7248 -3.5728 1.925 -3.5728 C 2.1252 -3.5728 2.5872 -3.5112 2.8028 -3.4187999 C 3.1262 -3.2648 3.5574 -2.8952 3.7268 -2.5872 Z "/>
+        </symbol>
+        <symbol id="g295DFB81A5E395C1DFE0CF122DF08D85" overflow="visible">
+            <path d="M 6.237 1.8942 L 6.237 7.7462 C 6.237 8.7318 6.391 9.3015995 6.9453998 9.3015995 L 7.2842 9.3015995 C 8.4392 9.3015995 9.0859995 8.9166 9.3478 7.7308 C 9.5171995 7.7308 9.8098 7.7462 9.9484 7.8078 C 9.8406 8.5162 9.7636 9.317 9.7482 10.01 C 9.7482 10.0254 9.7174 10.0562 9.702 10.0562 C 9.1784 10.01 7.469 9.933 6.2524 9.933 L 4.081 9.933 C 2.8952 9.933 1.078 10.01 0.4928 10.0562 C 0.462 10.0562 0.4312 10.0254 0.4312 10.01 C 0.3696 9.317 0.2156 8.5008 0.0462 7.7616 C 0.20019999 7.7 0.462 7.6846 0.6468 7.6846 C 0.9548 8.9166 1.5862 9.3015995 2.6026 9.3015995 L 3.3572 9.3015995 C 3.927 9.3015995 4.081 8.7318 4.081 7.7924 L 4.081 1.8942 C 4.081 0.616 3.8192 0.539 2.5872 0.4928 C 2.4948 0.40039998 2.4948 0.0616 2.5872 -0.0308 C 3.3418 -0.0154 4.1426 0 5.1282 0 C 6.1446 0 6.9608 -0.0154 7.7308 -0.0308 C 7.8231997 0.0616 7.8231997 0.40039998 7.7308 0.4928 C 6.4988 0.539 6.237 0.616 6.237 1.8942 Z "/>
+        </symbol>
+        <symbol id="g6D73600544136687ECCA2FDBD828407D" overflow="visible">
+            <path d="M 10.6876 5.0666 C 10.6876 8.1312 8.4084 10.1332 5.5902 10.1332 C 4.0502 10.1332 2.7104 9.471 1.8172 8.4084 C 1.0164 7.4536 0.5698 6.1754 0.5698 4.7585998 C 0.5698 1.7093999 2.9876 -0.154 5.6056 -0.154 C 7.1918 -0.154 8.4854 0.4158 9.3632 1.3706 C 10.2102 2.2946 10.6876 3.5574 10.6876 5.0666 Z M 5.4054 9.4864 C 7.0532 9.4864 8.3622 7.8694 8.3622 4.7432 C 8.3622 2.1868 7.469 0.4928 5.9136 0.4928 C 4.2196 0.4928 2.8952 2.1714 2.8952 5.0666 C 2.8952 8.2081995 4.0348 9.4864 5.4054 9.4864 Z "/>
+        </symbol>
+        <symbol id="g767A293D1BC7743CA9408AC17A782327" overflow="visible">
+            <path d="M 3.85 1.342 L 3.85 5.544 C 3.85 6.248 3.96 6.666 4.356 6.666 L 4.598 6.666 C 5.423 6.666 5.94 6.38 6.127 5.533 C 6.248 5.533 6.402 5.544 6.501 5.588 C 6.424 6.094 6.369 6.6549997 6.358 7.15 C 6.358 7.161 6.336 7.183 6.325 7.183 C 5.9509997 7.15 4.73 7.095 3.861 7.095 L 2.915 7.095 C 2.068 7.095 0.77 7.15 0.352 7.183 C 0.32999998 7.183 0.308 7.161 0.308 7.15 C 0.264 6.6549997 0.154 6.083 0.033 5.555 C 0.143 5.511 0.275 5.5 0.407 5.5 C 0.627 6.38 1.133 6.666 1.859 6.666 L 2.398 6.666 C 2.805 6.666 2.915 6.248 2.915 5.577 L 2.915 1.342 C 2.915 0.429 2.728 0.374 1.848 0.341 C 1.782 0.275 1.782 0.044 1.848 -0.022 C 2.387 -0.011 2.948 0 3.388 0 C 3.806 0 4.367 -0.011 4.917 -0.022 C 4.983 0.044 4.983 0.275 4.917 0.341 C 4.037 0.374 3.85 0.429 3.85 1.342 Z "/>
+        </symbol>
+        <symbol id="g1ACC4969B3C6B01DA31AF0AEF7B25079" overflow="visible">
+            <path d="M 7.3259997 3.619 C 7.3259997 5.896 5.753 7.238 3.784 7.238 C 1.65 7.238 0.407 5.544 0.407 3.41 C 0.407 1.243 1.98 -0.11 3.85 -0.11 C 5.071 -0.11 6.039 0.41799998 6.644 1.276 C 7.084 1.903 7.3259997 2.695 7.3259997 3.619 Z M 3.641 6.842 C 5.093 6.842 6.27 5.632 6.27 3.41 C 6.27 1.441 5.324 0.286 4.07 0.286 C 2.728 0.286 1.4629999 1.485 1.4629999 3.597 C 1.4629999 5.907 2.552 6.842 3.641 6.842 Z "/>
+        </symbol>
+        <symbol id="g3ACBDEFEE62D886C68713244CC221B65" overflow="visible">
+            <path d="M 1.628 7.095 C 1.232 7.095 0.649 7.106 0.20899999 7.117 C 0.143 7.051 0.143 6.82 0.20899999 6.754 C 0.979 6.721 1.166 6.666 1.166 5.753 L 1.166 1.342 C 1.166 0.429 0.979 0.374 0.20899999 0.341 C 0.143 0.275 0.143 0.044 0.20899999 -0.022 C 0.638 -0.011 1.221 0 1.6389999 0 C 2.046 0 2.508 -0.022 3.641 -0.022 C 5.192 -0.022 7.238 0.682 7.238 3.388 C 7.238 5.434 5.555 7.117 3.443 7.117 C 2.662 7.117 2.057 7.095 1.628 7.095 Z M 2.101 0.924 L 2.101 6.204 C 2.101 6.5889997 2.486 6.743 3.025 6.743 C 5.401 6.743 6.182 4.818 6.182 3.124 C 6.182 0.902 4.851 0.352 3.3 0.352 C 2.222 0.352 2.101 0.572 2.101 0.924 Z "/>
+        </symbol>
+        <symbol id="g670F26D21C61EF57D19F8F107A62B0CA" overflow="visible">
+            <path d="M 0.528 1.518 C 0.572 0.979 0.605 0.462 0.605 0 C 0.715 0.022 0.825 0.033 0.88 0.033 C 0.957 0.033 1.023 0.033 1.1 0.011 C 1.397 -0.066 1.694 -0.11 2.101 -0.11 C 2.717 -0.11 3.85 0.187 3.85 1.276 C 3.85 2.024 3.3109999 2.464 2.563 2.739 C 1.903 2.992 1.4629999 3.157 1.4629999 3.762 C 1.4629999 4.213 1.859 4.466 2.233 4.466 C 2.475 4.466 3.113 4.378 3.256 3.443 C 3.322 3.377 3.542 3.388 3.608 3.454 C 3.641 3.85 3.6629999 4.257 3.674 4.62 C 3.333 4.675 2.805 4.829 2.233 4.829 C 1.419 4.829 0.682 4.301 0.682 3.597 C 0.682 2.794 1.045 2.453 1.892 2.101 C 2.805 1.727 3.014 1.496 3.014 1.023 C 3.014 0.484 2.486 0.253 2.079 0.253 C 1.65 0.253 1.408 0.396 1.298 0.517 C 1.056 0.77 0.935 1.254 0.869 1.529 C 0.803 1.595 0.594 1.584 0.528 1.518 Z "/>
+        </symbol>
+        <symbol id="g1B8E9BF6DE9807F61775E11A6D0CAB0D" overflow="visible">
+            <path d="M 3.223 0.528 C 3.289 0.187 3.41 -0.11 3.96 -0.11 C 4.378 -0.11 4.774 0.077 5.005 0.297 C 4.983 0.429 4.939 0.528 4.818 0.594 C 4.741 0.528 4.554 0.41799998 4.411 0.41799998 C 4.092 0.41799998 4.081 0.847 4.081 1.353 L 4.081 2.97 C 4.081 4.532 3.223 4.829 2.42 4.829 C 1.518 4.829 0.605 4.235 0.605 3.608 C 0.605 3.3439999 0.737 3.212 0.99 3.212 C 1.309 3.212 1.507 3.443 1.507 3.586 C 1.507 3.6629999 1.496 3.74 1.474 3.784 C 1.4629999 3.817 1.452 3.883 1.452 4.004 C 1.452 4.345 1.914 4.466 2.332 4.466 C 2.706 4.466 3.223 4.279 3.223 3.036 C 3.223 2.9589999 3.19 2.915 3.157 2.904 L 2.211 2.673 C 1.155 2.409 0.396 1.826 0.396 1.078 C 0.396 0.176 1.012 -0.11 1.782 -0.11 C 2.167 -0.11 2.497 -0.022 2.981 0.352 L 3.201 0.528 Z M 3.223 2.563 L 3.223 1.111 C 3.223 0.968 3.157 0.891 3.069 0.825 C 2.783 0.594 2.409 0.341 2.101 0.341 C 1.551 0.341 1.309 0.781 1.309 1.122 C 1.309 1.617 1.54 2.123 2.354 2.332 Z "/>
+        </symbol>
+        <symbol id="g8030D7A0BE4B4880ADF7A940D8D531F4" overflow="visible">
+            <path d="M 1.936 3.938 C 1.914 4.378 1.903 4.664 1.848 4.774 C 1.826 4.829 1.804 4.862 1.716 4.862 C 1.408 4.741 1.122 4.642 0.363 4.5429997 C 0.341 4.4769998 0.363 4.301 0.385 4.235 C 0.979 4.18 1.1 4.125 1.1 3.487 L 1.1 1.342 C 1.1 0.429 0.968 0.385 0.286 0.341 C 0.22 0.275 0.22 0.044 0.286 -0.022 C 0.671 -0.011 1.1 0 1.54 0 C 1.98 0 2.486 -0.011 2.871 -0.022 C 2.937 0.044 2.937 0.275 2.871 0.341 C 2.101 0.396 1.969 0.429 1.969 1.342 L 1.969 2.871 C 1.969 3.157 2.101 3.41 2.233 3.608 C 2.354 3.784 2.6069999 4.147 2.739 4.147 C 2.838 4.147 2.937 4.125 3.025 4.004 C 3.102 3.894 3.234 3.751 3.421 3.751 C 3.685 3.751 3.938 4.026 3.938 4.301 C 3.938 4.5099998 3.74 4.829 3.2779999 4.829 C 2.761 4.829 2.31 4.345 2.057 3.916 C 1.9909999 3.795 1.936 3.883 1.936 3.938 Z "/>
+        </symbol>
+        <symbol id="gBE0D1B008B2A7A3ED176E6F0B57CEAEE" overflow="visible">
+            <path d="M 4.246 1.023 C 3.839 0.605 3.52 0.429 2.882 0.429 C 2.486 0.429 2.024 0.65999997 1.683 1.221 C 1.4629999 1.584 1.331 2.09 1.331 2.728 L 4.257 2.706 C 4.389 2.706 4.466 2.772 4.466 2.893 C 4.466 3.817 4.136 4.807 2.6069999 4.807 C 1.65 4.807 0.407 3.894 0.407 2.222 C 0.407 1.606 0.561 1.012 0.924 0.594 C 1.298 0.154 1.8149999 -0.11 2.6069999 -0.11 C 3.443 -0.11 4.037 0.275 4.4769998 0.847 C 4.444 0.957 4.378 1.012 4.246 1.023 Z M 1.364 3.102 C 1.573 4.345 2.343 4.444 2.6069999 4.444 C 3.025 4.444 3.52 4.213 3.52 3.289 C 3.52 3.19 3.476 3.135 3.355 3.135 Z "/>
+        </symbol>
+        <symbol id="gD81BBE63D3896E389D965841F55FD823" overflow="visible">
+            <path d="M 2.387 -0.11 C 2.816 -0.11 3.333 0.11 3.872 0.55 C 3.927 0.594 4.026 0.616 4.037 0.539 C 4.07 0.264 4.158 -0.11 4.158 -0.11 C 4.246 -0.143 4.301 -0.132 4.367 -0.11 C 4.609 0.088 4.994 0.253 5.665 0.32999998 C 5.731 0.396 5.731 0.561 5.665 0.627 C 4.961 0.682 4.862 0.891 4.862 1.43 L 4.862 3.542 C 4.862 3.872 4.906 4.675 4.906 4.675 C 4.906 4.708 4.873 4.741 4.818 4.741 C 4.763 4.73 4.598 4.719 4.433 4.719 C 4.081 4.719 3.685 4.73 3.3109999 4.741 C 3.245 4.675 3.245 4.444 3.3109999 4.378 C 3.85 4.345 3.993 4.213 3.993 3.487 L 3.993 1.364 C 3.993 1.155 3.971 1.067 3.817 0.935 C 3.41 0.583 2.992 0.407 2.717 0.407 C 2.387 0.407 1.837 0.561 1.837 1.54 L 1.837 3.542 C 1.837 3.872 1.881 4.675 1.881 4.675 C 1.881 4.708 1.848 4.741 1.793 4.741 C 1.738 4.73 1.573 4.719 1.408 4.719 C 1.056 4.719 0.65999997 4.73 0.286 4.741 C 0.22 4.675 0.22 4.444 0.286 4.378 C 0.814 4.334 0.968 4.213 0.968 3.498 L 0.968 1.386 C 0.968 0.627 1.298 -0.11 2.387 -0.11 Z "/>
+        </symbol>
+        <symbol id="g1B62498D59215C22335138D632626DDB" overflow="visible">
+            <path d="M 0.473 4.719 C 0.319 4.719 0.275 4.587 0.275 4.499 L 0.275 4.356 C 0.275 4.301 0.286 4.29 0.32999998 4.29 L 0.979 4.29 L 0.979 0.979 C 0.979 0.198 1.3199999 -0.11 1.826 -0.11 C 2.332 -0.11 2.882 0.132 3.3109999 0.616 C 3.289 0.726 3.223 0.792 3.113 0.803 C 2.827 0.583 2.497 0.495 2.211 0.495 C 1.914 0.495 1.848 0.825 1.848 1.507 L 1.848 4.29 L 2.992 4.29 C 3.102 4.29 3.256 4.334 3.256 4.433 L 3.256 4.653 C 3.256 4.697 3.223 4.719 3.168 4.719 L 1.848 4.719 L 1.848 5.148 C 1.848 5.863 1.892 6.303 1.892 6.303 C 1.892 6.369 1.859 6.402 1.804 6.402 C 1.76 6.402 1.661 6.358 1.562 6.303 C 1.441 6.237 1.331 6.182 1.188 6.149 C 1.056 6.105 0.946 6.072 0.946 5.995 C 0.946 5.863 0.979 5.94 0.979 4.719 Z "/>
+        </symbol>
+        <symbol id="g56D1BA11FCB90BD281F2B56DA5344C18" overflow="visible">
+            <path d="M 0.451 2.2549999 C 0.451 1.133 1.199 -0.11 2.761 -0.11 C 3.465 -0.11 4.004 0.143 4.378 0.506 C 4.873 0.99 5.093 1.683 5.093 2.354 C 5.093 3.498 4.466 4.829 2.783 4.829 C 2.057 4.829 1.4629999 4.532 1.056 4.059 C 0.65999997 3.586 0.451 2.948 0.451 2.2549999 Z M 2.618 4.444 C 3.564 4.444 4.147 3.586 4.147 2.002 C 4.147 0.616 3.432 0.275 2.915 0.275 C 1.771 0.275 1.397 1.661 1.397 2.508 C 1.397 3.465 1.628 4.444 2.618 4.444 Z "/>
+        </symbol>
+        <symbol id="g85670A81F105DEDF150C249F023CD5C5" overflow="visible">
+            <path d="M 1.87 3.938 C 1.859 4.268 1.837 4.664 1.782 4.774 C 1.76 4.829 1.738 4.862 1.65 4.862 C 1.342 4.741 1.056 4.642 0.297 4.5429997 C 0.275 4.4769998 0.297 4.301 0.319 4.235 C 0.913 4.18 1.034 4.125 1.034 3.487 L 1.034 1.342 C 1.034 0.44 0.891 0.385 0.286 0.341 C 0.22 0.275 0.22 0.044 0.286 -0.022 C 0.616 -0.011 1.034 0 1.474 0 C 1.914 0 2.2549999 -0.011 2.585 -0.022 C 2.651 0.044 2.651 0.275 2.585 0.341 C 2.024 0.396 1.903 0.44 1.903 1.342 L 1.903 3.146 C 1.903 3.377 2.002 3.509 2.09 3.608 C 2.53 4.037 2.937 4.257 3.2779999 4.257 C 3.696 4.257 4.004 3.993 4.004 3.256 L 4.004 1.342 C 4.004 0.44 3.916 0.385 3.322 0.341 C 3.267 0.275 3.267 0.044 3.322 -0.022 C 3.597 -0.011 4.004 0 4.444 0 C 4.884 0 5.2469997 -0.011 5.522 -0.022 C 5.577 0.044 5.577 0.275 5.522 0.341 C 4.972 0.385 4.873 0.44 4.873 1.342 L 4.873 3.091 C 4.873 3.245 4.873 3.399 4.862 3.531 C 5.39 4.114 5.8849998 4.257 6.314 4.257 C 6.732 4.257 6.974 4.015 6.974 3.2779999 L 6.974 1.342 C 6.974 0.44 6.864 0.385 6.292 0.341 C 6.237 0.275 6.237 0.044 6.292 -0.022 C 6.567 -0.011 6.974 0 7.414 0 C 7.854 0 8.239 -0.011 8.547 -0.022 C 8.602 0.044 8.602 0.275 8.547 0.341 C 7.942 0.385 7.843 0.44 7.843 1.342 L 7.843 3.08 C 7.843 4.059 7.678 4.829 6.71 4.829 C 6.149 4.829 5.467 4.62 4.895 4.015 C 4.862 3.9819999 4.796 3.927 4.774 4.026 C 4.675 4.4769998 4.246 4.829 3.674 4.829 C 3.036 4.829 2.464 4.455 2.002 3.938 C 1.947 3.883 1.881 3.806 1.87 3.938 Z "/>
+        </symbol>
+        <symbol id="g2601149520DEB11192D8871B69705481" overflow="visible">
+            <path d="M 1.9909999 1.342 L 1.9909999 3.531 C 1.9909999 4.081 2.035 4.785 2.035 4.785 C 2.035 4.829 1.98 4.862 1.892 4.862 C 1.584 4.741 1.144 4.642 0.385 4.5429997 C 0.363 4.4769998 0.385 4.301 0.407 4.235 C 1.012 4.18 1.122 4.114 1.122 3.487 L 1.122 1.342 C 1.122 0.429 1.001 0.396 0.32999998 0.341 C 0.264 0.275 0.264 0.044 0.32999998 -0.022 C 0.693 -0.011 1.122 0 1.562 0 C 2.002 0 2.42 -0.011 2.783 -0.022 C 2.849 0.044 2.849 0.275 2.783 0.341 C 2.112 0.385 1.9909999 0.429 1.9909999 1.342 Z M 0.99 6.5889997 C 0.99 6.303 1.254 6.017 1.518 6.017 C 1.826 6.017 2.09 6.314 2.09 6.545 C 2.09 6.809 1.859 7.117 1.562 7.117 C 1.298 7.117 0.99 6.853 0.99 6.5889997 Z "/>
+        </symbol>
+        <symbol id="gE5375F7960F3BFC8B71B32E6E573207A" overflow="visible">
+            <path d="M 4.378 1.001 C 4.334 1.1 4.246 1.144 4.147 1.155 C 3.773 0.671 3.3 0.429 2.827 0.429 C 2.024 0.429 1.353 1.243 1.353 2.53 C 1.353 3.74 1.881 4.466 2.6069999 4.466 C 3.256 4.466 3.3439999 4.081 3.388 3.696 C 3.421 3.399 3.575 3.3 3.806 3.3 C 4.037 3.3 4.345 3.443 4.345 3.784 C 4.345 4.389 3.718 4.829 2.662 4.829 C 1.573 4.829 0.407 3.85 0.407 2.288 C 0.407 0.869 1.199 -0.11 2.585 -0.11 C 3.245 -0.11 3.828 0.099 4.378 1.001 Z "/>
+        </symbol>
+        <symbol id="g77BC2A2BD0F2C981307857FA0DC1A2C2" overflow="visible">
+            <path d="M 1.045 1.342 C 1.045 0.429 0.924 0.374 0.253 0.341 C 0.187 0.275 0.187 0.044 0.253 -0.022 C 0.638 -0.011 1.045 0 1.485 0 C 1.925 0 2.343 -0.011 2.706 -0.022 C 2.772 0.044 2.772 0.275 2.706 0.341 C 2.035 0.374 1.914 0.429 1.914 1.342 L 1.914 6.413 C 1.914 7.128 1.958 7.568 1.958 7.568 C 1.958 7.645 1.914 7.678 1.8149999 7.678 C 1.54 7.568 0.715 7.414 0.275 7.381 C 0.253 7.2929997 0.275 7.117 0.341 7.051 C 0.979 7.007 1.045 6.974 1.045 6.149 Z "/>
+        </symbol>
+        <symbol id="gED11A2FABFE2E5A685ACE8A9144B017E" overflow="visible">
+            <path d="M 2.244 -1.76 C 2.42 -1.452 2.563 -1.144 2.695 -0.814 C 3.575 1.309 4.07 2.442 4.642 3.674 C 4.862 4.136 5.016 4.312 5.533 4.378 C 5.599 4.444 5.599 4.675 5.533 4.741 C 5.313 4.73 5.06 4.719 4.752 4.719 C 4.422 4.719 4.081 4.73 3.751 4.741 C 3.685 4.675 3.685 4.444 3.751 4.378 C 4.103 4.345 4.455 4.279 4.279 3.883 L 3.19 1.364 C 3.113 1.188 3.014 1.155 2.9259999 1.375 L 1.947 3.6629999 C 1.749 4.125 1.694 4.334 2.31 4.378 C 2.376 4.444 2.376 4.675 2.31 4.741 C 1.903 4.73 1.4629999 4.719 1.067 4.719 C 0.693 4.719 0.396 4.73 0.176 4.741 C 0.11 4.675 0.11 4.444 0.176 4.378 C 0.616 4.323 0.759 4.224 1.045 3.553 L 2.288 0.65999997 C 2.387 0.44 2.552 -0.066 2.442 -0.374 C 2.31 -0.737 2.178 -1.045 2.013 -1.386 C 1.892 -1.606 1.738 -1.705 1.4629999 -1.705 C 1.309 -1.705 1.265 -1.6719999 1.144 -1.6719999 C 0.825 -1.6719999 0.65999997 -2.002 0.65999997 -2.145 C 0.65999997 -2.376 0.88 -2.552 1.177 -2.552 C 1.408 -2.552 1.848 -2.464 2.244 -1.76 Z "/>
+        </symbol>
+        <symbol id="g5C1EAF09AC09CDE799FC6A983FC1D9F7" overflow="visible">
+            <path d="M 1.716 4.048 C 1.705 4.378 1.683 4.664 1.628 4.774 C 1.606 4.829 1.584 4.862 1.496 4.862 C 1.188 4.741 0.902 4.642 0.143 4.5429997 C 0.121 4.4769998 0.143 4.301 0.16499999 4.235 C 0.759 4.18 0.88 4.125 0.88 3.487 L 0.88 -1.21 C 0.88 -2.123 0.759 -2.178 0.088 -2.211 C 0.022 -2.277 0.022 -2.508 0.088 -2.574 C 0.473 -2.563 0.88 -2.552 1.3199999 -2.552 C 1.76 -2.552 2.288 -2.563 2.651 -2.574 C 2.717 -2.508 2.717 -2.277 2.651 -2.211 C 1.87 -2.167 1.749 -2.123 1.749 -1.21 L 1.749 -0.022 C 1.749 0.121 1.793 0.11 1.903 0.066 C 2.178 -0.044 2.508 -0.11 2.86 -0.11 C 3.476 -0.11 4.026 0.077 4.4769998 0.506 C 4.994 1.012 5.291 1.694 5.291 2.585 C 5.291 3.751 4.466 4.829 3.3439999 4.829 C 2.838 4.829 2.277 4.499 1.837 4.004 C 1.771 3.938 1.727 3.938 1.716 4.048 Z M 1.925 3.641 C 2.211 3.993 2.717 4.323 3.036 4.323 C 3.74 4.323 4.345 3.531 4.345 2.288 C 4.345 1.386 4.026 0.264 2.794 0.264 C 2.596 0.264 2.211 0.319 2.013 0.495 C 1.793 0.693 1.749 0.759 1.749 1.155 L 1.749 3.157 C 1.749 3.388 1.793 3.487 1.925 3.641 Z "/>
+        </symbol>
+        <symbol id="g2F91D5573DDAB4A30BCA3F6C6E2FFFB8" overflow="visible">
+            <path d="M 2.024 3.938 C 1.958 3.861 1.892 3.839 1.892 3.938 C 1.881 4.235 1.859 4.664 1.804 4.774 C 1.782 4.829 1.76 4.862 1.6719999 4.862 C 1.364 4.741 1.078 4.642 0.319 4.5429997 C 0.297 4.4769998 0.319 4.301 0.341 4.235 C 0.935 4.18 1.056 4.125 1.056 3.487 L 1.056 1.342 C 1.056 0.44 0.946 0.396 0.286 0.341 C 0.22 0.275 0.22 0.044 0.286 -0.022 C 0.616 -0.011 1.056 0 1.496 0 C 1.936 0 2.266 -0.011 2.596 -0.022 C 2.662 0.044 2.662 0.275 2.596 0.341 C 2.035 0.396 1.925 0.44 1.925 1.342 L 1.925 3.146 C 1.925 3.377 2.024 3.509 2.112 3.608 C 2.53 4.015 3.025 4.257 3.454 4.257 C 3.674 4.257 3.905 4.114 4.037 3.861 C 4.147 3.641 4.169 3.3439999 4.169 3.014 L 4.169 1.342 C 4.169 0.44 4.059 0.396 3.487 0.341 C 3.432 0.275 3.432 0.044 3.487 -0.022 C 3.817 -0.011 4.169 0 4.609 0 C 5.049 0 5.445 -0.011 5.775 -0.022 C 5.83 0.044 5.83 0.275 5.775 0.341 C 5.159 0.396 5.038 0.44 5.038 1.342 L 5.038 2.981 C 5.038 3.586 4.994 4.114 4.741 4.455 C 4.554 4.697 4.213 4.829 3.828 4.829 C 3.289 4.829 2.673 4.686 2.024 3.938 Z "/>
+        </symbol>
+        <symbol id="gBE6F033D381DE263D17F3D282D6F4539" overflow="visible">
+            <path d="M 3.674 0.55 C 3.729 0.594 3.828 0.616 3.839 0.539 C 3.872 0.275 3.96 -0.11 3.96 -0.11 C 4.048 -0.143 4.103 -0.132 4.169 -0.11 C 4.411 0.088 4.796 0.253 5.467 0.32999998 C 5.533 0.396 5.533 0.561 5.467 0.627 C 4.763 0.682 4.664 0.891 4.664 1.43 L 4.664 6.413 C 4.664 7.128 4.708 7.568 4.708 7.568 C 4.708 7.645 4.664 7.678 4.565 7.678 C 4.29 7.568 3.465 7.414 3.025 7.381 C 3.003 7.2929997 3.025 7.117 3.091 7.051 C 3.124 7.051 3.157 7.051 3.19 7.051 C 3.674 7.018 3.795 7.018 3.795 6.149 L 3.795 4.741 C 3.795 4.664 3.773 4.642 3.696 4.642 C 3.652 4.642 3.201 4.829 2.838 4.829 C 2.112 4.829 1.628 4.587 1.188 4.169 C 0.715 3.696 0.429 3.047 0.429 2.233 C 0.429 0.88 1.111 -0.11 2.299 -0.11 C 2.728 -0.11 3.135 0.11 3.674 0.55 Z M 3.795 1.364 C 3.795 1.155 3.773 1.067 3.619 0.935 C 3.212 0.583 2.86 0.407 2.585 0.407 C 1.9909999 0.407 1.375 1.056 1.375 2.431 C 1.375 3.223 1.529 3.6629999 1.694 3.894 C 2.035 4.411 2.497 4.444 2.717 4.444 C 3.113 4.444 3.388 4.301 3.608 4.048 C 3.762 3.872 3.795 3.795 3.795 3.454 Z "/>
+        </symbol>
+        <symbol id="g84F7D56C26B4F026CB730340333F3592" overflow="visible">
+            <path d="M 1.837 3.146 C 1.837 3.377 1.936 3.509 2.024 3.608 C 2.442 4.015 3.003 4.257 3.432 4.257 C 3.652 4.257 3.883 4.114 4.015 3.861 C 4.125 3.641 4.147 3.3439999 4.147 3.014 L 4.147 1.342 C 4.147 0.44 4.037 0.396 3.465 0.341 C 3.41 0.275 3.41 0.044 3.465 -0.022 C 3.773 -0.011 4.147 0 4.587 0 C 5.027 0 5.39 -0.011 5.753 -0.022 C 5.808 0.044 5.808 0.275 5.753 0.341 C 5.137 0.396 5.016 0.44 5.016 1.342 L 5.016 2.981 C 5.016 3.586 4.972 4.125 4.719 4.455 C 4.532 4.697 4.191 4.829 3.806 4.829 C 3.267 4.829 2.6069999 4.686 1.936 3.938 C 1.936 3.927 1.925 3.927 1.914 3.916 C 1.881 3.872 1.826 3.806 1.826 3.938 L 1.837 6.413 C 1.837 7.128 1.881 7.568 1.881 7.568 C 1.881 7.645 1.837 7.678 1.738 7.678 C 1.4629999 7.568 0.638 7.414 0.198 7.381 C 0.176 7.2929997 0.198 7.117 0.264 7.051 C 0.297 7.051 0.32999998 7.051 0.363 7.051 C 0.847 7.018 0.968 7.018 0.968 6.149 L 0.968 1.342 C 0.968 0.429 0.83599997 0.385 0.198 0.341 C 0.132 0.275 0.132 0.044 0.198 -0.022 C 0.561 -0.011 0.968 0 1.408 0 C 1.826 0 2.189 -0.011 2.497 -0.022 C 2.563 0.044 2.563 0.275 2.497 0.341 C 1.936 0.385 1.837 0.429 1.837 1.342 Z "/>
+        </symbol>
+        <symbol id="g7F5F86196ADADB0032CB2049EB771F59" overflow="visible">
+            <path d="M 4.884 4.257 C 5.093 4.257 5.291 4.455 5.291 4.675 C 5.291 4.906 5.082 5.082 4.785 5.082 C 4.499 5.082 3.971 4.895 3.685 4.521 C 3.553 4.609 3.19 4.829 2.541 4.829 C 1.562 4.829 0.65999997 4.169 0.65999997 3.157 C 0.65999997 2.563 0.924 2.222 1.232 1.925 C 0.924 1.661 0.748 1.188 0.748 0.814 C 0.748 0.41799998 0.968 0.11 1.254 -0.033 C 0.65999997 -0.385 0.352 -0.891 0.352 -1.364 C 0.352 -2.321 1.254 -2.618 2.101 -2.618 C 3.586 -2.618 5.192 -1.903 5.192 -0.715 C 5.192 -0.363 5.027 -0.088 4.708 0.176 C 4.279 0.528 3.509 0.539 3.102 0.539 C 2.904 0.539 2.629 0.517 2.365 0.484 C 2.2 0.473 2.09 0.462 2.035 0.462 C 1.716 0.462 1.331 0.616 1.331 1.089 C 1.331 1.309 1.397 1.54 1.529 1.727 C 1.793 1.573 2.101 1.496 2.53 1.496 C 3.498 1.496 4.389 2.101 4.389 3.179 C 4.389 3.696 4.235 3.993 3.916 4.323 C 3.993 4.433 4.213 4.587 4.356 4.587 C 4.433 4.587 4.5099998 4.554 4.576 4.455 C 4.62 4.367 4.763 4.257 4.884 4.257 Z M 1.452 -0.11 C 1.573 -0.143 1.749 -0.16499999 1.892 -0.16499999 C 2.233 -0.16499999 2.541 -0.132 2.695 -0.132 C 3.245 -0.132 3.707 -0.143 4.026 -0.319 C 4.455 -0.561 4.587 -0.715 4.587 -1.001 C 4.587 -1.793 3.421 -2.211 2.431 -2.211 C 2.035 -2.211 1.111 -1.892 1.111 -1.144 C 1.111 -0.77 1.133 -0.495 1.452 -0.11 Z M 3.509 3.069 C 3.509 2.046 2.992 1.837 2.585 1.837 C 1.661 1.837 1.562 2.618 1.562 3.322 C 1.562 4.092 1.837 4.488 2.442 4.488 C 3.135 4.488 3.509 3.9819999 3.509 3.069 Z "/>
+        </symbol>
+        <symbol id="g4DA78131B4AE5A2575D972CF0C2113FB" overflow="visible">
+            <path d="M 0.627 0.473 C 0.627 0.154 0.891 -0.11 1.21 -0.11 C 1.529 -0.11 1.793 0.154 1.793 0.473 C 1.793 0.792 1.529 1.056 1.21 1.056 C 0.891 1.056 0.627 0.792 0.627 0.473 Z "/>
+        </symbol>
+        <symbol id="gAFF10F80711561B34177BDAF77CC0EC4" overflow="visible">
+            <path d="M 1.925 4.29 L 4.059 4.29 L 4.059 0.979 C 4.059 0.198 4.4 -0.11 4.906 -0.11 C 5.412 -0.11 5.962 0.132 6.391 0.616 C 6.369 0.726 6.303 0.792 6.193 0.803 C 5.907 0.583 5.577 0.495 5.291 0.495 C 4.994 0.495 4.928 0.825 4.928 1.507 L 4.928 4.29 L 6.072 4.29 C 6.182 4.29 6.336 4.334 6.336 4.433 L 6.336 4.653 C 6.336 4.697 6.303 4.719 6.248 4.719 L 4.928 4.719 L 4.928 5.148 C 4.928 5.863 4.972 6.303 4.972 6.303 C 4.972 6.38 4.928 6.413 4.829 6.413 L 4.191 6.127 C 4.18 6.116 4.158 6.105 4.136 6.094 C 4.081 6.072 4.037 6.039 4.037 5.984 C 4.059 5.742 4.059 5.643 4.059 4.84 C 4.059 4.796 4.059 4.763 4.059 4.719 L 1.925 4.719 L 1.925 5.346 C 1.925 5.533 1.925 5.72 1.925 5.8849998 C 1.914 6.347 1.903 6.699 1.969 6.886 C 2.057 7.15 2.299 7.304 2.464 7.304 C 2.772 7.304 2.9259999 7.117 3.058 6.798 C 3.135 6.611 3.267 6.49 3.487 6.49 C 3.696 6.49 3.85 6.6549997 3.85 6.886 C 3.85 7.062 3.751 7.249 3.531 7.414 C 3.3109999 7.579 2.981 7.678 2.563 7.678 C 2.244 7.678 1.738 7.502 1.474 7.15 C 1.144 6.71 1.056 6.127 1.056 5.159 L 1.056 4.719 L 0.495 4.719 C 0.297 4.719 0.242 4.587 0.242 4.499 L 0.242 4.356 C 0.242 4.301 0.253 4.29 0.297 4.29 L 1.056 4.29 L 1.056 1.342 C 1.056 0.429 0.935 0.385 0.341 0.341 C 0.275 0.275 0.275 0.044 0.341 -0.022 C 0.715 -0.011 1.111 0 1.496 0 C 1.881 0 2.354 -0.011 2.794 -0.022 C 2.86 0.044 2.86 0.275 2.794 0.341 C 2.046 0.385 1.925 0.429 1.925 1.342 Z "/>
+        </symbol>
+        <symbol id="g48E25B73E0A9EDA398E65EF73A37635E" overflow="visible">
+            <path d="M 2.101 1.342 L 2.101 5.753 C 2.101 6.666 2.288 6.721 3.058 6.754 C 3.124 6.82 3.124 7.051 3.058 7.117 C 2.574 7.106 2.057 7.095 1.628 7.095 C 1.265 7.095 0.726 7.106 0.20899999 7.117 C 0.143 7.051 0.143 6.82 0.20899999 6.754 C 0.979 6.721 1.166 6.666 1.166 5.753 L 1.166 1.342 C 1.166 0.429 0.979 0.374 0.20899999 0.341 C 0.143 0.275 0.143 0.044 0.20899999 -0.022 C 0.704 -0.011 1.243 0 1.6389999 0 C 2.035 0 2.563 -0.011 3.058 -0.022 C 3.124 0.044 3.124 0.275 3.058 0.341 C 2.288 0.374 2.101 0.429 2.101 1.342 Z "/>
+        </symbol>
+        <symbol id="gBE06C4B72531F49CBE9DB12FC3B2B6B4" overflow="visible">
+            <path d="M 1.925 1.342 L 1.925 4.29 L 2.948 4.29 C 3.047 4.29 3.201 4.334 3.201 4.433 L 3.201 4.653 C 3.201 4.697 3.168 4.719 3.113 4.719 L 1.925 4.719 L 1.925 5.346 C 1.925 7.04 2.431 7.304 2.794 7.304 C 3.124 7.304 3.3 7.172 3.454 6.787 C 3.542 6.5889997 3.6629999 6.435 3.894 6.435 C 4.081 6.435 4.345 6.666 4.345 6.886 C 4.345 7.073 4.224 7.271 3.993 7.447 C 3.707 7.645 3.421 7.678 3.003 7.678 C 2.079 7.678 1.056 6.875 1.056 5.159 L 1.056 4.719 L 0.495 4.719 C 0.297 4.719 0.242 4.587 0.242 4.499 L 0.242 4.356 C 0.242 4.301 0.253 4.29 0.297 4.29 L 1.056 4.29 L 1.056 1.342 C 1.056 0.429 0.88 0.385 0.286 0.341 C 0.22 0.275 0.22 0.044 0.286 -0.022 C 0.671 -0.011 1.056 0 1.496 0 C 1.936 0 2.464 -0.011 2.849 -0.022 C 2.915 0.044 2.915 0.275 2.849 0.341 C 1.9909999 0.385 1.925 0.429 1.925 1.342 Z "/>
+        </symbol>
+        <symbol id="g1295BAC9495BE95B0AA9CA96F2C2AB56" overflow="visible">
+            <path d="M 1.419 7.678 C 1.078 7.678 0.83599997 7.447 0.83599997 7.139 C 0.83599997 6.798 1.122 6.6879997 1.3199999 6.6549997 C 1.529 6.633 1.716 6.567 1.716 6.314 C 1.716 6.083 1.3199999 5.577 0.748 5.434 C 0.748 5.324 0.77 5.2469997 0.847 5.17 C 1.507 5.291 2.145 5.819 2.145 6.5889997 C 2.145 7.249 1.859 7.678 1.419 7.678 Z "/>
+        </symbol>
+        <symbol id="gC23C47A73633CA682D6E6C5BB47A559" overflow="visible">
+            <path d="M 5.17 1.342 L 5.17 3.6629999 C 5.17 4.092 5.2139997 4.796 5.2139997 4.796 C 5.2139997 4.84 5.148 4.862 5.104 4.862 C 4.774 4.73 4.455 4.719 4.07 4.719 L 1.903 4.719 L 1.903 5.346 C 1.903 6.391 2.277 7.304 3.025 7.304 C 3.498 7.304 3.872 7.183 3.96 6.732 C 4.07 6.182 4.301 6.017 4.642 6.017 C 4.884 6.017 5.115 6.237 5.115 6.468 C 5.115 7.15 4.18 7.678 3.157 7.678 C 2.651 7.678 2.046 7.48 1.595 6.952 C 1.133 6.413 1.034 5.742 1.034 4.884 L 1.034 4.719 L 0.495 4.719 C 0.297 4.719 0.242 4.587 0.242 4.499 L 0.242 4.356 C 0.242 4.301 0.253 4.29 0.297 4.29 L 1.034 4.29 L 1.034 1.342 C 1.034 0.429 0.913 0.385 0.319 0.341 C 0.253 0.275 0.253 0.044 0.319 -0.022 C 0.693 -0.011 1.089 0 1.474 0 C 1.859 0 2.354 -0.011 2.717 -0.022 C 2.783 0.044 2.783 0.275 2.717 0.341 C 2.013 0.385 1.903 0.429 1.903 1.342 L 1.903 4.29 L 3.872 4.29 C 4.213 4.29 4.301 4.07 4.301 3.509 L 4.301 1.342 C 4.301 0.429 4.169 0.385 3.564 0.341 C 3.498 0.275 3.498 0.044 3.564 -0.022 C 3.949 -0.011 4.345 0 4.741 0 C 5.126 0 5.555 -0.011 5.962 -0.022 C 6.028 0.044 6.028 0.275 5.962 0.341 C 5.291 0.385 5.17 0.429 5.17 1.342 Z "/>
+        </symbol>
+        <symbol id="g9EB1D08A7B1324D48AADD79859AC05BD" overflow="visible">
+            <path d="M 1.144 1.045 C 0.803 1.045 0.561 0.814 0.561 0.506 C 0.561 0.16499999 0.847 0.055 1.045 0.022 C 1.254 0 1.441 -0.066 1.441 -0.319 C 1.441 -0.55 1.045 -1.056 0.473 -1.199 C 0.473 -1.309 0.495 -1.386 0.572 -1.4629999 C 1.232 -1.342 1.87 -0.814 1.87 -0.044 C 1.87 0.616 1.584 1.045 1.144 1.045 Z "/>
+        </symbol>
+        <symbol id="g9BA8B627FB15C42338CB980C362A00D2" overflow="visible">
+            <path d="M 3.575 4.378 C 4.169 4.334 4.235 4.202 4.004 3.641 L 3.113 1.485 C 2.937 1.056 2.882 1.056 2.706 1.518 L 1.914 3.641 C 1.716 4.169 1.6719999 4.301 2.2549999 4.378 C 2.321 4.444 2.321 4.675 2.2549999 4.741 C 1.892 4.73 1.507 4.719 1.144 4.719 C 0.781 4.719 0.451 4.73 0.121 4.741 C 0.055 4.675 0.055 4.444 0.121 4.378 C 0.704 4.312 0.781 4.136 1.001 3.575 L 2.409 0.099 C 2.475 -0.066 2.541 -0.132 2.684 -0.132 C 2.794 -0.132 2.871 -0.066 2.948 0.121 L 4.411 3.564 C 4.62 4.048 4.741 4.323 5.357 4.378 C 5.423 4.444 5.423 4.675 5.357 4.741 C 5.137 4.73 4.873 4.719 4.587 4.719 C 4.224 4.719 3.85 4.73 3.575 4.741 C 3.509 4.675 3.509 4.444 3.575 4.378 Z "/>
+        </symbol>
+        <symbol id="g48F357F36910BC90E94F31A287082659" overflow="visible">
+            <path d="M 3.707 1.342 L 3.707 2.838 C 3.707 3.168 3.718 3.3439999 3.905 3.674 L 5.2139997 6.05 C 5.522 6.611 5.764 6.71 6.259 6.754 C 6.325 6.82 6.325 7.051 6.259 7.117 C 5.9509997 7.106 5.599 7.095 5.346 7.095 C 5.093 7.095 4.697 7.106 4.345 7.117 C 4.279 7.051 4.279 6.82 4.345 6.754 C 4.829 6.721 5.005 6.611 4.774 6.171 L 3.553 3.872 C 3.465 3.707 3.41 3.718 3.3109999 3.894 L 2.035 6.149 C 1.771 6.611 1.8149999 6.721 2.431 6.754 C 2.497 6.82 2.497 7.051 2.431 7.117 C 2.035 7.106 1.617 7.095 1.177 7.095 C 0.748 7.095 0.385 7.106 0.055 7.117 C -0.011 7.051 0 6.82 0.066 6.754 C 0.528 6.721 0.715 6.6549997 1.1 6.017 L 2.541 3.586 C 2.739 3.267 2.772 3.146 2.772 2.739 L 2.772 1.342 C 2.772 0.429 2.585 0.374 1.705 0.341 C 1.6389999 0.275 1.6389999 0.044 1.705 -0.022 C 2.244 -0.011 2.816 0 3.245 0 C 3.674 0 4.224 -0.011 4.774 -0.022 C 4.84 0.044 4.84 0.275 4.774 0.341 C 3.894 0.374 3.707 0.429 3.707 1.342 Z "/>
+        </symbol>
+        <symbol id="g6243475FABEC8A0579537E4EA4C95CD7" overflow="visible">
+            <path d="M 1.837 4.334 C 1.771 4.268 1.727 4.29 1.727 4.389 L 1.727 6.413 C 1.727 7.128 1.771 7.568 1.771 7.568 C 1.771 7.645 1.727 7.678 1.628 7.678 C 1.353 7.568 0.528 7.414 0.088 7.381 C 0.066 7.2929997 0.088 7.117 0.154 7.051 C 0.187 7.051 0.22 7.051 0.253 7.051 C 0.737 7.018 0.858 7.018 0.858 6.149 L 0.858 0.781 C 0.858 0.352 0.847 0.154 0.814 0 C 0.869 -0.088 0.924 -0.132 1.056 -0.132 C 1.122 -0.066 1.232 0.033 1.3199999 0.132 C 1.43 0.264 1.496 0.264 1.617 0.16499999 C 1.87 -0.044 2.2 -0.11 2.585 -0.11 C 3.707 -0.11 5.016 0.913 5.016 2.662 C 5.016 4.004 4.026 4.829 3.069 4.829 C 2.596 4.829 2.178 4.642 1.837 4.334 Z M 1.914 3.993 C 2.2 4.246 2.53 4.345 2.849 4.345 C 3.52 4.345 4.07 3.531 4.07 2.464 C 4.07 1.21 3.564 0.264 2.519 0.264 C 2.178 0.264 1.947 0.506 1.727 0.781 L 1.727 3.531 C 1.727 3.762 1.771 3.872 1.914 3.993 Z "/>
+        </symbol>
+        <symbol id="gACA8C8372E397B2A6390FB0ABD8B454F" overflow="visible">
+            <path d="M 2.002 3.938 C 1.749 4.312 1.826 4.323 2.321 4.378 C 2.387 4.444 2.387 4.675 2.321 4.741 C 2.024 4.73 1.54 4.719 1.21 4.719 C 0.88 4.719 0.55 4.73 0.264 4.741 C 0.198 4.675 0.198 4.444 0.264 4.378 C 0.638 4.345 0.946 4.158 1.254 3.707 L 2.211 2.31 C 2.266 2.233 2.266 2.2 2.222 2.145 L 1.298 0.957 C 0.858 0.396 0.616 0.363 0.231 0.341 C 0.16499999 0.275 0.16499999 0.044 0.231 -0.022 C 0.451 -0.011 0.693 0 1.023 0 C 1.353 0 1.661 -0.011 1.947 -0.022 C 2.013 0.044 2.013 0.275 1.947 0.341 C 1.551 0.385 1.4629999 0.429 1.705 0.781 L 2.398 1.782 C 2.486 1.914 2.53 1.903 2.596 1.804 L 3.234 0.924 C 3.619 0.396 3.443 0.374 3.091 0.341 C 3.025 0.275 3.025 0.044 3.091 -0.022 C 3.421 -0.011 3.784 0 4.18 0 C 4.598 0 4.895 -0.011 5.159 -0.022 C 5.225 0.044 5.225 0.275 5.159 0.341 C 4.664 0.374 4.499 0.407 4.059 1.034 L 3.069 2.431 C 3.025 2.497 3.014 2.53 3.069 2.596 L 3.993 3.773 C 4.4 4.29 4.664 4.345 5.06 4.378 C 5.126 4.444 5.126 4.675 5.06 4.741 C 4.84 4.73 4.587 4.719 4.257 4.719 C 3.927 4.719 3.619 4.73 3.333 4.741 C 3.267 4.675 3.267 4.444 3.333 4.378 C 3.74 4.334 3.861 4.301 3.597 3.927 L 2.882 2.9259999 C 2.805 2.816 2.761 2.827 2.673 2.948 Z "/>
+        </symbol>
+        <symbol id="gA68DA6B3B3D238AE928C954AEAD7F96A" overflow="visible">
+            <path d="M 8.91 6.215 L 7.194 1.441 L 7.161 1.452 L 5.643 6.094 C 5.456 6.6879997 5.841 6.721 6.215 6.754 C 6.281 6.82 6.281 7.051 6.215 7.117 C 5.764 7.106 5.2799997 7.095 4.84 7.095 C 4.4769998 7.095 4.092 7.106 3.74 7.117 C 3.674 7.051 3.674 6.82 3.74 6.754 C 4.323 6.721 4.565 6.38 4.664 6.094 L 4.917 5.368 C 4.961 5.236 4.994 5.126 4.994 5.027 C 4.994 4.917 4.983 4.829 4.895 4.642 L 3.476 1.419 L 3.421 1.43 L 1.8149999 6.292 C 1.683 6.677 1.98 6.732 2.365 6.754 C 2.431 6.82 2.431 7.051 2.365 7.117 C 2.002 7.106 1.518 7.095 1.089 7.095 C 0.704 7.095 0.385 7.106 0.066 7.117 C 0 7.051 0 6.82 0.066 6.754 C 0.561 6.721 0.638 6.71 0.847 6.116 L 2.915 0.16499999 C 2.97 -0.011 3.036 -0.132 3.157 -0.132 C 3.3 -0.132 3.366 -0.022 3.443 0.16499999 L 5.082 3.85 C 5.1809998 4.07 5.2139997 4.125 5.269 4.125 C 5.313 4.125 5.357 4.004 5.423 3.817 L 6.6879997 0.16499999 C 6.754 -0.022 6.809 -0.132 6.941 -0.132 C 7.062 -0.132 7.139 -0.011 7.194 0.154 L 9.405 6.083 C 9.548 6.468 9.746 6.721 10.351 6.754 C 10.417 6.82 10.417 7.051 10.351 7.117 C 10.032 7.106 9.68 7.095 9.394 7.095 C 9.108 7.095 8.624 7.106 8.184 7.117 C 8.118 7.051 8.118 6.82 8.184 6.754 C 8.635 6.721 9.075 6.6879997 8.91 6.215 Z "/>
+        </symbol>
+        <symbol id="g974A285F6CE2EF207BE5DE97B66461CA" overflow="visible">
+            <path d="M 1.584 0.033 L 2.805 0 L 2.805 0.429 C 2.409 0.429 2.167 0.44 2.09 0.484 C 2.013 0.528 1.98 0.65999997 1.98 0.869 L 1.98 7.634 L 0.363 7.513 L 0.363 7.095 C 0.748 7.095 0.99 7.062 1.067 6.996 C 1.144 6.93 1.188 6.776 1.188 6.523 L 1.188 0.869 C 1.188 0.65999997 1.155 0.528 1.078 0.484 C 1.001 0.44 0.759 0.429 0.363 0.429 L 0.363 0 Z "/>
+        </symbol>
+        <symbol id="g58D62D4C1CABAD108A850FB1F742AC89" overflow="visible">
+            <path d="M 2.134 6.611 C 2.134 6.941 1.859 7.2269998 1.529 7.2269998 C 1.199 7.2269998 0.913 6.941 0.913 6.611 C 0.913 6.281 1.188 5.984 1.518 5.984 C 1.859 5.984 2.134 6.27 2.134 6.611 Z M 1.573 0.033 L 2.717 0 L 2.717 0.429 C 2.354 0.429 2.134 0.451 2.068 0.495 C 2.002 0.539 1.98 0.65999997 1.98 0.858 L 1.98 4.895 L 0.407 4.763 L 0.407 4.345 C 0.77 4.345 1.001 4.312 1.078 4.257 C 1.155 4.202 1.188 4.048 1.188 3.795 L 1.188 0.869 C 1.188 0.65999997 1.155 0.528 1.078 0.484 C 1.001 0.44 0.759 0.429 0.363 0.429 L 0.363 0 Z "/>
+        </symbol>
+        <symbol id="g83B8E421B35ADFEF9620EAF15AAE496A" overflow="visible">
+            <path d="M 3.465 4.5429997 C 3.971 4.5429997 4.224 4.158 4.224 3.377 L 4.224 0.869 C 4.224 0.65999997 4.191 0.528 4.114 0.484 C 4.037 0.44 3.784 0.41799998 3.377 0.41799998 L 3.377 0 L 4.653 0.033 L 5.9179997 0 L 5.9179997 0.41799998 C 5.511 0.41799998 5.269 0.44 5.192 0.484 C 5.115 0.528 5.071 0.65999997 5.071 0.869 L 5.071 2.849 C 5.071 3.729 5.643 4.5429997 6.49 4.5429997 C 7.007 4.5429997 7.2599998 4.158 7.2599998 3.377 L 7.2599998 0.869 C 7.2599998 0.65999997 7.216 0.528 7.139 0.484 C 7.062 0.44 6.809 0.41799998 6.402 0.41799998 L 6.402 0 L 7.678 0.033 L 8.943 0 L 8.943 0.41799998 C 8.591 0.41799998 8.36 0.429 8.25 0.462 C 8.14 0.495 8.096 0.572 8.096 0.704 L 8.096 2.761 C 8.096 3.2779999 8.074 3.641 8.041 3.85 C 7.9309998 4.521 7.436 4.862 6.567 4.862 C 5.874 4.862 5.357 4.5429997 5.005 3.894 C 4.851 4.5429997 4.367 4.862 3.542 4.862 C 2.849 4.862 2.321 4.532 1.969 3.872 L 1.969 4.862 L 0.352 4.741 L 0.352 4.323 C 0.748 4.323 0.99 4.29 1.078 4.224 C 1.166 4.158 1.199 4.015 1.199 3.762 L 1.199 0.869 C 1.199 0.65999997 1.155 0.528 1.078 0.484 C 1.001 0.44 0.759 0.41799998 0.352 0.41799998 L 0.352 0 L 1.628 0.033 L 2.893 0 L 2.893 0.41799998 C 2.486 0.41799998 2.233 0.44 2.156 0.484 C 2.079 0.528 2.035 0.65999997 2.035 0.869 L 2.035 2.849 C 2.035 3.74 2.618 4.5429997 3.465 4.5429997 Z "/>
+        </symbol>
+        <symbol id="g82C9138B1F990639C9D4AF197D33953B" overflow="visible">
+            <path d="M 4.4891 2.8105 C 4.4891 3.2031999 4.0887 3.3957 3.6729 3.3957 C 3.3264 3.3957 3.0415 3.2263 2.8259 2.8875 C 2.6411 3.2263 2.3331 3.3957 1.9096 3.3957 C 1.6247 3.3957 1.3244 3.2725 1.0241 3.0184 C 0.7084 2.7566 0.5467 2.4871 0.5467 2.2099 C 0.5467 2.1252 0.6006 2.079 0.7007 2.079 C 0.7854 2.079 0.8393 2.1252 0.8778 2.2253 C 1.0164 2.6411 1.3937 3.1262 1.8865 3.1262 C 2.1714 3.1262 2.31 2.9722 2.31 2.6565 C 2.31 2.5564 2.2561 2.2946 2.156 1.8711 L 1.8942 0.8393 C 1.8249 0.5467 1.54 0.1925 1.2089 0.1925 C 1.078 0.1925 0.9625 0.2156 0.8701 0.2695 C 1.0241 0.3388 1.1626999 0.5082 1.1626999 0.6853 C 1.1626999 0.8701 1.0164 1.001 0.8316 1.001 C 0.5698 1.001 0.3696 0.77 0.3696 0.5082 C 0.3696 0.1232 0.7777 -0.077 1.1935 -0.077 C 1.5477 -0.077 1.8326 0.0924 2.0405 0.4312 C 2.2253 0.0924 2.5256 -0.077 2.9491 -0.077 C 3.3726 -0.077 3.7114 0.0924 3.9732 0.4312 C 4.1965 0.73149997 4.312 0.9625 4.312 1.1087999 C 4.312 1.1935 4.2658 1.2397 4.1657 1.2397 C 4.081 1.2397 4.0194 1.1858 3.9886 1.0857 C 3.8576999 0.6776 3.465 0.1925 2.9799 0.1925 C 2.695 0.1925 2.5487 0.3465 2.5487 0.6545 C 2.5487 0.77 2.6796 1.3475 2.9414 2.3716 C 3.0723 2.8720999 3.3033 3.1262 3.6498 3.1262 L 3.7191 3.1185 C 3.8115 3.1185 3.9039 3.0954 3.9886 3.0569 C 3.7961 2.9722 3.7037 2.8336 3.7037 2.6334 C 3.7037 2.4486 3.85 2.3177 4.0348 2.3177 C 4.2966 2.3177 4.4891 2.5487 4.4891 2.8105 Z "/>
+        </symbol>
+        <symbol id="gC58233CC6A8C89B5BA6C36DC8CD01DC1" overflow="visible">
+            <path d="M 7.1764 1.8018 C 7.2303 1.8249 7.2611 1.8711 7.2611 1.925 C 7.2611 1.9789 7.2303 2.0251 7.1764 2.0482 C 6.8068 2.1714 6.4603 2.4332 6.1369 2.8336 C 5.9213 3.1031 5.775 3.4187999 5.7057 3.7807 C 5.6826 3.8808 5.621 3.927 5.5209 3.927 C 5.3977 3.927 5.3361 3.8654 5.3361 3.7345 L 5.3438 3.7191 L 5.3438 3.7114 C 5.4747 3.0415 5.8135 2.5102 6.3756 2.1098 L 0.6314 2.1098 C 0.5082 2.1098 0.4466 2.0482 0.4466 1.925 C 0.4466 1.8018 0.5082 1.7402 0.6314 1.7402 L 6.3756 1.7402 C 5.8135 1.3398 5.4747 0.8085 5.3438 0.13859999 L 5.3438 0.1309 L 5.3361 0.1155 C 5.3361 -0.0154 5.3977 -0.077 5.5209 -0.077 C 5.621 -0.077 5.6826 -0.0308 5.7057 0.069299996 C 5.775 0.4312 5.9213 0.7469 6.1369 1.0164 C 6.4603 1.4168 6.8068 1.6786 7.1764 1.8018 Z "/>
+        </symbol>
+        <symbol id="gA845BF5A6E6958A52079EDE8CD31C40A" overflow="visible">
+            <path d="M 6.4988 -0.077 C 6.9685 -0.077 7.3689 0.0924 7.6846 0.4312 C 8.0003 0.77 8.162 1.1858 8.162 1.6632 C 8.162 2.1329 8.008 2.541 7.7 2.8798 C 7.392 3.2186 6.9993 3.3957 6.5296 3.3957 C 5.9983 3.3957 5.544 3.2263 5.159 2.8952 C 4.8818 2.6565 4.6431 2.4024 4.4429 2.1483 C 4.2042 2.4409 3.9424 2.695 3.6729 2.9183 C 3.2725 3.234 2.8028 3.3957 2.2638 3.3957 C 1.7864 3.3957 1.3937 3.2186 1.078 2.8798 C 0.7623 2.541 0.6006 2.1329 0.6006 1.6554999 C 0.6006 1.1858 0.7546 0.77 1.0626 0.4312 C 1.3706 0.0924 1.7633 -0.077 2.233 -0.077 C 2.7642999 -0.077 3.2186 0.0924 3.6036 0.4235 C 3.8808 0.6622 4.1195 0.9163 4.3197 1.1704 C 4.5584 0.8778 4.8202 0.6237 5.0896997 0.40039998 C 5.4901 0.0847 5.9598 -0.077 6.4988 -0.077 Z M 6.6297 0.40039998 C 6.2908998 0.40039998 5.9674997 0.539 5.6672 0.8162 C 5.4208 1.0395 5.1128 1.3783 4.7355 1.8249 C 5.2591 2.6411 5.8751 3.0492 6.5912 3.0492 C 6.9608 3.0492 7.2688 2.9106 7.5152 2.6334 C 7.7616 2.3562 7.8848 2.0405 7.8848 1.6632 C 7.8848 0.9702 7.3227 0.40039998 6.6297 0.40039998 Z M 2.1329 2.9183 C 2.4717 2.9183 2.7951 2.7797 3.0954 2.5025 C 3.3418 2.2792 3.6498 1.9404 4.0271 1.4938 C 3.5035 0.6776 2.8875 0.2695 2.1714 0.2695 C 1.8018 0.2695 1.4938 0.40039998 1.2474 0.6776 C 1.001 0.9548 0.8778 1.2782 0.8778 1.6554999 C 0.8778 2.3485 1.4399 2.9183 2.1329 2.9183 Z "/>
+        </symbol>
+        <symbol id="g89FD5B500F3A7CF8EB197275F181B2CD" overflow="visible">
+            <path d="M 3.806 -1.221 C 3.806 -2.134 3.685 -2.178 3.014 -2.211 C 2.948 -2.277 2.948 -2.508 3.014 -2.574 C 3.399 -2.563 3.806 -2.552 4.246 -2.552 C 4.686 -2.552 5.104 -2.563 5.467 -2.574 C 5.533 -2.508 5.533 -2.277 5.467 -2.211 C 4.796 -2.178 4.675 -2.134 4.675 -1.221 L 4.675 4.587 C 4.675 4.741 4.631 4.862 4.5099998 4.862 C 4.433 4.862 4.367 4.774 4.279 4.653 C 4.136 4.455 4.092 4.422 3.96 4.5099998 C 3.608 4.73 3.179 4.829 2.717 4.829 C 1.375 4.829 0.385 3.729 0.385 2.277 C 0.385 1.254 1.078 -0.11 2.662 -0.11 C 2.9589999 -0.11 3.322 -0.044 3.509 0.066 C 3.762 0.20899999 3.806 0.231 3.806 0 Z M 3.542 4.048 C 3.762 3.806 3.806 3.641 3.806 3.377 L 3.806 0.847 C 3.806 0.649 3.795 0.594 3.652 0.517 C 3.399 0.385 3.102 0.374 2.9259999 0.374 C 2.288 0.374 1.331 0.83599997 1.331 2.497 C 1.331 3.641 1.793 4.455 2.673 4.455 C 3.003 4.455 3.3 4.323 3.542 4.048 Z "/>
+        </symbol>
+        <symbol id="gAE16D62B0766FCB252798197B2E66D5D" overflow="visible">
+            <path d="M 4.345 6.941 C 3.707 7.029 3.729 7.238 2.651 7.238 C 1.54 7.238 0.561 6.501 0.561 5.335 C 0.561 4.18 1.518 3.652 2.486 3.2779999 C 3.146 3.025 3.96 2.717 3.96 1.6389999 C 3.96 0.748 3.465 0.286 2.585 0.286 C 1.562 0.286 0.902 0.759 0.65999997 1.848 C 0.517 1.892 0.407 1.87 0.297 1.8149999 C 0.341 0.968 0.385 0.682 0.517 0.143 C 1.21 0.143 1.518 -0.11 2.497 -0.11 C 2.992 -0.11 3.465 0.011 3.85 0.253 C 4.488 0.649 4.884 1.3199999 4.884 2.024 C 4.884 3.19 4.004 3.707 3.102 4.048 C 2.442 4.29 1.342 4.708 1.342 5.632 C 1.342 6.248 1.903 6.864 2.552 6.864 C 3.619 6.864 3.96 6.182 4.18 5.456 C 4.301 5.434 4.444 5.445 4.5429997 5.522 C 4.499 6.05 4.455 6.358 4.345 6.941 Z "/>
+        </symbol>
+        <symbol id="g4AA98C76A3CD9D099D3A2BA331297E03" overflow="visible">
+            <path d="M 2.31 0.8052 L 2.31 3.3264 C 2.31 3.7488 2.376 3.9996 2.6136 3.9996 L 2.7588 3.9996 C 3.2538 3.9996 3.564 3.828 3.6762 3.3198 C 3.7488 3.3198 3.8411999 3.3264 3.9006 3.3528 C 3.8544 3.6564 3.8214 3.993 3.8148 4.29 C 3.8148 4.2966 3.8016 4.3098 3.795 4.3098 C 3.5706 4.29 2.838 4.257 2.3166 4.257 L 1.749 4.257 C 1.2408 4.257 0.462 4.29 0.2112 4.3098 C 0.198 4.3098 0.1848 4.2966 0.1848 4.29 C 0.1584 3.993 0.0924 3.6498 0.0198 3.333 C 0.0858 3.3066 0.16499999 3.3 0.24419999 3.3 C 0.3762 3.828 0.6798 3.9996 1.1154 3.9996 L 1.4388 3.9996 C 1.683 3.9996 1.749 3.7488 1.749 3.3462 L 1.749 0.8052 C 1.749 0.2574 1.6368 0.2244 1.1087999 0.2046 C 1.0692 0.16499999 1.0692 0.0264 1.1087999 -0.0132 C 1.4322 -0.0066 1.7688 0 2.0328 0 C 2.2836 0 2.6202 -0.0066 2.9502 -0.0132 C 2.9898 0.0264 2.9898 0.16499999 2.9502 0.2046 C 2.4222 0.2244 2.31 0.2574 2.31 0.8052 Z "/>
+        </symbol>
+        <symbol id="gE0064DA460A3F923796CBC34360CE325" overflow="visible">
+            <path d="M 1.1022 1.8876 C 1.1022 2.0262 1.1616 2.1054 1.2144 2.1648 C 1.4652 2.409 1.8018 2.5542 2.0592 2.5542 C 2.1912 2.5542 2.3298 2.4684 2.409 2.3166 C 2.475 2.1845999 2.4882 2.0064 2.4882 1.8084 L 2.4882 0.8052 C 2.4882 0.264 2.4222 0.2376 2.079 0.2046 C 2.046 0.16499999 2.046 0.0264 2.079 -0.0132 C 2.2638 -0.0066 2.4882 0 2.7522 0 C 3.0162 0 3.234 -0.0066 3.4517999 -0.0132 C 3.4847999 0.0264 3.4847999 0.16499999 3.4517999 0.2046 C 3.0822 0.2376 3.0096 0.264 3.0096 0.8052 L 3.0096 1.7886 C 3.0096 2.1516 2.9832 2.475 2.8314 2.673 C 2.7192 2.8181999 2.5146 2.8974 2.2836 2.8974 C 1.9602 2.8974 1.5642 2.8116 1.1616 2.3628 C 1.1616 2.3562 1.155 2.3562 1.1484 2.3496 C 1.1286 2.3232 1.0956 2.2836 1.0956 2.3628 L 1.1022 3.8478 C 1.1022 4.2768 1.1286 4.5408 1.1286 4.5408 C 1.1286 4.587 1.1022 4.6068 1.0428 4.6068 C 0.8778 4.5408 0.38279998 4.4484 0.1188 4.4286 C 0.1056 4.3758 0.1188 4.2702 0.1584 4.2306 C 0.1782 4.2306 0.198 4.2306 0.21779999 4.2306 C 0.5082 4.2108 0.5808 4.2108 0.5808 3.6894 L 0.5808 0.8052 C 0.5808 0.2574 0.5016 0.231 0.1188 0.2046 C 0.0792 0.16499999 0.0792 0.0264 0.1188 -0.0132 C 0.3366 -0.0066 0.5808 0 0.8448 0 C 1.0956 0 1.3134 -0.0066 1.4981999 -0.0132 C 1.5378 0.0264 1.5378 0.16499999 1.4981999 0.2046 C 1.1616 0.231 1.1022 0.2574 1.1022 0.8052 Z "/>
+        </symbol>
+        <symbol id="gD915A41BD839830DDF95593AB4587147" overflow="visible">
+            <path d="M 1.1946 0.8052 L 1.1946 2.1186 C 1.1946 2.4486 1.221 2.871 1.221 2.871 C 1.221 2.8974 1.188 2.9172 1.1352 2.9172 C 0.9504 2.8446 0.6864 2.7851999 0.231 2.7258 C 0.21779999 2.6862 0.231 2.5806 0.24419999 2.541 C 0.6072 2.508 0.6732 2.4684 0.6732 2.0922 L 0.6732 0.8052 C 0.6732 0.2574 0.6006 0.2376 0.198 0.2046 C 0.1584 0.16499999 0.1584 0.0264 0.198 -0.0132 C 0.4158 -0.0066 0.6732 0 0.9372 0 C 1.2012 0 1.452 -0.0066 1.6698 -0.0132 C 1.7093999 0.0264 1.7093999 0.16499999 1.6698 0.2046 C 1.2672 0.231 1.1946 0.2574 1.1946 0.8052 Z M 0.594 3.9534 C 0.594 3.7818 0.7524 3.6102 0.9108 3.6102 C 1.0956 3.6102 1.254 3.7884 1.254 3.927 C 1.254 4.0854 1.1154 4.2702 0.9372 4.2702 C 0.7788 4.2702 0.594 4.1118 0.594 3.9534 Z "/>
+        </symbol>
+        <symbol id="g813EA6BAE404C14A9B381CCCD713CECC" overflow="visible">
+            <path d="M 0.3168 0.9108 C 0.3432 0.5874 0.363 0.27719998 0.363 0 C 0.429 0.0132 0.495 0.0198 0.528 0.0198 C 0.5742 0.0198 0.6138 0.0198 0.65999997 0.0066 C 0.8382 -0.0396 1.0164 -0.066 1.2606 -0.066 C 1.6302 -0.066 2.31 0.1122 2.31 0.76559997 C 2.31 1.2144 1.9866 1.4784 1.5378 1.6434 C 1.1418 1.7952 0.8778 1.8942 0.8778 2.2572 C 0.8778 2.5278 1.1154 2.6796 1.3398 2.6796 C 1.485 2.6796 1.8678 2.6268 1.9535999 2.0658 C 1.9932 2.0262 2.1252 2.0328 2.1648 2.0724 C 2.1845999 2.31 2.1978 2.5542 2.2044 2.772 C 1.9998 2.805 1.683 2.8974 1.3398 2.8974 C 0.8514 2.8974 0.4092 2.5806 0.4092 2.1582 C 0.4092 1.6764 0.627 1.4718 1.1352 1.2606 C 1.683 1.0362 1.8084 0.8976 1.8084 0.6138 C 1.8084 0.2904 1.4916 0.1518 1.2474 0.1518 C 0.99 0.1518 0.8448 0.2376 0.7788 0.3102 C 0.6336 0.462 0.561 0.7524 0.5214 0.9174 C 0.4818 0.957 0.3564 0.9504 0.3168 0.9108 Z "/>
+        </symbol>
+        <symbol id="gF8C22B8E9428DE19ED5E76D0B6F94D79" overflow="visible">
+            <path d="M 1.3398 2.6268 C 1.3794 2.6664 1.3794 2.805 1.3398 2.8446 C 1.1418 2.838 0.9108 2.8314 0.6732 2.8314 C 0.4224 2.8314 0.24419999 2.838 0.0726 2.8446 C 0.033 2.805 0.033 2.6664 0.0726 2.6268 C 0.38279998 2.5938 0.4554 2.5278 0.594 2.1845999 L 1.4586 0.0528 C 1.4981999 -0.0396 1.551 -0.0792 1.617 -0.0792 C 1.6764 -0.0792 1.7292 -0.0396 1.7754 0.066 L 2.442 1.6896 L 3.1218 0.0528 C 3.1614 -0.0396 3.2142 -0.0792 3.2802 -0.0792 C 3.3396 -0.0792 3.3924 -0.0396 3.432 0.0594 L 4.2966 2.1516 C 4.4021997 2.4222 4.5144 2.6069999 4.851 2.6268 C 4.8906 2.6664 4.8906 2.805 4.851 2.8446 C 4.719 2.838 4.5738 2.8314 4.3758 2.8314 C 4.1778 2.8314 3.9006 2.838 3.7026 2.8446 C 3.6629999 2.805 3.6629999 2.6664 3.7026 2.6268 C 4.1976 2.6004 4.1316 2.409 4.0392 2.178 L 3.4847999 0.8052 C 3.4187999 0.6402 3.3924 0.6402 3.3396 0.7788 L 2.772 2.2242 C 2.6466 2.5344 2.6598 2.6004 3.0096 2.6268 C 3.0492 2.6664 3.0492 2.805 3.0096 2.8446 C 2.8116 2.838 2.5476 2.8314 2.3496 2.8314 C 2.1845999 2.8314 1.9668 2.838 1.7688 2.8446 C 1.7292 2.805 1.7292 2.6664 1.7688 2.6268 C 2.079 2.6004 2.1582 2.409 2.277 2.112 L 2.3166 2.0064 L 1.8546 0.8382 C 1.7688 0.6204 1.7556 0.6138 1.6698 0.825 L 1.1418 2.1845999 C 1.0164 2.5014 1.023 2.6069999 1.3398 2.6268 Z "/>
+        </symbol>
+        <symbol id="gE178D7F47461E6A52FD78FD9F0543213" overflow="visible">
+            <path d="M 0.627 0.8052 C 0.627 0.2574 0.55439997 0.2244 0.1518 0.2046 C 0.1122 0.16499999 0.1122 0.0264 0.1518 -0.0132 C 0.38279998 -0.0066 0.627 0 0.891 0 C 1.155 0 1.4058 -0.0066 1.6236 -0.0132 C 1.6632 0.0264 1.6632 0.16499999 1.6236 0.2046 C 1.221 0.2244 1.1484 0.2574 1.1484 0.8052 L 1.1484 3.8478 C 1.1484 4.2768 1.1748 4.5408 1.1748 4.5408 C 1.1748 4.587 1.1484 4.6068 1.089 4.6068 C 0.924 4.5408 0.429 4.4484 0.16499999 4.4286 C 0.1518 4.3758 0.16499999 4.2702 0.2046 4.2306 C 0.5874 4.2042 0.627 4.1844 0.627 3.6894 Z "/>
+        </symbol>
+        <symbol id="g37A521866C3DDB88EADD371B6489FA" overflow="visible">
+            <path d="M 1.1022 2.6004 C 1.0626 2.5608 1.0362 2.574 1.0362 2.6334 L 1.0362 3.8478 C 1.0362 4.2768 1.0626 4.5408 1.0626 4.5408 C 1.0626 4.587 1.0362 4.6068 0.97679996 4.6068 C 0.8118 4.5408 0.3168 4.4484 0.0528 4.4286 C 0.0396 4.3758 0.0528 4.2702 0.0924 4.2306 C 0.1122 4.2306 0.132 4.2306 0.1518 4.2306 C 0.4422 4.2108 0.5148 4.2108 0.5148 3.6894 L 0.5148 0.4686 C 0.5148 0.2112 0.5082 0.0924 0.48839998 0 C 0.5214 -0.0528 0.55439997 -0.0792 0.6336 -0.0792 C 0.6732 -0.0396 0.7392 0.0198 0.792 0.0792 C 0.858 0.1584 0.8976 0.1584 0.9702 0.099 C 1.122 -0.0264 1.3199999 -0.066 1.551 -0.066 C 2.2242 -0.066 3.0096 0.5478 3.0096 1.5972 C 3.0096 2.4024 2.4156 2.8974 1.8414 2.8974 C 1.5576 2.8974 1.3068 2.7851999 1.1022 2.6004 Z M 1.1484 2.3957999 C 1.3199999 2.5476 1.518 2.6069999 1.7093999 2.6069999 C 2.112 2.6069999 2.442 2.1186 2.442 1.4784 C 2.442 0.726 2.1384 0.1584 1.5114 0.1584 C 1.3068 0.1584 1.1682 0.3036 1.0362 0.4686 L 1.0362 2.1186 C 1.0362 2.2572 1.0626 2.3232 1.1484 2.3957999 Z "/>
+        </symbol>
+        <symbol id="gF165E978833A3682C842FC6D491F1148" overflow="visible">
+            <path d="M 2.5476 0.6138 C 2.3034 0.363 2.112 0.2574 1.7292 0.2574 C 1.4916 0.2574 1.2144 0.396 1.0098 0.7326 C 0.8778 0.9504 0.7986 1.254 0.7986 1.6368 L 2.5542 1.6236 C 2.6334 1.6236 2.6796 1.6632 2.6796 1.7358 C 2.6796 2.2902 2.4816 2.8842 1.5642 2.8842 C 0.99 2.8842 0.24419999 2.3364 0.24419999 1.3332 C 0.24419999 0.9636 0.3366 0.6072 0.55439997 0.3564 C 0.7788 0.0924 1.089 -0.066 1.5642 -0.066 C 2.0658 -0.066 2.4222 0.16499999 2.6862 0.5082 C 2.6664 0.5742 2.6268 0.6072 2.5476 0.6138 Z M 0.8184 1.8612 C 0.9438 2.6069999 1.4058 2.6664 1.5642 2.6664 C 1.8149999 2.6664 2.112 2.5278 2.112 1.9734 C 2.112 1.914 2.0856 1.881 2.013 1.881 Z "/>
+        </symbol>
+        <symbol id="gFF67C7F08C47ECAA5515ACD903E6A3E3" overflow="visible">
+            <path d="M 1.2144 2.3628 C 1.1748 2.3166 1.1352 2.3034 1.1352 2.3628 C 1.1286 2.541 1.1154 2.7984 1.0824 2.8644 C 1.0692 2.8974 1.056 2.9172 1.0032 2.9172 C 0.8184 2.8446 0.6468 2.7851999 0.19139999 2.7258 C 0.1782 2.6862 0.19139999 2.5806 0.2046 2.541 C 0.561 2.508 0.6336 2.475 0.6336 2.0922 L 0.6336 0.8052 C 0.6336 0.264 0.5676 0.2376 0.1716 0.2046 C 0.132 0.16499999 0.132 0.0264 0.1716 -0.0132 C 0.3696 -0.0066 0.6336 0 0.8976 0 C 1.1616 0 1.3596 -0.0066 1.5576 -0.0132 C 1.5972 0.0264 1.5972 0.16499999 1.5576 0.2046 C 1.221 0.2376 1.155 0.264 1.155 0.8052 L 1.155 1.8876 C 1.155 2.0262 1.2144 2.1054 1.2672 2.1648 C 1.518 2.409 1.8149999 2.5542 2.0724 2.5542 C 2.2044 2.5542 2.343 2.4684 2.4222 2.3166 C 2.4882 2.1845999 2.5014 2.0064 2.5014 1.8084 L 2.5014 0.8052 C 2.5014 0.264 2.4354 0.2376 2.0922 0.2046 C 2.0592 0.16499999 2.0592 0.0264 2.0922 -0.0132 C 2.2902 -0.0066 2.5014 0 2.7654 0 C 3.0293999 0 3.267 -0.0066 3.465 -0.0132 C 3.498 0.0264 3.498 0.16499999 3.465 0.2046 C 3.0954 0.2376 3.0228 0.264 3.0228 0.8052 L 3.0228 1.7886 C 3.0228 2.1516 2.9963999 2.4684 2.8446 2.673 C 2.7324 2.8181999 2.5278 2.8974 2.2968 2.8974 C 1.9734 2.8974 1.6037999 2.8116 1.2144 2.3628 Z "/>
+        </symbol>
+        <symbol id="g3508090D5DB08745FDAC16BE13B23CF0" overflow="visible">
+            <path d="M 3.102 0.8052 L 3.102 2.1978 C 3.102 2.4552 3.1284 2.8776 3.1284 2.8776 C 3.1284 2.904 3.0888 2.9172 3.0623999 2.9172 C 2.8644 2.838 2.673 2.8314 2.442 2.8314 L 1.1418 2.8314 L 1.1418 3.2075999 C 1.1418 3.8346 1.3662 4.3824 1.8149999 4.3824 C 2.0988 4.3824 2.3232 4.3098 2.376 4.0392 C 2.442 3.7092 2.5806 3.6102 2.7851999 3.6102 C 2.9304 3.6102 3.069 3.7422 3.069 3.8808 C 3.069 4.29 2.508 4.6068 1.8942 4.6068 C 1.5906 4.6068 1.2276 4.488 0.957 4.1712 C 0.6798 3.8478 0.6204 3.4452 0.6204 2.9304 L 0.6204 2.8314 L 0.297 2.8314 C 0.1782 2.8314 0.1452 2.7522 0.1452 2.6994 L 0.1452 2.6136 C 0.1452 2.5806 0.1518 2.574 0.1782 2.574 L 0.6204 2.574 L 0.6204 0.8052 C 0.6204 0.2574 0.5478 0.231 0.19139999 0.2046 C 0.1518 0.16499999 0.1518 0.0264 0.19139999 -0.0132 C 0.4158 -0.0066 0.6534 0 0.8844 0 C 1.1154 0 1.4124 -0.0066 1.6302 -0.0132 C 1.6698 0.0264 1.6698 0.16499999 1.6302 0.2046 C 1.2078 0.231 1.1418 0.2574 1.1418 0.8052 L 1.1418 2.574 L 2.3232 2.574 C 2.5278 2.574 2.5806 2.442 2.5806 2.1054 L 2.5806 0.8052 C 2.5806 0.2574 2.5014 0.231 2.1384 0.2046 C 2.0988 0.16499999 2.0988 0.0264 2.1384 -0.0132 C 2.3694 -0.0066 2.6069999 0 2.8446 0 C 3.0756 0 3.333 -0.0066 3.5772 -0.0132 C 3.6168 0.0264 3.6168 0.16499999 3.5772 0.2046 C 3.1746 0.231 3.102 0.2574 3.102 0.8052 Z "/>
+        </symbol>
+        <symbol id="gF2C65265520F47D93ECEB2A9CD8CD2B" overflow="visible">
+            <path d="M 1.0296 2.4288 C 1.023 2.6268 1.0098 2.7984 0.97679996 2.8644 C 0.9636 2.8974 0.9504 2.9172 0.8976 2.9172 C 0.7128 2.8446 0.5412 2.7851999 0.0858 2.7258 C 0.0726 2.6862 0.0858 2.5806 0.099 2.541 C 0.4554 2.508 0.528 2.475 0.528 2.0922 L 0.528 -0.726 C 0.528 -1.2738 0.4554 -1.3068 0.0528 -1.3266 C 0.0132 -1.3662 0.0132 -1.5048 0.0528 -1.5444 C 0.2838 -1.5378 0.528 -1.5311999 0.792 -1.5311999 C 1.056 -1.5311999 1.3728 -1.5378 1.5906 -1.5444 C 1.6302 -1.5048 1.6302 -1.3662 1.5906 -1.3266 C 1.122 -1.3002 1.0494 -1.2738 1.0494 -0.726 L 1.0494 -0.0132 C 1.0494 0.0726 1.0758 0.066 1.1418 0.0396 C 1.3068 -0.0264 1.5048 -0.066 1.716 -0.066 C 2.0856 -0.066 2.4156 0.0462 2.6862 0.3036 C 2.9963999 0.6072 3.1746 1.0164 3.1746 1.551 C 3.1746 2.2506 2.6796 2.8974 2.0064 2.8974 C 1.7028 2.8974 1.3662 2.6994 1.1022 2.4024 C 1.0626 2.3628 1.0362 2.3628 1.0296 2.4288 Z M 1.155 2.1845999 C 1.3266 2.3957999 1.6302 2.5938 1.8216 2.5938 C 2.244 2.5938 2.6069999 2.1186 2.6069999 1.3728 C 2.6069999 0.8316 2.4156 0.1584 1.6764 0.1584 C 1.5576 0.1584 1.3266 0.19139999 1.2078 0.297 C 1.0758 0.4158 1.0494 0.4554 1.0494 0.693 L 1.0494 1.8942 C 1.0494 2.0328 1.0758 2.0922 1.155 2.1845999 Z "/>
+        </symbol>
+        <symbol id="gC15FD23282FB7CA5B3EE5FAD299A288" overflow="visible">
+            <path d="M 1.1616 2.3628 C 1.1484 2.6268 1.1418 2.7984 1.1087999 2.8644 C 1.0956 2.8974 1.0824 2.9172 1.0296 2.9172 C 0.8448 2.8446 0.6732 2.7851999 0.21779999 2.7258 C 0.2046 2.6862 0.21779999 2.5806 0.231 2.541 C 0.5874 2.508 0.65999997 2.475 0.65999997 2.0922 L 0.65999997 0.8052 C 0.65999997 0.2574 0.5808 0.231 0.1716 0.2046 C 0.132 0.16499999 0.132 0.0264 0.1716 -0.0132 C 0.4026 -0.0066 0.65999997 0 0.924 0 C 1.188 0 1.4916 -0.0066 1.7226 -0.0132 C 1.7622 0.0264 1.7622 0.16499999 1.7226 0.2046 C 1.2606 0.2376 1.1814 0.2574 1.1814 0.8052 L 1.1814 1.7226 C 1.1814 1.8942 1.2606 2.046 1.3398 2.1648 C 1.4124 2.2704 1.5642 2.4882 1.6434 2.4882 C 1.7028 2.4882 1.7622 2.475 1.8149999 2.4024 C 1.8612 2.3364 1.9404 2.2506 2.0526 2.2506 C 2.211 2.2506 2.3628 2.4156 2.3628 2.5806 C 2.3628 2.706 2.244 2.8974 1.9668 2.8974 C 1.6566 2.8974 1.386 2.6069999 1.2342 2.3496 C 1.1946 2.277 1.1616 2.3298 1.1616 2.3628 Z "/>
+        </symbol>
+        <symbol id="g9959320E8E7A94EFAC8C7F4415EB4833" overflow="visible">
+            <path d="M 0.2838 2.8314 C 0.19139999 2.8314 0.16499999 2.7522 0.16499999 2.6994 L 0.16499999 2.6136 C 0.16499999 2.5806 0.1716 2.574 0.198 2.574 L 0.5874 2.574 L 0.5874 0.5874 C 0.5874 0.1188 0.792 -0.066 1.0956 -0.066 C 1.3992 -0.066 1.7292 0.0792 1.9866 0.3696 C 1.9734 0.43559998 1.9338 0.4752 1.8678 0.4818 C 1.6962 0.3498 1.4981999 0.297 1.3266 0.297 C 1.1484 0.297 1.1087999 0.495 1.1087999 0.9042 L 1.1087999 2.574 L 1.7952 2.574 C 1.8612 2.574 1.9535999 2.6004 1.9535999 2.6598 L 1.9535999 2.7918 C 1.9535999 2.8181999 1.9338 2.8314 1.9008 2.8314 L 1.1087999 2.8314 L 1.1087999 3.0888 C 1.1087999 3.5178 1.1352 3.7818 1.1352 3.7818 C 1.1352 3.8214 1.1154 3.8411999 1.0824 3.8411999 C 1.056 3.8411999 0.9966 3.8148 0.9372 3.7818 C 0.8646 3.7422 0.7986 3.7092 0.7128 3.6894 C 0.6336 3.6629999 0.5676 3.6432 0.5676 3.597 C 0.5676 3.5178 0.5874 3.564 0.5874 2.8314 Z "/>
+        </symbol>
+        <symbol id="gD05C8665D544229CD7C233365E808FE" overflow="visible">
+            <path d="M 0.781 4.829 C 0.759 4.829 0.715 4.785 0.715 4.763 C 0.704 4.268 0.649 3.883 0.55 3.3439999 C 0.649 3.3 0.781 3.2779999 0.913 3.3109999 C 1.133 4.114 1.474 4.301 1.804 4.312 L 3.212 4.345 C 2.464 3.091 1.364 1.507 0.506 0.352 C 0.407 0.22 0.407 0.187 0.407 0.132 C 0.407 0.055 0.495 0 0.65999997 0 L 4.092 -0.033 C 4.224 0.341 4.367 0.913 4.444 1.4629999 C 4.378 1.507 4.246 1.529 4.114 1.529 L 3.96 1.21 C 3.685 0.627 3.454 0.385 2.882 0.374 L 1.419 0.374 C 2.233 1.408 3.377 3.135 4.059 4.257 C 4.224 4.532 4.257 4.62 4.257 4.664 C 4.257 4.708 4.202 4.741 4.125 4.741 C 4.07 4.741 3.762 4.719 3.443 4.719 L 1.43 4.719 C 1.078 4.719 0.946 4.774 0.781 4.829 Z "/>
+        </symbol>
+        <symbol id="g2A9009985370E4784889D5A432B8A008" overflow="visible">
+            <path d="M 2.233 4.378 C 2.299 4.444 2.299 4.675 2.233 4.741 C 1.903 4.73 1.518 4.719 1.122 4.719 C 0.704 4.719 0.407 4.73 0.121 4.741 C 0.055 4.675 0.055 4.444 0.121 4.378 C 0.638 4.323 0.759 4.213 0.99 3.641 L 2.431 0.088 C 2.497 -0.066 2.585 -0.132 2.695 -0.132 C 2.794 -0.132 2.882 -0.066 2.9589999 0.11 L 4.07 2.816 L 5.203 0.088 C 5.269 -0.066 5.357 -0.132 5.467 -0.132 C 5.566 -0.132 5.654 -0.066 5.72 0.099 L 7.161 3.586 C 7.337 4.037 7.524 4.345 8.085 4.378 C 8.151 4.444 8.151 4.675 8.085 4.741 C 7.865 4.73 7.623 4.719 7.2929997 4.719 C 6.963 4.719 6.501 4.73 6.171 4.741 C 6.105 4.675 6.105 4.444 6.171 4.378 C 6.996 4.334 6.886 4.015 6.732 3.6299999 L 5.808 1.342 C 5.698 1.067 5.654 1.067 5.566 1.298 L 4.62 3.707 C 4.411 4.224 4.433 4.334 5.016 4.378 C 5.082 4.444 5.082 4.675 5.016 4.741 C 4.686 4.73 4.246 4.719 3.916 4.719 C 3.641 4.719 3.2779999 4.73 2.948 4.741 C 2.882 4.675 2.882 4.444 2.948 4.378 C 3.465 4.334 3.597 4.015 3.795 3.52 L 3.861 3.3439999 L 3.091 1.397 C 2.948 1.034 2.9259999 1.023 2.783 1.375 L 1.903 3.641 C 1.694 4.169 1.705 4.345 2.233 4.378 Z "/>
+        </symbol>
+        <symbol id="g8C05BBC574D5FE4CFE5913B9029DB694" overflow="visible">
+            <path d="M 2.6382813 6.1789064 L 2.6382813 4.8125 L 4.4343753 4.8125 L 4.4343753 4.198047 L 2.6382813 4.198047 L 2.6382813 1.5855469 Q 2.6382813 1.0527344 2.8402345 0.8421875 Q 3.0421875 0.6316406 3.5449219 0.6316406 L 4.4343753 0.6316406 L 4.4343753 0 L 3.4675782 0 Q 2.578125 0 2.2128906 0.35664064 Q 1.8476563 0.7132813 1.8476563 1.5855469 L 1.8476563 4.198047 L 0.56289065 4.198047 L 0.56289065 4.8125 L 1.8476563 4.8125 L 1.8476563 6.1789064 L 2.6382813 6.1789064 Z "/>
+        </symbol>
+        <symbol id="g23110B8D3E178F349F41AF3F1139706F" overflow="visible">
+            <path d="M 4.7781253 2.6039064 L 4.7781253 2.2171876 L 1.3535156 2.2171876 L 1.3535156 2.1914063 Q 1.3535156 1.4050782 1.7638673 0.9753907 Q 2.174219 0.5457031 2.921875 0.5457031 Q 3.3000002 0.5457031 3.7125 0.6660156 Q 4.125 0.78632814 4.5933595 1.03125 L 4.5933595 0.24492188 Q 4.1421876 0.060156252 3.7232423 -0.032226563 Q 3.304297 -0.12460938 2.9132812 -0.12460938 Q 1.7917969 -0.12460938 1.1601563 0.54785156 Q 0.52851564 1.2203125 0.52851564 2.4019532 Q 0.52851564 3.5535157 1.1472657 4.241016 Q 1.7660156 4.928516 2.7972658 4.928516 Q 3.7167969 4.928516 4.247461 4.305469 Q 4.7781253 3.682422 4.7781253 2.6039064 Z M 3.9875002 2.8359375 Q 3.9703126 3.5320313 3.6587892 3.8951173 Q 3.3472657 4.258203 2.7628906 4.258203 Q 2.1914063 4.258203 1.8218751 3.8800783 Q 1.4523438 3.5019531 1.3835938 2.8316407 L 3.9875002 2.8359375 Z "/>
+        </symbol>
+        <symbol id="g3BCE8E5AFB034A1CFA0F275699E216B3" overflow="visible">
+            <path d="M 4.8039064 4.8125 L 3.0808594 2.509375 L 4.9714847 0 L 4.05625 0 L 2.6468751 1.929297 L 1.2417969 0 L 0.3265625 0 L 2.2171876 2.509375 L 0.49414063 4.8125 L 1.3707031 4.8125 L 2.6468751 3.0722656 L 3.9144533 4.8125 L 4.8039064 4.8125 Z "/>
+        </symbol>
+        <symbol id="g1D73A7A3000FC25AB5C09DB0E511C1F1" overflow="visible">
+            <path d="M 1.705 0.869 L 2.31 2.464 C 2.365 2.6069999 2.431 2.651 2.695 2.651 L 5.016 2.651 L 5.654 0.792 C 5.786 0.41799998 5.368 0.374 4.84 0.341 C 4.774 0.275 4.774 0.044 4.84 -0.022 C 5.2469997 -0.011 5.8519998 0 6.281 0 C 6.732 0 7.15 -0.011 7.535 -0.022 C 7.601 0.044 7.601 0.275 7.535 0.341 C 7.106 0.385 6.732 0.41799998 6.545 0.946 L 4.279 7.238 C 4.114 7.139 3.817 7.018 3.674 7.018 L 1.177 1.122 C 0.891 0.44 0.561 0.374 0.077 0.341 C 0.011 0.275 0.011 0.044 0.077 -0.022 C 0.363 -0.011 0.726 0 1.056 0 C 1.507 0 2.057 -0.011 2.464 -0.022 C 2.53 0.044 2.53 0.275 2.464 0.341 C 2.046 0.374 1.529 0.41799998 1.705 0.869 Z M 2.893 3.113 C 2.651 3.113 2.574 3.146 2.618 3.256 L 3.74 6.105 L 3.806 6.105 L 4.84 3.113 Z "/>
+        </symbol>
+        <symbol id="g62E645D0BABB53DB5C64FC1234E3D1C" overflow="visible">
+            <path d="M 0.77 0.65999997 C 0.77 0.341 1.034 0.077 1.353 0.077 C 1.6719999 0.077 1.936 0.341 1.936 0.65999997 C 1.936 0.979 1.6719999 1.243 1.353 1.243 C 1.034 1.243 0.77 0.979 0.77 0.65999997 Z M 0.77 3.938 C 0.77 3.619 1.034 3.355 1.353 3.355 C 1.6719999 3.355 1.936 3.619 1.936 3.938 C 1.936 4.257 1.6719999 4.521 1.353 4.521 C 1.034 4.521 0.77 4.257 0.77 3.938 Z "/>
+        </symbol>
+        <symbol id="g52F53110020E971308997FA33FA7F046" overflow="visible">
+            <path d="M 3.168 1.342 L 3.168 5.159 C 3.168 5.819 3.179 6.49 3.201 6.633 C 3.201 6.6879997 3.179 6.6879997 3.135 6.6879997 C 2.53 6.314 1.947 6.039 0.979 5.588 C 1.001 5.467 1.045 5.357 1.144 5.291 C 1.65 5.5 1.892 5.566 2.101 5.566 C 2.288 5.566 2.321 5.302 2.321 4.928 L 2.321 1.342 C 2.321 0.429 2.024 0.374 1.254 0.341 C 1.188 0.275 1.188 0.044 1.254 -0.022 C 1.793 -0.011 2.189 0 2.783 0 C 3.3109999 0 3.575 -0.011 4.125 -0.022 C 4.191 0.044 4.191 0.275 4.125 0.341 C 3.355 0.374 3.168 0.429 3.168 1.342 Z "/>
+        </symbol>
+        <symbol id="g8133231E88A02C601D4A13E78DD5AB79" overflow="visible">
+            <path d="M 0.671 5.148 C 0.671 4.917 0.88 4.719 1.111 4.719 C 1.298 4.719 1.628 4.917 1.628 5.159 C 1.628 5.2469997 1.606 5.313 1.584 5.39 C 1.562 5.467 1.496 5.566 1.496 5.654 C 1.496 5.929 1.782 6.325 2.585 6.325 C 2.981 6.325 3.542 6.05 3.542 4.994 C 3.542 4.29 3.289 3.718 2.6399999 3.058 L 1.826 2.2549999 C 0.748 1.155 0.572 0.627 0.572 -0.022 C 0.572 -0.022 1.133 0 1.485 0 L 3.41 0 C 3.762 0 4.268 -0.022 4.268 -0.022 C 4.411 0.561 4.521 1.386 4.532 1.716 C 4.466 1.771 4.323 1.793 4.213 1.771 C 4.026 0.99 3.839 0.715 3.443 0.715 L 1.485 0.715 C 1.485 1.243 2.244 1.9909999 2.299 2.046 L 3.41 3.113 C 4.037 3.718 4.5099998 4.202 4.5099998 5.038 C 4.5099998 6.226 3.542 6.71 2.651 6.71 C 1.43 6.71 0.671 5.808 0.671 5.148 Z "/>
+        </symbol>
+        <symbol id="g6E676F4AC4E0A6739716B2650049D122" overflow="visible">
+            <path d="M 2.365 6.325 C 2.838 6.325 3.2779999 6.039 3.2779999 5.335 C 3.2779999 4.785 2.6399999 3.938 1.551 3.784 L 1.606 3.432 C 1.793 3.454 1.9909999 3.454 2.134 3.454 C 2.761 3.454 3.575 3.2779999 3.575 2.035 C 3.575 0.572 2.596 0.275 2.211 0.275 C 1.65 0.275 1.551 0.528 1.419 0.726 C 1.309 0.88 1.166 1.012 0.946 1.012 C 0.715 1.012 0.484 0.803 0.484 0.627 C 0.484 0.187 1.408 -0.11 2.068 -0.11 C 3.377 -0.11 4.5429997 0.737 4.5429997 2.189 C 4.5429997 3.388 3.641 3.817 2.992 3.927 L 2.981 3.949 C 3.883 4.378 4.136 4.829 4.136 5.412 C 4.136 5.742 4.059 6.006 3.795 6.281 C 3.553 6.523 3.168 6.71 2.596 6.71 C 0.979 6.71 0.517 5.654 0.517 5.291 C 0.517 5.137 0.627 4.917 0.891 4.917 C 1.276 4.917 1.3199999 5.2799997 1.3199999 5.489 C 1.3199999 6.193 2.079 6.325 2.365 6.325 Z "/>
+        </symbol>
+        <symbol id="g3D755F22EA44077C36D6DAB39CE77D75" overflow="visible">
+            <path d="M 4.73 2.409 L 3.817 2.409 L 3.817 5.621 C 3.817 6.171 3.817 6.6 3.839 6.6879997 L 3.817 6.71 L 3.465 6.71 C 3.388 6.71 3.333 6.644 3.289 6.5889997 C 2.596 5.742 1.3199999 3.927 0.308 2.354 C 0.341 2.189 0.407 1.892 0.737 1.892 L 2.981 1.892 L 2.981 0.88 C 2.981 0.374 2.563 0.374 2.09 0.341 C 2.024 0.275 2.024 0.044 2.09 -0.022 C 2.442 -0.011 2.882 0 3.388 0 C 3.817 0 4.235 -0.011 4.587 -0.022 C 4.653 0.044 4.653 0.275 4.587 0.341 C 4.048 0.385 3.817 0.363 3.817 0.88 L 3.817 1.892 L 4.576 1.892 C 4.73 1.892 4.895 2.101 4.895 2.233 C 4.895 2.343 4.851 2.409 4.73 2.409 Z M 2.981 5.577 L 2.981 2.409 L 0.88 2.409 C 1.441 3.3109999 2.222 4.5429997 2.981 5.577 Z "/>
+        </symbol>
+        <symbol id="g59FDDD5E0FE4FB61395B3BF25C03A511" overflow="visible">
+            <path d="M 3.509 2.079 C 3.509 1.034 2.9589999 0.264 2.299 0.264 C 1.881 0.264 1.738 0.539 1.573 0.759 C 1.43 0.946 1.243 1.111 1.012 1.111 C 0.803 1.111 0.594 0.924 0.594 0.704 C 0.594 0.253 1.529 -0.121 2.156 -0.121 C 3.52 -0.121 4.488 0.891 4.488 2.277 C 4.488 3.3439999 3.751 4.301 2.519 4.301 C 2.046 4.301 1.6389999 4.202 1.441 4.125 L 1.661 5.962 C 2.068 5.9179997 2.42 5.863 2.948 5.863 C 3.2779999 5.863 3.652 5.8849998 4.103 5.929 L 4.279 6.677 L 4.202 6.721 C 3.575 6.6549997 2.981 6.6 2.398 6.6 C 1.9909999 6.6 1.595 6.6219997 1.21 6.6549997 L 0.83599997 3.487 C 1.419 3.707 1.837 3.751 2.233 3.751 C 2.948 3.751 3.509 3.2779999 3.509 2.079 Z "/>
+        </symbol>
+    </defs>
+</svg>

--- a/packages/preview/dashy-todo/0.1.1/example.typ
+++ b/packages/preview/dashy-todo/0.1.1/example.typ
@@ -1,0 +1,20 @@
+#import "/lib/todo.typ": todo
+
+#set page(width: 16cm, height: 12cm, margin: (left: 20%, right: 20%), fill: white)
+#show link: underline
+
+= Dashy TODOs
+
+#let blue-todo = todo.with(stroke: blue)
+
+TODOs are automatically positioned on the closer#todo[On the right] side to the method call.#blue-todo[On the left] If it doesn't fit, you can manually override it. #todo(position: "inline")[You can also place them in an inline box.]
+
+You can add custom content.#todo(position: right, stroke: (paint: green, thickness: 1pt, dash: "densely-dashed"))[We need to fix the $lim_(x -> oo)$ equation. See #link("https://example.com")[example.com]]
+
+#let small-todo = (..args) => text(size: 0.6em)[#todo(..args)]
+
+We can also control the text #small-todo[This will be in fine print]size if we wrap it in a `text` call.
+
+And finally, you can create a table of all your TODOs:
+
+#outline(title: "TODOs", target: figure.where(kind: "todo"))

--- a/packages/preview/dashy-todo/0.1.1/lib/box-placement.typ
+++ b/packages/preview/dashy-todo/0.1.1/lib/box-placement.typ
@@ -1,0 +1,47 @@
+// Given a set of box heights and the preferred positions for the boxes this function calculates the position for each box
+#let calculate-box-positions(boxes) = {
+  let total-height = boxes.map(box => box.height).sum()
+  
+  let positions = ()
+  // If the total height of the boxes is bigger than the page height, we don't have room to re-arrange the boxes based on their preferred position. Just start at the top and place them underneath each other
+  if total-height >= page.height {
+    let accumulated-height = 0mm
+    for box in boxes {
+      let top = accumulated-height
+      let bottom = top + box.height
+      positions.push((top: top, bottom: bottom))
+      accumulated-height = bottom
+    }
+  }
+  // If there is still room available, try to move as many boxes to their preferred position as possible
+  else {
+    // `slack` is the amount of free space we still have available to move around the boxes
+    let slack = page.height - total-height
+    // Start filling the page at the bottom with the last box and work upwards
+    let last-box-pos = page.height
+    for box in boxes.rev() {
+      let preferred-pos = box.preferred-pos.to-absolute() // We cannot compare pt to em, so we need to make the position absolute first
+      // `lowest-possible-pos` is the lowest position we can give the box to make it barely fit the available space
+      let lowest-possible-pos = last-box-pos - box.height
+      // `highest-possible-pos` is the highest possible postion we can give the box so the remaining boxes still barely fit on the remaining page (all slack would be used up in this case)
+      let highest-possible-pos = lowest-possible-pos - slack
+      let box-pos
+      // If the preferred position can be achieved, just give it to the box
+      if preferred-pos >= highest-possible-pos and preferred-pos <= lowest-possible-pos {
+        box-pos = preferred-pos
+      }
+      // If putting the box at its preferred position is impossible, move it down as much as possible to give the other boxes as much space as possible to move to their preferred positions
+      else {
+        box-pos = lowest-possible-pos
+      }
+      let top = box-pos
+      let bottom = top + box.height
+      positions.push((top: top, bottom: bottom))
+      last-box-pos = box-pos
+      // Track how much of the slack we've used up
+      slack -= lowest-possible-pos - box-pos
+    }
+    positions = positions.rev()
+  }
+  positions
+}

--- a/packages/preview/dashy-todo/0.1.1/lib/side-margin.typ
+++ b/packages/preview/dashy-todo/0.1.1/lib/side-margin.typ
@@ -1,0 +1,46 @@
+#let rel-to-abs = (rel, size) => rel.length + rel.ratio * size
+
+// must run within a context
+#let calc-side-margin(side) = {
+  // https://typst.app/docs/reference/layout/page/#parameters-margin
+  let auto-margin = calc.min(page.width, page.height) * 2.5 / 21
+
+  if page.margin == auto {
+    auto-margin
+  } else if type(page.margin) == relative {
+    rel-to-abs(page.margin, page.width)
+  } else {
+    if side == left and page.margin.left == auto or side == right and page.margin.right == auto {
+      auto-margin
+    } else {
+      if side == left {
+        rel-to-abs(page.margin.left, page.width)
+      } else {
+        rel-to-abs(page.margin.right, page.width)
+      }
+    }
+  }
+}
+
+// must run within a context
+#let calculate-page-margin-box(side) = {
+  assert(side in (left, right))
+
+  let margin = calc-side-margin(side)
+
+  if side == left {
+    (
+      "x": 0pt,
+      "y": 0pt,
+      "width": margin,
+      "height": page.height,
+    )
+  } else {
+    (
+      "x": page.width - margin,
+      "y": 0pt,
+      "width": margin,
+      "height": page.height,
+    )
+  }
+}

--- a/packages/preview/dashy-todo/0.1.1/lib/todo.typ
+++ b/packages/preview/dashy-todo/0.1.1/lib/todo.typ
@@ -1,0 +1,126 @@
+#import "box-placement.typ": calculate-box-positions
+#import "side-margin.typ": calculate-page-margin-box
+
+#let to-string(content) = {
+  if type(content) == str {
+    content
+  } else if content.has("text") {
+    content.text
+  } else if content.has("children") {
+    content.children.map(to-string).join("")
+  } else if content.has("body") {
+    to-string(content.body)
+  } else if content == [ ] {
+    " "
+  }
+}
+
+#let outline-entry(body) = {
+  // invisible figure, s.t. we can reference it in the outline
+  // probably depends on https://github.com/typst/typst/issues/147 for a cleaner solution
+  hide(
+    box(
+      height: 0pt,
+      width: 0pt,
+      figure(
+        none,
+        kind: "todo",
+        supplement: [TODO],
+        caption: to-string(body),
+        outlined: true,
+      ),
+    ),
+  )
+}
+
+#let inline-todo(body, stroke) = {
+  box(stroke: stroke, width: 100%, inset: 4pt)[#body]
+  outline-entry(body)
+}
+
+#let side-todo(body, position, stroke) = {
+  box(context {
+    let text-position = here().position()
+
+    let side = position
+    if position == auto {
+      if text-position.x > page.width / 2 {
+        side = right
+      } else {
+        side = left
+      }
+    }
+
+    let page-margin-box = calculate-page-margin-box(side)
+    let shift-y = .5em
+    let outer-box-inset = 4pt
+
+    // Create the todo box. It will later be measured to determine it's location
+    let todo-box = box(inset: outer-box-inset, width: page-margin-box.width)[
+      #box(stroke: stroke, width: 100%)[
+        #box(body, inset: 0.2em)
+      ]
+      #outline-entry(body)
+    ]
+
+    // Create a state that accumulates all the todo box sizes of the current page
+    // There are two states per page. One for the boxes on the left, one for the boxes on the right
+    let boxes = state("dashy-todo-page-" + str(here().page()) + "-" + repr(side) + "-boxes", ())
+
+    let box-size = measure(todo-box)
+
+    // Register the box in the state and determine the index of the box within the state. This index will later be used to retrieve the final position for the box.
+    let box-index = boxes.get().len()
+    boxes.update(boxes => {
+      boxes.push((
+        height: box-size.height, // Height of the box in pt, including margins
+        preferred-pos: text-position.y - shift-y // Where is the ideal y-position for the box?
+      ))
+      return boxes
+    })
+
+    let boxes = boxes.final()
+
+    if boxes.len() > box-index { // The typst compiler will skip state updates during initial layout, leaving the list empty, leading to boxes.len() < box-index. To avoid compiler errors, we'll wait for the states to be updated before placing the boxes
+      let box-positions = calculate-box-positions(boxes)
+
+      // This place will shift the coordinate system so (0, 0) will address the top left corner of the page
+      place(dx: - text-position.x, dy: - text-position.y)[
+        // Retrieve the calculated position for the current box & render it
+        #let box-pos = box-positions.at(box-index)
+        #place(dx: page-margin-box.x, dy: box-pos.top)[#todo-box]
+
+        // Draw the tick mark within the text
+        #let line-margin = page-margin-box.x - text-position.x
+        #place[#line(start: (text-position.x, text-position.y), end: (text-position.x, text-position.y + shift-y), stroke: stroke)]
+
+        // Horizontally connect the tick mark to the position of the box
+        #let box-border-x = if side == left {
+          page-margin-box.width - outer-box-inset
+        } else {
+          page-margin-box.x + outer-box-inset
+        }
+        #place[#line(start: (text-position.x, text-position.y + shift-y), end: (box-border-x, text-position.y + shift-y), stroke: stroke)]
+
+        // If the box is above or below the line, connect it vertically
+        #if text-position.y + shift-y.to-absolute() < box-pos.top + outer-box-inset {
+          place[#line(start: (box-border-x, text-position.y + shift-y), end: (box-border-x, box-pos.top + outer-box-inset), stroke: stroke)]
+        } else if text-position.y + shift-y.to-absolute() > box-pos.bottom - outer-box-inset {
+          place[#line(start: (box-border-x, text-position.y + shift-y), end: (box-border-x, box-pos.bottom - outer-box-inset), stroke: stroke)]
+        }
+      ]
+    }
+  })
+}
+
+#let todo(body, position: auto, stroke: orange) = {
+  assert(
+    position in (auto, left, right, "inline"),
+    message: "Can only position todo either inline, or on the left or right side.",
+  )
+  if position == "inline" {
+    inline-todo(body, stroke)
+  } else {
+    side-todo(body, position, stroke)
+  }
+}

--- a/packages/preview/dashy-todo/0.1.1/typst.toml
+++ b/packages/preview/dashy-todo/0.1.1/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dashy-todo"
+version = "0.1.1"
+entrypoint = "lib/todo.typ"
+authors = ["Otto-AA"]
+license = "MIT-0"
+description = "A method to display TODOs at the side of the page."
+repository = "https://github.com/Otto-AA/dashy-todo"
+keywords = ["todo"]
+categories = ["utility"]
+exclude = ["*.svg*", "example.typ"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package


Fix bug that outline only included inline todos (worked before 0.1.0, and now it's fixed again).
