### PR TITLE
Deploy: don't purge the CDN endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,17 +46,3 @@ jobs:
           azcopy_v10 cp --recursive ./dist/* "https://$ACCOUNT_NAME.blob.core.windows.net/\$web" \
             --overwrite true --include-pattern '*.json' \
             --cache-control 'must-revalidate' --put-md5
-
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_PACKAGE_CREDENTIALS }}
-
-      - name: Purge CDN endpoint
-        uses: azure/CLI@v2
-        with:
-          inlineScript: az afd endpoint purge -g Landing-Page --profile-name LandingPage --content-paths '/*' --endpoint-name 'packages'
-
-      - name: logout
-        run: az logout
-        if: always()


### PR DESCRIPTION
It is not necessary anymore, as the archives are now fully immutable, and the correct cache headers are defined for each uploaded file.

It was causing the CI to fail these last days because Azure Front Door configuration changes are temporarily forbidden, following the recent outage.