### PR TITLE
Document the format of the `exclude` field in `typst.toml`

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -72,8 +72,8 @@ Optional:
   otherwise unnecessarily increase the bundle size. Don't exclude the README or
   the LICENSE, see [what to exclude]. Globs provided here have the same semantics
   as lines in a [gitignore file](https://git-scm.com/docs/gitignore). They are
-  applied _recursively_ throughout the entire project directory. Prepend a
-  forward slash (e.g., `/assets*/`) to avoid recursivity.
+  applied _recursively_ throughout the project directory. Prepend a forward
+  slash (e.g., `/assets*/`) to avoid recursive matching.
 
 Packages always live in folders named as `{name}/{version}`. The name and
 version in the folder name and manifest must match. Paths in a package are local


### PR DESCRIPTION
~~Resolves~~ Relates to #3617

~~I only provided two examples with a link to the git documentation.~~

I didn't mention details like `trim("./", at: start)`.
For those who have used git, it's sufficient to know that it's the gitignore format. For others, knowing ~~these two examples~~ the key point is enough.