### PR TITLE
testyfy:0.2.0

### DIFF
--- a/packages/preview/testyfy/0.2.0/LICENSE
+++ b/packages/preview/testyfy/0.2.0/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2025  Andreas Hartmann
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) 2025  Andreas Hartmann
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/packages/preview/testyfy/0.2.0/README.md
+++ b/packages/preview/testyfy/0.2.0/README.md
@@ -1,0 +1,178 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# testyfy
+
+by [Andreas Hartmann (@hartan)][01]
+
+Assert specific conditions and requirements in [typst][typst].
+
+[01]: https://gitlab.com/hartan
+
+
+## Table of Contents
+
+<!--toc:start-->
+- [testyfy][0]
+    - [Table of Contents][a]
+    - [Project description][b]
+    - [Who this project is for][c]
+    - [Project dependencies][d]
+    - [Instructions for using testyfy][e]
+    - [Documentation][f]
+    - [Contributing][g]
+    - [Getting help][h]
+<!--toc:end-->
+
+[0]: #testyfy
+[a]: #table-of-contents
+[b]: #project-description
+[c]: #who-this-project-is-for
+[d]: #project-dependencies
+[e]: #instructions-for-using-testyfy
+[f]: #documentation
+[g]: #contributing
+[h]: #getting-help
+
+
+## Project description
+
+With `testyfy` you can check conditions and assumptions in [typst][typst]-Documents (syn. "assert").
+The first unfulfilled condition terminates document compilation with an expressive error message.
+
+Unlike the generic [`assert()`][b0] function in [typst][typst], this package provides many
+specialized functions for certain situations. In addition, the functions from this package try to
+provide helpful error messages by default, allowing partial customization by callers.
+
+[b0]: https://typst.app/docs/reference/foundations/assert/
+
+
+## Who this project is for
+
+This project is intended for end users as well as authors of [typst][typst] packages that want to
+explicitly check whether user input and/or data from external documents (JSON/YAML/...) satisfies
+certain criteria such as data formats.
+
+
+## Project dependencies
+
+None, all you need is [typst][typst].
+
+
+## Instructions for using testyfy
+
+Import the package in a [typst][typst] document, like so:
+
+```typst
+#import "@preview/testyfy:0.2.0"
+```
+
+The available versions (in the example *0.2.0*) can be taken [from the releases][releases]. Now you
+can assert conditions:
+
+```typst
+#import "@preview/testyfy:0.2.0"
+
+Here's a bit of text.
+#testyfy.typeof(5, int) // Validate inputs, ...
+And here is, without a gap, even more text.
+```
+
+Detailed instructions can be found in the [documentation][f].
+
+
+## Documentation
+
+**TL;DR**: [Docs for the latest version][f0]
+
+Next to a list of all functions, the documentation also contains a few examples for how to use this
+code. The documentation for a specific version of this package is always attached as asset to [the
+respective release][releases].
+
+The documentation can be created locally. The following command creates a PDF version of the docs
+including references to external sources etc.:
+
+```bash
+bin/make pdf
+```
+
+The following command shows an overview of all unreleased changes:
+
+```bash
+bin/make changelog
+```
+
+[f0]: https://gitlab.com/api/v4/projects/72702551/packages/generic/release/0.2.0/docs.pdf
+
+
+## Contributing
+
+All contributions are welcome, don't hesitate to open merge requests. The contributed code must be
+documented and should (ideally) include tests to verify the basic functionality.
+
+All tests live in the `test/` subfolder. The following command runs all the tests:
+
+```bash
+./test/run.sh
+# Or alternatively
+bin/make test
+```
+
+If existing source code is changed it's easily possible that many tests start failing (due to e.g.
+changed line numbers in panic messages). In this case the reference outputs for tests can be updated
+as follows:
+
+```bash
+./test/run.sh -u
+```
+
+The script `test/add.sh` adds new tests and is used like this:
+
+```bash
+/test/add.sh <<"TYPST"
+#panic("Amazing test code here")
+TYPST
+```
+
+It creates the following output:
+
+```bash
+test_status='1'
+test_stdin='#panic("Amazing test code here")'
+test_stdout=''
+test_stderr=$'error: panicked with: "Amazing test code here"
+  ┌─ stdin.typ:1:1
+  │
+1 │ #panic("Amazing test code here")
+  │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+```
+
+The output must be written into a file with an ending of `.test`, for example:
+
+```bash
+./test/add.sh <<"TYPST" > test/my-amazing.test
+...
+TYPST
+```
+
+If in doubt, both `test/run.sh` and `test/add.sh` explain their functionality when passing `--help`
+as argument:
+
+```bash
+./test/run.sh --help
+./test/add.sh --help
+```
+
+
+## Getting help
+
+Is something not working as expected? Is a function buggy or broken? Do you have wishes and/or
+feedback? Please let us know! Open an [issue on GitLab][h0] and tell us what's on your mind.
+
+[h0]: https://gitlab.com/hartang/typst/testyfy/-/issues/new
+
+
+<!-- Globale Quellen -->
+[typst]: https://typst.app/docs/
+[releases]: https://gitlab.com/hartang/typst/testyfy/-/releases

--- a/packages/preview/testyfy/0.2.0/src/collections.typ
+++ b/packages/preview/testyfy/0.2.0/src/collections.typ
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#import "types.typ" as testyfy_types
+
+/// Assert that a collection is not empty.
+///
+/// ==== Panics
+///
+/// - If `value` is not a supported collection type
+/// - If `value` is empty
+///
+/// -> none
+#let nonempty(
+    /// A collection of some sort.
+    ///
+    /// -> array | dictionary | str
+    value,
+
+    /// The human-readable name (i.e. variable name or similar) that _value_ has in the code/API.
+    /// Useful to hint users towards what exactly they did wrong. If not present, a generic error
+    /// message is generated.
+    ///
+    /// -> str
+    value-name: ""
+) = {
+    testyfy_types.type-one-of(value, (array, dictionary, str), value-name: "value")
+    testyfy_types.typeof(value-name, str, value-name: "value-name")
+
+    if value.len() <= 0 {
+        let message = "collection "
+        if value-name.len() > 0 {
+            message += "'" + value-name + "' "
+        }
+        message += "must contain at least one item"
+        panic(message)
+    }
+
+    none
+}
+
+/// Assert that a collection contains a specific element.
+///
+/// For `dictionary` types, the _needle_ is searched for in both *keys* and *values*. To restrict
+/// the assertion to either, pass `keys()` or `values()` as input to this function.
+///
+/// -> none
+#let contains(
+    /// A collection of some sort.
+    ///
+    /// -> array | dictionary
+    value,
+
+    /// An element to look for in _value_.
+    ///
+    /// -> any
+    needle,
+
+    /// The human-readable name (i.e. variable name or similar) that _value_ has in the code/API.
+    /// Useful to hint users towards what exactly they did wrong. If not present, a generic error
+    /// message is generated.
+    ///
+    /// -> str
+    value-name: ""
+) = {
+    testyfy_types.type-one-of(value, (array, dictionary), value-name: "value")
+    testyfy_types.typeof(value-name, str, value-name: "value-name")
+
+    let message = "collection "
+    if value-name.len() > 0 {
+        message += "'" + value-name + "' "
+    }
+    message += "of type " + str(type(value)) + " must contain element '" + repr(needle) + "'"
+
+    if type(value) == array {
+        if not value.contains(needle) {
+            panic(message)
+        }
+    } else if type(value) == dictionary {
+        if not value.pairs().flatten().contains(needle) {
+            panic(message)
+        }
+    } else {
+        panic("unreachable")
+    }
+
+    none
+}
+
+/// Assert that the elements of an `array` have the expected `type`.
+///
+/// To assert the `type` of scalar values, see #ref.fn.with("types", "typeof")().
+#let eltype(
+    /// The `array` whose elements are to be checked.
+    ///
+    /// -> array
+    value,
+
+    /// One or more expected `type`s. If an `array` of `type`s is given, refer to the _allequal_
+    /// parameter for additional checks.
+    ///
+    /// -> type | array
+    expected-type,
+
+    /// Whether all the `array` elements must be of the same `type`. This parameter only has an
+    /// effect when _expected\_type_ is an `array` of `type`s.
+    ///
+    /// *If _allequal_ is false* each element of the input `array` _value_ is checked individually
+    /// and must be one of the `type`s mentioned in _expected\_type_.
+    ///
+    /// ```typst
+    /// #let x = (1, "2", (3,))
+    /// #testyfy.eltype(x, (int, str, array), allequal: false)
+    /// ```
+    ///
+    /// *If _allequal_ is true*, all elements of the input `array` _value_ must have the same
+    /// `type`, which must be one of the `type`s mentioned in _expected\_type_.
+    ///
+    /// ```typst
+    /// #let x = (1, 2, 3)
+    /// #testyfy.eltype(x, (int, str), allequal: true)
+    ///
+    /// #let y = ("a", "bc", "def")
+    /// #testyfy.eltype(y, (int, str), allequal: true)
+    /// ```
+    ///
+    /// -> bool
+    allequal: false,
+
+    /// The human-readable name (i.e. variable name or similar) that _value_ has in the code/API.
+    /// Useful to hint users towards what exactly they did wrong. If not present, a generic error
+    /// message is generated.
+    ///
+    /// -> str
+    value-name: ""
+) = {
+    testyfy_types.typeof(value, array, value-name: "value")
+    testyfy_types.type-one-of(expected-type, (type, array), value-name: "expected-type")
+    if value.len() == 0 {
+        // No need to check an empty array, arrays themselves aren't typed
+        return none
+    }
+
+    testyfy_types.typeof(value-name, str, value-name: "value-name")
+    let value_eltypes = value.map(type).dedup()
+    nonempty(value_eltypes, value-name: "elements of input array")
+
+    let err_msg = "array "
+    if value-name.len() > 0 {
+        err_msg += "'" + value-name + "' "
+    }
+
+    if (type(expected-type) == array) {
+        // Ensure all elements of 'expected-type' are actually types
+        let invalid_expected-type_elements = expected-type
+            .map(type)
+            .enumerate()
+            .filter(((idx, eltype)) => eltype != type)
+        if invalid_expected-type_elements.len() > 1 {
+            panic(
+                "input 'expected-type'" +
+                "must be an array consisting only of types, found invalid elements: " +
+                invalid_expected-type_elements
+                    .map(((idx, eltype)) => "'" + str(eltype) + "' at index " + str(idx))
+                    .join(", ", last: " and ")
+            )
+        }
+
+        if allequal {
+            // Eltypes may be one of the input types, but they must all be the same one.
+            if value_eltypes.len() == 1 {
+                let value_eltype = value_eltypes.at(0)
+                if value_eltype in expected-type {
+                    // Ok
+                    none
+                } else {
+                    panic(
+                        err_msg +
+                        "only has elements of type '" +
+                        str(value_eltype) +
+                        "' but expected one of '" +
+                        expected-type.map(str).join("', '", last: "' or '") +
+                        "'"
+                    )
+                }
+            } else {
+                panic(
+                    err_msg +
+                    "has elements of type '" +
+                    value_eltypes.map(str).join("', '", last: "' and '") +
+                    "' but expected all elements to be of the same type"
+                )
+            }
+        } else {
+            let invalid_elements = value
+                .map(type)
+                .enumerate()
+                .filter(((idx, eltype)) => eltype not in expected-type)
+            if invalid_elements.len() > 0 {
+                panic(
+                    err_msg +
+                    "has invalid element types, expected one of '" +
+                    expected-type.map(str).join("', '", last: "' or '") +
+                    "' but found: " +
+                    invalid_elements
+                        .map(((idx, eltype)) => "'" + str(eltype) + "' at index " + str(idx))
+                        .join(", ", last: " and ")
+                )
+            }
+        }
+    } else if (type(expected-type) == type) {
+        if value_eltypes == (expected-type,) {
+            // Ok
+            none
+        } else {
+            let invalid_elements = value
+                .map(type)
+                .enumerate()
+                .filter(((idx, eltype)) => eltype != expected-type)
+            if invalid_elements.len() > 0 {
+                panic(
+                    err_msg +
+                    "has invalid element types, expected '" +
+                    str(expected-type) +
+                    "' but found: " +
+                    invalid_elements
+                        .map(((idx, eltype)) => "'" + str(eltype) + "' at index " + str(idx))
+                        .join(", ", last: " and ")
+                )
+            }
+        }
+    } else {
+        panic("unreachable")
+    }
+
+    none
+}

--- a/packages/preview/testyfy/0.2.0/src/lib.typ
+++ b/packages/preview/testyfy/0.2.0/src/lib.typ
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#import "types.typ": *
+#import "collections.typ": *

--- a/packages/preview/testyfy/0.2.0/src/types.typ
+++ b/packages/preview/testyfy/0.2.0/src/types.typ
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/// Assert that the argument has the expected `type`.
+///
+/// See also #ref.fn.with("types", "type-one-of")() when _value_ can be one of multiple `type`s.
+///
+/// ==== Panics
+///
+/// - If `value` is not of type `expected-type`
+/// - If `expected-type` is not a type
+///
+/// ==== Examples
+///
+/// ```example
+/// #testyfy.typeof(5, int)
+/// This is indeed an integer.
+///
+/// #testyfy.typeof("hello", str)
+/// And this is a string.
+/// ```
+#let typeof(
+    /// The value whose `type` is to be checked.
+    ///
+    /// -> any
+    value,
+
+    /// The `type` that _value_ should have.
+    ///
+    /// -> type
+    expected-type,
+
+    /// The human-readable name (i.e. variable name or similar) that _value_ has in the code/API.
+    /// Useful to hint users towards what exactly they did wrong. If not present, a generic error
+    /// message is generated.
+    ///
+    /// -> str
+    value-name: ""
+) = {
+    assert(
+        type(expected-type) == type,
+        message: "input 'expected-type' must be an actual data type, found '" +
+            str(type(expected-type)) + "'"
+    )
+    assert(
+        type(value-name) == str,
+        message: "input 'value-name' must be of type 'str', found '" + str(type(value-name)) + "'"
+    )
+
+    if type(value) != expected-type {
+        let message = "input "
+        if value-name.len() > 0 {
+            message += "'" + value-name + "' "
+        }
+        message += "must be of type '" + str(expected-type) + "', found '" + str(type(value)) + "'"
+        panic(message)
+    }
+
+    none
+}
+
+/// Assert that the argument has one of the expected `type`s.
+///
+/// See also #ref.fn.with("types", "typeof")() when _value_ must have a specific `type`.
+///
+/// ```example
+/// #testyfy.type-one-of(5, (int, float))
+/// This is fine.
+///
+/// #testyfy.type-one-of((1, 2, 3), (array, regex, label))
+/// So is this!
+/// ```
+#let type-one-of(
+    /// The value whose `type` is to be checked.
+    ///
+    /// -> any
+    value,
+
+    /// An `array` of `type`s that _value_ is allowed have.
+    ///
+    /// -> array
+    expected-types,
+
+    /// The human-readable name (i.e. variable name or similar) that _value_ has in the code/API.
+    /// Useful to hint users towards what exactly they did wrong. If not present, a generic error
+    /// message is generated.
+    ///
+    /// -> str
+    value-name: ""
+) = {
+    let testyfy_typeof = typeof
+
+    testyfy_typeof(expected-types, array, value-name: "expected-types")
+    // NOTE: This duplicates a little code from 'testyfy.eltype' but it keeps the module structure
+    // intact.
+    {
+        let invalid_types = expected-types
+            .map(type)
+            .enumerate()
+            .filter(((_, x)) => x != type)
+        if invalid_types.len() > 0 {
+            panic(
+                "argument 'expected-types' must contain only types, found invalid elements: '" +
+                invalid_types
+                    .map(((idx, dtype)) => str(dtype) + " at index " + str(idx))
+                    .join("', '", last: "' and '")
+            )
+        }
+    }
+    testyfy_typeof(value-name, str, value-name: "value-name")
+
+    if expected-types.len() == 0 {
+        return none
+    } else if expected-types.len() == 1 {
+        return testyfy_typeof(value, expected-types.first())
+    }
+
+    for allowed_type in expected-types {
+        if type(value) == allowed_type {
+            return none
+        }
+    }
+
+    // We only get here if nothing matched
+    let message = "value "
+    if value-name.len() > 0 {
+        message += "'" + value-name + "' "
+    }
+    message += "must be of type '" + expected-types.map(str).join("', '", last: "' or '")
+    message += "', found '" + str(type(value)) + "'"
+    panic(message)
+}

--- a/packages/preview/testyfy/0.2.0/typst.toml
+++ b/packages/preview/testyfy/0.2.0/typst.toml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[package]
+# See: <https://github.com/typst/packages/blob/main/docs/manifest.md>
+# Required by Compiler
+name = "testyfy"
+version = "0.2.0"
+entrypoint = "src/lib.typ"
+# Required for Submission to Typst Universe
+# See: https://github.com/typst/packages/blob/main/docs/README.md
+authors = ["Andreas Hartmann <hartan@7x.de>"]
+license = "GPL-3.0-or-later"
+description = "Assert specific conditions and requirements"
+# Optional
+repository = "https://gitlab.com/hartang/typst/testyfy"
+keywords = ["assert", "check", "verify"]
+categories = ["scripting", "utility"]
+exclude = [
+    "bin/",
+    "test/",
+]


### PR DESCRIPTION
Initially register the `testyfy` package in version 0.2.0.

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

With `testyfy` you can check conditions and assumptions in [typst][typst]-Documents (syn. "assert").
The first unfulfilled condition terminates document compilation with an expressive error message.

Unlike the generic [`assert()`][b0] function in [typst][typst], this package provides many
specialized functions for certain situations. In addition, the functions from this package try to
provide helpful error messages by default, allowing partial customization by callers.

[typst]: https://typst.app/docs/
[b0]: https://typst.app/docs/reference/foundations/assert/


<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
