### PR TITLE
datify:1.0.0

### DIFF
--- a/packages/preview/datify/1.0.0/LICENSE
+++ b/packages/preview/datify/1.0.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jeomhps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/datify/1.0.0/README.md
+++ b/packages/preview/datify/1.0.0/README.md
@@ -1,0 +1,179 @@
+# Datify
+![Test Datify](https://github.com/Jeomhps/datify/actions/workflows/test.yml/badge.svg?branch=main)
+> **⚠️ Major Breaking Changes in v1.0.0+**
+>
+> - The user-facing API of Datify has been completely rewritten.
+> - Functions like `day-name`, `month-name`, etc. are **no longer available directly in Datify**.
+>   They have been moved to [datify-core](https://github.com/Jeomhps/datify-core), which Datify uses as its backend.
+>   Example migration:
+>   ```typst
+>   #import "@preview/datify-core:1.0.0": *
+>   #get-day-name(datetime.today(), lang: "en") // Now available in datify-core
+>   ```
+> - The new backend is based on the [Unicode CLDR project](https://cldr.unicode.org/), providing robust internationalization.
+> - If you need to resolve a single day or month name, it is recommended to use `datify-core` directly.
+>   You can also use `custom-date-format` for this, but it is less practical for single values.
+> - The core logic for string transformation now uses a formal language and automata approach, similar to many modern date libraries.
+>   This introduces a new quoting system for escaping text in patterns.
+> - **If you are migrating from a previous version, your code will need to be updated.**
+>   The old usage is not compatible with this version.
+
+---
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Installation](#installation)
+3. [Usage](#usage)
+   - [Formatting Dates](#formatting-dates)
+   - [Format Tokens](#format-tokens)
+   - [Named Patterns](#named-patterns)
+   - [Literal Text in Patterns](#literal-text-in-patterns)
+4. [Supported Languages](#supported-languages)
+5. [Contributing](#contributing)
+6. [License](#license)
+7. [Development & Testing](#development--testing)
+8. [Planned Features](#planned-features)
+9. [Glossary](#glossary)
+
+---
+
+## Overview
+Datify is a Typst package for flexible, locale-aware date formatting.
+It leverages [datify-core](https://github.com/Jeomhps/datify-core) for internationalization and supports CLDR-style date patterns.
+
+---
+
+## Installation
+Add Datify to your Typst project (specify the version you want):
+```typst
+#import "@preview/datify:1.0.0": *
+```
+
+---
+
+## Usage
+
+### Function Reference
+| Argument | Type      | Required | Default | Description                                      |
+|----------|-----------|----------|---------|--------------------------------------------------|
+| date     | datetime  | Yes      | –       | The date to format                               |
+| pattern  | str       | No       | "full"  | Pattern string or CLDR named pattern             |
+| lang     | str       | No       | "en"    | ISO 639-1 language code (e.g., "en", "fr", "es") |
+
+**If you only provide `lang`, the pattern defaults to `"full"` for that locale.**
+**All arguments must be named except for the first (`date`).**
+
+#### Example usage
+```typst
+#let mydate = datetime(year: 2025, month: 1, day: 5)
+#custom-date-format(mydate) // Output: Sunday, January 5, 2025 (in English, full format)
+#custom-date-format(mydate, lang: "es") // Output: domingo, 5 de enero de 2025
+#custom-date-format(mydate, pattern: "yyyy-MM-dd") // Output: 2025-01-05
+#custom-date-format(mydate, pattern: "full", lang: "fr") // Output: dimanche 5 janvier 2025
+```
+
+---
+
+### Pattern Syntax
+The `pattern` argument can be either:
+- A **CLDR named pattern** (`"full"`, `"long"`, `"medium"`, `"short"`) for locale-appropriate formatting.
+- A **custom string pattern** using the tokens below.
+
+#### CLDR Pattern Example
+```typst
+#custom-date-format(mydate, pattern: "full", lang: "fr") // Output: dimanche 5 janvier 2025
+```
+
+#### Custom Pattern Example
+```typst
+#custom-date-format(mydate, pattern: "EEEE, MMMM dd, yyyy") // Output: Sunday, January 05, 2025
+#custom-date-format(mydate, pattern: "EEE, MMM d, yyyy") // Output: Sun, Jan 5, 2025
+```
+
+---
+
+### Format Tokens
+| Token   | Description                        | Example Output      |
+|---------|------------------------------------|---------------------|
+| `EEEE`  | Full weekday name                  | Sunday              |
+| `EEE`   | Abbreviated weekday name           | Sun                 |
+| `MMMM`  | Full month name                    | January             |
+| `MMM`   | Abbreviated month name             | Jan                 |
+| `MM`    | Month number, 2 digits             | 01                  |
+| `M`     | Month number, 1-2 digits           | 1                   |
+| `dd`    | Day of month, 2 digits             | 05                  |
+| `d`     | Day of month, 1-2 digits           | 5                   |
+| `yyyy`  | 4-digit year                       | 2025                |
+| `y`     | Year (same as `yyyy`)              | 2025                |
+
+- **Tokens are case-sensitive.**
+- Only the tokens above are supported.
+
+---
+
+### Named Patterns
+You can use CLDR-style named patterns: `"full"`, `"long"`, `"medium"`, `"short"`.
+These will be resolved to locale-appropriate patterns for the given language.
+
+| Pattern | English (en)               | French (fr)               |
+|---------|----------------------------|---------------------------|
+| full    | Sunday, January 5, 2025    | dimanche 5 janvier 2025   |
+| long    | January 5, 2025            | 5 janvier 2025            |
+| medium  | Jan 5, 2025                | 5 janv. 2025              |
+| short   | 1/5/25                     | 05/01/2025                |
+
+---
+
+### Literal Text in Patterns
+To include **literal text** in patterns, wrap it in single quotes (`'`).
+To include a single quote, use `''` (two single quotes).
+
+| Example Pattern               | Output                     |
+|-------------------------------|----------------------------|
+| `'Today is' EEEE`             | Today is Sunday            |
+| `yyyy'/'MM'/'dd`               | 2025/01/05                 |
+| `'''Quoted text'''`           | 'Quoted text'              |
+| `EEE 'the' dd`                | Sun the 05                 |
+
+⚠️ **Important**: Always quote literal text to avoid misinterpretation as tokens.
+While unquoted text may work now, it could cause errors in future versions.
+
+---
+
+## Supported Languages
+Datify supports all languages provided by [datify-core](https://github.com/Jeomhps/datify-core?tab=readme-ov-file#supported-locales).
+If you pass an unsupported language code, an error will be thrown.
+
+---
+
+## Contributing
+- **Native speakers wanted!**
+  If you notice missing or incorrect translations for a language, please contribute directly to [datify-core](https://github.com/Jeomhps/datify-core), which manages all locale data for Datify.
+- Pull requests for bug fixes, improvements, ideas, or feedback are welcome here.
+- For upstream locale data and structure, see [cldr-json](https://github.com/unicode-org/cldr-json).
+
+---
+
+## License
+MIT © 2025 Jeomhps
+CLDR data © Unicode, Inc., used under the [Unicode License](https://unicode.org/copyright.html).
+
+---
+
+## Development & Testing
+To run the full test suite locally, you have two options:
+1. **Using [tt (tytanic)](https://github.com/taiki-e/tytanic)**
+   ```sh
+   tt run
+   ```
+2. **Using [act](https://github.com/nektos/act)**
+   ```sh
+   act --artifact-server-path /tmp/artifact
+   ```
+
+---
+
+## Glossary
+- **CLDR**: Unicode Common Locale Data Repository, a project for locale-specific data (e.g., date formats, language rules).
+- **ISO 639-1**: Two-letter codes for representing languages (e.g., `en` for English, `fr` for French).
+- **Typst**: A markup-based typesetting system.

--- a/packages/preview/datify/1.0.0/src/formats.typ
+++ b/packages/preview/datify/1.0.0/src/formats.typ
@@ -1,0 +1,98 @@
+#import "@preview/datify-core:1.0.0": *
+#import "utils.typ": *
+
+#let custom-date-format = (
+  date,
+  pattern: "full",
+  lang: "en",
+) => {
+  // Validate date type (must be a datetime)
+  if type(date) != datetime {
+    panic("Invalid date: must be a datetime object, got " + str(type(date)))
+  }
+
+  // Validate pattern
+  if type(pattern) != str {
+    panic("Invalid pattern: must be a string, got " + str(type(pattern)))
+  }
+
+  // Validate lang
+  if type(lang) != str {
+    panic("Invalid language: must be a string, got " + str(type(lang)))
+  }
+
+  // Symbol lookup
+  let symbol-values = (
+    "EEEE": get-day-name(date.weekday(), lang: lang, usage: "format", width: "wide"),
+    "EEE": get-day-name(date.weekday(), lang: lang, usage: "format", width: "abbreviated"),
+    "MMMM": get-month-name(date.month(), lang: lang, usage: "format", width: "wide"),
+    "MMM": get-month-name(date.month(), lang: lang, usage: "format", width: "abbreviated"),
+    "MM": pad(date.month(), 2),
+    "M": str(date.month()),
+    "dd": pad(date.day(), 2),
+    "d": str(date.day()),
+    "yyyy": str(date.year()),
+    "y": str(date.year()),
+  )
+
+  let tokens = ("EEEE", "MMMM", "yyyy", "EEE", "MMM", "MM", "dd", "M", "d", "y")
+
+  // If named pattern, resolve it
+  if pattern == "full" or pattern == "long" or pattern == "medium" or pattern == "short" {
+    pattern = get-date-pattern(pattern, lang: lang)
+  }
+
+  // Parse the pattern string into the final result
+  let result = ""
+  let in_literal_mode = false
+  let current_position = 0
+  let pattern_length = pattern.clusters().len()
+
+  while (current_position < pattern_length) {
+    let current_char = safe-slice(pattern, current_position, current_position + 1)
+
+    // Handle literal mode (quoted text)
+    if (current_char == "'") {
+      // Check for escaped quote (two single quotes in a row)
+      if (current_position + 1 < pattern_length and
+          safe-slice(pattern, current_position + 1, current_position + 2) == "'") {
+        result += "'"
+        current_position += 2
+        continue
+      }
+      // Toggle literal mode
+      in_literal_mode = not in_literal_mode
+      current_position += 1
+      continue
+    }
+
+    // In literal mode, append characters as-is
+    if (in_literal_mode) {
+      result += current_char
+      current_position += 1
+      continue
+    }
+
+    // Try to match any token at the current position
+    let token_matched = false
+    for token in tokens {
+      let token_length = token.len()
+      // Check if the token matches the current position in the pattern
+      if (current_position + token_length <= pattern_length and
+          safe-slice(pattern, current_position, current_position + token_length) == token) {
+        result += symbol-values.at(token)
+        current_position += token_length
+        token_matched = true
+        break
+      }
+    }
+
+    // If no token matched, append the character as-is
+    if (not token_matched) {
+      result += current_char
+      current_position += 1
+    }
+  }
+
+  return result
+}

--- a/packages/preview/datify/1.0.0/src/main.typ
+++ b/packages/preview/datify/1.0.0/src/main.typ
@@ -1,0 +1,1 @@
+#import "formats.typ": custom-date-format

--- a/packages/preview/datify/1.0.0/src/utils.typ
+++ b/packages/preview/datify/1.0.0/src/utils.typ
@@ -1,0 +1,18 @@
+// Take a number as an input and a length,
+// if number is not as big as length, return the number
+// with 0 padding in front, like 9 with length 2
+// will return 09
+#let pad = (number, length, pad_char: "0") => {
+  let str_num = str(number)
+  let padding = ""
+  while str_num.len() + padding.len() < length {
+    padding += pad_char
+  }
+  return padding + str_num
+}
+
+#let safe-slice = (s, start, end) => {
+  let clusters = s.clusters()
+  let n = if end > clusters.len() { clusters.len() } else { end }
+  return clusters.slice(start, n).join()
+}

--- a/packages/preview/datify/1.0.0/typst.toml
+++ b/packages/preview/datify/1.0.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "datify"
+version = "1.0.0"
+entrypoint = "src/main.typ"
+authors = ["Jeomhps"]
+license = "MIT"
+description = "Datify is a Typst package for flexible, locale-aware date formatting. It leverages datify-core for internationalization and supports CLDR-style date patterns."
+repository = "https://github.com/Jeomhps/datify"
+compiler = "0.13.1"
+exclude = ["tests*"]
+
+[dependencies]
+datify-core = "1.0.0"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

# **Datify v1.0.0 Released!** 🎉

## **Major Changes & Improvements**
This release is a **complete rewrite** of Datify, introducing breaking changes and powerful new features.

### **🔄 API Migration to `datify-core`**
- Functions like `day-name`, `month-name`, and other standalone utilities have been **moved to [datify-core](https://github.com/Jeomhps/datify-core)**.
  **Migration example:**
  ```typst
  #import "@preview/datify-core:1.0.0": *
  #get-day-name(datetime.today(), lang: "en") // Now in datify-core
  ```

### **🌍 Hundreds of Locales via Unicode CLDR**
- Datify now uses the **[Unicode CLDR project](https://cldr.unicode.org/)** as its locale data source.
- **Supports hundreds of languages** out of the box, including right-to-left scripts, complex calendars, and regional formats.
- See the [full list of supported locales](https://github.com/Jeomhps/datify-core?tab=readme-ov-file#supported-locales).

### **⚡ Formal Language & Automata-Based Parsing**
- The new backend uses **language theory and automata** for token replacement, ensuring:
  - **Robust parsing** of date patterns.
  - **Predictable behavior** for custom formats.
  - **Future-proof syntax** for complex use cases.

### **📝 Safe Literal Text with Quoting**
- You can now **embed raw text** in patterns without fear of misinterpretation by wrapping it in **single quotes (`'`)**.
  ```typst
  #custom-date-format(mydate, pattern: "'Today is' EEEE") // Today is Sunday
  #custom-date-format(mydate, pattern: "yyyy'/'MM'/'dd") // 2025/01/05
  ```
  ⚠️ **Always quote literals** to avoid ambiguity and ensure compatibility with future versions.

### **📅 CLDR Named Patterns**
- Use standard CLDR pattern names (`"full"`, `"long"`, `"medium"`, `"short"`) for locale-aware formatting:
  ```typst
  #custom-date-format(mydate, pattern: "full", lang: "fr") // dimanche 5 janvier 2025
  ```

### **⚠️ Breaking Changes**
- **Old API is incompatible** with v1.0.0+.
- **Update your code** if you were using `day-name`, `month-name`, or similar functions to use datify-core with the new functions.
- **Quoting literals is now strongly encouraged** (unquoted text may behave unexpectedly).

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
