### PR TITLE
to-stuff:0.4.0

### DIFF
--- a/packages/preview/to-stuff/0.4.0/LICENSE.md
+++ b/packages/preview/to-stuff/0.4.0/LICENSE.md
@@ -1,0 +1,10 @@
+Copyright 2025 Nik Mennega
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/packages/preview/to-stuff/0.4.0/README.md
+++ b/packages/preview/to-stuff/0.4.0/README.md
@@ -1,0 +1,842 @@
+# To-Stuff
+
+To-Stuff is a small package of [Typst](https://typst.app/) functions for converting string values to native types. This is most useful when loading layout data from an external configuration source, such as a YAML file.
+
+- Avoids any use of [`eval()`](https://typst.app/docs/reference/foundations/eval/).
+- When a conversion fails, the module panics with a sensible error message.
+- Panics can be suppressed if desired, forcing a failed conversion to silently return `none` instead.
+
+
+## How To Use
+
+Import the module into the current scope, optionally renamed using the `as` keyword:
+
+```typ
+#import "@preview/to-stuff:0.4.0"
+// Bindings available as to-stuff.alignment(), to-stuff.angle(), etc.
+
+// …or…
+
+#import "@preview/to-stuff:0.4.0" as to
+// Bindings available as to.alignment(), to.angle(), etc.
+```
+
+The module’s `let` bindings have the same names as their return types, and rely on Typst’s `import` syntax to scope safely. It is not recommended to load the individual bindings into the current scope, as that may cause collisions with the types themselves.
+
+```typ
+#assert(type(42pt) == length) // Expected behaviour
+
+#import "@preview/to-stuff:0.4.0": * // NOT RECOMMENDED
+
+#assert(type(42pt) != length) // To-Stuff bindings collide with standard types
+#assert(type(42pt) == std.length) // Workaround
+```
+
+
+## Localisation
+
+All conversions involving numeric values assume the number strings to be in a format understood by Typst code; specifically:
+
+- All numeric digits must be ASCII characters 0-9 and/or A-F (case non-sensitive).
+- Decimal separators must be a full stop/period; commas, apostrophes, etc. are not supported.
+- Thousands separators are not supported.
+
+
+## Functions
+
+### `alignment()`
+
+Attempts to convert a value to an `alignment`.
+
+```typ
+#alignment(
+	value, // str | alignment | dictionary
+	quiet: false, // bool
+) -> none | alignment
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `alignment` or `dictionary` (positional, required)
+
+The value that should be converted to an `alignment`.
+
+- An `alignment` is returned unchanged.
+- A string representation of any of the eight `alignment` values is converted to that value.
+	- If the string includes the `alignment.…` scoping prefix, the conversion fails.
+- A string consisting of two `alignment` representations joined by a plus sign is converted to the corresponding 2D alignment, provided the two strings do not correspond to alignments on the same axis.
+- A `dictionary` containing one or more of the keys `x` and `y`, and no other keys, is converted.
+	- The value of `x`, if present, must be either a horizontal `alignment` or a value that would convert to one.
+	- The value of `y`, if present, must be either a vertical `alignment` or a value that would convert to one.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.alignment("top + right")
+// -> right + top
+
+#let b = to.alignment(top + right)
+// -> right + top
+
+#let c = to.alignment((x: "right", y: "top"))
+// -> right + top
+
+#let d = to.alignment("turnwise")
+// panics with: "could not convert to alignment: \"turnwise\""
+
+#let e = to.alignment("top + bottom")
+// panics with: "cannot add two vertical alignments: \"top + bottom\""
+
+#let f = to.alignment(quiet: true, "top + bottom")
+// -> none
+```
+</details>
+
+
+### `angle()`
+
+Attempts to convert a value to an `angle`.
+
+```typ
+#angle(
+	value, // str | angle
+	quiet: false, // bool
+) -> none | angle
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `angle` (positional, required)
+
+The value that should be converted to an `angle`.
+
+- An `angle` is returned unchanged.
+- A string representation of a number followed by the letters `deg` or `rad` is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.angle("45deg")
+// -> 45deg
+
+#let b = to.angle(45deg)
+// -> 45deg
+
+#let c = to.angle("42")
+// panics with: "could not convert to angle: \"42\""
+
+#let d = to.angle(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `color()`
+
+Attempts to convert a value to a `color`.
+
+```typ
+#color(
+	value, // str | color
+	quiet: false, // bool
+) -> none | color
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `color` (positional, required)
+
+The value that should be converted to a `color`.
+
+- A `color` is returned unchanged.
+- A string representation of a predefined color value is converted to that built-in color.
+- A string representation of a hash symbol followed by a 6- or 8-digit hexadecimal code is converted to the corresponding RGB or RGBA value.
+- A string representation of a color space function followed by parentheses and arguments is converted.
+	- If the string includes the `color.…` scoping prefix, the conversion fails. This includes the `hsl`, `hsv`, and `linear-rgb` functions.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.color("red")
+// -> rgb("#ff4136")
+
+#let b = to.color(red)
+// -> rgb("#ff4136")
+
+#let c = to.color("#FF4136FF")
+// -> rgb("#ff4136")
+
+#let d = to.color("rgb(255, 65, 54)")
+// -> rgb("#ff4136")
+
+#let e = to.color("hsv(135deg,75%,127,100)")
+// -> color.hsv(135deg, 75%, 49.8%, 39.22%)
+
+#let f = to.color("indigo")
+// panics with: "could not convert to color: \"indigo\""
+
+#let g = to.color(quiet: true, "indigo")
+// -> none
+```
+</details>
+
+
+### `direction()`
+
+Attempts to convert a value to a `direction`.
+
+```typ
+#direction(
+	value, // str | direction
+	quiet: false, // bool
+) -> none | direction
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `direction` (positional, required)
+
+The value that should be converted to a `direction`.
+
+- A `direction` is returned unchanged.
+- A string representation of any of the four `direction` values is converted to that value.
+	- If the string includes the `direction.…` scoping prefix, the conversion fails.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.direction("rtl")
+// -> rtl
+
+#let b = to.direction(rtl)
+// -> rtl
+
+#let c = to.direction("btf")
+// panics with: "could not convert to direction: \"btf\""
+
+#let d = to.direction(quiet: true, "btf")
+// -> none
+```
+</details>
+
+
+### `float()`
+
+Attempts to convert a value to a `float`.
+
+Unlike the standard [`float` constructor](https://typst.app/docs/reference/foundations/float/#constructor), this function allows errors (panics) to be suppressed if desired.
+
+```typ
+#float(
+	value, // str | float
+	quiet: false, // bool
+) -> none | float
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `float` (positional, required)
+
+The value that should be converted to a `float`.
+
+- A `float` is returned unchanged.
+- A string representation of a number is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.float("2.5")
+// -> 2.5
+
+#let b = to.float(2.5)
+// -> 2.5
+
+#let c = to.float("25e-1")
+// -> 2.5
+
+#let d = to.float("42%")
+// panics with: "could not convert to float: \"42%\""
+
+#let e = to.float(quiet: true, "42%")
+// -> none
+```
+</details>
+
+
+### `fraction()`
+
+Attempts to convert a value to a `fraction`.
+
+```typ
+#fraction(
+	value, // str | fraction
+	quiet: false, // bool
+) -> none | fraction
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `fraction` (positional, required)
+
+The value that should be converted to a `fraction`.
+
+- A `fraction` is returned unchanged.
+- A string representation of a number followed by the letters `fr` is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.fraction("2.5fr")
+// -> 2.5fr
+
+#let b = to.fraction(2.5fr)
+// -> 2.5fr
+
+#let c = to.fraction("42")
+// panics with: "could not convert to fraction: \"42\""
+
+#let d = to.fraction(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `int()`
+
+Attempts to convert a value to an `int`.
+
+Unlike the standard [`int` constructor](https://typst.app/docs/reference/foundations/int/#constructor), this function allows errors (panics) to be suppressed if desired, and is also capable of parsing hexadecimal, octal and binary strings.
+
+```typ
+#int(
+	value, // str | int
+	quiet: false, // bool
+) -> none | int
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `int` (positional, required)
+
+The value that should be converted to an `int`.
+
+- An `int` is returned unchanged.
+- A string representation of a number is converted.
+	- The number may be positive or negative, but may *not* contain decimal places.
+	- Hexadecimal numbers, prefixed with `0x`, are permitted.
+	- Octal numbers, prefixed with `0o`, are permitted.
+	- Binary numbers, prefixed with `0b`, are permitted.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.int("42")
+// -> 42
+
+#let b = to.int(42)
+// -> 42
+
+#let c = to.int("0x2a")
+// -> 42
+
+#let d = to.int("2.5")
+// panics with: "could not convert to int: \"2.5\""
+
+#let e = to.int(quiet: true, "2.5")
+// -> none
+```
+</details>
+
+
+### `length()`
+
+Attempts to convert a value to a `length`.
+
+```typ
+#length(
+	value, // str | length
+	quiet: false, // bool
+) -> none | length
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `length` (positional, required)
+
+The value that should be converted to a `length`.
+
+- A `length` is returned unchanged.
+- A string representation of a number followed by the letters `pt`, `mm`, `cm`, `in`, or `em`, is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.length("45pt")
+// -> 45pt
+
+#let b = to.length(45pt)
+// -> 45pt
+
+#let c = to.length("42")
+// panics with: "could not convert to length: \"42\""
+
+#let d = to.length(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `ratio()`
+
+Attempts to convert a value to a `ratio`.
+
+```typ
+#ratio(
+	value, // str | ratio
+	quiet: false, // bool
+) -> none | ratio
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `ratio` (positional, required)
+
+The value that should be converted to a `ratio`.
+
+- A `ratio` is returned unchanged.
+- A string representation of a number followed by a percent sign is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.ratio("45%")
+// -> 45%
+
+#let b = to.ratio(45%)
+// -> 45%
+
+#let c = to.ratio("42")
+// panics with: "could not convert to ratio: \"42\""
+
+#let d = to.ratio(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `relative()`
+
+Attempts to convert a value to a `relative`.
+
+```typ
+#relative(
+	value, // str | relative | ratio | length | dictionary
+	quiet: false, // bool
+) -> none | relative
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `relative` or `ratio` or `length` or `dictionary` (positional, required)
+
+The value that should be converted to a `relative`.
+
+- A `relative` is returned unchanged.
+- A `ratio` is returned as a `relative` with a `length` of `0pt`.
+- A `length` is returned as a `relative` with a `ratio` of `0%`.
+- A string representation of a `ratio` (see [above](#ratio)) is converted.
+- A string representation of a `length` (see [above](#length)) is converted.
+- A string consisting of multiple `ratio`s and `lengths` joined by plus signs or minus signs is converted to a single `relative` length.
+	- All `length`-like substrings are added.
+	- All `ratio`-like substrings are added.
+- A `dictionary` containing one or more of the keys `ratio` and `length`, and no other keys, is converted.
+	- The value of `ratio`, if present, must be either a `ratio` or a value that would convert to one.
+	- The value of `length`, if present, must be either a `length` or a value that would convert to one.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.relative("45pt + 3%")
+// -> 3% + 45pt
+
+#let b = to.relative(45pt + 3%)
+// -> 3% + 45pt
+
+#let c = to.relative((ratio: "3%", length: "45pt"))
+// -> 3% + 45pt
+
+#let d = to.relative("42")
+// panics with: "could not convert to relative: \"42\""
+
+#let e = to.relative(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `scalar()`
+
+Attempts to convert a value to a `float` or an `int` as appropriate.
+
+
+```typ
+#scalar(
+	value, // str | float | int
+	quiet: false, // bool
+) -> none | float | int
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `float` or `int` (positional, required)
+
+The value that should be converted to a `float` or `int`.
+
+- A `float` or `int` is returned unchanged.
+- A string representation of a `float` (see [above](#float)) is converted.
+- A string representation of an `int` (see [above](#int)) is converted.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.scalar("42")
+// -> 42
+
+#let b = to.scalar(42)
+// -> 42
+
+#let c = to.scalar("0x2a")
+// -> 42
+
+#let d = to.scalar("2.5")
+// -> 2.5
+
+#let e = to.scalar(2.5)
+// -> 2.5
+
+#let f = to.float("25e-1")
+// -> 2.5
+
+#let g = to.scalar("45%")
+// panics with: "could not convert to int or float: \"45%\""
+
+#let h = to.scalar(quiet: true, "45%")
+// -> none
+```
+</details>
+
+
+### `stroke()`
+
+Attempts to convert a value to a `stroke`.
+
+```typ
+#stroke(
+	value, // str | stroke | color | length | array | dictionary
+	quiet: false, // bool
+) -> none | stroke
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `stroke` or `color` or `length` or `array` or `dictionary` (positional, required)
+
+The value that should be converted to a `stroke`.
+
+- A `stroke`, `color` or `length` is returned unchanged.
+- A string representation of a `color` (see [above](#color)) is converted.
+- A string representation of a `length` (see [above](#length)) is converted.
+- A valid [dash pattern](https://typst.app/docs/reference/visualize/stroke/#constructor-dash) is converted.
+- A string representation of one or more valid `color`s, `length`s and/or predefined dash patterns joined by plus signs is converted.
+	- All `color`-like substrings are combined via `color.mix()`.
+	- All `length`-like substrings added.
+- A `dictionary` that would otherwise be accepted as a valid `stroke` is converted.
+
+#### `quiet`
+
+`bool`
+
+Whether to return `none` if the value could not be converted. If `false`, invalid values cause a panic.
+
+Default: `false`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.4.0" as to
+
+#let a = to.stroke("red")
+// -> rgb("#ff4136")
+
+#let b = to.stroke(45pt)
+// -> 45pt
+
+#let c = to.stroke("densely-dashed")
+// -> (dash: array(3pt, 2pt), phase: 0pt)
+
+#let d = to.stroke((3pt, 2pt))
+// -> (dash: array(3pt, 2pt), phase: 0pt)
+
+#let e = to.stroke((paint: red, thickness: 2pt, dash: "densely-dashed"))
+// -> (paint: rgb("#ff4136"), thickness: 2pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let f = to.stroke("2pt + red + densely-dashed + silver + 5pt")
+// -> (paint: oklab(77.85%, 0.1, 0.054), thickness: 7pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let g = to.stroke("deep-dish")
+// panics with: "could not convert to stroke: \"deep-dish\""
+
+#let h = to.stroke(quiet: true, "deep-dish")
+// -> none
+```
+</details>
+
+
+## Development
+
+### Requirements
+
+Local development of To-Stuff relies on the following software:
+
+- [`tytanic`](https://github.com/typst-community/tytanic)
+- [`task`](https://github.com/go-task/task)
+- [`direnv`](https://github.com/direnv/direnv)
+- [`yq`](https://github.com/mikefarah/yq)
+
+
+### Setup
+
+1. Fork the [Typst Packages][setup_universe] repository and clone it locally. A [sparse checkout][setup_sparse] is recommended.
+
+	For demonstration purposes, we assume your local clone of your Typst Packages fork is at `~/my-typst-dev/universe`.
+
+2. Clone this repository.
+
+	```sh
+	cd ~/my-typst-dev
+	git clone https://codeberg.org/boondoc/typst-to-stuff
+	```
+
+3. Create and activate an environment file to link To-Stuff’s `taskfile` to your local copy of Typst Packages. You may need to edit your `direnv` settings to recognise `.env` files.
+
+	```sh
+	cd ~/my-typst-dev/typst-to-stuff
+	echo "LOCAL_UNIVERSE=${HOME}/my-typst-dev/universe/packages/preview" > .env
+	direnv allow
+	```
+
+	Note that the above command should write an **absolute path** to `.env`; `task` seems not to parse shell variables inside `.env` files, even when `direnv` itself expands them correctly.
+
+4. Initialise tests.
+
+	```sh
+	cd ~/my-typst-dev/typst-to-stuff
+	task
+	```
+
+	The default `task` operation runs all unit tests once.
+
+5. Begin monitoring the repository for file edits.
+
+	```sh
+	cd ~/my-typst-dev/typst-to-stuff
+	task watch
+	```
+
+	Running the `watch` task in a clean repository can incorrectly skip several tests, taking multiple refreshes to successfully compile the entire suite; running a single pass first (see step 4) seems to solve the problem.
+
+
+### Updating the project version
+
+To set a new project version:
+
+1. Edit the `package.version` setting in `typst.toml`
+2. Run `task docs` to automatically update the `README.md` file to reflect the correct version number.
+
+
+### Packaging for Universe
+
+Running `task package` will copy selected files to the the path specified in `$LOCAL_UNIVERSE` (set in `.env`), under a subdirectory structure according to the project name and version specified in `typst.toml`. The list of files copied is defined in `taskfile.yml` under `vars.MODULE` and `vars.IGNORE`.
+
+Only files [relevant][setup_exclude] to Typst Universe itself should be packaged in this way; for instance, Universe has no use for the `tests` subdirectory.
+
+
+[setup_universe]: https://github.com/typst/packages
+[setup_sparse]: https://github.com/typst/packages/blob/main/docs/tips.md#sparse-checkout-of-the-repository
+[setup_exclude]: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude
+

--- a/packages/preview/to-stuff/0.4.0/exports.typ
+++ b/packages/preview/to-stuff/0.4.0/exports.typ
@@ -1,0 +1,9 @@
+
+#import	"/internals/scalars.typ"	:   float, int, scalar
+#import	"/internals/units.typ"		:   angle, fraction, length, ratio
+#import	"/internals/alignment.typ"	:   alignment
+#import	"/internals/color.typ"		:   color
+#import	"/internals/direction.typ"	:   direction
+#import	"/internals/relative.typ"	:   relative
+#import	"/internals/stroke.typ"		:   stroke
+

--- a/packages/preview/to-stuff/0.4.0/internals/alignment.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/alignment.typ
@@ -1,0 +1,91 @@
+
+#import	"/internals/utils.typ"		:   list-predefined, message-unexpected-keys
+
+#let	alignment(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) == std.alignment {
+		return value
+	}
+
+	if type(value) == dictionary {
+		let	original			=   repr(value)
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			x				:  "horizontal",
+			y				:  "vertical",
+		)
+
+		if keys_this.all(x => x in keys_valid.keys()) {
+			for (field, axis) in keys_valid {
+				if field in value {
+					value.at(field)			=   alignment(quiet : true, value.at(field))
+
+					if none == value.at(field) or value.at(field).axis() != axis {
+						if quiet {
+							return none
+						}
+
+						panic("could not convert “" + field + "” component to " + axis + " alignment: " + original)
+					}
+				}
+			}
+
+			return value.values().sum()
+		}
+
+		if quiet {
+			return none
+		}
+
+		panic(message-unexpected-keys(
+			found				:   keys_this,
+			valid				:   keys_valid.keys(),
+			repr(value),
+		))
+	}
+
+
+	let	panic-message			=  "could not convert to alignment: " + repr(value)
+
+	if type(value) != std.str {
+		if quiet {
+			return none
+		}
+
+		panic(panic-message)
+	}
+
+
+	let	value				=   value.trim()
+	let	constants			=   list-predefined(std.alignment)
+
+	if value in constants {
+		return constants.at(value)
+	}
+
+
+	let	parts				=   value.split("+").map(std.str.trim)
+
+	if not parts.all(x => x in constants) {
+		if quiet {
+			return none
+		}
+
+		panic(panic-message)
+	}
+
+	let	axes				=   parts.map(x => constants.at(x).axis())
+
+	if axes.at(0) == axes.at(1) {
+		if quiet {
+			return none
+		}
+
+		panic("cannot add two " + axes.at(0) + " alignments: " + repr(value))
+	}
+
+	return parts.map(alignment).sum()
+}
+

--- a/packages/preview/to-stuff/0.4.0/internals/color.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/color.typ
@@ -1,0 +1,212 @@
+
+#import "/internals/scalars.typ"	:   int, scalar
+#import "/internals/units.typ"		:   angle, ratio
+#import	"/internals/utils.typ"		:   list-predefined
+
+
+#let	color(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) == std.color {
+		return value
+	}
+
+
+	let	panic-message			=  "could not convert to color: " + repr(value)
+
+	if type(value) != std.str {
+		if quiet {
+			return none
+		}
+
+		panic(panic-message)
+	}
+
+
+	let	value				=   value.trim()
+	let	constants			=   list-predefined(std.color)
+	let	constructors			= (
+		rgb				: (
+			constructor			:  std.color.rgb,
+			args				: (
+				red				: (optional: false,	types: (ratio, int)),
+				green				: (optional: false,	types: (ratio, int)),
+				blue				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		linear-rgb			: (
+			constructor			:  std.color.linear-rgb,
+			args				: (
+				red				: (optional: false,	types: (ratio, int)),
+				green				: (optional: false,	types: (ratio, int)),
+				blue				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		luma				: (
+			constructor			:  std.color.luma,
+			args				: (
+				lightness			: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+		cmyk				: (
+			constructor			:  std.color.cmyk,
+			args				: (
+				cyan				: (optional: false,	types: (ratio,)),
+				magenta				: (optional: false,	types: (ratio,)),
+				yellow				: (optional: false,	types: (ratio,)),
+				black				: (optional: false,	types: (ratio,)),
+			),
+		),
+		hsl				: (
+			constructor			:  std.color.hsl,
+			args				: (
+				hue				: (optional: false,	types: (angle,)),
+				saturation			: (optional: false,	types: (ratio, int)),
+				lightness			: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		hsv				: (
+			constructor			:  std.color.hsv,
+			args				: (
+				hue				: (optional: false,	types: (angle,)),
+				saturation			: (optional: false,	types: (ratio, int)),
+				value				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		oklab				: (
+			constructor			:  std.color.oklab,
+			args				: (
+				lightness			: (optional: false,	types: (ratio,)),
+				A				: (optional: false,	types: (ratio, scalar),	clamp: false),
+				B				: (optional: false,	types: (ratio, scalar),	clamp: false),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+		oklch				: (
+			constructor			:  std.color.oklch,
+			args				: (
+				lightness			: (optional: false,	types: (ratio,)),
+				chroma				: (optional: false,	types: (ratio, scalar), clamp: false),
+				hue				: (optional: false,	types: (angle,)),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+	)
+
+	let	clamps				= (
+		int 				: (
+			fails				:   x => 0 > x or x > 255,
+			error				:  "component must be between 0 and 255",
+		),
+		ratio				: (
+			fails				:   x => 0% > x or x > 100%,
+			error				:  "component must be between 0% and 100%",
+		),
+	)
+
+
+	if value in constants {
+		return constants.at(value)
+	}
+
+	if value.contains(regex("^#?([[:xdigit:]]{3,4}|[[:xdigit:]]{6}|[[:xdigit:]]{8})$")) {
+		return std.color.rgb(value)
+	}
+
+
+	let	rx-funcs			=   regex( "^(" + constructors.keys().join("|") + ")\((.*)\)$")
+
+	if value.contains(rx-funcs) {
+		let	(func, args)			=   value.match(rx-funcs).captures
+
+		if func not in constructors {
+			if quiet {
+				return none
+			}
+
+			panic(panic-message)
+		}
+
+		let	allowed				=   constructors.at(func).args.pairs()
+		let	required			=   allowed.filter(x => not x.last().optional)
+		let	args				=   args
+			.split(",")
+			.map(str.trim)
+			.filter(x => "" != x)
+			.enumerate()
+			.map(((offset, arg)) => {
+				if offset >= allowed.len() {
+					return ("panic", "unexpected argument " + repr(arg))
+				}
+
+				let	(name, rules)			=   allowed.at(offset)
+
+				for	parse in rules.types {
+					let	clamp				=   clamps.at(
+						default				: (:),
+						repr(parse),
+					)
+					let	parsed				=   parse(
+						quiet				:   true,
+						arg,
+					)
+
+					if none == parsed {
+						continue;
+					}
+
+
+					if repr(parse) in clamps and rules.at(
+						default				:   true,
+						"clamp",
+					) and clamp.at("fails")(parsed) {
+						return ("panic", (name, clamp.error).join(" "))
+					}
+
+					return (name, parsed)
+				}
+
+				return ("panic", (
+					name,
+					"component expected",
+					rules.types.map(repr).join(
+						last				:  ", or ",
+						", ",
+					).replace("scalar", "float"),
+				).join(" "))
+			})
+			.to-dict()
+
+		if "panic" in args {
+			if quiet {
+				return none
+			}
+
+			panic(panic-message + "; " + args.panic)
+		}
+
+		if args.len() < required.len() {
+			if quiet {
+				return none
+			}
+
+			panic(panic-message + "; missing " + required.at(args.len()).first() + " component")
+		}
+
+		return	constructors.at(func).at("constructor")(..args.values())
+	}
+
+
+	if quiet {
+		return none
+	}
+
+	panic(panic-message)
+}
+

--- a/packages/preview/to-stuff/0.4.0/internals/direction.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/direction.typ
@@ -1,0 +1,25 @@
+
+#import	"/internals/utils.typ"		:   list-predefined
+
+#let	direction(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) == std.direction {
+		return value
+	}
+
+
+	let	constants			=   list-predefined(std.direction)
+
+	if type(value) == std.str and value.trim() in constants {
+		return constants.at(value.trim())
+	}
+
+	if quiet {
+		return none
+	}
+
+	panic("could not convert to direction: " + repr(value))
+}
+

--- a/packages/preview/to-stuff/0.4.0/internals/relative.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/relative.typ
@@ -1,0 +1,86 @@
+
+#import	"/internals/scalars.typ"	:   rx-flt-signed
+#import	"/internals/units.typ"		:   length, ratio
+#import	"/internals/utils.typ"		:   message-unexpected-keys
+
+#let	relative(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) in (std.relative, std.ratio, std.length) {
+		return value + 0pt + 0%
+	}
+
+	if type(value) == dictionary {
+		let	original			=   repr(value)
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			ratio				:   ratio,
+			length				:   length,
+		)
+
+		if keys_this.all(x => x in keys_valid.keys()) {
+			for (field, func) in keys_valid {
+				if field in value {
+					value.at(field)			=   func(quiet : true, value.at(field))
+
+					if none == value.at(field) {
+						if quiet {
+							return none
+						}
+
+						panic("could not convert “" + field + "” component to " + field + ": " + original)
+					}
+				}
+			}
+
+			return value.values().sum()
+		}
+
+		if quiet {
+			return none
+		}
+
+		panic(message-unexpected-keys(
+			found				:   keys_this,
+			valid				:   keys_valid.keys(),
+			repr(value),
+		))
+	}
+
+
+	let	rx				=  "^(" + rx-flt-signed + "(pt|mm|cm|in|em|%))"
+
+	if type(value) == std.str and value.trim().contains(regex(rx + "+$")) {
+		let	value				=   value.trim()
+		let	parts				= (
+			ratio				:   0%,
+			length				:   0pt,
+		)
+
+		while value.len() > 0 {
+			let	match				=   value.match(regex(rx))
+
+			if none == match {
+				break
+			}
+
+			if match.captures.at(5) == "%" {
+				parts.ratio			=   parts.ratio + ratio(quiet : true, match.text)
+			} else {
+				parts.length			=   parts.length + length(quiet : true, match.text)
+			}
+
+			value				=   value.slice(match.end)
+		}
+
+		return relative(parts)
+	}
+
+	if quiet {
+		return none
+	}
+
+	panic("could not convert to relative: " + repr(value))
+}
+

--- a/packages/preview/to-stuff/0.4.0/internals/scalars.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/scalars.typ
@@ -1,0 +1,201 @@
+
+#let	rx-int-number			=  "[[:digit:]]+"
+#let	rx-flt-number			=  "[[:digit:]]*\.?[[:digit:]]+(e[+-]?[[:digit:]]+)?"
+#let	rx-xob-number			=  "0([xob])(.+)"
+
+#let	rx-int-signed			=  "(([-+\s]*)(" + rx-int-number + "))"
+#let	rx-flt-signed			=  "(([-+\s]*)(" + rx-flt-number + "))"
+#let	rx-xob-signed			=  "(([-+\s]*)"  + rx-xob-number +  ")"
+
+
+#let	int_from_base(value, base)	= {
+	let	digits				=  "0123456789abcdefghijklmnopqrstuvwxyz"
+	let	max				=   digits.len()
+
+	if base != calc.clamp(base, 2, max) {
+		// Intentionally non-suppressible panic.
+		panic("Base must be between 2 and {max}: {base}"
+			.replace("{max}",	max)
+			.replace("{base}",	base)
+		)
+	}
+
+	let	v				=   lower(value)
+	let	d				=   digits.slice(0, base)
+
+	if none != v.match(regex("([^" + d + "]+)")) {
+		let	base				=   std.str(base)
+		let	debug				= (
+			"16"				:  "hexadecimal",
+			 "8"				:  "octal",
+			 "2"				:  "binary",
+		).at(
+			default				:  "base-" + base,
+			base,
+		)
+
+		let	xob				= (
+			"16"				:  "0x",
+			 "8"				:  "0o",
+			 "2"				:  "0b",
+		).at(
+			default				:  "",
+			base
+		)
+
+		return	"invalid {base} number: {value}"
+			.replace("{value}",	repr(xob + value))
+			.replace("{base}",	debug)
+	}
+
+	return	 v
+		.rev()
+		.clusters()
+		.enumerate()
+		.map(((x, c)) => d.position(c) * calc.pow(base, x))
+		.sum()
+}
+
+
+#let	xob(
+	quiet				:   false,
+	value,
+) = {
+	let	(_, signs, xob, num)		=   value.trim().matches(regex("^" + rx-xob-signed + "$")).first().captures
+	let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+	let	v				=   int_from_base(num, (
+			x				:   16,
+			o				:    8,
+			b				:    2,
+		)
+		.at(xob))
+
+	if type(v) == std.str {
+		if quiet {
+			return none
+		}
+
+		panic(v)
+	}
+
+	return v * {
+		if negative {
+			-1
+		} else {
+			 1
+		}
+	}
+}
+
+#let	int(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) == std.int {
+		return value
+	}
+
+
+	if type(value) == std.str {
+		let	rx				=   regex("^" + rx-int-signed + "$")
+
+		if value.trim().contains(rx) {
+			let	(_, signs, num)			=   value.trim().matches(rx).first().captures
+			let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+			return std.int(std.float(num) * {
+				if negative {
+					-1
+				} else {
+					 1
+				}
+			})
+		}
+
+		if value.trim().contains(regex("^" + rx-xob-signed + "$")) {
+			return xob(
+				quiet				:   quiet,
+				value,
+			)
+		}
+	}
+
+	if quiet {
+		return none
+	}
+
+	panic("could not convert to int: " + repr(value))
+}
+
+
+
+#let	float(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) == std.float {
+		return value
+	}
+
+
+	let	rx				=   regex("^" + rx-flt-signed + "$")
+
+	if type(value) == std.str and value.trim().contains(rx) {
+		let	(_, signs, num, _)		=   value.trim().matches(rx).first().captures
+		let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+		return std.float(num) * {
+			if negative {
+				-1.0
+			} else {
+				 1.0
+			}
+		}
+	}
+
+	if quiet {
+		return none
+	}
+
+	panic("could not convert to float: " + repr(value))
+}
+
+
+#let	scalar(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) in (std.int, std.float) {
+		return value
+	}
+
+
+	if type(value) == std.str {
+		let	vals				= (
+			int(quiet: true, value),
+			float(quiet: true, value),
+		)
+
+		vals				=   vals.filter(x => none != x).dedup()
+
+		if vals.len() > 0 {
+			return vals.last()
+		}
+
+		if value.trim().contains(regex("^" + rx-xob-signed + "$")) {
+			return xob(
+				quiet				:   quiet,
+				value,
+			)
+		}
+	}
+
+
+	if quiet {
+		return none
+	}
+
+	panic("could not convert to int or float: " + repr(value))
+}
+

--- a/packages/preview/to-stuff/0.4.0/internals/stroke.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/stroke.typ
@@ -1,0 +1,387 @@
+
+#import	"/internals/scalars.typ"	:   scalar
+#import	"/internals/units.typ"		:   length
+#import	"/internals/color.typ"		:   color
+#import	"/internals/utils.typ"		:   message-unexpected-keys
+
+#let	valid-preset(
+	valid				: ( ),
+	quiet				:   false,
+	value,
+) = {
+	if value.trim() in valid {
+		return value.trim()
+	}
+
+	if quiet {
+		return none
+	}
+
+	"expected “" + valid.join(
+		last				:  "”, or “",
+		"”, “",
+	) + "”, found " + repr(value)
+}
+
+
+#let	stroke-cap-preset(
+	quiet				:   false,
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"butt",
+		"round",
+		"square",
+	),
+	quiet				:   quiet,
+	value,
+)
+
+#let	stroke-join-preset(
+	quiet				:   false,
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"miter",
+		"round",
+		"bevel",
+	),
+	quiet				:   quiet,
+	value,
+)
+
+#let	stroke-dash-preset(
+	quiet				:   false,
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"solid",
+		"dotted",
+		"densely-dotted",
+		"loosely-dotted",
+		"dashed",
+		"densely-dashed",
+		"loosely-dashed",
+		"dash-dotted",
+		"densely-dash-dotted",
+		"loosely-dash-dotted",
+	),
+	quiet				:   quiet,
+	value,
+)
+
+#let	stroke-dash-array(
+	quiet				:   false,
+	value,
+) = {
+	let	dash				=   value.map(x => {
+		if x == "dot" {
+			return x
+		}
+
+		length(quiet : true, x)
+	})
+
+	if dash.all(x => none != x) {
+		return dash
+	}
+
+	if quiet {
+		return none
+	}
+
+	"expected array of “dot” or length, found " + repr(value)
+}
+
+#let	stroke-dash-dict(
+	strict				:   true,
+	quiet				:   false,
+	value,
+) = {
+	let	dash				= (
+		array				: ( ),
+		phase				:   0pt,
+	)
+
+	let	test				=   x => x in dash.keys()
+	let	maybe				=   value.keys().any(test)
+	let	valid				=   value.keys().all(test)
+
+	if not strict and not maybe { // Not attempting to be a dash: let it through
+		return none
+	}
+
+	if (strict or maybe) and not valid {
+		if quiet {
+			return none
+		}
+
+		return message-unexpected-keys(
+			found				:   value.keys(),
+			valid				:   dash.keys(),
+			repr(value),
+		)
+	}
+
+	if "array" in value {
+		dash.array			=   dash.array + stroke-dash-array(value.array)
+	}
+
+	if "phase" in value {
+		dash.phase			=   dash.phase + length(value.phase)
+	}
+
+	dash
+}
+
+#let	stroke(
+	quiet				:   false,
+	value,
+) = {
+	if type(value) in (std.stroke, std.color, std.length) {
+		return std.stroke(value)
+	}
+
+	// An array of lengths is assumed to be the dash
+	if type(value) == array {
+		let	dash				=   stroke-dash-array(
+			quiet				:   quiet,
+			value,
+		)
+
+		if type(dash) == array {
+			return std.stroke(dash : dash)
+		}
+
+		if quiet {
+			return none
+		}
+
+		panic(dash)
+	}
+
+	if type(value) == dictionary {
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			"paint",
+			"thickness",
+			"dash",
+			"cap",
+			"join",
+			"miter-limit",
+		)
+
+		// A dictionary containing valid pattern parameters for keys could be the dash
+		let	dash				=   stroke-dash-dict(
+			strict				:   false,
+			quiet				:   quiet,
+			value,
+		)
+
+		if none != dash {
+			if type(dash) == str {
+				panic(dash)
+			}
+
+			if type(dash) == dictionary {
+				return std.stroke(
+					dash				:   dash,
+				)
+			}
+		}
+
+		// Any other dictionary must be a whole stroke
+		if keys_this.all(x => x in keys_valid) {
+			if "paint" in value {
+				value.paint			=   color(
+					quiet				:   quiet,
+					value.paint,
+				)
+
+				if none == value.paint { // Implies quiet
+					return none
+				}
+			}
+
+			if "thickness" in value {
+				value.thickness			=   length(
+					quiet				:   quiet,
+					value.thickness,
+				)
+
+				if none == value.thickness { // Implies quiet
+					return none
+				}
+			}
+
+			if "dash" in value {
+				let	funcs				= (
+					array				:   stroke-dash-array,
+					dictionary			:   stroke-dash-dict,
+					str				:   stroke-dash-preset,
+				)
+
+				if repr(type(value.dash)) in funcs {
+					let	key				=   repr(type(value.dash))
+					let	dash				=   funcs.at(key)(
+						quiet				:   quiet,
+						value.dash,
+					)
+
+					if none == dash { // Implies quiet
+						return none
+					}
+
+					if key != "str" and type(dash) == str {
+						panic(dash)
+					}
+
+					if key == "str" and dash != value.dash.trim() {
+						panic(dash)
+					}
+
+					value.dash			=   dash
+				}
+			}
+
+			if "cap" in value {
+				let	cap				=   stroke-cap-preset(
+					quiet				:   quiet,
+					value.cap,
+				)
+
+				if none == cap { // Implies quiet
+					return none
+				}
+
+				if cap != value.cap.trim() {
+					panic(cap)
+				}
+
+				value.cap			=   cap
+			}
+
+			if "join" in value {
+				let	join				=   stroke-join-preset(
+					quiet				:   quiet,
+					value.join,
+				)
+
+				if none == join { // Implies quiet
+					return none
+				}
+
+				if join != value.join.trim() {
+					panic(join)
+				}
+
+				value.join			=   join
+			}
+
+			if "miter-limit" in value {
+				value.miter-limit		=   scalar(
+					quiet				:   quiet,
+					value.miter-limit,
+				)
+
+				if none == value.miter-limit { // Implies quiet
+					return none
+				}
+			}
+
+			return std.stroke(value)
+		}
+
+
+		if quiet {
+			return none
+		}
+
+		panic(message-unexpected-keys(
+			found				:   keys_this,
+			valid				:   keys_valid,
+			repr(value),
+		))
+	}
+
+
+	let	panic-message			=  "could not convert to stroke: " + repr(value)
+
+	// We’ve covered full stroke definitions, as well as individual paint, thickness and dash values;
+	// an individual cap, join or miter-limit value isn’t really worth worrying about. That leaves
+	// string depictions of compound paint+length+dash declarations.
+	if type(value) != std.str {
+		if quiet {
+			return none
+		}
+
+		panic(panic-message)
+	}
+
+
+	// Splitting on `+` and evaluating components separately catches more edge cases than one big regex,
+	// e.g. a non-ridiculous regex would probably pass `invalid + 3pt`, which would be an error.
+	// Allowing addition of multiple paints/thicknesses is a little cheeky; we can’t easily do subtraction
+	// since splitting on `-` breaks dash pattern strings.
+	let	o				= (:)
+
+	for	c in value.split("+").map(std.str.trim).filter(x => x != "") {
+		let	d				=   stroke-dash-preset(quiet : true, c)
+		if none != d {
+			if "dash" in o {
+				if quiet {
+					return none
+				}
+
+				panic("cannot add two stroke arrays: " + repr(value))
+			}
+
+			o.insert("dash", d)
+			continue
+		}
+
+		let	k				=   color(quiet : true, c)
+		if none != k {
+			o.insert(
+				"paint",
+				if "paint" in o {
+					std.color.mix(o.paint, k)
+				} else {
+					k
+				},
+			)
+			continue
+		}
+
+		let	t				=   length(quiet : true, c)
+		if none != t {
+			o.insert(
+				"thickness",
+				t + o.at(
+					default				:   0pt,
+					"thickness",
+				),
+			)
+			continue
+		}
+
+		// Value cannot be processed
+		if quiet {
+			return none
+		}
+
+		panic(panic-message)
+	}
+
+
+	if o.keys().len() > 0 {
+		return std.stroke(o)
+	}
+
+	if quiet {
+		return none
+	}
+
+	panic(panic-message)
+}
+

--- a/packages/preview/to-stuff/0.4.0/internals/units.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/units.typ
@@ -1,0 +1,94 @@
+
+#import	"/internals/scalars.typ"	:   rx-flt-signed
+
+#let	units(
+	units				: (:),
+	target				:   none,
+	quiet				:   false,
+	value,
+) = {
+	if type(value) == target {
+		return value
+	}
+
+
+	let	rx				=   regex("^" + rx-flt-signed + "(" + units.keys().join("|") + ")$")
+
+	if type(value) == std.str and value.trim().contains(rx) {
+		let	(_, signs, num, _, unit)	=   value.trim().matches(rx).first().captures
+		let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+		return std.float(num) * units.at(unit) * {
+			if negative {
+				-1
+			} else {
+				 1
+			}
+		}
+	}
+
+	if quiet {
+		return none
+	}
+
+	panic("could not convert to " + repr(target) + ": " + repr(value))
+}
+
+
+#let	length(
+	quiet				:   false,
+	value,
+) = units(
+	units				: (
+		"pt"				:   1pt,
+		"mm"				:   1mm,
+		"cm"				:   1cm,
+		"in"				:   1in,
+		"em"				:   1em,
+	),
+	target				:   std.length,
+	quiet				:   quiet,
+	value,
+)
+
+
+#let	fraction(
+	quiet				:   false,
+	value,
+) = units(
+	units				: (
+		"fr"				:   1fr,
+	),
+	target				:   std.fraction,
+	quiet				:   quiet,
+	value,
+)
+
+
+#let	ratio(
+	quiet				:   false,
+	value,
+) = units(
+	units				: (
+		"%"				:   1%,
+	),
+	target				:   std.ratio,
+	quiet				:   quiet,
+	value,
+)
+
+
+#let	angle(
+	quiet				:   false,
+	value,
+) = units(
+	units				: (
+		"deg"				:   1deg,
+		"rad"				:   1rad,
+	),
+	target				:   std.angle,
+	quiet				:   quiet,
+	value,
+)
+
+

--- a/packages/preview/to-stuff/0.4.0/internals/utils.typ
+++ b/packages/preview/to-stuff/0.4.0/internals/utils.typ
@@ -1,0 +1,19 @@
+
+#let	list-predefined(type)		=   dictionary(std).pairs().filter(
+						x => std.type(x.last()) == type
+					).to-dict()
+
+#let	message-unexpected-keys(
+	found				: ( ),
+	valid				: ( ),
+	value,
+) = {
+	return "unexpected key/s “" + found.filter(x => x not in valid).join(
+		last				:  "”, and “",
+		"”, “",
+	) + "”; valid keys are “" + valid.join(
+		last				:  "”, and “",
+		"”, “",
+	) + "” in " + value
+}
+

--- a/packages/preview/to-stuff/0.4.0/typst.toml
+++ b/packages/preview/to-stuff/0.4.0/typst.toml
@@ -1,0 +1,30 @@
+[package]
+name				= 'to-stuff'
+version				= '0.4.0'
+compiler			= '0.13.1'
+repository			= 'https://codeberg.org/boondoc/typst-to-stuff'
+license				= 'BSD-3-Clause'
+entrypoint			= 'exports.typ'
+description			= 'Parse strings into typed lengths, alignments, colors, and more.'
+authors				= [
+	'Nik Mennega',
+]
+categories			= [
+	'scripting',
+	'utility',
+]
+keywords			= [
+	'string',
+	'parse',
+	'parsing',
+	'alignment',
+	'angle',
+	'color',
+	'direction',
+	'fraction',
+	'length',
+	'ratio',
+	'relative',
+	'stroke',
+]
+


### PR DESCRIPTION
I am submitting
- [x] an update for a package

Description:
- All use of `eval()` now entirely eliminated.
- Remove reliance on `eval()` from:
	- color
- Color conversion via constructor now checks validity of all arguments.
- Expose new conversions:
	- float
	- int
	- scalar (returns either float or int as appropriate)
- Stroke miter-limit now treated as scalar.
