### PR TITLE
algorithmic:1.0.7

### DIFF
--- a/packages/preview/algorithmic/1.0.7/LICENSE
+++ b/packages/preview/algorithmic/1.0.7/LICENSE
@@ -1,0 +1,12 @@
+MIT License
+
+Copyright (c) 2023 Jade Lovelace
+Copyright (c) 2025 Pascal Quach
+Copyright (c) 2025 Typst Community
+Copyright (c) 2025 Contributors to the typst-algorithmic project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/algorithmic/1.0.7/NEWS.md
+++ b/packages/preview/algorithmic/1.0.7/NEWS.md
@@ -1,0 +1,106 @@
+# Algorithmic NEWS
+
+## v1.0.7
+
+> [!NOTE]
+> @JL170 added an option to customize line number formatting (#32).
+> ```typ
+> #algorithm(
+> line-numbers-format: x => [#x:],
+> { ... }
+> )
+> ```
+
+> [!NOTE]
+> @avlouis added inline command `IfElseInline` for ternary if-then-else statements (#31).
+> ```typ
+> #{
+>   Assign($m$, IfElseInline($x < y$, $x$, $y$))
+> }
+> ```
+
+> [!NOTE]
+> @wamserma fixed an issue with the width of the column offset not scaling with
+> the font size (#26).
+> Now, the column is specified relative to the font size in [`em`](https://typst.app/docs/reference/layout/length/).
+> This is not a breaking change.
+
+> [!NOTE]
+> @nonl4331 fixed an issue with `LineComment` not working with certain input types (#27, #28).
+>
+> LineComment statements similar to the instances below will now render correctly.
+> ```typ
+> #{
+>   LineComment([Initialize hashmap], [Count instances])
+>   LineComment([$c += a-b$], [Sum of differences])
+> }
+> ```
+
+## v1.0.6
+
+> [!NOTE]
+> @TimeTravelPenguin fixed an issue with `Assign` not working with nested blocks (#23, #24).
+>
+> Algorithms similar to the one below will now render correctly.
+> ```typ
+> #{
+>   let Solve = Call.with("Solve")
+>   Assign($x$, Solve[$A$, $b$])
+> }
+> ```
+
+## v1.0.5
+
+> [!NOTE]
+> Added an option `line-numbers` to toggle line numbers on/off (#22).
+> ```typ
+> #algorithm(line-numbers: false, ...)
+> #algorithm-figure(line-numbers: false, ...)
+> ```
+> If you would like to remove line numbers globally, you can define
+> ```typ
+> #let algorithm = algorithm.with(line-numbers: false)
+> #let algorithm-figure = algorithm-figure.with(line-numbers: false)
+> ```
+
+> [!NOTE]
+> Fix an issue with `algorithm-figure` float placement (#21).
+> `style-algorithm` now has options `placement` and `scope` mimicking `figure`.
+> By default, options set on `figure(kind: "algorithm")` supersede those of
+> `style-algorithm`.
+> ```typ
+> #show: style-algorithm.with(placement: top, scope: "column")
+> #show figure.where(kind: "algorithm").with(placement: bottom, scope: "parent")
+> ```
+> The above example will place algorithm figures at the bottom of the parent scope.
+
+## v1.0.4
+
+> [!NOTE]
+> @drecouse fixed an issue with `LineComment` preventing loops' body from displaying (#20).
+> Now, you can use `LineComment` on loops without issues.
+> ```typ
+> LineComment(
+>   While($j <= 10$, {
+>     Assign[$x$][1]
+>   }),
+>   "This is inside a nested block",
+> )
+> ```
+> [!Screenshot of an algorithm showing a for-loop from i = 1 to 10, with each iteration containing a line calculation (1+1) and a nested while-loop from j = 1 to 10 assigning x = 1, with line comments describing "This is inside a nested block" and "This is a line comment after a block".](https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.4/tests/linecommentfor/ref/1.png)
+
+> [!NOTE]
+> `algorithm-figure` does not set `placement: none` anymore (#21).
+
+
+## v1.0.3
+
+> [!WARNING]
+> algorithmic now use grids instead of tables for accessibility purposes, see [layout/grid](https://typst.app/docs/reference/layout/grid/#:~:text=Typst%20will%20annotate%20its%20output%20such%20that%20screenreaders%20will%20announce%20content%20in%20table%20as%20tabular).
+> Any `table.hlines` in `style-algorithm` will error and `grid.hlines` must be used instead.
+
+> [!NOTE]
+> This version fixes an issue with the indentation offset where the last column corresponding to comments goes in the margin.
+
+> [!NOTE]
+> `State` is renamed to `Line` and will now work with other commands such as `LineComment`. Documentation is added in the [README](README.md).

--- a/packages/preview/algorithmic/1.0.7/README.md
+++ b/packages/preview/algorithmic/1.0.7/README.md
@@ -1,0 +1,466 @@
+<!--
+SPDX-FileCopyrightText: 2023 Jade Lovelace
+SPDX-FileCopyrightText: 2025 Pascal Quach
+SPDX-FileCopyrightText: 2025 Typst Community
+SPDX-FileCopyrightText: 2025 Contributors to the typst-algorithmic project
+SPDX-License-Identifier: MIT
+-->
+
+# typst-algorithmic
+
+This is a package inspired by the LaTeX [`algorithmicx`][algorithmicx] package
+for Typst. It's useful for writing pseudocode and typesetting it all nicely.
+
+[algorithmicx]: https://ctan.org/pkg/algorithmicx
+
+![screenshot of the typst-algorithmic output, showing line numbers, automatic
+indentation, bolded keywords, and such](https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/docs/assets/algorithmic-demo.png)
+
+Example:
+
+```typst
+#import "@preview/algorithmic:1.0.7"
+#import algorithmic: style-algorithm, algorithm-figure
+#show: style-algorithm
+#algorithm-figure(
+  "Binary Search",
+  vstroke: .5pt + luma(200),
+  {
+    import algorithmic: *
+    Procedure(
+      "Binary-Search",
+      ("A", "n", "v"),
+      {
+        Comment[Initialize the search range]
+        Assign[$l$][$1$]
+        Assign[$r$][$n$]
+        LineBreak
+        While(
+          $l <= r$,
+          {
+            Assign([mid], FnInline[floor][$(l + r) / 2$])
+            IfElseChain(
+              $A ["mid"] < v$,
+              {
+                Assign[$l$][$"mid" + 1$]
+              },
+              [$A ["mid"] > v$],
+              {
+                Assign[$r$][$"mid" - 1$]
+              },
+              Return[mid],
+            )
+          },
+        )
+        Return[*null*]
+      },
+    )
+  }
+)
+```
+
+This DSL is implemented using the same trick as [CeTZ] uses: a code block of
+arrays gets those arrays joined together.
+
+[CeTZ]: https://github.com/johannes-wolf/typst-canvas
+
+## Reference
+
+### Documentation
+
+#### `algorithm(inset: 0.2em, indent: 0.5em, vstroke: 0pt + luma(200), line-numbers: true, line-numbers-format: x => [#x:], ..bits)`
+
+This is the main function of the package. It takes a list of arrays and
+returns a typesetting of the algorithm. You can modify the inset
+between lines with the `inset` parameter.
+If you want to customize line numbers, you can pass a function, that takes a number and returns **content**, to the `line-numbers-format` parameter instead of a default value.
+
+```typst
+#algorithm(
+  inset: 1em, // more spacing between lines
+  indent: 0.5em, // indentation for the algorithm
+  vstroke: 0pt + luma(200), // vertical stroke for indentation guide
+  line-numbers: true, // show line numbers
+  line-numbers-format: x => [#x:], // change the line numbers format
+  { // provide an array
+    import algorithmic: * // import all names in the array
+    Assign[$x$][$y$]
+  },
+  { // provide another array
+    import algorithmic: *
+    Assign[$y$][$x$]
+  },
+  { // provide a third array
+    import algorithmic: *
+    Assign[$z$][$x + y$]
+  }
+)
+```
+![image of the algorithm with three lines of code assigning x to y, y to x, and z to x + y. The inset is set to 1em, the indent to 0.5em](https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/algorithm/ref/1.png)
+
+#### `algorithm-figure(title, supplement: "Algorithm", inset: 0.2em, indent: 0.5em, vstroke: 0pt + luma(200), line-numbers: true, line-numbers-format: x => [#x:], ..bits)`
+
+The `algorithm-figure` function is a wrapper around `algorithm` that returns a
+figure element of the algorithm. It takes the same parameters as
+`algorithm`, but also takes a `title` and a `supplement` parameter for the figure.
+
+```typst
+#let algorithm-figure(
+  title,
+  supplement: "Algorithm",
+  inset: 0.2em,
+  indent: 0.5em,
+  vstroke: 0pt + luma(200),
+  line-numbers: true,
+  ..bits,
+) = {
+  return figure(supplement: supplement, kind: "algorithm", caption: title, algorithm(
+    indent: indent,
+    inset: inset,
+    vstroke: vstroke,
+    line-numbers: line-numbers,
+    ..bits,
+  ))
+}
+```
+
+In order to use the `algorithm-figure` function, you need to style the figure
+with the `style-algorithm` show rule, or provide your own styling.
+
+```typst
+#import algorithmic: algorithm-figure, style-algorithm
+#show: style-algorithm // Do not forget!
+#algorithm-figure("Variable Assignment", {
+  import algorithmic: *
+  Assign[$x$][$y$]
+})
+```
+
+`style-algorithm` provides several options to customize the appearance of the algorithm figure:
+
+- `caption-style (function): strong` is applied to the algorithm's title. Normal text can be used with `caption-style: text`, or `caption-style: c => c`.
+- `caption-align (alignment): start` aligns the title to the start (left for LTR, and right for RTL languages) by default
+- `breakable (bool): true` controls whether or not the figure will break across pages.
+- `hlines (array of 3 content): (grid.hline(), grid.hline(), grid.hline())` provides horizontal lines at the top, middle, and bottom of the algorithm figure.
+- `placement (none, auto, top or bottom): none` controls the float placement of the algorithm figure. See [`figure(placement)`](https://typst.app/docs/reference/model/figure/#parameters-placement)
+- `scope (string): "column"` controls the floating scope of the algorithm figure. See [`figure(placement)`](https://typst.app/docs/reference/model/figure/#parameters-placement)
+
+An example of how to style the algorithm figure:
+
+```typst
+#show: style-algorithm.with(
+  breakable: false,
+  caption-align: end,
+  caption-style: emph,
+  hlines: (grid.hline(stroke: 2pt + red), grid.hline(stroke: 2pt + blue), grid.hline(stroke: 2pt + green)),
+  placement: none,
+  scope: "column",
+)
+```
+which will result in something like
+![image of the binary search algorithm with a right-aligned and italics figure caption enclosed within a red and blue 2pt grid horizontal lines. The algorithm is finally ended with a green 2pt horizontal line](https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/style-2/ref/1.png).
+
+#### Control flow
+
+Algorithmic provides basic control flow statements: `If`, `While`, `For`,
+`Else`, `ElseIf`, and a `IfElseChain` utility.
+
+<!-- Table -->
+<table>
+<thead>
+<tr>
+<th>Statement</th>
+<th>Description</th>
+<th>Usage</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>If</code></td>
+<td><code>If(condition: content, ..bits)</code></td>
+<td>
+
+```typst
+If($x < y$, {
+  Assign[$x$][$y$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/if/ref/1.png" alt="image of an if statement with condition x < y and conditional statement assign y to x" width="500"></td>
+</tr>
+<tr>
+<td><code>ElseIf</code></td>
+<td><code>ElseIf(condition: content, ..bits)</code></td>
+<td>
+
+```typst
+ElseIf($x > y$, {
+  Assign[$y$][$x$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/elseif/ref/1.png" alt="image of an elseif statement with condition x > y and conditional statement assign x to y" width="500"></td>
+</tr>
+<tr>
+<td><code>Else</code></td>
+<td><code>Else(..bits)</code></td>
+<td>
+
+```typst
+Else({
+  Return[$y$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/else/ref/1.png" alt="image of an else statement with conditional statement return y" width="500"></td>
+</tr>
+<tr>
+<td><code>While</code></td>
+<td><code>While(condition: content, ..bits)</code></td>
+<td>
+
+```typst
+While($i < 10$, {
+  Assign[$i$][$i + 1$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/while/ref/1.png" alt="image of a while statement with condition i < 10 and conditional statement assign i + 1 to i" width="500"></td>
+</tr>
+<tr>
+<td><code>For</code></td>
+<td><code>For(condition: content, ..bits)</code></td>
+<td>
+
+```typst
+For($i <= 10$, {
+  Assign[$x_i$][$i$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/for/ref/1.png" alt="image of a for loop with condition i <= 10 and conditional statement assign i to x_i" width="500"></td>
+</tr>
+<tr>
+<td><code>IfElseChain</code></td>
+<td><code>IfElseChain(..bits)</code></td>
+<td>
+
+```typst
+IfElseChain( // Alternating content and bits
+  $x < y$, // If: content 1 (condition)
+  { // Then: bits 1
+    Assign[$x$][$y$]
+  },
+  [$x > y$], // ElseIf: content 2 (condition)
+  { // Then: bits 2
+    Assign[$y$][$x$]
+  },
+  Return[$y$], // Else: content 3 (no more bits afterwards)
+)
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/ifelsechain/ref/1.png" alt="image of an ifelsechain statement with condition x < y and conditional statement assign y to x, then condition x" width="500"></td>
+</tr>
+<tr>
+<td><code>IfElseInline</code></td>
+<td><code>IfElseInline(condition: content, true-case: content, false-case: content)</code></td>
+<td>
+
+```typst
+Assign($m$, IfElseInline($x < y$, $x$, $y$))
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/ifelseinline/ref/1.png" alt="image of an ifelseinline expression with condition x < y, true expression x, and false expression y being assigned to m" width="500"></td>
+</tr>
+</tbody>
+</table>
+
+#### Commands
+
+The package provides a few commands: `Function`, `Procedure`, `Assign`,
+`Return`, `Terminate` and `Break`.
+
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+<th>Usage</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Function</code></td>
+<td><code>Function(name, args, ..bits)</code>
+<td>
+
+```typst
+Function("Add", ($a$, $b$), {
+Assign[$a$][$b$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/function/ref/1.png" alt="image of a function definition with name 'Add' and arguments 'a' and 'b' with body 'return a+b'" width="500"></td>
+</tr>
+<tr>
+<td><code>Procedure</code></td>
+<td><code>Procedure(name, args, ..bits)</code>
+<td>
+
+```typst
+Procedure("Add", ("a", "b"), {
+Assign[$a$][$a+b$]
+})
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/procedure/ref/1.png" alt="image of a procedure definition with name 'Add' and arguments 'a' and 'b' with body 'assign a+b to a'" width="500"></td>
+</tr>
+<tr>
+<td><code>Assign</code></td>
+<td><code>Assign(var, value)</code>
+<td>
+
+```typst
+Assign[$x$][$y$]
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/assign/ref/1.png" alt="image of an assignment statement assigning y to x" width="500"></td>
+</tr>
+<tr>
+<td><code>Return</code></td>
+<td><code>Return(value)</code>
+<td>
+
+```typst
+Return[$x$]
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/return/ref/1.png" alt="image of a return statement returning x" width="500"></td>
+</tr>
+<tr>
+<td><code>Terminate</code></td>
+<td><code>Terminate(value)</code>
+<td>
+
+```typst
+Terminate[$x$]
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/terminate/ref/1.png" alt="image of a terminate statement terminating x" width="500"></td>
+</tr>
+<tr>
+<td><code>Break</code></td>
+<td><code>Break()</code>
+<td>
+
+```typst
+Break()
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/break/ref/1.png" alt="image of a break statement" width="500"></td>
+</tr>
+</tbody>
+</table>
+
+Users can also define their own commands using both `Call(..args)` and
+`Fn(..args)` and their inline versions `CallInline` and `FnInline`.
+
+```typst
+#import "../../algorithmic.typ"
+#import algorithmic: algorithm
+#set page(margin: .1cm, width: 4cm, height: auto)
+#algorithm({
+  import algorithmic: *
+  let Solve = Call.with("Solve")
+  let mean = Fn.with("mean")
+  Assign($x$, Solve[$A$, $b$])
+  Assign($y$, mean[$x$])
+})
+```
+![image of a custom call "Solve" given parameters "A" and "b" and a custom function "mean" given parameter "x" in the algorithmic environment. The call "Solve" is rendered in smallcaps and the function "mean" is rendered in a strong emphasis.](https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/docs/assets/custom-call-function.png)
+
+#### Standalone lines and line breaks
+
+You can use `Line` to create a standalone line and `LineBreak` to insert a line break.
+
+```typst
+#algorithm({
+  import algorithmic: *
+  Line($1+1$)
+  LineBreak
+})
+```
+![image of a standalone line with content "1+1" and a line break in the algorithmic environment](https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/line/ref/1.png)
+
+
+#### Comments
+
+There are three kinds of comments: `Comment`, `CommentInline`, and `LineComment`.
+
+1. `Comment` is a block comment that takes up a whole line.
+2. `CommentInline` is an inline comment that returns content on the same line.
+3. `LineComment` places a comment on the same line as a line of code to the right.
+
+<table>
+<thead>
+<tr>
+<th>Comment</th>
+<th>Description</th>
+<th>Usage</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Comment</code></td>
+<td><code>Comment(content)</code></td>
+<td>
+
+```typst
+Comment[This is a comment]
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/comment/ref/1.png" alt="image of a block comment with text 'This is a comment'" width="500"></td>
+</tr>
+<tr>
+<td><code>CommentInline</code></td>
+<td><code>CommentInline(content)</code></td>
+<td>
+
+```typst
+CommentInline[This is a comment]
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/commentinline/ref/1.png" alt="image of an inline comment with text 'This is a comment'" width="500"></td>
+</tr>
+<tr>
+<td><code>LineComment</code></td>
+<td><code>LineComment(line, comment)</code></td>
+<td>
+
+```typst
+LineComment(Assign[a][1], [Initialize $a$ to 1])
+```
+
+</td>
+<td><img src="https://raw.githubusercontent.com/typst-community/typst-algorithmic/refs/tags/v1.0.7/tests/linecomment/ref/1.png" alt="image of a line comment with text 'Initialize a to 1'" width="500"></td>
+</tr>
+</tbody>
+</table>

--- a/packages/preview/algorithmic/1.0.7/algorithmic.typ
+++ b/packages/preview/algorithmic/1.0.7/algorithmic.typ
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2023 Jade Lovelace
+// SPDX-FileCopyrightText: 2025 Pascal Quach
+// SPDX-FileCopyrightText: 2025 Typst Community
+// SPDX-FileCopyrightText: 2025 Contributors to the typst-algorithmic project
+// SPDX-License-Identifier: MIT
+
+/*
+ * Generated AST:
+ * (change-indent: int, body: ((ast | content)[] | content | ast)
+ */
+
+#let ast-to-content-list(indent, ast) = {
+  if type(ast) == array {
+    // array of (ast | content)
+    ast.map(d => ast-to-content-list(indent, d))
+  } else if type(ast) == content {
+    // (line-content: ast, line-indent: int)
+    (line-content: ast, line-indent: indent)
+  } else if type(ast) == dictionary {
+    // (change-indent: int, body: ((ast | content)[] | content | ast))
+    let new-indent = ast.at("change-indent", default: 0) + indent
+    ast-to-content-list(new-indent, ast.body)
+  }
+}
+
+#let style-algorithm(
+  body,
+  caption-style: strong,
+  caption-align: start,
+  breakable: true,
+  hlines: (grid.hline(), grid.hline(), grid.hline()),
+  placement: none,
+  scope: "column",
+) = {
+  show figure.where(kind: "algorithm"): it => {
+    set block(breakable: breakable)
+    let algo = grid(
+      columns: 1,
+      stroke: none,
+      inset: 0% + 5pt,
+      hlines.at(0),
+      caption-style(align(caption-align, it.caption)),
+      hlines.at(1),
+      align(start, it.body),
+      hlines.at(2),
+    )
+    let _placement = placement
+    let _scope = scope
+    if it.placement != none { _placement = it.placement }
+    if it.scope != "column" { _scope = it.scope }
+    if _placement != none {
+      place(_placement, scope: _scope, float: true, algo)
+    } else {
+      algo
+    }
+  }
+  body
+}
+
+#let algorithm(
+  inset: 0.2em,
+  indent: 0.5em,
+  vstroke: 0pt + luma(200),
+  line-numbers: true,
+  line-numbers-format: x => [#x:],
+  horizontal-offset: 1.63640em,
+  ..bits,
+) = {
+  let content = bits.pos().map(b => ast-to-content-list(0, b)).flatten()
+  if content.len() == 0 or content == (none,) {
+    return none
+  }
+  let grid-bits = ()
+  let line-number = 1
+
+  let indent-list = content.map(c => c.line-indent)
+  let max-indent = indent-list.sorted().last()
+  let colspans = indent-list.map(i => max-indent + 1 - i)
+  let indent-content = indent-list.map(i => (
+    ([], grid.vline(stroke: vstroke), []) * int(i / 2)
+  ))
+  let indents = (indent,) * max-indent
+  let offset = horizontal-offset + if indents.len() != 0 { indents.sum() }
+  let columns = (..indents, 100% - offset)
+  if line-numbers {
+    columns.insert(0, horizontal-offset)
+  }
+
+  while line-number <= content.len() {
+    if line-numbers {
+      grid-bits.push(line-numbers-format(line-number))
+    }
+    grid-bits = grid-bits + indent-content.at(line-number - 1)
+    grid-bits.push(grid.cell(
+      content.at(line-number - 1).line-content,
+      colspan: colspans.at(line-number - 1),
+    ))
+    line-number = line-number + 1
+  }
+  return grid(
+    columns: columns,
+    // line spacing
+    inset: inset,
+    stroke: none,
+    ..grid-bits
+  )
+}
+
+#let algorithm-figure(
+  title,
+  supplement: "Algorithm",
+  inset: 0.2em,
+  indent: 0.5em,
+  vstroke: 0pt + luma(200),
+  line-numbers: true,
+  line-numbers-format: x => [#x:],
+  horizontal-offset: 1.63640em,
+  ..bits,
+) = {
+  return figure(
+    supplement: supplement,
+    kind: "algorithm",
+    caption: title,
+    algorithm(
+      indent: indent,
+      inset: inset,
+      vstroke: vstroke,
+      line-numbers: line-numbers,
+      line-numbers-format: line-numbers-format,
+      horizontal-offset: horizontal-offset,
+      ..bits,
+    ),
+  )
+}
+
+#let iflike-unterminated(kw1: "", kw2: "", cond, ..body) = (
+  (strong(kw1) + " " + cond + " " + strong(kw2)),
+  (change-indent: 2, body: body.pos()),
+)
+#let iflike-terminated(kw1: "", kw2: "", kw3: "", cond, ..body) = (
+  (strong(kw1) + " " + cond + " " + strong(kw2)),
+  (change-indent: 2, body: body.pos()),
+  strong(kw3),
+)
+#let iflike(kw1: "", kw2: "", kw3: none, cond, ..body) = (
+  if kw3 == "" or kw3 == none {
+    iflike-unterminated(kw1: kw1, kw2: kw2, cond, ..body)
+  } else {
+    iflike-terminated(kw1: kw1, kw2: kw2, kw3: kw3, cond, ..body)
+  }
+)
+#let arraify(v) = {
+  if type(v) == array {
+    v
+  } else {
+    (v,)
+  }
+}
+#let call(
+  name,
+  kw: "function",
+  inline: false,
+  style: smallcaps,
+  args,
+  ..body,
+) = (
+  if inline {
+    [#style(name)\(#arraify(args).join(", ")\)]
+  } else {
+    iflike(
+      kw1: kw,
+      kw3: "end",
+      (style(name) + $(#arraify(args).join(", "))$),
+      ..body,
+    )
+  }
+)
+
+// Named blocks
+#let Function = call.with(kw: "function")
+#let Procedure = call.with(kw: "procedure")
+
+// Misc
+#let Line(block) = (block,)
+#let LineBreak = Line[]
+
+/// Inline call
+#let CallInline(name, args) = call(inline: true, name, args)
+#let FnInline(f, args) = call(inline: true, style: strong, f, args)
+#let CommentInline(c) = sym.triangle.stroked.r + " " + c
+
+// Block calls
+#let Call(..args) = (CallInline(..args),)
+#let Fn(..args) = (FnInline(..args),)
+#let Comment(c) = (CommentInline(c),)
+#let LineComment(l, c) = {
+  let l = arraify(l).flatten()
+  ([#l.first()#h(1fr)#CommentInline(c)], ..l.slice(1))
+}
+
+// Control flow
+#let If = iflike.with(kw1: "if", kw2: "then", kw3: "end")
+#let While = iflike.with(kw1: "while", kw2: "do", kw3: "end")
+#let For = iflike.with(kw1: "for", kw2: "do", kw3: "end")
+#let Else = iflike.with(kw1: "else", kw2: "", kw3: "end", "")
+#let ElseIf = iflike.with(kw1: "else if", kw2: "then", kw3: "end")
+#let IfElseChain(..conditions-and-bodies) = {
+  let result = ()
+  let conditions-and-bodies = conditions-and-bodies.pos()
+  let len = conditions-and-bodies.len()
+  let i = 0
+
+  while i < len {
+    if i == len - 1 and calc.odd(len) {
+      // Last element is the "else" block
+      result.push(Else(..arraify(conditions-and-bodies.at(i))))
+    } else if calc.even(i) {
+      // Condition
+      let cond = conditions-and-bodies.at(i)
+      let body = arraify(conditions-and-bodies.at(i + 1))
+      if i == 0 {
+        // First condition is a regular "if"
+        result.push(If(cond, ..body, kw3: ""))
+      } else if i + 2 == len {
+        // Last condition before "else" is an "elseif" with "end"
+        result.push(ElseIf(cond, ..body, kw3: "end"))
+      } else {
+        // Intermediate conditions are "elseif" without "end"
+        result.push(ElseIf(cond, ..body, kw3: ""))
+      }
+    } else {
+      // Skip body since it's already processed
+    }
+    i = i + 1
+  }
+  result
+}
+#let IfElseInline(condition, true-case, false-case) = (
+  [#true-case *if* #condition *else* #false-case],
+)
+
+// Instructions
+#let Assign(var, val) = (var + " " + $<-$ + " " + arraify(val).join(", "),)
+#let Return(arg) = (strong("return") + " " + arraify(arg).join(", "),)
+#let Terminate = (smallcaps("terminate"),)
+#let Break = (smallcaps("break"),)

--- a/packages/preview/algorithmic/1.0.7/typst.toml
+++ b/packages/preview/algorithmic/1.0.7/typst.toml
@@ -1,0 +1,28 @@
+[package]
+name = "algorithmic"
+version = "1.0.7"
+entrypoint = "algorithmic.typ"
+authors = ["Jade Lovelace <https://github.com/lf->", "Pascal Quach <@quachpas>"]
+license = "MIT"
+description = "Algorithm pseudocode typesetting for Typst, inspired by algorithmicx in LaTeX"
+repository = "https://github.com/typst-community/typst-algorithmic"
+keywords = ["algorithm", "pseudocode", "procedure"]
+categories = ["components", "visualization"]
+disciplines = ["computer-science", "mathematics"]
+compiler = "0.13.0"
+exclude = [
+  "docs/",
+  "tests/",
+  "tbump.toml",
+  "justfile",
+  ".gitignore",
+  ".git",
+  ".gtm",
+  ".vscode",
+  ".reuse",
+  "package.sh",
+  ".github",
+]
+
+[tool.tytanic]
+default.ppi = 300


### PR DESCRIPTION
> [!NOTE]
> @JL170 added an option to customize line number formatting (#32).
> ```typ
> #algorithm(
> line-numbers-format: x => [#x:],
> { ... }
> )
> ```

> [!NOTE]
> @avlouis added inline command `IfElseInline` for ternary if-then-else statements (#31).
> ```typ
> #{
>   Assign($m$, IfElseInline($x < y$, $x$, $y$))
> }
> ```

> [!NOTE]
> @wamserma fixed an issue with the width of the column offset not scaling with
> the font size (#26).
> Now, the column is specified relative to the font size in [`em`](https://typst.app/docs/reference/layout/length/).
> This is not a breaking change.

> [!NOTE]
> @nonl4331 fixed an issue with `LineComment` not working with certain input types (#27, #28).
>
> LineComment statements similar to the instances below will now render correctly.
> ```typ
> #{
>   LineComment([Initialize hashmap], [Count instances])
>   LineComment([$c += a-b$], [Sum of differences])
> }
> ```
