### PR TITLE
Pull READMEs out of full index

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,5 +44,5 @@ jobs:
             --cache-control 'public, max-age=7776000' --put-md5
 
           azcopy_v10 cp --recursive ./dist/* "https://$ACCOUNT_NAME.blob.core.windows.net/\$web" \
-            --overwrite true --include-pattern '*.json' \
+            --overwrite true --include-pattern '*.json' --exclude-pattern '*index.full.json' \
             --cache-control 'must-revalidate' --put-md5

--- a/bundler/src/model.rs
+++ b/bundler/src/model.rs
@@ -28,12 +28,38 @@ impl From<&FullIndexPackageInfo> for IndexPackageInfo {
 /// A parsed package manifest + extra metadata.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FullIndexPackageInfo {
+pub struct ExtraIndexPackageInfo {
     /// The package information from the package manifest.
     #[serde(flatten)]
     pub package: PackageInfo,
     /// The template information from the package manifest.
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<TemplateInfo>,
+    /// The compressed archive size in bytes.
+    pub size: usize,
+    /// Release time of this version of the package.
+    pub updated_at: u64,
+    /// Release time of the first version of this package.
+    pub released_at: u64,
+}
+
+impl From<&FullIndexPackageInfo> for ExtraIndexPackageInfo {
+    fn from(info: &FullIndexPackageInfo) -> Self {
+        ExtraIndexPackageInfo {
+            package: info.package.clone(),
+            template: info.template.clone(),
+            size: info.size,
+            updated_at: info.updated_at,
+            released_at: info.released_at,
+        }
+    }
+}
+
+/// A parsed package manifest + extra metadata and the Readme.
+pub struct FullIndexPackageInfo {
+    /// The package information from the package manifest.
+    pub package: PackageInfo,
+    /// The template information from the package manifest.
     pub template: Option<TemplateInfo>,
     /// The compressed archive size in bytes.
     pub size: usize,


### PR DESCRIPTION
Aside from index.json, the bundler creates a second _full index,_ which is an implementation detail of typst.app. This index has grown to 18MB due to the READMEs included within. This makes it annoying to work with:

- Our CDN, Azure Front Door, does not automatically compress files larger than 8MB
- Downloads from JavaScript and WebKit spuriously fail due to keepalives
- The file occupies a relatively large amount of memory once loaded

Instead, we factor out the READMEs into their own folder that can be loaded on demand.

The new full index without the README field is called `index.extra.json`. To prevent disruption of running infrastructure, `index.full.json` is retained in storage but no longer updated. This exception can be removed soon. The new `readmes` folder is also an implementation detail of typst.app and should not be used by third parties.