### PR TITLE
Adjust README for clarity on namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ locally on your system. Here, `{data-dir}` is
 - `~/Library/Application Support` on macOS
 - `%APPDATA%` on Windows
 
-Packages in the data directory have precedence over ones in the cache directory.
-While you can create arbitrary namespaces with folders, a good namespace for
-system-local packages is `local`:
+You can create an arbitrary `{namespace}`. A good namespace for system-local
+packages is `local`. Using this namespace:
 
-- Store a package in `~/.local/share/typst/packages/local/mypkg/1.0.0`
-- Import from it with `#import "@local/mypkg:1.0.0": *`
+- Store a package in `{data-dir}/typst/packages/local/mypkg/1.0.0`
+- Import from it with `#import "@local/mypkg:1.0.0": *`.
+
+Packages in the data directory have precedence over ones in the cache directory.
 
 Note that future iterations of Typst's package management may change/break this
 local setup.


### PR DESCRIPTION
It took me quite some debugging to figure out how to install local packages, as I had:

- placed my package in `{data-dir}/typst/packages/preview/mypkg/1.0.0`
- attempted to import it via `#import @local/mypkg:1.0.0`

Note the preview/local skew.

This occurred because I hadn't originally appreciated that `@foo` in the import statement actually refers to the `{namespace}`. Instead, I had interpreted the instructions as meaning that (a) `preview` is the only valid namespace and that (b) import statements would interpret `@preview` as remote and `@local` as local.

I'm suggesting a tweak to the instructions to help emphasise this, in particular by explicitly styling things as '`{namespace}`'. rather than simply 'namespace'.