### PR TITLE
irif:0.0.2

### DIFF
--- a/packages/preview/irif/0.0.2/LICENSE
+++ b/packages/preview/irif/0.0.2/LICENSE
@@ -1,0 +1,14 @@
+MIT No Attribution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/irif/0.0.2/README.md
+++ b/packages/preview/irif/0.0.2/README.md
@@ -1,0 +1,99 @@
+# irif
+A [Typst](https://typst.app/) package for Numerical Methods to find roots, gradients and areas of functions.
+Graph plotting for integrals built on top of [CeTZ](https://github.com/johannes-wolf/cetz).
+
+Examples can be found [here as a .pdf](examples/examples.pdf) and [here as .typ](examples/examples.typ).
+
+
+```typ
+#plot-integral(f_x:x=>calc.pow(calc.e,x)+1/(x - 2),
+             x0:0.5,
+             x1:1.8, 
+             size-x:3,
+             size-y:2,
+             label-a:"0.5",
+             label-b:"1.8",
+             n-strips:8)
+
+#nm-table-integrate(f_x:x=>calc.pow(calc.e,x)+1/(x - 2),
+                    x0:0.5,
+                    x1:1.8,
+                    show-diffs:false,
+                    n-rows:10)
+
+```
+
+Functions names are as follows: `nm-[operation type]-[method]`
+Creates the following functions:
+```typ
+#nm-differentiate-forward()
+#nm-differentiate-central()
+
+#nm-integrate-midpoint()
+#nm-integrate-trapezium()
+#nm-integrate-simpsons()
+#nm-integrate-simpsons-38()
+
+#nm-iterate-FPI()
+#nm-iterate-relaxed-FPI()
+#nm-iterate-newton-raphson()
+#nm-iterate-secant()
+#nm-iterate-false-position()
+#nm-iterate-bisection()
+
+#nm-table-integrate()
+#nm-table-differentiate()
+#nm-table-iterate()
+
+#plot-integral()
+```
+
+## nm-differentiation
+Differentiation tools take the following inputs/defaults:
+```typ
+f_x:x=>x*x, x0:1, h:1, accuracy:12
+```
+The function will approximate $f'(x_0)$ using either the Forward Difference or Central Difference method.
+
+## nm-integrate
+Integration tools take the following inputs/defaults:
+```typ
+f_x:x=>x*x, x0:0, x1:1, accuracy:12, n:1
+```
+These will approximate $\int_{x 0}^{x 1}(f_x(x))\text{d}x $
+
+Trapezium rule will return $T_n$, Midpoint rule will return $M_n$, Simpsons rule will return $S_{2n}$ and Simpsons-38 will return $S_{3n}$
+
+## nm-iterate
+These functions provide the root-finding methods Bisection, False Position, Secant, Newton Raphson, Fixed Point Iteration (FPI) and Relaxed Fixed Point Iteration.
+
+All functions take the parameter `f_x`, except FPI and Relaxed FPI, which take the function `g_x`.
+
+Bisection and False Position will return the region in which the root lies, whereas the others will return their nearest approximation.
+
+The parameter `return-all` can be made true to see every step of the iteration, rather than just the last one requested.
+
+*NOTE*: The Newton-Raphson method utilises the Central Difference gradient with `h = 0.0000000001` calculated to 15 decimal places. Thus it is not a true Newton-Raphson approximation.
+
+## nm-table
+These tables are useful for seeing or demonstrating convergence. They have been designed with the A Level Further Maths OCR MEI B specification in mind.
+
+By default, they will include the changing variable ($n$ or $h$ typically), as well as the approximation they have reached.
+
+Optionally, the differences between the estimates can be shown.
+
+If the differences are being shown, then the ratios between the differences can also be shown, with a customizeable order for iterative methods.
+
+*NOTE*: For exam purposes, differences and ratios are caluclated from the *table values*, which are rounded, rather than the greater precision stored values.
+
+## plot-integral
+Useful for demonstrating different types of numerical integration methods. Uses CeTZ to plot.
+
+The number of strips is customizable, and the method should be chosen from:
+
+`integral,mid,left,right,trapezium,simpsons,simpsons-38`
+
+If `integral` is chosen, or any non-listed input is given for the `method` variable, the function defaults to simply highlighting the area to be found.
+
+*NOTE*: Labels aren't in mathematical format, simply New Computer Modern Math font.
+

--- a/packages/preview/irif/0.0.2/examples/examples.pdf
+++ b/packages/preview/irif/0.0.2/examples/examples.pdf
@@ -1,0 +1,12797 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 5
+  /Kids [818 0 R 820 0 R 822 0 R 824 0 R 826 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Outlines
+  /First 3 0 R
+  /Last 12 0 R
+  /Count 5
+>>
+endobj
+
+3 0 obj
+<<
+  /Parent 2 0 R
+  /Next 4 0 R
+  /Title (#nm-integrate)
+  /Dest 804 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Parent 2 0 R
+  /Next 5 0 R
+  /Prev 3 0 R
+  /Title (#nm-differentiate)
+  /Dest 805 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Parent 2 0 R
+  /Next 9 0 R
+  /Prev 4 0 R
+  /First 6 0 R
+  /Last 8 0 R
+  /Count -3
+  /Title (#nm-iterate)
+  /Dest 809 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Parent 5 0 R
+  /Next 7 0 R
+  /Title (-FPI and -relaxed-FPI)
+  /Dest 806 0 R
+>>
+endobj
+
+7 0 obj
+<<
+  /Parent 5 0 R
+  /Next 8 0 R
+  /Prev 6 0 R
+  /Title (-newton-raphson)
+  /Dest 807 0 R
+>>
+endobj
+
+8 0 obj
+<<
+  /Parent 5 0 R
+  /Prev 7 0 R
+  /Title (-secant, -false-position, -bisection for sin(x)=0)
+  /Dest 808 0 R
+>>
+endobj
+
+9 0 obj
+<<
+  /Parent 2 0 R
+  /Next 12 0 R
+  /Prev 5 0 R
+  /First 10 0 R
+  /Last 11 0 R
+  /Count -2
+  /Title (nm-plot-integral)
+  /Dest 812 0 R
+>>
+endobj
+
+10 0 obj
+<<
+  /Parent 9 0 R
+  /Next 11 0 R
+  /Title (Limits: inc-0: true, inc-0: false)
+  /Dest 810 0 R
+>>
+endobj
+
+11 0 obj
+<<
+  /Parent 9 0 R
+  /Prev 10 0 R
+  /Title (n-strips: 1, 2, 4, 8, 16, 32)
+  /Dest 811 0 R
+>>
+endobj
+
+12 0 obj
+<<
+  /Parent 2 0 R
+  /Prev 9 0 R
+  /First 13 0 R
+  /Last 15 0 R
+  /Count -3
+  /Title (#nm-table)
+  /Dest 816 0 R
+>>
+endobj
+
+13 0 obj
+<<
+  /Parent 12 0 R
+  /Next 14 0 R
+  /Title (Integral Table, -integrate)
+  /Dest 813 0 R
+>>
+endobj
+
+14 0 obj
+<<
+  /Parent 12 0 R
+  /Next 15 0 R
+  /Prev 13 0 R
+  /Title (Differential Table, -differentiate)
+  /Dest 814 0 R
+>>
+endobj
+
+15 0 obj
+<<
+  /Parent 12 0 R
+  /Prev 14 0 R
+  /Title (Iteration Table, -iterate)
+  /Dest 815 0 R
+>>
+endobj
+
+16 0 obj
+<<
+  /Type /StructTreeRoot
+  /RoleMap <<
+    /Datetime /Span
+    /Terms /Part
+    /Title /P
+    /Strong /Span
+    /Em /Span
+  >>
+  /K [22 0 R]
+  /ParentTree <<
+    /Nums [0 17 0 R 1 18 0 R 2 19 0 R 3 20 0 R 4 21 0 R]
+  >>
+  /IDTree <<
+    /Names [(U10x0y0) 318 0 R (U10x1y0) 316 0 R (U10x2y0) 315 0 R (U10x3y0) 314 0 R (U11x0y0) 286 0 R (U11x1y0) 284 0 R (U11x2y0) 283 0 R (U11x3y0) 282 0 R (U12x0y0) 245 0 R (U12x1y0) 243 0 R (U12x2y0) 242 0 R (U12x3y0) 241 0 R (U13x0y0) 208 0 R (U13x1y0) 206 0 R (U13x2y0) 205 0 R (U13x3y0) 204 0 R (U14x0y0) 169 0 R (U14x1y0) 167 0 R (U14x2y0) 166 0 R (U14x3y0) 165 0 R (U15x0y0) 132 0 R (U15x1y0) 130 0 R (U15x2y0) 129 0 R (U15x3y0) 128 0 R (U16x0y0) 95 0 R (U16x1y0) 93 0 R (U16x2y0) 92 0 R (U16x3y0) 91 0 R (U17x0y0) 58 0 R (U17x1y0) 56 0 R (U17x2y0) 55 0 R (U17x3y0) 54 0 R (U1x0y0) 774 0 R (U1x1y0) 772 0 R (U1x2y0) 771 0 R (U1x3y0) 770 0 R (U1x4y0) 769 0 R (U1x5y0) 768 0 R (U2x0y0) 710 0 R (U2x1y0) 708 0 R (U2x2y0) 707 0 R (U2x3y0) 706 0 R (U3x0y0) 665 0 R (U3x1y0) 664 0 R (U3x2y0) 662 0 R (U3x3y0) 660 0 R (U4x0y0) 647 0 R (U4x0y1) 639 0 R (U4x0y2) 634 0 R (U4x0y3) 629 0 R (U4x0y4) 624 0 R (U4x0y5) 619 0 R (U4x0y6) 614 0 R (U4x0y7) 609 0 R (U4x0y8) 604 0 R (U4x0y9) 599 0 R (U4x1y0) 645 0 R (U4x1y1) 638 0 R (U4x1y2) 633 0 R (U4x1y3) 628 0 R (U4x1y4) 623 0 R (U4x1y5) 618 0 R (U4x1y6) 613 0 R (U4x1y7) 608 0 R (U4x1y8) 603 0 R (U4x1y9) 598 0 R (U4x2y0) 643 0 R (U4x2y1) 637 0 R (U4x2y2) 632 0 R (U4x2y3) 627 0 R (U4x2y4) 622 0 R (U4x2y5) 617 0 R (U4x2y6) 612 0 R (U4x2y7) 607 0 R (U4x2y8) 602 0 R (U4x2y9) 597 0 R (U4x3y0) 641 0 R (U4x3y1) 636 0 R (U4x3y2) 631 0 R (U4x3y3) 626 0 R (U4x3y4) 621 0 R (U4x3y5) 616 0 R (U4x3y6) 611 0 R (U4x3y7) 606 0 R (U4x3y8) 601 0 R (U4x3y9) 596 0 R (U5x0y0) 591 0 R (U5x1y0) 590 0 R (U6x0y0) 578 0 R (U6x1y0) 576 0 R (U6x2y0) 574 0 R (U7x0y0) 540 0 R (U7x1y0) 539 0 R (U7x2y0) 538 0 R (U7x3y0) 537 0 R (U8x0y0) 392 0 R (U8x1y0) 390 0 R (U8x2y0) 389 0 R (U8x3y0) 388 0 R (U9x0y0) 355 0 R (U9x1y0) 353 0 R (U9x2y0) 352 0 R (U9x3y0) 351 0 R]
+  >>
+  /ParentTreeNextKey 5
+>>
+endobj
+
+17 0 obj
+[775 0 R 774 0 R 773 0 R 771 0 R 770 0 R 769 0 R 768 0 R 763 0 R 762 0 R 761 0 R 760 0 R 759 0 R 757 0 R 756 0 R 755 0 R 754 0 R 753 0 R 751 0 R 750 0 R 749 0 R 748 0 R 747 0 R 765 0 R 765 0 R 764 0 R 745 0 R 744 0 R 743 0 R 742 0 R 741 0 R 737 0 R 736 0 R 735 0 R 734 0 R 733 0 R 731 0 R 730 0 R 729 0 R 728 0 R 727 0 R 725 0 R 724 0 R 723 0 R 722 0 R 721 0 R 739 0 R 739 0 R 739 0 R 738 0 R 719 0 R 718 0 R 717 0 R 716 0 R 715 0 R 711 0 R 710 0 R 709 0 R 707 0 R 706 0 R 701 0 R 699 0 R 698 0 R 696 0 R 696 0 R 696 0 R 694 0 R 693 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 703 0 R 691 0 R 691 0 R 691 0 R 691 0 R 689 0 R 688 0 R 684 0 R 682 0 R 681 0 R 679 0 R 679 0 R 679 0 R 677 0 R 676 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 686 0 R 674 0 R 674 0 R 674 0 R 674 0 R 672 0 R 671 0 R]
+endobj
+
+18 0 obj
+[667 0 R 666 0 R 665 0 R 664 0 R 662 0 R 663 0 R 663 0 R 663 0 R 663 0 R 663 0 R 660 0 R 661 0 R 661 0 R 661 0 R 661 0 R 661 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 657 0 R 655 0 R 654 0 R 653 0 R 649 0 R 648 0 R 645 0 R 646 0 R 646 0 R 643 0 R 644 0 R 644 0 R 644 0 R 644 0 R 644 0 R 641 0 R 642 0 R 642 0 R 642 0 R 642 0 R 642 0 R 639 0 R 638 0 R 637 0 R 636 0 R 634 0 R 633 0 R 632 0 R 631 0 R 629 0 R 628 0 R 627 0 R 626 0 R 624 0 R 623 0 R 622 0 R 621 0 R 619 0 R 618 0 R 617 0 R 616 0 R 614 0 R 613 0 R 612 0 R 611 0 R 609 0 R 608 0 R 607 0 R 606 0 R 604 0 R 603 0 R 602 0 R 601 0 R 599 0 R 598 0 R 597 0 R 596 0 R 593 0 R 592 0 R 591 0 R 590 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 587 0 R 585 0 R 585 0 R 580 0 R 579 0 R 576 0 R 577 0 R 577 0 R 577 0 R 577 0 R 574 0 R 575 0 R 575 0 R 575 0 R 575 0 R 575 0 R 571 0 R 570 0 R 569 0 R 567 0 R 566 0 R 565 0 R 563 0 R 562 0 R 561 0 R 559 0 R 558 0 R 557 0 R 555 0 R 554 0 R 553 0 R 551 0 R 550 0 R 549 0 R 542 0 R 543 0 R 543 0 R 543 0 R 543 0 R 543 0 R 543 0 R 541 0 R 539 0 R 538 0 R 537 0 R 534 0 R 534 0 R 534 0 R 534 0 R 534 0 R 534 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 532 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 530 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 528 0 R 525 0 R 525 0 R 525 0 R 525 0 R 525 0 R 525 0 R 525 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 523 0 R 521 0 R 520 0 R 518 0 R 518 0 R 518 0 R 518 0 R 518 0 R 518 0 R 518 0 R 518 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 516 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 514 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R 512 0 R]
+endobj
+
+19 0 obj
+[507 0 R 506 0 R 505 0 R 504 0 R 503 0 R 502 0 R 501 0 R 500 0 R 498 0 R 497 0 R 496 0 R 495 0 R 494 0 R 493 0 R 491 0 R 490 0 R 489 0 R 488 0 R 487 0 R 486 0 R 484 0 R 483 0 R 482 0 R 481 0 R 480 0 R 479 0 R 477 0 R 476 0 R 475 0 R 474 0 R 473 0 R 472 0 R 470 0 R 469 0 R 468 0 R 467 0 R 466 0 R 465 0 R 463 0 R 462 0 R 461 0 R 460 0 R 459 0 R 458 0 R 456 0 R 455 0 R 454 0 R 453 0 R 452 0 R 451 0 R 448 0 R 447 0 R 446 0 R 445 0 R 444 0 R 443 0 R 441 0 R 440 0 R 439 0 R 438 0 R 434 0 R 433 0 R 432 0 R 431 0 R 430 0 R 429 0 R 427 0 R 426 0 R 425 0 R 424 0 R 423 0 R 421 0 R 420 0 R 419 0 R 418 0 R 417 0 R 415 0 R 414 0 R 413 0 R 412 0 R 411 0 R 409 0 R 408 0 R 407 0 R 406 0 R 405 0 R 403 0 R 402 0 R 401 0 R 400 0 R 399 0 R]
+endobj
+
+20 0 obj
+[396 0 R 395 0 R 394 0 R 393 0 R 391 0 R 391 0 R 389 0 R 388 0 R 385 0 R 384 0 R 380 0 R 379 0 R 378 0 R 375 0 R 374 0 R 373 0 R 372 0 R 370 0 R 369 0 R 368 0 R 367 0 R 365 0 R 364 0 R 363 0 R 362 0 R 357 0 R 356 0 R 354 0 R 354 0 R 352 0 R 351 0 R 348 0 R 347 0 R 343 0 R 342 0 R 341 0 R 338 0 R 337 0 R 336 0 R 335 0 R 333 0 R 332 0 R 331 0 R 330 0 R 328 0 R 327 0 R 326 0 R 325 0 R 320 0 R 319 0 R 317 0 R 317 0 R 317 0 R 315 0 R 314 0 R 311 0 R 310 0 R 306 0 R 305 0 R 304 0 R 301 0 R 300 0 R 299 0 R 298 0 R 296 0 R 295 0 R 294 0 R 293 0 R 288 0 R 287 0 R 285 0 R 285 0 R 285 0 R 283 0 R 282 0 R 279 0 R 278 0 R 274 0 R 273 0 R 272 0 R 269 0 R 268 0 R 267 0 R 266 0 R 264 0 R 263 0 R 262 0 R 261 0 R 259 0 R 258 0 R 257 0 R 256 0 R 248 0 R 247 0 R 246 0 R 244 0 R 244 0 R 244 0 R 244 0 R 244 0 R 242 0 R 241 0 R 238 0 R 237 0 R 233 0 R 232 0 R 231 0 R 228 0 R 227 0 R 226 0 R 225 0 R 223 0 R 222 0 R 221 0 R 220 0 R 218 0 R 217 0 R 216 0 R 215 0 R 210 0 R 209 0 R 207 0 R 207 0 R 207 0 R 207 0 R 207 0 R 205 0 R 204 0 R 201 0 R 200 0 R 196 0 R 195 0 R 194 0 R 191 0 R 190 0 R 189 0 R 188 0 R 186 0 R 185 0 R 184 0 R 183 0 R 181 0 R 180 0 R 179 0 R 178 0 R 172 0 R 171 0 R 170 0 R 168 0 R 168 0 R 166 0 R 165 0 R 162 0 R 161 0 R 157 0 R 156 0 R 155 0 R 152 0 R 151 0 R 150 0 R 149 0 R 147 0 R 146 0 R 145 0 R 144 0 R 142 0 R 141 0 R 140 0 R 139 0 R 134 0 R 133 0 R 131 0 R 131 0 R 129 0 R 128 0 R 125 0 R 124 0 R 120 0 R 119 0 R 118 0 R 115 0 R 114 0 R 113 0 R 112 0 R 110 0 R 109 0 R 108 0 R 107 0 R 105 0 R 104 0 R 103 0 R 102 0 R 97 0 R 96 0 R 94 0 R 94 0 R 92 0 R 91 0 R 88 0 R 87 0 R 83 0 R 82 0 R 81 0 R 78 0 R 77 0 R 76 0 R 75 0 R 73 0 R 72 0 R 71 0 R 70 0 R 60 0 R 59 0 R 57 0 R 57 0 R 55 0 R 54 0 R 51 0 R 50 0 R 46 0 R 45 0 R 44 0 R 41 0 R 40 0 R 39 0 R 38 0 R 36 0 R 35 0 R 34 0 R 33 0 R]
+endobj
+
+21 0 obj
+[68 0 R 67 0 R 66 0 R 65 0 R 31 0 R 30 0 R 29 0 R 28 0 R]
+endobj
+
+22 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 16 0 R
+  /K [775 0 R 712 0 R 711 0 R 668 0 R 667 0 R 666 0 R 650 0 R 649 0 R 594 0 R 593 0 R 544 0 R 542 0 R 508 0 R 507 0 R 506 0 R 449 0 R 448 0 R 435 0 R 434 0 R 397 0 R 396 0 R 395 0 R 249 0 R 248 0 R 173 0 R 172 0 R 23 0 R]
+>>
+endobj
+
+23 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [135 0 R 98 0 R 61 0 R 24 0 R]
+>>
+endobj
+
+24 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K [60 0 R 25 0 R]
+>>
+endobj
+
+25 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 24 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [52 0 R 26 0 R]
+>>
+endobj
+
+26 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 25 0 R
+  /K [47 0 R 42 0 R 37 0 R 32 0 R 27 0 R]
+>>
+endobj
+
+27 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 26 0 R
+  /K [31 0 R 30 0 R 29 0 R 28 0 R]
+>>
+endobj
+
+28 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 27 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [7]
+  /Pg 826 0 R
+>>
+endobj
+
+29 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 27 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [6]
+  /Pg 826 0 R
+>>
+endobj
+
+30 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 27 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [5]
+  /Pg 826 0 R
+>>
+endobj
+
+31 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 27 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [4]
+  /Pg 826 0 R
+>>
+endobj
+
+32 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 26 0 R
+  /K [36 0 R 35 0 R 34 0 R 33 0 R]
+>>
+endobj
+
+33 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 32 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [229]
+  /Pg 824 0 R
+>>
+endobj
+
+34 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 32 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [228]
+  /Pg 824 0 R
+>>
+endobj
+
+35 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 32 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [227]
+  /Pg 824 0 R
+>>
+endobj
+
+36 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 32 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [226]
+  /Pg 824 0 R
+>>
+endobj
+
+37 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 26 0 R
+  /K [41 0 R 40 0 R 39 0 R 38 0 R]
+>>
+endobj
+
+38 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 37 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [225]
+  /Pg 824 0 R
+>>
+endobj
+
+39 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 37 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [224]
+  /Pg 824 0 R
+>>
+endobj
+
+40 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 37 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [223]
+  /Pg 824 0 R
+>>
+endobj
+
+41 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 37 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [222]
+  /Pg 824 0 R
+>>
+endobj
+
+42 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 26 0 R
+  /K [46 0 R 45 0 R 44 0 R 43 0 R]
+>>
+endobj
+
+43 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 42 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+44 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 42 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [221]
+  /Pg 824 0 R
+>>
+endobj
+
+45 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 42 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [220]
+  /Pg 824 0 R
+>>
+endobj
+
+46 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 42 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [219]
+  /Pg 824 0 R
+>>
+endobj
+
+47 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 26 0 R
+  /K [51 0 R 50 0 R 49 0 R 48 0 R]
+>>
+endobj
+
+48 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 47 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+49 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 47 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+50 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 47 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [218]
+  /Pg 824 0 R
+>>
+endobj
+
+51 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 47 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U17x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [217]
+  /Pg 824 0 R
+>>
+endobj
+
+52 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 25 0 R
+  /K [53 0 R]
+>>
+endobj
+
+53 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 52 0 R
+  /K [58 0 R 56 0 R 55 0 R 54 0 R]
+>>
+endobj
+
+54 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 53 0 R
+  /ID (U17x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [216]
+  /Pg 824 0 R
+>>
+endobj
+
+55 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 53 0 R
+  /ID (U17x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [215]
+  /Pg 824 0 R
+>>
+endobj
+
+56 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 53 0 R
+  /ID (U17x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [57 0 R]
+>>
+endobj
+
+57 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 56 0 R
+  /K [213 214]
+  /Pg 824 0 R
+>>
+endobj
+
+58 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 53 0 R
+  /ID (U17x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [59 0 R]
+>>
+endobj
+
+59 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 58 0 R
+  /K [212]
+  /Pg 824 0 R
+>>
+endobj
+
+60 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 24 0 R
+  /K [211]
+  /Pg 824 0 R
+>>
+endobj
+
+61 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K [97 0 R 62 0 R]
+>>
+endobj
+
+62 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 61 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [89 0 R 63 0 R]
+>>
+endobj
+
+63 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 62 0 R
+  /K [84 0 R 79 0 R 74 0 R 69 0 R 64 0 R]
+>>
+endobj
+
+64 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 63 0 R
+  /K [68 0 R 67 0 R 66 0 R 65 0 R]
+>>
+endobj
+
+65 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 64 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [3]
+  /Pg 826 0 R
+>>
+endobj
+
+66 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 64 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [2]
+  /Pg 826 0 R
+>>
+endobj
+
+67 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 64 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [1]
+  /Pg 826 0 R
+>>
+endobj
+
+68 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 64 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [0]
+  /Pg 826 0 R
+>>
+endobj
+
+69 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 63 0 R
+  /K [73 0 R 72 0 R 71 0 R 70 0 R]
+>>
+endobj
+
+70 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 69 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [210]
+  /Pg 824 0 R
+>>
+endobj
+
+71 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 69 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [209]
+  /Pg 824 0 R
+>>
+endobj
+
+72 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 69 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [208]
+  /Pg 824 0 R
+>>
+endobj
+
+73 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 69 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [207]
+  /Pg 824 0 R
+>>
+endobj
+
+74 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 63 0 R
+  /K [78 0 R 77 0 R 76 0 R 75 0 R]
+>>
+endobj
+
+75 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 74 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [206]
+  /Pg 824 0 R
+>>
+endobj
+
+76 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 74 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [205]
+  /Pg 824 0 R
+>>
+endobj
+
+77 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 74 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [204]
+  /Pg 824 0 R
+>>
+endobj
+
+78 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 74 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [203]
+  /Pg 824 0 R
+>>
+endobj
+
+79 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 63 0 R
+  /K [83 0 R 82 0 R 81 0 R 80 0 R]
+>>
+endobj
+
+80 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+81 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [202]
+  /Pg 824 0 R
+>>
+endobj
+
+82 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [201]
+  /Pg 824 0 R
+>>
+endobj
+
+83 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [200]
+  /Pg 824 0 R
+>>
+endobj
+
+84 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 63 0 R
+  /K [88 0 R 87 0 R 86 0 R 85 0 R]
+>>
+endobj
+
+85 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+86 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+87 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [199]
+  /Pg 824 0 R
+>>
+endobj
+
+88 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U16x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [198]
+  /Pg 824 0 R
+>>
+endobj
+
+89 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 62 0 R
+  /K [90 0 R]
+>>
+endobj
+
+90 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 89 0 R
+  /K [95 0 R 93 0 R 92 0 R 91 0 R]
+>>
+endobj
+
+91 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 90 0 R
+  /ID (U16x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [197]
+  /Pg 824 0 R
+>>
+endobj
+
+92 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 90 0 R
+  /ID (U16x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [196]
+  /Pg 824 0 R
+>>
+endobj
+
+93 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 90 0 R
+  /ID (U16x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [94 0 R]
+>>
+endobj
+
+94 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 93 0 R
+  /K [194 195]
+  /Pg 824 0 R
+>>
+endobj
+
+95 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 90 0 R
+  /ID (U16x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [96 0 R]
+>>
+endobj
+
+96 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 95 0 R
+  /K [193]
+  /Pg 824 0 R
+>>
+endobj
+
+97 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 61 0 R
+  /K [192]
+  /Pg 824 0 R
+>>
+endobj
+
+98 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K [134 0 R 99 0 R]
+>>
+endobj
+
+99 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 98 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [126 0 R 100 0 R]
+>>
+endobj
+
+100 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 99 0 R
+  /K [121 0 R 116 0 R 111 0 R 106 0 R 101 0 R]
+>>
+endobj
+
+101 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 100 0 R
+  /K [105 0 R 104 0 R 103 0 R 102 0 R]
+>>
+endobj
+
+102 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 101 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [191]
+  /Pg 824 0 R
+>>
+endobj
+
+103 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 101 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [190]
+  /Pg 824 0 R
+>>
+endobj
+
+104 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 101 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [189]
+  /Pg 824 0 R
+>>
+endobj
+
+105 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 101 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [188]
+  /Pg 824 0 R
+>>
+endobj
+
+106 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 100 0 R
+  /K [110 0 R 109 0 R 108 0 R 107 0 R]
+>>
+endobj
+
+107 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 106 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [187]
+  /Pg 824 0 R
+>>
+endobj
+
+108 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 106 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [186]
+  /Pg 824 0 R
+>>
+endobj
+
+109 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 106 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [185]
+  /Pg 824 0 R
+>>
+endobj
+
+110 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 106 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [184]
+  /Pg 824 0 R
+>>
+endobj
+
+111 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 100 0 R
+  /K [115 0 R 114 0 R 113 0 R 112 0 R]
+>>
+endobj
+
+112 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 111 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [183]
+  /Pg 824 0 R
+>>
+endobj
+
+113 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 111 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [182]
+  /Pg 824 0 R
+>>
+endobj
+
+114 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 111 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [181]
+  /Pg 824 0 R
+>>
+endobj
+
+115 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 111 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [180]
+  /Pg 824 0 R
+>>
+endobj
+
+116 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 100 0 R
+  /K [120 0 R 119 0 R 118 0 R 117 0 R]
+>>
+endobj
+
+117 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 116 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+118 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 116 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [179]
+  /Pg 824 0 R
+>>
+endobj
+
+119 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 116 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [178]
+  /Pg 824 0 R
+>>
+endobj
+
+120 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 116 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [177]
+  /Pg 824 0 R
+>>
+endobj
+
+121 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 100 0 R
+  /K [125 0 R 124 0 R 123 0 R 122 0 R]
+>>
+endobj
+
+122 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 121 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+123 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 121 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+124 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 121 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [176]
+  /Pg 824 0 R
+>>
+endobj
+
+125 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 121 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U15x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [175]
+  /Pg 824 0 R
+>>
+endobj
+
+126 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 99 0 R
+  /K [127 0 R]
+>>
+endobj
+
+127 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 126 0 R
+  /K [132 0 R 130 0 R 129 0 R 128 0 R]
+>>
+endobj
+
+128 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 127 0 R
+  /ID (U15x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [174]
+  /Pg 824 0 R
+>>
+endobj
+
+129 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 127 0 R
+  /ID (U15x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [173]
+  /Pg 824 0 R
+>>
+endobj
+
+130 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 127 0 R
+  /ID (U15x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [131 0 R]
+>>
+endobj
+
+131 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 130 0 R
+  /K [171 172]
+  /Pg 824 0 R
+>>
+endobj
+
+132 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 127 0 R
+  /ID (U15x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [133 0 R]
+>>
+endobj
+
+133 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 132 0 R
+  /K [170]
+  /Pg 824 0 R
+>>
+endobj
+
+134 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 98 0 R
+  /K [169]
+  /Pg 824 0 R
+>>
+endobj
+
+135 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K [171 0 R 136 0 R]
+>>
+endobj
+
+136 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 135 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [163 0 R 137 0 R]
+>>
+endobj
+
+137 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 136 0 R
+  /K [158 0 R 153 0 R 148 0 R 143 0 R 138 0 R]
+>>
+endobj
+
+138 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 137 0 R
+  /K [142 0 R 141 0 R 140 0 R 139 0 R]
+>>
+endobj
+
+139 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 138 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [168]
+  /Pg 824 0 R
+>>
+endobj
+
+140 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 138 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [167]
+  /Pg 824 0 R
+>>
+endobj
+
+141 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 138 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [166]
+  /Pg 824 0 R
+>>
+endobj
+
+142 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 138 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [165]
+  /Pg 824 0 R
+>>
+endobj
+
+143 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 137 0 R
+  /K [147 0 R 146 0 R 145 0 R 144 0 R]
+>>
+endobj
+
+144 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 143 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [164]
+  /Pg 824 0 R
+>>
+endobj
+
+145 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 143 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [163]
+  /Pg 824 0 R
+>>
+endobj
+
+146 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 143 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [162]
+  /Pg 824 0 R
+>>
+endobj
+
+147 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 143 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [161]
+  /Pg 824 0 R
+>>
+endobj
+
+148 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 137 0 R
+  /K [152 0 R 151 0 R 150 0 R 149 0 R]
+>>
+endobj
+
+149 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 148 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [160]
+  /Pg 824 0 R
+>>
+endobj
+
+150 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 148 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [159]
+  /Pg 824 0 R
+>>
+endobj
+
+151 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 148 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [158]
+  /Pg 824 0 R
+>>
+endobj
+
+152 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 148 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [157]
+  /Pg 824 0 R
+>>
+endobj
+
+153 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 137 0 R
+  /K [157 0 R 156 0 R 155 0 R 154 0 R]
+>>
+endobj
+
+154 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 153 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+155 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 153 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [156]
+  /Pg 824 0 R
+>>
+endobj
+
+156 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 153 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [155]
+  /Pg 824 0 R
+>>
+endobj
+
+157 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 153 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [154]
+  /Pg 824 0 R
+>>
+endobj
+
+158 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 137 0 R
+  /K [162 0 R 161 0 R 160 0 R 159 0 R]
+>>
+endobj
+
+159 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 158 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+160 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 158 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+161 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 158 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [153]
+  /Pg 824 0 R
+>>
+endobj
+
+162 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 158 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U14x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [152]
+  /Pg 824 0 R
+>>
+endobj
+
+163 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 136 0 R
+  /K [164 0 R]
+>>
+endobj
+
+164 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 163 0 R
+  /K [169 0 R 167 0 R 166 0 R 165 0 R]
+>>
+endobj
+
+165 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 164 0 R
+  /ID (U14x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [151]
+  /Pg 824 0 R
+>>
+endobj
+
+166 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 164 0 R
+  /ID (U14x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [150]
+  /Pg 824 0 R
+>>
+endobj
+
+167 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 164 0 R
+  /ID (U14x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [168 0 R]
+>>
+endobj
+
+168 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [148 149]
+  /Pg 824 0 R
+>>
+endobj
+
+169 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 164 0 R
+  /ID (U14x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [170 0 R]
+>>
+endobj
+
+170 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 169 0 R
+  /K [147]
+  /Pg 824 0 R
+>>
+endobj
+
+171 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 135 0 R
+  /K [146]
+  /Pg 824 0 R
+>>
+endobj
+
+172 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (Iteration Table, -iterate)
+  /K [145]
+  /Pg 824 0 R
+>>
+endobj
+
+173 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [211 0 R 174 0 R]
+>>
+endobj
+
+174 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 173 0 R
+  /K [210 0 R 175 0 R]
+>>
+endobj
+
+175 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 174 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [202 0 R 176 0 R]
+>>
+endobj
+
+176 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 175 0 R
+  /K [197 0 R 192 0 R 187 0 R 182 0 R 177 0 R]
+>>
+endobj
+
+177 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 176 0 R
+  /K [181 0 R 180 0 R 179 0 R 178 0 R]
+>>
+endobj
+
+178 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 177 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [144]
+  /Pg 824 0 R
+>>
+endobj
+
+179 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 177 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [143]
+  /Pg 824 0 R
+>>
+endobj
+
+180 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 177 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [142]
+  /Pg 824 0 R
+>>
+endobj
+
+181 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 177 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [141]
+  /Pg 824 0 R
+>>
+endobj
+
+182 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 176 0 R
+  /K [186 0 R 185 0 R 184 0 R 183 0 R]
+>>
+endobj
+
+183 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 182 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [140]
+  /Pg 824 0 R
+>>
+endobj
+
+184 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 182 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [139]
+  /Pg 824 0 R
+>>
+endobj
+
+185 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 182 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [138]
+  /Pg 824 0 R
+>>
+endobj
+
+186 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 182 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [137]
+  /Pg 824 0 R
+>>
+endobj
+
+187 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 176 0 R
+  /K [191 0 R 190 0 R 189 0 R 188 0 R]
+>>
+endobj
+
+188 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 187 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [136]
+  /Pg 824 0 R
+>>
+endobj
+
+189 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 187 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [135]
+  /Pg 824 0 R
+>>
+endobj
+
+190 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 187 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [134]
+  /Pg 824 0 R
+>>
+endobj
+
+191 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 187 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [133]
+  /Pg 824 0 R
+>>
+endobj
+
+192 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 176 0 R
+  /K [196 0 R 195 0 R 194 0 R 193 0 R]
+>>
+endobj
+
+193 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 192 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+194 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 192 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [132]
+  /Pg 824 0 R
+>>
+endobj
+
+195 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 192 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [131]
+  /Pg 824 0 R
+>>
+endobj
+
+196 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 192 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [130]
+  /Pg 824 0 R
+>>
+endobj
+
+197 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 176 0 R
+  /K [201 0 R 200 0 R 199 0 R 198 0 R]
+>>
+endobj
+
+198 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 197 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+199 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 197 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+200 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 197 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [129]
+  /Pg 824 0 R
+>>
+endobj
+
+201 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 197 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U13x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [128]
+  /Pg 824 0 R
+>>
+endobj
+
+202 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 175 0 R
+  /K [203 0 R]
+>>
+endobj
+
+203 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 202 0 R
+  /K [208 0 R 206 0 R 205 0 R 204 0 R]
+>>
+endobj
+
+204 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 203 0 R
+  /ID (U13x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [127]
+  /Pg 824 0 R
+>>
+endobj
+
+205 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 203 0 R
+  /ID (U13x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [126]
+  /Pg 824 0 R
+>>
+endobj
+
+206 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 203 0 R
+  /ID (U13x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [207 0 R]
+>>
+endobj
+
+207 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 206 0 R
+  /K [121 122 123 124 125]
+  /Pg 824 0 R
+>>
+endobj
+
+208 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 203 0 R
+  /ID (U13x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [209 0 R]
+>>
+endobj
+
+209 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 208 0 R
+  /K [120]
+  /Pg 824 0 R
+>>
+endobj
+
+210 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 174 0 R
+  /K [119]
+  /Pg 824 0 R
+>>
+endobj
+
+211 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 173 0 R
+  /K [247 0 R 212 0 R]
+>>
+endobj
+
+212 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 211 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [239 0 R 213 0 R]
+>>
+endobj
+
+213 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 212 0 R
+  /K [234 0 R 229 0 R 224 0 R 219 0 R 214 0 R]
+>>
+endobj
+
+214 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 213 0 R
+  /K [218 0 R 217 0 R 216 0 R 215 0 R]
+>>
+endobj
+
+215 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 214 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [118]
+  /Pg 824 0 R
+>>
+endobj
+
+216 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 214 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [117]
+  /Pg 824 0 R
+>>
+endobj
+
+217 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 214 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [116]
+  /Pg 824 0 R
+>>
+endobj
+
+218 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 214 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [115]
+  /Pg 824 0 R
+>>
+endobj
+
+219 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 213 0 R
+  /K [223 0 R 222 0 R 221 0 R 220 0 R]
+>>
+endobj
+
+220 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 219 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [114]
+  /Pg 824 0 R
+>>
+endobj
+
+221 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 219 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [113]
+  /Pg 824 0 R
+>>
+endobj
+
+222 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 219 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [112]
+  /Pg 824 0 R
+>>
+endobj
+
+223 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 219 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [111]
+  /Pg 824 0 R
+>>
+endobj
+
+224 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 213 0 R
+  /K [228 0 R 227 0 R 226 0 R 225 0 R]
+>>
+endobj
+
+225 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 224 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [110]
+  /Pg 824 0 R
+>>
+endobj
+
+226 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 224 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [109]
+  /Pg 824 0 R
+>>
+endobj
+
+227 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 224 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [108]
+  /Pg 824 0 R
+>>
+endobj
+
+228 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 224 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [107]
+  /Pg 824 0 R
+>>
+endobj
+
+229 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 213 0 R
+  /K [233 0 R 232 0 R 231 0 R 230 0 R]
+>>
+endobj
+
+230 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 229 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+231 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 229 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [106]
+  /Pg 824 0 R
+>>
+endobj
+
+232 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 229 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [105]
+  /Pg 824 0 R
+>>
+endobj
+
+233 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 229 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [104]
+  /Pg 824 0 R
+>>
+endobj
+
+234 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 213 0 R
+  /K [238 0 R 237 0 R 236 0 R 235 0 R]
+>>
+endobj
+
+235 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 234 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+236 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 234 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+237 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 234 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [103]
+  /Pg 824 0 R
+>>
+endobj
+
+238 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 234 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U12x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [102]
+  /Pg 824 0 R
+>>
+endobj
+
+239 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 212 0 R
+  /K [240 0 R]
+>>
+endobj
+
+240 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 239 0 R
+  /K [245 0 R 243 0 R 242 0 R 241 0 R]
+>>
+endobj
+
+241 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 240 0 R
+  /ID (U12x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [101]
+  /Pg 824 0 R
+>>
+endobj
+
+242 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 240 0 R
+  /ID (U12x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [100]
+  /Pg 824 0 R
+>>
+endobj
+
+243 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 240 0 R
+  /ID (U12x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [244 0 R]
+>>
+endobj
+
+244 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 243 0 R
+  /K [95 96 97 98 99]
+  /Pg 824 0 R
+>>
+endobj
+
+245 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 240 0 R
+  /ID (U12x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [246 0 R]
+>>
+endobj
+
+246 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 245 0 R
+  /K [94]
+  /Pg 824 0 R
+>>
+endobj
+
+247 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 211 0 R
+  /K [93]
+  /Pg 824 0 R
+>>
+endobj
+
+248 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (Differential Table, -differentiate)
+  /K [92]
+  /Pg 824 0 R
+>>
+endobj
+
+249 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [358 0 R 321 0 R 289 0 R 252 0 R 251 0 R 250 0 R]
+>>
+endobj
+
+250 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 249 0 R
+  /K []
+>>
+endobj
+
+251 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 249 0 R
+  /K []
+>>
+endobj
+
+252 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 249 0 R
+  /K [288 0 R 253 0 R]
+>>
+endobj
+
+253 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 252 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [280 0 R 254 0 R]
+>>
+endobj
+
+254 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 253 0 R
+  /K [275 0 R 270 0 R 265 0 R 260 0 R 255 0 R]
+>>
+endobj
+
+255 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 254 0 R
+  /K [259 0 R 258 0 R 257 0 R 256 0 R]
+>>
+endobj
+
+256 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 255 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [91]
+  /Pg 824 0 R
+>>
+endobj
+
+257 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 255 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [90]
+  /Pg 824 0 R
+>>
+endobj
+
+258 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 255 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [89]
+  /Pg 824 0 R
+>>
+endobj
+
+259 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 255 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [88]
+  /Pg 824 0 R
+>>
+endobj
+
+260 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 254 0 R
+  /K [264 0 R 263 0 R 262 0 R 261 0 R]
+>>
+endobj
+
+261 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 260 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [87]
+  /Pg 824 0 R
+>>
+endobj
+
+262 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 260 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [86]
+  /Pg 824 0 R
+>>
+endobj
+
+263 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 260 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [85]
+  /Pg 824 0 R
+>>
+endobj
+
+264 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 260 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [84]
+  /Pg 824 0 R
+>>
+endobj
+
+265 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 254 0 R
+  /K [269 0 R 268 0 R 267 0 R 266 0 R]
+>>
+endobj
+
+266 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 265 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [83]
+  /Pg 824 0 R
+>>
+endobj
+
+267 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 265 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [82]
+  /Pg 824 0 R
+>>
+endobj
+
+268 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 265 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [81]
+  /Pg 824 0 R
+>>
+endobj
+
+269 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 265 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [80]
+  /Pg 824 0 R
+>>
+endobj
+
+270 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 254 0 R
+  /K [274 0 R 273 0 R 272 0 R 271 0 R]
+>>
+endobj
+
+271 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 270 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+272 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 270 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [79]
+  /Pg 824 0 R
+>>
+endobj
+
+273 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 270 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [78]
+  /Pg 824 0 R
+>>
+endobj
+
+274 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 270 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [77]
+  /Pg 824 0 R
+>>
+endobj
+
+275 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 254 0 R
+  /K [279 0 R 278 0 R 277 0 R 276 0 R]
+>>
+endobj
+
+276 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 275 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+277 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 275 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+278 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 275 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [76]
+  /Pg 824 0 R
+>>
+endobj
+
+279 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 275 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U11x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [75]
+  /Pg 824 0 R
+>>
+endobj
+
+280 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 253 0 R
+  /K [281 0 R]
+>>
+endobj
+
+281 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 280 0 R
+  /K [286 0 R 284 0 R 283 0 R 282 0 R]
+>>
+endobj
+
+282 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 281 0 R
+  /ID (U11x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [74]
+  /Pg 824 0 R
+>>
+endobj
+
+283 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 281 0 R
+  /ID (U11x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [73]
+  /Pg 824 0 R
+>>
+endobj
+
+284 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 281 0 R
+  /ID (U11x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [285 0 R]
+>>
+endobj
+
+285 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 284 0 R
+  /K [70 71 72]
+  /Pg 824 0 R
+>>
+endobj
+
+286 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 281 0 R
+  /ID (U11x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [287 0 R]
+>>
+endobj
+
+287 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 286 0 R
+  /K [69]
+  /Pg 824 0 R
+>>
+endobj
+
+288 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 252 0 R
+  /K [68]
+  /Pg 824 0 R
+>>
+endobj
+
+289 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 249 0 R
+  /K [320 0 R 290 0 R]
+>>
+endobj
+
+290 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 289 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [312 0 R 291 0 R]
+>>
+endobj
+
+291 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 290 0 R
+  /K [307 0 R 302 0 R 297 0 R 292 0 R]
+>>
+endobj
+
+292 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 291 0 R
+  /K [296 0 R 295 0 R 294 0 R 293 0 R]
+>>
+endobj
+
+293 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 292 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [67]
+  /Pg 824 0 R
+>>
+endobj
+
+294 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 292 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [66]
+  /Pg 824 0 R
+>>
+endobj
+
+295 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 292 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [65]
+  /Pg 824 0 R
+>>
+endobj
+
+296 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 292 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [64]
+  /Pg 824 0 R
+>>
+endobj
+
+297 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 291 0 R
+  /K [301 0 R 300 0 R 299 0 R 298 0 R]
+>>
+endobj
+
+298 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 297 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [63]
+  /Pg 824 0 R
+>>
+endobj
+
+299 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 297 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [62]
+  /Pg 824 0 R
+>>
+endobj
+
+300 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 297 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [61]
+  /Pg 824 0 R
+>>
+endobj
+
+301 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 297 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [60]
+  /Pg 824 0 R
+>>
+endobj
+
+302 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 291 0 R
+  /K [306 0 R 305 0 R 304 0 R 303 0 R]
+>>
+endobj
+
+303 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 302 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+304 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 302 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [59]
+  /Pg 824 0 R
+>>
+endobj
+
+305 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 302 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [58]
+  /Pg 824 0 R
+>>
+endobj
+
+306 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 302 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [57]
+  /Pg 824 0 R
+>>
+endobj
+
+307 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 291 0 R
+  /K [311 0 R 310 0 R 309 0 R 308 0 R]
+>>
+endobj
+
+308 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 307 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+309 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 307 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+310 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 307 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [56]
+  /Pg 824 0 R
+>>
+endobj
+
+311 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 307 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U10x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [55]
+  /Pg 824 0 R
+>>
+endobj
+
+312 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 290 0 R
+  /K [313 0 R]
+>>
+endobj
+
+313 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 312 0 R
+  /K [318 0 R 316 0 R 315 0 R 314 0 R]
+>>
+endobj
+
+314 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 313 0 R
+  /ID (U10x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [54]
+  /Pg 824 0 R
+>>
+endobj
+
+315 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 313 0 R
+  /ID (U10x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [53]
+  /Pg 824 0 R
+>>
+endobj
+
+316 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 313 0 R
+  /ID (U10x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [317 0 R]
+>>
+endobj
+
+317 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 316 0 R
+  /K [50 51 52]
+  /Pg 824 0 R
+>>
+endobj
+
+318 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 313 0 R
+  /ID (U10x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [319 0 R]
+>>
+endobj
+
+319 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 318 0 R
+  /K [49]
+  /Pg 824 0 R
+>>
+endobj
+
+320 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 289 0 R
+  /K [48]
+  /Pg 824 0 R
+>>
+endobj
+
+321 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 249 0 R
+  /K [357 0 R 322 0 R]
+>>
+endobj
+
+322 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 321 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [349 0 R 323 0 R]
+>>
+endobj
+
+323 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 322 0 R
+  /K [344 0 R 339 0 R 334 0 R 329 0 R 324 0 R]
+>>
+endobj
+
+324 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 323 0 R
+  /K [328 0 R 327 0 R 326 0 R 325 0 R]
+>>
+endobj
+
+325 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 324 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [47]
+  /Pg 824 0 R
+>>
+endobj
+
+326 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 324 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [46]
+  /Pg 824 0 R
+>>
+endobj
+
+327 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 324 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [45]
+  /Pg 824 0 R
+>>
+endobj
+
+328 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 324 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [44]
+  /Pg 824 0 R
+>>
+endobj
+
+329 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 323 0 R
+  /K [333 0 R 332 0 R 331 0 R 330 0 R]
+>>
+endobj
+
+330 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 329 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [43]
+  /Pg 824 0 R
+>>
+endobj
+
+331 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 329 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [42]
+  /Pg 824 0 R
+>>
+endobj
+
+332 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 329 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [41]
+  /Pg 824 0 R
+>>
+endobj
+
+333 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 329 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [40]
+  /Pg 824 0 R
+>>
+endobj
+
+334 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 323 0 R
+  /K [338 0 R 337 0 R 336 0 R 335 0 R]
+>>
+endobj
+
+335 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 334 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [39]
+  /Pg 824 0 R
+>>
+endobj
+
+336 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 334 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [38]
+  /Pg 824 0 R
+>>
+endobj
+
+337 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 334 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [37]
+  /Pg 824 0 R
+>>
+endobj
+
+338 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 334 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [36]
+  /Pg 824 0 R
+>>
+endobj
+
+339 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 323 0 R
+  /K [343 0 R 342 0 R 341 0 R 340 0 R]
+>>
+endobj
+
+340 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 339 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+341 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 339 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [35]
+  /Pg 824 0 R
+>>
+endobj
+
+342 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 339 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [34]
+  /Pg 824 0 R
+>>
+endobj
+
+343 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 339 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [33]
+  /Pg 824 0 R
+>>
+endobj
+
+344 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 323 0 R
+  /K [348 0 R 347 0 R 346 0 R 345 0 R]
+>>
+endobj
+
+345 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 344 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+346 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 344 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+347 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 344 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [32]
+  /Pg 824 0 R
+>>
+endobj
+
+348 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 344 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U9x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [31]
+  /Pg 824 0 R
+>>
+endobj
+
+349 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 322 0 R
+  /K [350 0 R]
+>>
+endobj
+
+350 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 349 0 R
+  /K [355 0 R 353 0 R 352 0 R 351 0 R]
+>>
+endobj
+
+351 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 350 0 R
+  /ID (U9x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [30]
+  /Pg 824 0 R
+>>
+endobj
+
+352 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 350 0 R
+  /ID (U9x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [29]
+  /Pg 824 0 R
+>>
+endobj
+
+353 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 350 0 R
+  /ID (U9x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [354 0 R]
+>>
+endobj
+
+354 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 353 0 R
+  /K [27 28]
+  /Pg 824 0 R
+>>
+endobj
+
+355 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 350 0 R
+  /ID (U9x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [356 0 R]
+>>
+endobj
+
+356 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 355 0 R
+  /K [26]
+  /Pg 824 0 R
+>>
+endobj
+
+357 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 321 0 R
+  /K [25]
+  /Pg 824 0 R
+>>
+endobj
+
+358 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 249 0 R
+  /K [394 0 R 359 0 R]
+>>
+endobj
+
+359 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 358 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [386 0 R 360 0 R]
+>>
+endobj
+
+360 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 359 0 R
+  /K [381 0 R 376 0 R 371 0 R 366 0 R 361 0 R]
+>>
+endobj
+
+361 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 360 0 R
+  /K [365 0 R 364 0 R 363 0 R 362 0 R]
+>>
+endobj
+
+362 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 361 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [24]
+  /Pg 824 0 R
+>>
+endobj
+
+363 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 361 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [23]
+  /Pg 824 0 R
+>>
+endobj
+
+364 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 361 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [22]
+  /Pg 824 0 R
+>>
+endobj
+
+365 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 361 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [21]
+  /Pg 824 0 R
+>>
+endobj
+
+366 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 360 0 R
+  /K [370 0 R 369 0 R 368 0 R 367 0 R]
+>>
+endobj
+
+367 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 366 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [20]
+  /Pg 824 0 R
+>>
+endobj
+
+368 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 366 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [19]
+  /Pg 824 0 R
+>>
+endobj
+
+369 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 366 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [18]
+  /Pg 824 0 R
+>>
+endobj
+
+370 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 366 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [17]
+  /Pg 824 0 R
+>>
+endobj
+
+371 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 360 0 R
+  /K [375 0 R 374 0 R 373 0 R 372 0 R]
+>>
+endobj
+
+372 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 371 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [16]
+  /Pg 824 0 R
+>>
+endobj
+
+373 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 371 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [15]
+  /Pg 824 0 R
+>>
+endobj
+
+374 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 371 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [14]
+  /Pg 824 0 R
+>>
+endobj
+
+375 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 371 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [13]
+  /Pg 824 0 R
+>>
+endobj
+
+376 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 360 0 R
+  /K [380 0 R 379 0 R 378 0 R 377 0 R]
+>>
+endobj
+
+377 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 376 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+378 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 376 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [12]
+  /Pg 824 0 R
+>>
+endobj
+
+379 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 376 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [11]
+  /Pg 824 0 R
+>>
+endobj
+
+380 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 376 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [10]
+  /Pg 824 0 R
+>>
+endobj
+
+381 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 360 0 R
+  /K [385 0 R 384 0 R 383 0 R 382 0 R]
+>>
+endobj
+
+382 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 381 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+383 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 381 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K []
+>>
+endobj
+
+384 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 381 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [9]
+  /Pg 824 0 R
+>>
+endobj
+
+385 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 381 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U8x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [8]
+  /Pg 824 0 R
+>>
+endobj
+
+386 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 359 0 R
+  /K [387 0 R]
+>>
+endobj
+
+387 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 386 0 R
+  /K [392 0 R 390 0 R 389 0 R 388 0 R]
+>>
+endobj
+
+388 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 387 0 R
+  /ID (U8x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [7]
+  /Pg 824 0 R
+>>
+endobj
+
+389 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 387 0 R
+  /ID (U8x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [6]
+  /Pg 824 0 R
+>>
+endobj
+
+390 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 387 0 R
+  /ID (U8x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [391 0 R]
+>>
+endobj
+
+391 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 390 0 R
+  /K [4 5]
+  /Pg 824 0 R
+>>
+endobj
+
+392 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 387 0 R
+  /ID (U8x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [393 0 R]
+>>
+endobj
+
+393 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 392 0 R
+  /K [3]
+  /Pg 824 0 R
+>>
+endobj
+
+394 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 358 0 R
+  /K [2]
+  /Pg 824 0 R
+>>
+endobj
+
+395 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (Integral Table, -integrate)
+  /K [1]
+  /Pg 824 0 R
+>>
+endobj
+
+396 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (#nm-table)
+  /K [0]
+  /Pg 824 0 R
+>>
+endobj
+
+397 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [428 0 R 422 0 R 416 0 R 410 0 R 404 0 R 398 0 R]
+>>
+endobj
+
+398 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 397 0 R
+  /K [403 0 R 402 0 R 401 0 R 400 0 R 399 0 R]
+>>
+endobj
+
+399 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 398 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [90]
+  /Pg 822 0 R
+>>
+endobj
+
+400 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 398 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [89]
+  /Pg 822 0 R
+>>
+endobj
+
+401 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 398 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [88]
+  /Pg 822 0 R
+>>
+endobj
+
+402 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 398 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [87]
+  /Pg 822 0 R
+>>
+endobj
+
+403 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 398 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [86]
+  /Pg 822 0 R
+>>
+endobj
+
+404 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 397 0 R
+  /K [409 0 R 408 0 R 407 0 R 406 0 R 405 0 R]
+>>
+endobj
+
+405 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 404 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [85]
+  /Pg 822 0 R
+>>
+endobj
+
+406 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 404 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [84]
+  /Pg 822 0 R
+>>
+endobj
+
+407 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 404 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [83]
+  /Pg 822 0 R
+>>
+endobj
+
+408 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 404 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [82]
+  /Pg 822 0 R
+>>
+endobj
+
+409 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 404 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [81]
+  /Pg 822 0 R
+>>
+endobj
+
+410 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 397 0 R
+  /K [415 0 R 414 0 R 413 0 R 412 0 R 411 0 R]
+>>
+endobj
+
+411 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 410 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [80]
+  /Pg 822 0 R
+>>
+endobj
+
+412 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 410 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [79]
+  /Pg 822 0 R
+>>
+endobj
+
+413 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 410 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [78]
+  /Pg 822 0 R
+>>
+endobj
+
+414 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 410 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [77]
+  /Pg 822 0 R
+>>
+endobj
+
+415 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 410 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [76]
+  /Pg 822 0 R
+>>
+endobj
+
+416 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 397 0 R
+  /K [421 0 R 420 0 R 419 0 R 418 0 R 417 0 R]
+>>
+endobj
+
+417 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 416 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [75]
+  /Pg 822 0 R
+>>
+endobj
+
+418 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 416 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [74]
+  /Pg 822 0 R
+>>
+endobj
+
+419 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 416 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [73]
+  /Pg 822 0 R
+>>
+endobj
+
+420 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 416 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [72]
+  /Pg 822 0 R
+>>
+endobj
+
+421 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 416 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [71]
+  /Pg 822 0 R
+>>
+endobj
+
+422 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 397 0 R
+  /K [427 0 R 426 0 R 425 0 R 424 0 R 423 0 R]
+>>
+endobj
+
+423 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 422 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [70]
+  /Pg 822 0 R
+>>
+endobj
+
+424 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 422 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [69]
+  /Pg 822 0 R
+>>
+endobj
+
+425 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 422 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [68]
+  /Pg 822 0 R
+>>
+endobj
+
+426 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 422 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [67]
+  /Pg 822 0 R
+>>
+endobj
+
+427 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 422 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [66]
+  /Pg 822 0 R
+>>
+endobj
+
+428 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 397 0 R
+  /K [433 0 R 432 0 R 431 0 R 430 0 R 429 0 R]
+>>
+endobj
+
+429 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 428 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [65]
+  /Pg 822 0 R
+>>
+endobj
+
+430 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 428 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [64]
+  /Pg 822 0 R
+>>
+endobj
+
+431 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 428 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [63]
+  /Pg 822 0 R
+>>
+endobj
+
+432 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 428 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [62]
+  /Pg 822 0 R
+>>
+endobj
+
+433 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 428 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [61]
+  /Pg 822 0 R
+>>
+endobj
+
+434 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (n-strips: 1, 2, 4, 8, 16, 32)
+  /K [60]
+  /Pg 822 0 R
+>>
+endobj
+
+435 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [442 0 R 437 0 R 436 0 R]
+>>
+endobj
+
+436 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 435 0 R
+  /K []
+>>
+endobj
+
+437 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 435 0 R
+  /K [441 0 R 440 0 R 439 0 R 438 0 R]
+>>
+endobj
+
+438 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 437 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [59]
+  /Pg 822 0 R
+>>
+endobj
+
+439 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 437 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [58]
+  /Pg 822 0 R
+>>
+endobj
+
+440 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 437 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [57]
+  /Pg 822 0 R
+>>
+endobj
+
+441 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 437 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [56]
+  /Pg 822 0 R
+>>
+endobj
+
+442 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 435 0 R
+  /K [447 0 R 446 0 R 445 0 R 444 0 R 443 0 R]
+>>
+endobj
+
+443 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 442 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [55]
+  /Pg 822 0 R
+>>
+endobj
+
+444 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 442 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [54]
+  /Pg 822 0 R
+>>
+endobj
+
+445 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 442 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [53]
+  /Pg 822 0 R
+>>
+endobj
+
+446 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 442 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [52]
+  /Pg 822 0 R
+>>
+endobj
+
+447 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 442 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [51]
+  /Pg 822 0 R
+>>
+endobj
+
+448 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (Limits: inc-0: true, inc-0: false)
+  /K [50]
+  /Pg 822 0 R
+>>
+endobj
+
+449 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [499 0 R 492 0 R 485 0 R 478 0 R 471 0 R 464 0 R 457 0 R 450 0 R]
+>>
+endobj
+
+450 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [456 0 R 455 0 R 454 0 R 453 0 R 452 0 R 451 0 R]
+>>
+endobj
+
+451 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 450 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [49]
+  /Pg 822 0 R
+>>
+endobj
+
+452 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 450 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [48]
+  /Pg 822 0 R
+>>
+endobj
+
+453 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 450 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [47]
+  /Pg 822 0 R
+>>
+endobj
+
+454 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 450 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [46]
+  /Pg 822 0 R
+>>
+endobj
+
+455 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 450 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [45]
+  /Pg 822 0 R
+>>
+endobj
+
+456 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 450 0 R
+  /K [44]
+  /Pg 822 0 R
+>>
+endobj
+
+457 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [463 0 R 462 0 R 461 0 R 460 0 R 459 0 R 458 0 R]
+>>
+endobj
+
+458 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 457 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [43]
+  /Pg 822 0 R
+>>
+endobj
+
+459 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 457 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [42]
+  /Pg 822 0 R
+>>
+endobj
+
+460 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 457 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [41]
+  /Pg 822 0 R
+>>
+endobj
+
+461 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 457 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [40]
+  /Pg 822 0 R
+>>
+endobj
+
+462 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 457 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [39]
+  /Pg 822 0 R
+>>
+endobj
+
+463 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 457 0 R
+  /K [38]
+  /Pg 822 0 R
+>>
+endobj
+
+464 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [470 0 R 469 0 R 468 0 R 467 0 R 466 0 R 465 0 R]
+>>
+endobj
+
+465 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 464 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [37]
+  /Pg 822 0 R
+>>
+endobj
+
+466 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 464 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [36]
+  /Pg 822 0 R
+>>
+endobj
+
+467 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 464 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [35]
+  /Pg 822 0 R
+>>
+endobj
+
+468 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 464 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [34]
+  /Pg 822 0 R
+>>
+endobj
+
+469 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 464 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [33]
+  /Pg 822 0 R
+>>
+endobj
+
+470 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 464 0 R
+  /K [32]
+  /Pg 822 0 R
+>>
+endobj
+
+471 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [477 0 R 476 0 R 475 0 R 474 0 R 473 0 R 472 0 R]
+>>
+endobj
+
+472 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 471 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [31]
+  /Pg 822 0 R
+>>
+endobj
+
+473 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 471 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [30]
+  /Pg 822 0 R
+>>
+endobj
+
+474 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 471 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [29]
+  /Pg 822 0 R
+>>
+endobj
+
+475 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 471 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [28]
+  /Pg 822 0 R
+>>
+endobj
+
+476 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 471 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [27]
+  /Pg 822 0 R
+>>
+endobj
+
+477 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 471 0 R
+  /K [26]
+  /Pg 822 0 R
+>>
+endobj
+
+478 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [484 0 R 483 0 R 482 0 R 481 0 R 480 0 R 479 0 R]
+>>
+endobj
+
+479 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 478 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [25]
+  /Pg 822 0 R
+>>
+endobj
+
+480 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 478 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [24]
+  /Pg 822 0 R
+>>
+endobj
+
+481 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 478 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [23]
+  /Pg 822 0 R
+>>
+endobj
+
+482 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 478 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [22]
+  /Pg 822 0 R
+>>
+endobj
+
+483 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 478 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [21]
+  /Pg 822 0 R
+>>
+endobj
+
+484 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 478 0 R
+  /K [20]
+  /Pg 822 0 R
+>>
+endobj
+
+485 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [491 0 R 490 0 R 489 0 R 488 0 R 487 0 R 486 0 R]
+>>
+endobj
+
+486 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 485 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [19]
+  /Pg 822 0 R
+>>
+endobj
+
+487 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 485 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [18]
+  /Pg 822 0 R
+>>
+endobj
+
+488 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 485 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [17]
+  /Pg 822 0 R
+>>
+endobj
+
+489 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 485 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [16]
+  /Pg 822 0 R
+>>
+endobj
+
+490 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 485 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [15]
+  /Pg 822 0 R
+>>
+endobj
+
+491 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 485 0 R
+  /K [14]
+  /Pg 822 0 R
+>>
+endobj
+
+492 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [498 0 R 497 0 R 496 0 R 495 0 R 494 0 R 493 0 R]
+>>
+endobj
+
+493 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 492 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [13]
+  /Pg 822 0 R
+>>
+endobj
+
+494 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 492 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [12]
+  /Pg 822 0 R
+>>
+endobj
+
+495 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 492 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [11]
+  /Pg 822 0 R
+>>
+endobj
+
+496 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 492 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [10]
+  /Pg 822 0 R
+>>
+endobj
+
+497 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 492 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [9]
+  /Pg 822 0 R
+>>
+endobj
+
+498 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 492 0 R
+  /K [8]
+  /Pg 822 0 R
+>>
+endobj
+
+499 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 449 0 R
+  /K [505 0 R 504 0 R 503 0 R 502 0 R 501 0 R 500 0 R]
+>>
+endobj
+
+500 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 499 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [7]
+  /Pg 822 0 R
+>>
+endobj
+
+501 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 499 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [6]
+  /Pg 822 0 R
+>>
+endobj
+
+502 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 499 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [5]
+  /Pg 822 0 R
+>>
+endobj
+
+503 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 499 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [4]
+  /Pg 822 0 R
+>>
+endobj
+
+504 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 499 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [3]
+  /Pg 822 0 R
+>>
+endobj
+
+505 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 499 0 R
+  /K [2]
+  /Pg 822 0 R
+>>
+endobj
+
+506 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [1]
+  /Pg 822 0 R
+>>
+endobj
+
+507 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (nm-plot-integral)
+  /K [0]
+  /Pg 822 0 R
+>>
+endobj
+
+508 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [535 0 R 509 0 R]
+>>
+endobj
+
+509 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 508 0 R
+  /K [526 0 R 519 0 R 510 0 R]
+>>
+endobj
+
+510 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 509 0 R
+  /K [517 0 R 515 0 R 513 0 R 511 0 R]
+>>
+endobj
+
+511 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 510 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [512 0 R]
+>>
+endobj
+
+512 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 511 0 R
+  /K [330 331 332 333 334 335 336 337 338 339 340 341 342 343 344 345 346 347 348 349 350 351 352 353 354 355 356 357 358 359 360 361 362 363 364 365 366 367 368 369 370 371 372 373 374 375 376 377 378 379 380]
+  /Pg 820 0 R
+>>
+endobj
+
+513 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 510 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [514 0 R]
+>>
+endobj
+
+514 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 513 0 R
+  /K [281 282 283 284 285 286 287 288 289 290 291 292 293 294 295 296 297 298 299 300 301 302 303 304 305 306 307 308 309 310 311 312 313 314 315 316 317 318 319 320 321 322 323 324 325 326 327 328 329]
+  /Pg 820 0 R
+>>
+endobj
+
+515 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 510 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [516 0 R]
+>>
+endobj
+
+516 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 515 0 R
+  /K [267 268 269 270 271 272 273 274 275 276 277 278 279 280]
+  /Pg 820 0 R
+>>
+endobj
+
+517 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 510 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [518 0 R]
+>>
+endobj
+
+518 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 517 0 R
+  /K [259 260 261 262 263 264 265 266]
+  /Pg 820 0 R
+>>
+endobj
+
+519 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 509 0 R
+  /K [524 0 R 522 0 R 521 0 R 520 0 R]
+>>
+endobj
+
+520 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 519 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [258]
+  /Pg 820 0 R
+>>
+endobj
+
+521 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 519 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [257]
+  /Pg 820 0 R
+>>
+endobj
+
+522 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 519 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [523 0 R]
+>>
+endobj
+
+523 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 522 0 R
+  /K [244 245 246 247 248 249 250 251 252 253 254 255 256]
+  /Pg 820 0 R
+>>
+endobj
+
+524 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 519 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [525 0 R]
+>>
+endobj
+
+525 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 524 0 R
+  /K [237 238 239 240 241 242 243]
+  /Pg 820 0 R
+>>
+endobj
+
+526 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 509 0 R
+  /K [533 0 R 531 0 R 529 0 R 527 0 R]
+>>
+endobj
+
+527 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 526 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [528 0 R]
+>>
+endobj
+
+528 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 527 0 R
+  /K [226 227 228 229 230 231 232 233 234 235 236]
+  /Pg 820 0 R
+>>
+endobj
+
+529 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 526 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [530 0 R]
+>>
+endobj
+
+530 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 529 0 R
+  /K [203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225]
+  /Pg 820 0 R
+>>
+endobj
+
+531 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 526 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [532 0 R]
+>>
+endobj
+
+532 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 531 0 R
+  /K [190 191 192 193 194 195 196 197 198 199 200 201 202]
+  /Pg 820 0 R
+>>
+endobj
+
+533 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 526 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U7x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [534 0 R]
+>>
+endobj
+
+534 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 533 0 R
+  /K [184 185 186 187 188 189]
+  /Pg 820 0 R
+>>
+endobj
+
+535 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 508 0 R
+  /K [536 0 R]
+>>
+endobj
+
+536 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 535 0 R
+  /K [540 0 R 539 0 R 538 0 R 537 0 R]
+>>
+endobj
+
+537 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 536 0 R
+  /ID (U7x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [183]
+  /Pg 820 0 R
+>>
+endobj
+
+538 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 536 0 R
+  /ID (U7x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [182]
+  /Pg 820 0 R
+>>
+endobj
+
+539 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 536 0 R
+  /ID (U7x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [181]
+  /Pg 820 0 R
+>>
+endobj
+
+540 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 536 0 R
+  /ID (U7x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [541 0 R]
+>>
+endobj
+
+541 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 540 0 R
+  /K [180]
+  /Pg 820 0 R
+>>
+endobj
+
+542 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (-secant, -false-position, -bisection for sin(x)=0)
+  /K [173 543 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+543 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 542 0 R
+  /K [174 175 176 177 178 179]
+  /Pg 820 0 R
+>>
+endobj
+
+544 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [581 0 R 545 0 R]
+>>
+endobj
+
+545 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 544 0 R
+  /K [580 0 R 546 0 R]
+>>
+endobj
+
+546 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 545 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [572 0 R 547 0 R]
+>>
+endobj
+
+547 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 546 0 R
+  /K [568 0 R 564 0 R 560 0 R 556 0 R 552 0 R 548 0 R]
+>>
+endobj
+
+548 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 547 0 R
+  /K [551 0 R 550 0 R 549 0 R]
+>>
+endobj
+
+549 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 548 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [172]
+  /Pg 820 0 R
+>>
+endobj
+
+550 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 548 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [171]
+  /Pg 820 0 R
+>>
+endobj
+
+551 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 548 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [170]
+  /Pg 820 0 R
+>>
+endobj
+
+552 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 547 0 R
+  /K [555 0 R 554 0 R 553 0 R]
+>>
+endobj
+
+553 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 552 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [169]
+  /Pg 820 0 R
+>>
+endobj
+
+554 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 552 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [168]
+  /Pg 820 0 R
+>>
+endobj
+
+555 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 552 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [167]
+  /Pg 820 0 R
+>>
+endobj
+
+556 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 547 0 R
+  /K [559 0 R 558 0 R 557 0 R]
+>>
+endobj
+
+557 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 556 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [166]
+  /Pg 820 0 R
+>>
+endobj
+
+558 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 556 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [165]
+  /Pg 820 0 R
+>>
+endobj
+
+559 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 556 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [164]
+  /Pg 820 0 R
+>>
+endobj
+
+560 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 547 0 R
+  /K [563 0 R 562 0 R 561 0 R]
+>>
+endobj
+
+561 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 560 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [163]
+  /Pg 820 0 R
+>>
+endobj
+
+562 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 560 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [162]
+  /Pg 820 0 R
+>>
+endobj
+
+563 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 560 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [161]
+  /Pg 820 0 R
+>>
+endobj
+
+564 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 547 0 R
+  /K [567 0 R 566 0 R 565 0 R]
+>>
+endobj
+
+565 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 564 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [160]
+  /Pg 820 0 R
+>>
+endobj
+
+566 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 564 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [159]
+  /Pg 820 0 R
+>>
+endobj
+
+567 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 564 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [158]
+  /Pg 820 0 R
+>>
+endobj
+
+568 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 547 0 R
+  /K [571 0 R 570 0 R 569 0 R]
+>>
+endobj
+
+569 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 568 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [157]
+  /Pg 820 0 R
+>>
+endobj
+
+570 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 568 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [156]
+  /Pg 820 0 R
+>>
+endobj
+
+571 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 568 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U6x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [155]
+  /Pg 820 0 R
+>>
+endobj
+
+572 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 546 0 R
+  /K [573 0 R]
+>>
+endobj
+
+573 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 572 0 R
+  /K [578 0 R 576 0 R 574 0 R]
+>>
+endobj
+
+574 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 573 0 R
+  /ID (U6x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [149 575 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+575 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 574 0 R
+  /K [150 151 152 153 154]
+  /Pg 820 0 R
+>>
+endobj
+
+576 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 573 0 R
+  /ID (U6x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [144 577 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+577 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 576 0 R
+  /K [145 146 147 148]
+  /Pg 820 0 R
+>>
+endobj
+
+578 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 573 0 R
+  /ID (U6x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [579 0 R]
+>>
+endobj
+
+579 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 578 0 R
+  /K [143]
+  /Pg 820 0 R
+>>
+endobj
+
+580 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 545 0 R
+  /K [142]
+  /Pg 820 0 R
+>>
+endobj
+
+581 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 544 0 R
+  /K [592 0 R 582 0 R]
+>>
+endobj
+
+582 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 581 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [588 0 R 583 0 R]
+>>
+endobj
+
+583 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 582 0 R
+  /K [584 0 R]
+>>
+endobj
+
+584 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 583 0 R
+  /K [586 0 R 585 0 R]
+>>
+endobj
+
+585 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 584 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U5x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [140 141]
+  /Pg 820 0 R
+>>
+endobj
+
+586 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 584 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U5x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [587 0 R]
+>>
+endobj
+
+587 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 586 0 R
+  /K [104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139]
+  /Pg 820 0 R
+>>
+endobj
+
+588 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 582 0 R
+  /K [589 0 R]
+>>
+endobj
+
+589 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 588 0 R
+  /K [591 0 R 590 0 R]
+>>
+endobj
+
+590 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 589 0 R
+  /ID (U5x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [103]
+  /Pg 820 0 R
+>>
+endobj
+
+591 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 589 0 R
+  /ID (U5x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [102]
+  /Pg 820 0 R
+>>
+endobj
+
+592 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 581 0 R
+  /K [101]
+  /Pg 820 0 R
+>>
+endobj
+
+593 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (-newton-raphson)
+  /K [100]
+  /Pg 820 0 R
+>>
+endobj
+
+594 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [640 0 R 635 0 R 630 0 R 625 0 R 620 0 R 615 0 R 610 0 R 605 0 R 600 0 R 595 0 R]
+>>
+endobj
+
+595 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [599 0 R 598 0 R 597 0 R 596 0 R]
+>>
+endobj
+
+596 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 595 0 R
+  /ID (U4x3y9)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [99]
+  /Pg 820 0 R
+>>
+endobj
+
+597 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 595 0 R
+  /ID (U4x2y9)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [98]
+  /Pg 820 0 R
+>>
+endobj
+
+598 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 595 0 R
+  /ID (U4x1y9)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [97]
+  /Pg 820 0 R
+>>
+endobj
+
+599 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 595 0 R
+  /ID (U4x0y9)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [96]
+  /Pg 820 0 R
+>>
+endobj
+
+600 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [604 0 R 603 0 R 602 0 R 601 0 R]
+>>
+endobj
+
+601 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 600 0 R
+  /ID (U4x3y8)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [95]
+  /Pg 820 0 R
+>>
+endobj
+
+602 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 600 0 R
+  /ID (U4x2y8)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [94]
+  /Pg 820 0 R
+>>
+endobj
+
+603 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 600 0 R
+  /ID (U4x1y8)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [93]
+  /Pg 820 0 R
+>>
+endobj
+
+604 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 600 0 R
+  /ID (U4x0y8)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [92]
+  /Pg 820 0 R
+>>
+endobj
+
+605 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [609 0 R 608 0 R 607 0 R 606 0 R]
+>>
+endobj
+
+606 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 605 0 R
+  /ID (U4x3y7)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [91]
+  /Pg 820 0 R
+>>
+endobj
+
+607 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 605 0 R
+  /ID (U4x2y7)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [90]
+  /Pg 820 0 R
+>>
+endobj
+
+608 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 605 0 R
+  /ID (U4x1y7)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [89]
+  /Pg 820 0 R
+>>
+endobj
+
+609 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 605 0 R
+  /ID (U4x0y7)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [88]
+  /Pg 820 0 R
+>>
+endobj
+
+610 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [614 0 R 613 0 R 612 0 R 611 0 R]
+>>
+endobj
+
+611 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 610 0 R
+  /ID (U4x3y6)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [87]
+  /Pg 820 0 R
+>>
+endobj
+
+612 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 610 0 R
+  /ID (U4x2y6)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [86]
+  /Pg 820 0 R
+>>
+endobj
+
+613 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 610 0 R
+  /ID (U4x1y6)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [85]
+  /Pg 820 0 R
+>>
+endobj
+
+614 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 610 0 R
+  /ID (U4x0y6)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [84]
+  /Pg 820 0 R
+>>
+endobj
+
+615 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [619 0 R 618 0 R 617 0 R 616 0 R]
+>>
+endobj
+
+616 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 615 0 R
+  /ID (U4x3y5)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [83]
+  /Pg 820 0 R
+>>
+endobj
+
+617 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 615 0 R
+  /ID (U4x2y5)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [82]
+  /Pg 820 0 R
+>>
+endobj
+
+618 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 615 0 R
+  /ID (U4x1y5)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [81]
+  /Pg 820 0 R
+>>
+endobj
+
+619 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 615 0 R
+  /ID (U4x0y5)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [80]
+  /Pg 820 0 R
+>>
+endobj
+
+620 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [624 0 R 623 0 R 622 0 R 621 0 R]
+>>
+endobj
+
+621 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 620 0 R
+  /ID (U4x3y4)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [79]
+  /Pg 820 0 R
+>>
+endobj
+
+622 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 620 0 R
+  /ID (U4x2y4)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [78]
+  /Pg 820 0 R
+>>
+endobj
+
+623 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 620 0 R
+  /ID (U4x1y4)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [77]
+  /Pg 820 0 R
+>>
+endobj
+
+624 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 620 0 R
+  /ID (U4x0y4)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [76]
+  /Pg 820 0 R
+>>
+endobj
+
+625 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [629 0 R 628 0 R 627 0 R 626 0 R]
+>>
+endobj
+
+626 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 625 0 R
+  /ID (U4x3y3)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [75]
+  /Pg 820 0 R
+>>
+endobj
+
+627 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 625 0 R
+  /ID (U4x2y3)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [74]
+  /Pg 820 0 R
+>>
+endobj
+
+628 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 625 0 R
+  /ID (U4x1y3)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [73]
+  /Pg 820 0 R
+>>
+endobj
+
+629 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 625 0 R
+  /ID (U4x0y3)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [72]
+  /Pg 820 0 R
+>>
+endobj
+
+630 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [634 0 R 633 0 R 632 0 R 631 0 R]
+>>
+endobj
+
+631 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 630 0 R
+  /ID (U4x3y2)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [71]
+  /Pg 820 0 R
+>>
+endobj
+
+632 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 630 0 R
+  /ID (U4x2y2)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [70]
+  /Pg 820 0 R
+>>
+endobj
+
+633 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 630 0 R
+  /ID (U4x1y2)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [69]
+  /Pg 820 0 R
+>>
+endobj
+
+634 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 630 0 R
+  /ID (U4x0y2)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [68]
+  /Pg 820 0 R
+>>
+endobj
+
+635 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [639 0 R 638 0 R 637 0 R 636 0 R]
+>>
+endobj
+
+636 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 635 0 R
+  /ID (U4x3y1)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [67]
+  /Pg 820 0 R
+>>
+endobj
+
+637 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 635 0 R
+  /ID (U4x2y1)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [66]
+  /Pg 820 0 R
+>>
+endobj
+
+638 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 635 0 R
+  /ID (U4x1y1)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [65]
+  /Pg 820 0 R
+>>
+endobj
+
+639 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 635 0 R
+  /ID (U4x0y1)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [64]
+  /Pg 820 0 R
+>>
+endobj
+
+640 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 594 0 R
+  /K [647 0 R 645 0 R 643 0 R 641 0 R]
+>>
+endobj
+
+641 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 640 0 R
+  /ID (U4x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [58 642 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+642 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 641 0 R
+  /K [59 60 61 62 63]
+  /Pg 820 0 R
+>>
+endobj
+
+643 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 640 0 R
+  /ID (U4x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [52 644 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+644 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 643 0 R
+  /K [53 54 55 56 57]
+  /Pg 820 0 R
+>>
+endobj
+
+645 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 640 0 R
+  /ID (U4x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [49 646 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+646 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 645 0 R
+  /K [50 51]
+  /Pg 820 0 R
+>>
+endobj
+
+647 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 640 0 R
+  /ID (U4x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [648 0 R]
+>>
+endobj
+
+648 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 647 0 R
+  /K [48]
+  /Pg 820 0 R
+>>
+endobj
+
+649 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [47]
+  /Pg 820 0 R
+>>
+endobj
+
+650 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [658 0 R 651 0 R]
+>>
+endobj
+
+651 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 650 0 R
+  /K [652 0 R]
+>>
+endobj
+
+652 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 651 0 R
+  /K [656 0 R 655 0 R 654 0 R 653 0 R]
+>>
+endobj
+
+653 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 652 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U3x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [46]
+  /Pg 820 0 R
+>>
+endobj
+
+654 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 652 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U3x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [45]
+  /Pg 820 0 R
+>>
+endobj
+
+655 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 652 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U3x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [44]
+  /Pg 820 0 R
+>>
+endobj
+
+656 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 652 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U3x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [657 0 R]
+>>
+endobj
+
+657 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 656 0 R
+  /K [16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43]
+  /Pg 820 0 R
+>>
+endobj
+
+658 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 650 0 R
+  /K [659 0 R]
+>>
+endobj
+
+659 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 658 0 R
+  /K [665 0 R 664 0 R 662 0 R 660 0 R]
+>>
+endobj
+
+660 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 659 0 R
+  /ID (U3x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [10 661 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+661 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 660 0 R
+  /K [11 12 13 14 15]
+  /Pg 820 0 R
+>>
+endobj
+
+662 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 659 0 R
+  /ID (U3x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [4 663 0 R]
+  /Pg 820 0 R
+>>
+endobj
+
+663 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 662 0 R
+  /K [5 6 7 8 9]
+  /Pg 820 0 R
+>>
+endobj
+
+664 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 659 0 R
+  /ID (U3x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [3]
+  /Pg 820 0 R
+>>
+endobj
+
+665 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 659 0 R
+  /ID (U3x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [2]
+  /Pg 820 0 R
+>>
+endobj
+
+666 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 22 0 R
+  /T (-FPI and -relaxed-FPI)
+  /K [1]
+  /Pg 820 0 R
+>>
+endobj
+
+667 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (#nm-iterate)
+  /K [0]
+  /Pg 820 0 R
+>>
+endobj
+
+668 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [704 0 R 669 0 R]
+>>
+endobj
+
+669 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 668 0 R
+  /K [697 0 R 692 0 R 687 0 R 680 0 R 675 0 R 670 0 R]
+>>
+endobj
+
+670 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 669 0 R
+  /K [673 0 R 672 0 R 671 0 R]
+>>
+endobj
+
+671 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 670 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [129]
+  /Pg 818 0 R
+>>
+endobj
+
+672 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 670 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [128]
+  /Pg 818 0 R
+>>
+endobj
+
+673 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 670 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [674 0 R]
+>>
+endobj
+
+674 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 673 0 R
+  /K [124 125 126 127]
+  /Pg 818 0 R
+>>
+endobj
+
+675 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 669 0 R
+  /K [678 0 R 677 0 R 676 0 R]
+>>
+endobj
+
+676 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 675 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [97]
+  /Pg 818 0 R
+>>
+endobj
+
+677 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 675 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [96]
+  /Pg 818 0 R
+>>
+endobj
+
+678 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 675 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [679 0 R]
+>>
+endobj
+
+679 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 678 0 R
+  /K [93 94 95]
+  /Pg 818 0 R
+>>
+endobj
+
+680 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 669 0 R
+  /K [685 0 R 683 0 R 682 0 R 681 0 R]
+>>
+endobj
+
+681 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 680 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [92]
+  /Pg 818 0 R
+>>
+endobj
+
+682 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 680 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [91]
+  /Pg 818 0 R
+>>
+endobj
+
+683 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 680 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [684 0 R]
+>>
+endobj
+
+684 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 683 0 R
+  /K [90]
+  /Pg 818 0 R
+>>
+endobj
+
+685 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 680 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x0y0)]
+    /RowSpan 3
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [686 0 R]
+>>
+endobj
+
+686 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 685 0 R
+  /K [98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123]
+  /Pg 818 0 R
+>>
+endobj
+
+687 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 669 0 R
+  /K [690 0 R 689 0 R 688 0 R]
+>>
+endobj
+
+688 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 687 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [89]
+  /Pg 818 0 R
+>>
+endobj
+
+689 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 687 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [88]
+  /Pg 818 0 R
+>>
+endobj
+
+690 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 687 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [691 0 R]
+>>
+endobj
+
+691 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 690 0 R
+  /K [84 85 86 87]
+  /Pg 818 0 R
+>>
+endobj
+
+692 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 669 0 R
+  /K [695 0 R 694 0 R 693 0 R]
+>>
+endobj
+
+693 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 692 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [66]
+  /Pg 818 0 R
+>>
+endobj
+
+694 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 692 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [65]
+  /Pg 818 0 R
+>>
+endobj
+
+695 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 692 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [696 0 R]
+>>
+endobj
+
+696 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 695 0 R
+  /K [62 63 64]
+  /Pg 818 0 R
+>>
+endobj
+
+697 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 669 0 R
+  /K [702 0 R 700 0 R 699 0 R 698 0 R]
+>>
+endobj
+
+698 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 697 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [61]
+  /Pg 818 0 R
+>>
+endobj
+
+699 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 697 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [60]
+  /Pg 818 0 R
+>>
+endobj
+
+700 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 697 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [701 0 R]
+>>
+endobj
+
+701 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 700 0 R
+  /K [59]
+  /Pg 818 0 R
+>>
+endobj
+
+702 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 697 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U2x0y0)]
+    /RowSpan 3
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [703 0 R]
+>>
+endobj
+
+703 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 702 0 R
+  /K [67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83]
+  /Pg 818 0 R
+>>
+endobj
+
+704 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 668 0 R
+  /K [705 0 R]
+>>
+endobj
+
+705 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 704 0 R
+  /K [710 0 R 708 0 R 707 0 R 706 0 R]
+>>
+endobj
+
+706 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 705 0 R
+  /ID (U2x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [58]
+  /Pg 818 0 R
+>>
+endobj
+
+707 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 705 0 R
+  /ID (U2x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [57]
+  /Pg 818 0 R
+>>
+endobj
+
+708 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 705 0 R
+  /ID (U2x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [709 0 R]
+>>
+endobj
+
+709 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 708 0 R
+  /K [56]
+  /Pg 818 0 R
+>>
+endobj
+
+710 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 705 0 R
+  /ID (U2x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [55]
+  /Pg 818 0 R
+>>
+endobj
+
+711 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (#nm-differentiate)
+  /K [54]
+  /Pg 818 0 R
+>>
+endobj
+
+712 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [766 0 R 713 0 R]
+>>
+endobj
+
+713 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 712 0 R
+  /K [758 0 R 752 0 R 746 0 R 740 0 R 732 0 R 726 0 R 720 0 R 714 0 R]
+>>
+endobj
+
+714 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [719 0 R 718 0 R 717 0 R 716 0 R 715 0 R]
+>>
+endobj
+
+715 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 714 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [53]
+  /Pg 818 0 R
+>>
+endobj
+
+716 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 714 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [52]
+  /Pg 818 0 R
+>>
+endobj
+
+717 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 714 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [51]
+  /Pg 818 0 R
+>>
+endobj
+
+718 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 714 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [50]
+  /Pg 818 0 R
+>>
+endobj
+
+719 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 714 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [49]
+  /Pg 818 0 R
+>>
+endobj
+
+720 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [725 0 R 724 0 R 723 0 R 722 0 R 721 0 R]
+>>
+endobj
+
+721 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 720 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [44]
+  /Pg 818 0 R
+>>
+endobj
+
+722 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 720 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [43]
+  /Pg 818 0 R
+>>
+endobj
+
+723 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 720 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [42]
+  /Pg 818 0 R
+>>
+endobj
+
+724 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 720 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [41]
+  /Pg 818 0 R
+>>
+endobj
+
+725 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 720 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [40]
+  /Pg 818 0 R
+>>
+endobj
+
+726 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [731 0 R 730 0 R 729 0 R 728 0 R 727 0 R]
+>>
+endobj
+
+727 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 726 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [39]
+  /Pg 818 0 R
+>>
+endobj
+
+728 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 726 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [38]
+  /Pg 818 0 R
+>>
+endobj
+
+729 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 726 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [37]
+  /Pg 818 0 R
+>>
+endobj
+
+730 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 726 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [36]
+  /Pg 818 0 R
+>>
+endobj
+
+731 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 726 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [35]
+  /Pg 818 0 R
+>>
+endobj
+
+732 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [738 0 R 737 0 R 736 0 R 735 0 R 734 0 R 733 0 R]
+>>
+endobj
+
+733 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 732 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [34]
+  /Pg 818 0 R
+>>
+endobj
+
+734 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 732 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [33]
+  /Pg 818 0 R
+>>
+endobj
+
+735 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 732 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [32]
+  /Pg 818 0 R
+>>
+endobj
+
+736 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 732 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [31]
+  /Pg 818 0 R
+>>
+endobj
+
+737 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 732 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [30]
+  /Pg 818 0 R
+>>
+endobj
+
+738 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 732 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x0y0)]
+    /RowSpan 4
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [739 0 R 48]
+  /Pg 818 0 R
+>>
+endobj
+
+739 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 738 0 R
+  /K [45 46 47]
+  /Pg 818 0 R
+>>
+endobj
+
+740 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [745 0 R 744 0 R 743 0 R 742 0 R 741 0 R]
+>>
+endobj
+
+741 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 740 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [29]
+  /Pg 818 0 R
+>>
+endobj
+
+742 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 740 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [28]
+  /Pg 818 0 R
+>>
+endobj
+
+743 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 740 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [27]
+  /Pg 818 0 R
+>>
+endobj
+
+744 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 740 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [26]
+  /Pg 818 0 R
+>>
+endobj
+
+745 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 740 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [25]
+  /Pg 818 0 R
+>>
+endobj
+
+746 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [751 0 R 750 0 R 749 0 R 748 0 R 747 0 R]
+>>
+endobj
+
+747 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 746 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [21]
+  /Pg 818 0 R
+>>
+endobj
+
+748 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 746 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [20]
+  /Pg 818 0 R
+>>
+endobj
+
+749 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 746 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [19]
+  /Pg 818 0 R
+>>
+endobj
+
+750 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 746 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [18]
+  /Pg 818 0 R
+>>
+endobj
+
+751 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 746 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [17]
+  /Pg 818 0 R
+>>
+endobj
+
+752 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [757 0 R 756 0 R 755 0 R 754 0 R 753 0 R]
+>>
+endobj
+
+753 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 752 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [16]
+  /Pg 818 0 R
+>>
+endobj
+
+754 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 752 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [15]
+  /Pg 818 0 R
+>>
+endobj
+
+755 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 752 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [14]
+  /Pg 818 0 R
+>>
+endobj
+
+756 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 752 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [13]
+  /Pg 818 0 R
+>>
+endobj
+
+757 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 752 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [12]
+  /Pg 818 0 R
+>>
+endobj
+
+758 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 713 0 R
+  /K [764 0 R 763 0 R 762 0 R 761 0 R 760 0 R 759 0 R]
+>>
+endobj
+
+759 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 758 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x5y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [11]
+  /Pg 818 0 R
+>>
+endobj
+
+760 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 758 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x4y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [10]
+  /Pg 818 0 R
+>>
+endobj
+
+761 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 758 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x3y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [9]
+  /Pg 818 0 R
+>>
+endobj
+
+762 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 758 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [8]
+  /Pg 818 0 R
+>>
+endobj
+
+763 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 758 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [7]
+  /Pg 818 0 R
+>>
+endobj
+
+764 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 758 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x0y0)]
+    /RowSpan 4
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [765 0 R 24]
+  /Pg 818 0 R
+>>
+endobj
+
+765 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 764 0 R
+  /K [22 23]
+  /Pg 818 0 R
+>>
+endobj
+
+766 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 712 0 R
+  /K [767 0 R]
+>>
+endobj
+
+767 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 766 0 R
+  /K [774 0 R 772 0 R 771 0 R 770 0 R 769 0 R 768 0 R]
+>>
+endobj
+
+768 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 767 0 R
+  /ID (U1x5y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [6]
+  /Pg 818 0 R
+>>
+endobj
+
+769 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 767 0 R
+  /ID (U1x4y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [5]
+  /Pg 818 0 R
+>>
+endobj
+
+770 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 767 0 R
+  /ID (U1x3y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [4]
+  /Pg 818 0 R
+>>
+endobj
+
+771 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 767 0 R
+  /ID (U1x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [3]
+  /Pg 818 0 R
+>>
+endobj
+
+772 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 767 0 R
+  /ID (U1x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [773 0 R]
+>>
+endobj
+
+773 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 772 0 R
+  /K [2]
+  /Pg 818 0 R
+>>
+endobj
+
+774 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 767 0 R
+  /ID (U1x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [1]
+  /Pg 818 0 R
+>>
+endobj
+
+775 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (#nm-integrate)
+  /K [0]
+  /Pg 818 0 R
+>>
+endobj
+
+776 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /LPOLTP+LibertinusSerif-Bold-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [777 0 R]
+  /ToUnicode 780 0 R
+>>
+endobj
+
+777 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /LPOLTP+LibertinusSerif-Bold
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 779 0 R
+  /DW 0
+  /W [0 0 500 1 1 514 2 2 616 3 3 905 4 4 358 5 5 322 6 6 358 7 7 489 8 8 521 9 9 428 10 10 505.99997 11 11 561 12 12 716 13 13 545 14 14 614 15 15 367 16 16 250 17 17 325 18 18 561 19 19 777 20 20 551 21 21 581 22 22 619 23 23 427 24 24 456 25 25 244 26 26 391 27 27 542 28 28 577 29 29 256 30 30 514 31 31 598 32 37 514 38 38 652 39 39 734]
+>>
+endobj
+
+778 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿÿÿÿ öü
+endstream
+endobj
+
+779 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /LPOLTP+LibertinusSerif-Bold
+  /Flags 131078
+  /FontBBox [0 -238 893 700]
+  /ItalicAngle 0
+  /Ascent 894
+  /Descent -246
+  /CapHeight 645
+  /StemV 168.6
+  /CIDSet 778 0 R
+  /FontFile3 781 0 R
+>>
+endobj
+
+780 0 obj
+<<
+  /Length 1156
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+39 beginbfchar
+<0001> <0023>
+<0002> <006E>
+<0003> <006D>
+<0004> <002D>
+<0005> <0069>
+<0006> <0074>
+<0007> <0065>
+<0008> <0067>
+<0009> <0072>
+<000A> <0061>
+<000B> <0064>
+<000C> <00660066>
+<000D> <0046>
+<000E> <0050>
+<000F> <0049>
+<0010> <0020>
+<0011> <006C>
+<0012> <0078>
+<0013> <0077>
+<0014> <006F>
+<0015> <0070>
+<0016> <0068>
+<0017> <0073>
+<0018> <0063>
+<0019> <002C>
+<001A> <0066>
+<001B> <0062>
+<001C> <004C>
+<001D> <003A>
+<001E> <0030>
+<001F> <0075>
+<0020> <0031>
+<0021> <0032>
+<0022> <0034>
+<0023> <0038>
+<0024> <0036>
+<0025> <0033>
+<0026> <0054>
+<0027> <0044>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+781 0 obj
+<<
+  /Length 4434
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ¥Xy|åºN™¤¥ì0µÌèLÄT.QQZ
+•
+¥iÒ%Ğ½I[º$M³ïM“´ºï{›J¨e‹•ÅËñ nÜ{PõåïÇùû‹TEW=¿ûG&ó}óûŞïyó=ïó>.gút—Ë%^MIdå¤¤åf¿.ÉJ‘>ü\úÎÄÀƒ5,ÅŞm
+¡Ù{B8t0‡1™n]Cwÿ¹]¾;œú#ÿ‡34ó‡;ãÎ{8œş3dn`ê/!ó__„ÜÇáq¹˜è•U‰é	’µ‰’´œ”œüÕéùY)IÉ9?Ş-Yü‡%/Y¼äñˆèdIÄ˜"^ËJO•ˆs"Våæ$§ge?ÂáLãp9J*Ùç«*« ÔÕímqb¨´I@OÓ¯!şd
+™á†°æ
+¹ƒ%x.‡Ãá<Èj¶Ùd2’à[¸å<¹óW>-sš›ÄÛ3ıN>Ã¯ÃÄ>¼'ÔÍ**
+º|l†bÆÉwÜu‡÷¢‡Eı3WÎôÍü|Ö’Yçï|öÎ±Ğ•¡ïâ«ğ“³·ÏşcŒi”½>Ê5²óGy¦é¬şÛ×nê±?ıƒ&`8aròobìa"p‡#( çwÏø7Ë(ÆÀ5L”&ş>ÚÊ¾‰¾—Å?7	Æ*&ø(k†UüÍ˜j£:JµQˆŸ|kƒUü×1ÕÆÒÀÄıXéZşW>©•jR5Ò[ãX:ZÅÇÜÇœãîÂ/°4´Š?†¹9Ç]'„0sNğQ0¶ÃO:zË;½ÂÏ0Ñéj9+¼ÈıÂàiãAˆxSĞìóÕì£|mùQZ.Xº»4AOk4¦\‡Fè7w˜‡Ç÷‡Ìw8Lu‡p½uwÅ‡$,À´¸Ñ'ÄÏo—DÓún]›‰ôÕö"JªÚP´¦Ô ±(,á¸Ö¥"ÑA¤Ò°^ûcP¿yì`ËmAwØTÖ+¤şúÀoh â·>³ïÆ/ßBºU`7ÙídC·Ëû+p‡Ûo‹,¶Ü‚Ûh¬Ñ»èê¾ı½”¯åßMU<ú„t©X¶‘Ş_(n}JZ-‘E1øˆ¾M_o"ñËÿÿÔÑf½Ïíƒn4Œ¨o¬t«]éŠÃäY	ÊJU#B»«ål”âo0›ûMàü
+oı*£¶#&Ú]ê(¢Ó•O© úŒÜ¦Mi½B"ŠM#RR}ƒM=Mm9=;ârd»hÚ¬z.Âı¡ŸBÂG8„ã_Ÿf×E…:e1“&Ğš6úmÌ°ÀˆfÇ’É)µùt^}Oi5~²¥¥†ñh%.ZUœ¥Ë£rs½£Ì¨ñï_‘_c®*[Ó.°é-Z¿Š‚0sßrÖzĞD:ôV-_+“*Ëv3eiš²RaY©.c9)zEõ1<æÜÚ¢ hÀñëìj ˆ	›”
+ÿë3[¿dÊÍ6;	eXƒİ[õQê5t?ƒ_Ÿ‹BAo¬]¿?‘IéÙ}š|§ûÂ(S©İ§¢Q9, Ìİö¾ªaÃŞf—›jîÍ\®1ŒH†Jı°ò³Mrx ä}ºC¡nà®¼ñ„À,•|Œ±I,M´ìõôVg¶J¶oLÍLcğÁ1W¾Ü²Šß¡ÊMe23·o´ÆgÒøÁgwflQyÖW!ETyÔ5a|æö¨Rê‰oÎ£3ú'4Ã0ğØ˜ÆàŒ¨Uí7ÓM‰è¡òUT~†Å·×Ue÷0ªÚZc;…ŒªlëbZ›jºÉ#é½)-´ËÙ¹ÏEU”k4V¦Ø¶OŞHáïG Á›K‰Kğ€>&iwBj>“¿s‹AB­İ6r¨ËTï®at®JC-… &ˆ…é%™ëÔ]Ü×Ü?T“ø4-BwVËáÌHI@Fj‰÷Ê=´ËYQ¾‡ªp—ªœŒºÜ«®§Z[ÚüM»Ú’’%»Ö¾Éè0C›vÄDVÕÎ"*®$¦hm™AcÉ»ÅÖÒÿ£^~­¢8Õ‰ïÂçşĞrLƒ`˜Àğ‘PŞœ€ï¯íîeğÎYâªŠUîiö0˜Ï‡ùKZ—=‡¦ïX›îÉíïiªk°Fmp\—Ğmvz:)w>Â™—ä||`nêª´§É5}IŸ´ëhê¤Í°‚@áEVÖî|*¾°µ½×Ú~®9UpÃ¯T@c¥IÚğ„ág†	K¶¥ÀD–˜Ú*ª×u¢j²Ââ0ÔÂMvåŞ£$#À÷¿mí5Ñe¶RZZ²\ù¼^_b.¶—
+OkíÆ5$
+àgyÙö4
+ˆøhÎkµkF$LzOcÑªùâªZÆ1DÈcrK¨ØÄ#4æ8XİÎ4{›÷¶QMúÔjS©YM‹`iµœ…d¿ÌúWƒ(Ã/C	Ì& ¢[°lwéúÛÄqĞ<şKâXñ±`Ÿ×îaê£-^pƒêê¼¶ÂìrZVÑ”ÕCu6ÔîoŞ9toÜë	¿®Óé´:­°5Kg$õfLaÂv&n»tõÓ¤¾D"-T3‚2›¾>‚ÜØo€À/OÁØÎ>N¨³´iI¤Eu	ğëğàDk·)?¥’Æ/»2kr[B‘ÚĞ5Áí·)B¿ˆkNü:húÂeÁduŞ6+ãĞ´›¡¡ÛÔVOÖ›»Ì­´Æ±Ó¤Ñ£õòÒ—¨§@‚5xèÿÄŞkŠ_SÇx•—]ˆ_ÖPit
+-F³Æ¯ëÔÆl
+b¦yæXó÷	¼«÷j#É›ó‘éºh=­Ò˜r]¡Ï|Ñìó}`ô…Ìw9Lu*‡0Ú*±]!E'«åĞá‡¡.`qÅù,äÁoçbTR&¦¦–ë[t‘äÍû~)èùŸM·]!Ù‚wÊkÇÍF¢yiÛ—ÊÍ–":ÏQTUJªôÆêÓS{:}Ìè€÷í1ÒWxb]/]'v?K‰Ğújù·÷(¸åWhx€±5ÄïŞ÷>Á•Û¸•šWÅâUfqÈüŸä!BGD(¯Zşíê@	}axïW€‘¿MÆ+$'À'¡ˆ”?‘Èièb±®ĞJx=	Û`lBÀ#øUxåqê›İjµjç/öÊTúdíœ©ıjÌ§Íc‡Ok¾ßOêH©”?w…k&«Õv8á-]=vë÷¼<©0î4¦&&˜!ó§¢àW{ôN¥"mÓŠp½VkÒ•oûpyO¥¥Ï6µHa|ÙıFÔmKk2Ä-ÌU„[u&¦lÎ£Ë’mWîÒ}Ÿ¬1·›;öıˆMˆ_Í·ítÔµES!g—tq] ešÇÊáC"o¸ä€‰Ì7æ™ò,‹7\_¦3è\Q°"Üh5ZŒÖ"¿fïqûT,©1Ş¸%y‹Yú=¤ceÖ¼ê- B“áyå•†JÊUm©u2Ÿédáç—Wë+)—×Zãd`&óî÷ö±Ï™
+–kÌ7fJãö–Î™÷ÆF´$\W¢1ë\B‘Aåg1?7 œ±Áë1îúË@;^Ó;@ô¾s„„»–\GF®KÛ–HK¶lx„lØL¼sğ)t
+‰“%-“ÁÌ‹Ş{ù,#jA)rÈñÃ—g¹ŸC¬ŞçpŠ¸¹ô÷µ(ëj5,ºñÜD~*±ŸéNİ³™JÛ”,Kf4˜¡E_÷+ŞÂ€
+ÃdwM­½•õÔÀp,
+ZºëáÇ•Yæ,F4ñéÍáÖ¿Ì6”xÊeKŸ—&GÑ$À¯ÿ*½o¾,ø×Bù‰Şa-¬¸BÂA“¿Ó³òuÿ.#ü½ÌŠP¨ªŸòsOÿ#ò†aa{Ãç”5Õgv¡.}áÿ¤KİœÓÈ¤wìh|³F(öu´’õÕÕ­İ]²õô>½Ûì*öèúJ;è*Y–+šŠ‰UÈdLN2=ƒÜåÉ®–Óí)ãÉmEB_¾;)›”É
+2¶m=xANï¶ª»uBÑCªóp-@ŠÇ>õ	á1T+i©8%/zöµ· xãc½{eV&ÃÚ¬è :êÛ7G\<ozàåú¨~)#í?Xx:1éïcDèZC\¸ó"¦NdJÅ9YµéÕZ¦R_¯Î%3·<¿­„Ö›Unu¯ã@cK‹°¥¥i¤›ü u`-BOŞê¥Y~îW?Tğ]ıw£Tœ»T)	Z5“q«şvœ:¥Ê_ gg»Å£‹‘w_œÀÓ"%:	ï×yÜz7UévUUìîê?©:H‚`Ì;š{DÖË$muÅP;c’åilü*Û í"ê:ë¬õÔHï¶—!áÓi9ú<FÔ`ò³ß(¦Ú¾ñ0yQõ	†]ğÓ6°Ì¸Ë(#ÌbúYøy_1ÀÒOC6Öú_ãu½í8¬²Ë-%áj…ôõ¹”ªFî	XÀ;q‚tìòùº:úúembqŠ,‘†CÓÿeN”¨ò³~nÌƒg`.œ*â„½¥ D3Ï.@Ä4Å¡È÷Ñ|XÀØÙ÷ˆşı¯ PÙ›ÑâeFXñè†ú|ŒhPu‘*¸Wo½´òØr˜CÀ*Á‡–’Ò«skt¾QaÌKÙœøƒ¾Òî-[J¢u•IeVÑY	©†|J¼Ëş.ËºRnÌß"1Çÿ°ò ¡Vµ”D‹÷ú7}Üs¡µãmÉ²äıŠÃ%ºØc^“"TößN|å¬Ï?ø¥1çQ]©¶•ª
+tÊz}ú‹Ù'™ÊwW©„õoõXª¨J‡.–A‚È­·Éæ!³Ï7hüà‡^F[·¬K¢é}¶x tôo÷B,Ùø¥Qö"«>­§µµ®İn(×WĞø5}¹Şé&ë»ê~uÃKºø˜XúÉ§Ğ,\®Ï˜c“ñÙ0ÌÓç™,?*t—Úr¨sÓ2¶Q(³v¸š;Û¿3`š¯áù—ÇÎ§ñKhŞš‡×1d!lˆ½OÁ…*˜uÍÉc !dïû¶r1â g—¡YBƒN«Ñ“êº¬r5­µÛ¼ Æ"%?I±ËìóuÜ–â-oæûPPµ§ÚãÒ9”Ê‚A¢W£^†»ÇÎE‰*ëïí‚™ÂL¸„‹`~İÌfbN »@çnXıLT}ò	S«äãWÅÅl]AÎ»8,¾øÅ¥ãÇ6vÑ¯wòñkÇ½c#gHü*Úzóu"JÒq­Ózæôæ­4şyI¹d+¹p}A<_r²~â]{tB|Ù6™‚‰mâÇ6©»ÛÉ!gÿ™ Íû¡â¸ VÉccØ	Âê1V«]è^İ³+×
+W®•Í]H¢TŞñ5,>¡ŸÄÃtô€$¥8WB;ÏwMõ¬8j¢ÔI4ôÕZöQg[Öl@ÙI±ÑığœÛÔhv3Se
+g x1øG`fß&üµÙq+×¯TÎ”‹ùZe…O¾PˆBàÅ,i¢¼Ñ[ÌìQÔI©ù™rwa’Éï+¡ Â¯s>îôRƒt ndì$y û,¢çíHN“Ñ¹
+MF1YdÏé<à©ïpĞ'İ~k%ºaèb'œŠPØø$û Ì$ØY‚3®Şº{ÏŸµÂË¸«Í¶
+ï-;¨=lš#OêSOû4…îÅğŞ(Øn•0ƒÁÈè¶©b”[…:—×è¡ğÉ?Õ4NP#X¯Kº¹‰"´Ëëóaó™‰1ãèb½ÜZ`üÑµÖàgOú¿Hè
+Øúua¾>êÓu§Î1ÃşÎ+ß°…À"d¤cvÅÔw"Éü†Fb=	3öÁxSMÄÖ¡gĞBô2â®[ùB¦ç,-ú_c“Ä
+endstream
+endobj
+
+782 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /NPRMKF+LibertinusSerif-Regular-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [783 0 R]
+  /ToUnicode 786 0 R
+>>
+endobj
+
+783 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /NPRMKF+LibertinusSerif-Regular
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 785 0 R
+  /DW 0
+  /W [0 0 500 1 1 597 2 2 457 3 3 372 4 4 500 5 5 447 6 6 316 7 7 338 8 8 790 9 9 271 10 10 505.99997 11 11 519 12 12 504 13 13 542 14 14 424 15 15 531 16 16 390 17 19 465 20 20 220 21 27 465 28 28 250 29 29 310 30 30 747 31 31 428 32 32 264 33 33 550 34 34 485 35 35 541 36 36 297 37 37 490 38 38 695 39 39 652 40 40 236 41 41 220 42 42 587 43 43 538 44 44 699 45 45 493 46 46 588 47 47 497 48 48 515 49 50 268 51 51 375 52 52 596 53 53 375 54 54 328 55 55 839 56 56 701 57 57 582 58 58 485 59 59 646]
+>>
+endobj
+
+784 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿ>  #Õê
+endstream
+endobj
+
+785 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /NPRMKF+LibertinusSerif-Regular
+  /Flags 131078
+  /FontBBox [-1 -238 821 736]
+  /ItalicAngle 0
+  /Ascent 894
+  /Descent -246
+  /CapHeight 658
+  /StemV 95.4
+  /CIDSet 784 0 R
+  /FontFile3 787 0 R
+>>
+endobj
+
+786 0 obj
+<<
+  /Length 1440
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+59 beginbfchar
+<0001> <0054>
+<0002> <0061>
+<0003> <0072>
+<0004> <0067>
+<0005> <0065>
+<0006> <0074>
+<0007> <002D>
+<0008> <006D>
+<0009> <0069>
+<000A> <0064>
+<000B> <0070>
+<000C> <006F>
+<000D> <006E>
+<000E> <007A>
+<000F> <0075>
+<0010> <0073>
+<0011> <0033>
+<0012> <0038>
+<0013> <0031>
+<0014> <002E>
+<0015> <0032>
+<0016> <0034>
+<0017> <0036>
+<0018> <0035>
+<0019> <0039>
+<001A> <0030>
+<001B> <0037>
+<001C> <0020>
+<001D> <0066>
+<001E> <0077>
+<001F> <0063>
+<0020> <006C>
+<0021> <2212>
+<0022> <0046>
+<0023> <0050>
+<0024> <0049>
+<0025> <0078>
+<0026> <0041>
+<0027> <0056>
+<0028> <003A>
+<0029> <002C>
+<002A> <0052>
+<002B> <0068>
+<002C> <004E>
+<002D> <0062>
+<002E> <0042>
+<002F> <0076>
+<0030> <0079>
+<0031> <2018>
+<0032> <2019>
+<0033> <201C>
+<0034> <00660074>
+<0035> <201D>
+<0036> <0066>
+<0037> <004D>
+<0038> <0044>
+<0039> <00660066>
+<003A> <0053>
+<003B> <0043>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+787 0 obj
+<<
+  /Length 6526
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ­xtTåÖvÆ0EÀñ:‡#É9ppAÅ‚EAéH5´@$!…ô2“™dê™3½¥gÒ3ÉLÊ$„ €  ôb@DE±+÷=øæ[şkIĞëõ»ë_ßZ³¦ïw×g¿ÏŞ,¯Q£¼X,–ÏêÈ=a‰É‘±)IÃ#÷¾º!,<%zw¢ç·eÎLP%˜‰c½ˆÑ^¤Zığy,wÂWYĞ<Áÿí{¢——WÏÓ½¼X£Ÿ™èåõûïc'{¾úyìÏË7c§zy³Xşª…¡q{ÂV„†Å&G&§-‹OKŒH~näßŒ™~¯úÍğ{ã¹MaÏ˜õÜºÄ¸¨°äç¦$GÄ%&M÷òzÂ‹åõvY˜_bã,ùæZ¹ÄhoëïcŸTÓ4ºL¿qìSL/êíÅòòòòzÇãÑ8Z­¦=xl{ÑóÔ'ğzÇsÜ¯Û¬¬'Æ{¼Ó½¿…°1v'‹s£x3xİO†?90:cÌSc¢Ç¨Æ>=V7ö§§ö>uŠ?¯àSO?óô¼ôé?êÙşÌmÁbdri\À8Õ¸Châ³ıf<í3É§Òw½/å{{Çñì	ÏNøbâvb+q‘|+@İÃ|İËR÷0Sz¼Õ£åÿ%çÚÿL@Á|`ó¡‘=ÀazPÏ;èùÒqğ7ö€w€C(œlp—ÃoW9™n“H Jn"gÁÏ€2î)KKQÎ¹Ü•0¿˜´Ğ:3‰4K;å½TVi(9«Œ„ŞòwğY¤y>­×†‘*•Š"A’-â@Âb£l8röZYgõGøAN³%ÌŸ@¹³Óås•„L¦d¼ƒt/İÚÒKõŒb0¨í2o®6]ã¿$iÛÓÍŒr
+šn¬º
+f}‚´În4Ú`ïÁ[šŠËì$­²)ÌbO&M—dã±”»“/pÁäy5‹æÌØdË©¨+±ç)£JGPZÊ`Åê÷[[\]é-U*”1KÈFÚ^NZ¶y96çhÂ¹F‡Éu€(+bkÀúp³eÒ<!LˆLÃ·¥´ÖwØ;/•’|¸²Tî}·æ­HğÃ•wû‘|°ü†ªZ©j¹…‡˜õ*•6'ä.ËUÉ4ïˆÜ*_Á-ÜÙ9Š5Š!çi7İÚÚI5;¿TŸ£½’‹TUÛ*l%D‘µÂiÃÍf•ØD"Ç$F[v1^YQUE"u¥iu»wìÙšL ù2±Ü¤Çø0·¬?-d=ˆ¿P¯	Îîùtáa°ıZIrÕÎ¬cÆ£¥%%eöÔ¢ø„ÀôÈ¹h7åD•­Ãıæ¬}- 2º6DÚ‚ã’2‚#±ğ²¸êl¹4#`_ÜÎ`ìOã¯<x5dVÅV¡Ké½8r>8-Q¥L"©L	%Çc#
+ÚËv[1™UY+uãŸ_ïû®+«&ÖAZŒeù¸Ñ¨Ì5ÈU{._bÅ‘K3àéI¨ÒZ¤Ê¯¯Õà=û©Œ:ÒbËJÀO
+›şVİ—¦ª®‘@.ÚÁZ°¾#uï[¹çO«jêûĞµs6ÁNr„¸Á'«ù3xË›yö.¶76c=¾ÛŞMŠœ9Ç1PªbÛŒëg1_@òÈ_ÙXà#C\]Iğ+Gµ’J‹LŸCó`!Xvé9s%ŞÒ!|+W!“|˜+éß¹Á3ëN¿w;³ÍRää‘Ù\9Méˆ÷áÎ’ú¸ÎÎònBe‘$4O”“—€ÇËÀğ×R 3“e\R#'àX7ç´®UM”Z¹"W!Ï%Ä2‰<[ÉËQH”Ò­zc|’N°ZÕT‚$4¿ ÖfQX$$Œãäd'§I¹f’Ä¥BÆ÷V$øºlô<ÆM@‚ùà7”r¨šäŞßÕåœlù¦áºtĞ-tkk=å®Ë­z±îSÌæ"×íf›ÉL¸[›Ëêñ–Ú¤÷H¸ˆ;'O  ä2µP/ãUÑÍtk«“ª;EoPÛåŞ6]®şS¼Î-PP6âpwG¾o)Oy„K¸s$ò-’m¤j‡e7=”õãŞÉ<÷úÖ5©›¶J¥L®2óÚrC¶àë·DîØM"år™”²ñø°©TÈ¬0ªEà™Ô"Á?¼ŞÔƒ€‚@.òaî”šĞÉµyDœ8d$}r‹lÃ >ÅJùPœƒøl¡œÃq@êıubİi›Á$ 	•	•µ•5öJam<8“â’’H~ ¤KZ~hAb‹Z$pßñıH-¸İƒêuf-åi“LjÌ¤ÔÓÙW^ÒXxÒh0¨eŞ*}néAŒÙÆ¬
+£B›K ­‰’Y!JU&Ã ãiµj-~@iU¿ƒÁq\©J%%{Š£ğ»RÂBÈàà„u1øô3Ôº›ËZ’ÖKhª*/+‡Ø·w_F"°ñ}ğÌ…‚ÖB;ÙU¿_[†7Ue'—‘Zi4Æ€‘BìbØZ‘àÚ•wûøÒf0£<u4Øá.ÿÇJx—;[,÷nïƒùì~,‚Kã¼¸ù:Ê¢ $UY~´§ØİFvuÖ|pC¾¹¿à»©;·Æ…H¿L¦PSòeé^´¡ºÓQ‡Ÿê[Ùsb§ÂQiú¢4RT¢04a`%×®3Û
+ş6I#ót#«íĞŞòn»Ñ©g L>u°Âé":”}xûex
+¾º" >x/œº~5¶@ôÖáyp
+¬ŒŞñÏH ¸zÛ~ç’Ÿ3„ª{P÷#ÁjğŠ´É¤2•£jTnOHœ.‰bípQ9èVºµÕñpIëôCp5·t”»ñ2{v²´ˆ4ñ1|ÅsÈùNtİÚÚä9äN6>Dè4nŸ¢;¹(O¶EàÈÅí³—¯#ùğYµ+Cø;‹{ıîõO±— ™ñFšÏ3«P•B¡"© yDîv³Â¦²iË.Ö;h0Në³r^€SæMæåæ¨•rLj’H<8­´¹ò{|u²M4gÅ&n¦l¡|¡/çÒ×¿€™üÄ+¬Òšt˜N®•ò8U,Wqöåèõ™$?Ùƒf´Hğy?ØÚt€	êîò”é<M‘#ğHıx€M\‡î¢šĞ*µrBNeR™ûÂéÈ±S†8…2?g†tÀ îPÙ‡e$â1Û
+î`åßŠv+
+Ä+1¸‰»ÌñŞ÷Î–8UBæ%§Z$è«L?&]A¢ºê¶kwìÆ4­Ç‘z£A­2’ÒšE3~ôçšïÏlo]^E"5k+B
+û°¶¦
+Wùñ¼7ó	ƒ¬Œ6xˆUÛ¤i¦<¤FX°_ø^àªEÎè«ûÈ‘¥Â`l{ p/Ô‡¦ä[%dJ…ø€¬Š‡DÉ©”LÆãûI™®FA×E°ì“­Ÿ#?‚}Ì´½5aÕ¶õó_Ì"õûØšâu>Ü=v)²¡¯_|ÄÖÜŠ’²@’máBajFÈgñ'À˜ûW`Íq¯³”†üø©»¢í0æV&Uå)Å[pøÂî—£²,¢ÊF³ôÔY[59¤¾óãİçÁŠs;."w™‰Lzaãáiruê
+ÿùköœ#«3ØÈØÌø´ÄŞğô Plê…€û`ü©{W'önn –´³‘»]WÂ;pî@0´¼şGş¹[ÇÈ®8öaU;±¤ÈUÓ…®Ş°9(^DF—²W·IõXgCË	‚ï§r2—D,~Õ´yıÜôIM>¡W©Ä¦ÈÍ‰¯ïÑˆu³ŒWÚYn(Å‹µI‘$ìçÎ—/}Œ‰6ÑGº+c¢K2Qx[rŸuì¾÷±v4¶2©®®²²®.©266))–àû©O3ÆFÁ¡//¸}œ>ÉD ÂÒ4{±£¤Ü¤2¨ŒrQe”™MXUuÓÅ¦ŞÄ—W%oY·–X¸ˆÜ™öBFà:Lİ«i ÀbNC§JMæ¶\¦2}¶F¢â-IOOÇá2N÷Ù3z=ñã·ìc}í®`ÀëõoÈiè½lÎZÒ0©‹ÁE,PyÅ›YâĞÙ ƒÓ£vkL„JÃŞÇ‘Êer¹z>äÁ9¯Áò2µ†x‚_ãìS¡n¥;İ-TÃp¶ë„ª.ì«³Ü‚ÂR›Ea“ğuĞ†Â6¸‘Ûûéy0êì×<¾Ÿ¸¼ßÈ:p„ßğSÀ=´æËS?ßMaÎÓÏÇ¬Ù½q%oÍâèï`pà†\ã äÖ­Wá„„Ğ¼¬"7-w:ébü»ò—·Á'voÛ¾zƒ¼[¡©6Ô‘ƒÎõ€ÉEpár\ ëÑW¶-]–]U–Ig§
+ñÔÔtÑ›‘ÇÀ?>ÿ
+¾}ï6¼7WšF–¹lEsƒ¼w¸4º6¹ZtFªc#weä›ñ½ám	ÛØe‡[tMøéŞ`È"ù~f! =ëyèÙ5`Fãg¬zúnãåèrMrâGÇûæ}p¡şË~ì‚ÜÖùp| DfÍêœ&T»MÂÜ„¦DEQéø´”{=à‰ı=?<	ßMQÅËb‡ğÄrßa·½Aª½
+üä|Ÿts×q²1a·# ñU8nÎùBß&2®Ö•åÆuÌ§hq‘Ll#ëjŞ…öšruÖVbNÊöÜ4|º¼{P';;H¾ŸUX%dZNz™'‘x0Ÿi@ÁrÎ<¸ù¸e9|Å$õAšÏhù}àm0
+TûfØØòôY÷p"5]©¤ÔJ’
+¯ÍÛbUZ(+ÍCâ¯•;8ãCe©™à9.Ö½~o°Øƒ?û]®ùq’ëuŒ¦wV:E9DšÉšeÇ‹+íeÅâaY’ Ãßš¾Î C¶rÓä#tú,´sfg(›˜ùÄÈÄ4O'ÓİÀø À,d¦;YF0ıg0D‚ÑŞ`3}ô¯*‚
+‹§†:}—Ü*±oãáŸ,ƒIfÁÍ&C‘‘üP?Cš=üU¡ãÁ¹¢¶âÚ^­ï£ÃDT
+³›:ì²B›ñõ‘$*ÔyöY Î'µKc9¬VBÅ$FHt)l±%A†Ÿ¥piv”ŠÊnğö¤vÓEİZ_>H2ŞNVó-ofò—¨Âœ§Ë¥y»"ƒS‚ñEş—À“à‰î>zß¡#ãµ¹vÜ^›_ß·¡õå'ùÁÉ½à'—~ÚCòa{©ğÁ2ı¦işğÑ¿ hS\­Xcvs‘³#ôô¸Â \€ñ@ØÃ:Á,òfB€Í/¨°˜f	9€sr²S3óyf’¿¬T>i9#ªM­:‘à×›H?hWĞ›Úä -iÙÕñªŠªsa.ºš®ö>ƒP-“ñ6)•ÙoâÓÁ{œ#6Ë¢ƒs¿*dY9i³j´&¹,oË¼§2ñ4­$~eºœJÄ¡‰³oM‡Ü;§,–ÏÆ¦z–#­¾‘î¡;:>>w¶z°“ËÏV9Îú\r‘à—› å.òí/Lúç#:èƒtSãûİótIb;Ÿ+-¯T6â`esóıĞÁ5dØ:i\ß»å1ËoÚv³­+l¼pöl2D ×–]/%†h´b‚-¥ÂE¬û7½ÁFÏFf*÷F±şœ–x¤nµƒ
+ÚNïæ.íë ¡MİTÇŸ¯µU*'xîs@:Å@ `|Lk:_Ş†/ƒ7 Aj€•à74Ùe¤;ô¤ã©]TLLÌ’\ÊÚôÚ=·!â£—ª•
+9©[ğô
+Ùš¢ŒPù>²¢Œ.§Zªzd’úY®ËÓ•7|ø¥É¦£¹Ççú4f¨ö)‡‰²“nj©¡*‡d‚´™Úc3â£0PZ½Á£é³5wUê›†±‰8¼DT27b!¹³ YaU&E®œá#•(è<+&©œ`ï~fŒˆ¥Ó¼Ákıh˜ÊÎ×t•8ç‡ól‘aŠ@åÍtínk)šP]¤6½îaÎúäfÆ‹³q(p&¬‰‘í–©¦´£­‡j’	ÓîĞµñ€FS¤Z‹ü	ØØÎ×°ŠÍÿÎ,|Àq²hğ6øLôf61¿¡—äêxa ô˜ê£àÀ7˜—“OòÏ‡Ü¡‚¨ğğ:Êã+-4Èúä¦ôše`Û€Ù'Ã`”Zp«Ñ\` Ac,í*r8,ééˆÉÉAôá(ñáyã}°é>ëÜ}ïs'şë€ŞQÿÎàmèRY`¼Ûû—oĞèa\tµ¤DI–ªŠeÉ˜0|ç–lB¢‘¥Ä	ëñîsØ‰wÁwJêUBĞé`ıÒÖ{îyÜÏJ3“ÈÁEìuí»Oà…Å½…Ô)³ÂÄJtµ'P ö²Û¾8ô+Ö“Şî":×hWïØ-Ç‘Øˆ4½ãï@İE·´tQFÊ±ı!,n0Rôä…8>³$î%2¤qêlç	~Æà84ÔŞöö#ƒ¹ÀÍl½ÿËÌVK»÷"Î¿šÙ&;ÍlÛ×f/÷')JMQ„R!—Ù0¤°‘Ë-¾üOãúáëÒééî-NÏ:ehÖÔå^—S­Â:!3àüt™vIe3f^ã¦ªÅREfIs,ï1Ë!®yx’o»ÒaHàÌâú¥Ë–J‡´ÓteE'µ¤»Óu_bà}®K]h2XÅ)ÅÒ~XÃÎ´æçáf[)ÉäpïÎ‡šÙj•$ÜIïlê9i±bÆ÷—¸”B†<0ùOúAä-¤ÌeT&ShÌXÍE‹NÒŒN&7”JSfHm^¯°áƒÅl2[lµ5——Zá5â?1wÁë€?óòÁaéqÑ¤1­¨v˜ëğ“=_‚œ³^‰–W‰H åÚu–|+Áw©œàˆ¨]‚û7AôõÈ»^|à‹†Ğtèß×¡›>B77U«>;ùşáÖ½÷úŞ¨"5\„é©ê8tû8ö6ô'"Táx;ü=ËA~ÍŸ¹(Î¾²4»ú$É,uXm¹M ÌÑ‹1Sß\3›\Èáo¢C¯Hğ¤7ø„™ŒQr„[ß†[}2BåêŒı‹A€OZ·ÂvØø(QT3BSËŒe[Á8xÖ'Ó`åã£¡ØH_ğQékÕQı%J¢¢"éÄ‘n
+3¯2=N¼
+€w!p‘» ¾Õæ×Ú×@@ÇÏ‡À¨²ıE]†!şèéŞq1Ñ#6ğ»ÊYFø‹0ÍGš‘«Ì+ó¡>iûå¥G‡øÕ^*„
+Œ§ECB­òüÜjÀ†E>fQáNI\NTN\f4O$ÎÊMÌRhÅxlfL¶°,£ÆŞj:ÕDò¡›ÑTÖEw¿ÙŒ­/·×6$˜Ó´dª&İPÙ›:å•Qj$ÖŠ×.ÅÖV‡¶|è~à/bno€>ğÿ¯; \ÎèAª Ûİov¸ûÍÈUÀaôÿ¦aş]-ruP1˜ùìkâ~I_Â GŸb¹îÜë›û‘l°˜ÁP°™ƒôÂ#Üÿ¯•õ ÚÖ'P”ŠRQ¾r•B)Ç4)êÜE
+µRÁÍÇ8ÅêâBŒÚO5Šy•¦ò‚B¼¶ =ÖF¦mâ2¼´ Ğ^”[,*$E1æ0<vgÆ¾$2&$oóëØ_ÌHölñc“€‹n¢Û©ÖáÎ³|p³È‡Ëâã£İŞ¿ş÷)3Ÿı¯“'üãÌÃ,DqÿOıƒ«Nº‰njn§ZşäêŸç,>hìêàiÈlµHPFÓÍL˜‰¬yğ2à¡ú·ÔÊ!~ÕL·ÒGçõ_®Uêd7b˜9>Š#ú‚3ÀÇ«|`Ä€-Q(*\¥Ô›”$²
+îfôpêĞõpVaPIğ5!3dks7È‡(gSYYÙ:²î\¡—×ëòÊf*[Ã!El©ÖgÀ:£IG" …©fk8|ğ‚ÊÅ|âbİ¿Épïy?ì©›ÿWrï¦Ó-ÍûU?&ÿS€şğUğ*ÜD.Ù¤
+ÅÛ£L2·±±à ˆ>Ãé0>µNš&.k øµS›èHk|Ñû‘ëŒ‡ûW„×aNİapªÍåx¥=Kd&…Kj^VXXÖ¶Ó¹pï†”Í‘$òmevk.Ÿ Í’ËB¢–@>¶óxÊ?şË”7¸ÛÃìÔe¦B;w¶X±kø¿utíjh§ÚGÈÌõ‡²ŒñGsÃ©PÍ\äÛ3¦FC)qÍŞa-ÄK’­¤ÈlUãÈu–¦i’¿LÒ”^cv¸½çAîgHC>ƒšÖkJ§áÏû½7iòíÀÏ#ÉÉ—â¦aoí;}mû÷)’š­“¨$rİ|]‚m;éø°6ùŞÑn-o$75<…İŸÛ5§X[şBËgØÑŞ£ï[¿fEaUåÓf£¢[Q+9Ìã%icn7³š¿ô$è·w:ïœ!Ír©AŒÏ[²<z:ñéàğü­ŠMäÉãµ‡p@ôÍ™UMÚ­Õ ?$í–ôñô[ƒZáÓø›K¢Ö‘+üC¦ıƒ‹~…Ïƒ}ÿÿÏ¤
+endstream
+endobj
+
+788 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /GVAHUA+NewCMMath-Book-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [789 0 R]
+  /ToUnicode 792 0 R
+>>
+endobj
+
+789 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /GVAHUA+NewCMMath-Book
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 791 0 R
+  /DW 0
+  /W [0 0 500 1 1 600 2 2 570 3 3 773 4 4 278 5 5 556 6 6 500 7 7 576 8 9 500 10 10 278 11 11 490 12 12 389 13 13 572 14 14 389 15 15 778 16 16 444 17 17 500 18 18 394 19 19 278 20 20 500 21 21 422 22 22 668 23 23 569 24 24 422 25 25 778 26 26 569 27 27 778 28 28 648 29 30 500 31 31 583 32 32 500 33 33 477 34 34 278 35 35 778 36 37 500 38 38 706 39 39 466 40 40 500 41 41 569 42 43 278 44 44 490 45 45 500 46 46 556 47 47 970 48 48 584 49 49 613 50 50 569 51 51 407]
+>>
+endobj
+
+790 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿ>  Üë
+endstream
+endobj
+
+791 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /GVAHUA+NewCMMath-Book
+  /Flags 131076
+  /FontBBox [15 -297 1044 797]
+  /ItalicAngle 0
+  /Ascent 806
+  /Descent -194
+  /CapHeight 683
+  /StemV 95.4
+  /CIDSet 790 0 R
+  /FontFile3 793 0 R
+>>
+endobj
+
+792 0 obj
+<<
+  /Length 1376
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+51 beginbfchar
+<0001> <D835DC5B>
+<0002> <D835DF0B>
+<0003> <2248>
+<0004> <006C>
+<0005> <006E>
+<0006> <0032>
+<0007> <210E>
+<0008> <0031>
+<0009> <0030>
+<000A> <002E>
+<000B> <D835DC53>
+<000C> <0028>
+<000D> <D835DC65>
+<000E> <0029>
+<000F> <003D>
+<0010> <0063>
+<0011> <006F>
+<0012> <0073>
+<0013> <002C>
+<0014> <0060>
+<0015> <0028>
+<0016> <D835DF0B>
+<0017> <0032>
+<0018> <0029>
+<0019> <2212>
+<001A> <0031>
+<001B> <002B>
+<001C> <D835DC65>
+<001D> <0037>
+<001E> <0034>
+<001F> <D835DF06>
+<0020> <0035>
+<0021> <D835DC54>
+<0022> <0069>
+<0023> <002B>
+<0024> <0036>
+<0025> <0038>
+<0026> <D835DC5B>
+<0027> <D835DC52>
+<0028> <0039>
+<0029> <0030>
+<002A> <005B>
+<002B> <005D>
+<002C> <D835DC66>
+<002D> <0061>
+<002E> <0062>
+<002F> <D835DC40>
+<0030> <D835DC47>
+<0031> <D835DC46>
+<0032> <0033>
+<0033> <2032>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+793 0 obj
+<<
+  /Length 6648
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ}X{X[U¶'¥!Û¶F%ÆÇXìxG½cmu:¾¦ÖÖjíË¶ÓÒ!<!@	ÏBÈk…¼$!„ 		oB¡Ô¾kíØª­Z_Ó:Ú)N}îS×¹ßi½ß½÷›ûİNöÙÙç¬½×Y¿ßZëG‹[¸0F£İµ-K¾ş72¤¹Ë_),Ì§¦6Ka	‡x˜ÆYÇ¸}]Âø%´ô‡%Kï"–Şùıá¸8ë.ê*½çá¸¸şsÉ2ê&uÉ£ÔOò’‹‹§Ñ˜İë…ü¬M‚,±T(-|ıIÏ¬|ú…åÏ¬|æé¤ubi¡XX’”\R(*,J…%O%-JÎ–$É%ùIÂ’$I–(+£$KT*dI’¤¹YI¯ïŞ•œ´¡P,MÚ*ÌÌ—d%-_T’••”+•½¸b…´4ç©BIÎŠìB±´d…èöš’ÔcË7lß–¼|ë¦õ¯mÛõÚSÒ2iRv¡$I%ÍŠJŠ‹[G‹{æ¦ï^â[vi±ŞƒÅàêJ ùFgÑÂäÂ%wX—,‚%‹‡µ9,fs£ÅºdÉĞâ!k“Ùb5›­Ö%wÆÇÑââââVQN¼×`¤œöp\\ÜjÊ'$Æ­¢Lü6ÓÔòLÆ§ÇÏ-ÓÒtOÂÆ„^†Šñ5zEîxø“‹îZôò¢ÎÅ/->¿äÅ%©Kú—ütçæÓÌæ»ïúäîÈ=Kïá'&%c¼w/û¶“ıî}Kî»x¿âÄşùàg¿9ôPñCe0Elš¢MMá™©ø©ûˆG‰ùG¦æ+ÙÄ&<3¿‰ÁÔ(C7D»t§Ÿµ½;ØOôà‡ÙÒÕy™|P€Ú	>h²»‡0­õ<ôÃ_R_ƒ°¯˜¿Õæöîƒ]Pº·:½6_SjPY4.°€Éhj°8L6£y?t‚ÕP
+M‘’v’rºNQ_»jÛ(N[kƒÅtÅÿJ'Ğ]OÀßŠôµÄ 
+-¥Àƒ,ÙË<2A]®«¤ôç4
+½Áà”oÈÙ	näĞX”º*U‡™ë”w¡}û^q4ğëÙä'	|È©‹ª«R·€Â¬†úF°ÕluD&‡ƒ“€%HWe$m'YšêöÆüÔÆ\¿÷-÷¨-ŒfqŞw@/"W?©(ÅµºßhõsÀ¢·keª8ÖC®ÃÓz=Á@¹EÂeâÕ±£—z^>J;!®uÇßÌ ^e70\‹’£V§VçVÉ+òÄ¹ÕY †—È¿sXPÚxÁ¬F! $xs­ì	¤cÔZ4.,æ»­×İÑê‰†z›!!ewé[™=R—:&¨éô|ß?‡HÑBÃù¿ËËÿ‡¡¶CÿjHÏPş?†doñÿÕ“ü‰ï\òDwÕ5±q¼é9PjT›Õf]#ø$u|L	Yô^hÓÙêmõæj¢yÊt5j­Z[jÈ$`0S` ãòP"¦}€÷ÀÃg‰§ÙcÜW¹dÙ¯Ög‚,Ì0áĞóAf¬5Õš´6hDx;&Q¯öDz÷jØ
+©¢í®ÒYoï¡Útöz{½IRD¶0 Lû¾5dÔ!´Ô!ğFÆÇ‡.\â0—Á§ø+¼ğËÁÄ)w]Ï²\{ó)ö>à•gçdç”eÀ>$JºÃÁp´$ÏÑôßähì\†ñWá°Q¸şõ—¹ƒÌ¥+ªŒF#‚tÖ!¼1èuûÔâz•FS ODş	®_£¿súós¡Ä"Z{½Ğ‹ğ¢—È%¦X&’Â8u’†/¿}ÊÌaKWçgfPPv€šoAù§Ö0ï¦¾
+{ ­TÀCğ4]ïĞ[¯¨†*}ª Ö¡ñ‚Æ†jDşnşsºNiPƒd.¥Z)ÔúĞ~Ş8éè·M6{“»µïğhçÌa–/%ó•T[UèÍ¾ìƒœ[ˆ=ô/ˆ]ƒDÛà)9|Ûn>Åægl—­¦aböhš71 \[£Ò¨4]& \AB°á°ñø‚z4˜ËàƒÄTg©³hÁ‹ˆCŒv½µ˜Ã\V¾‰Â´Á+X{%7”²ñ#Á	¸Œxyş·[§r;M|@ä#¯‘²’Ü:I>ƒÿÈÅ‰Û–kÚOÁ
+íëêŠ?egn)H2OQ rB}^4LÃ‡¾0°D³ŞŞ®æ¶FŸÕg okÇ-LüHûüÇxœ<Ã•´‹Å%%bq{I(ÔŞâ0I™v]#xé5W˜63‡ÌÅ“7ïdòºR9o /SºZS®ÜWùÚœPª4È”NŸ{^™¿Ÿ®ÜY›¡*¬É®(+…*¨1+mK‹"¨Cá.–Np‚púü‘hpÂ{Ê5è° £øôe œÆ€£Ö"ç®I°wáß;|N“ÓÍàÖºÔ"ue9ˆP±[ÑÙÓîá0IÑãñø]ÒÈvX,.˜ôfyïPÆÛ¢/‹>¬¾Ñ§¸Øt©óÃî/GŞ2™Ì`‡Æ¢è:ıö´ı¯óW"Á*ù°=Ç€Õ­/®^9õúñ4“Şd0bæİJE‰¡¹|unk„u‘h'î`§ösx ”§ÉÆsû 2¥ùéE‚j1”Q	Ç	°ZÈwtä³TèÉ€²ò—rÉßTl,ÈãA5(LJb]épº½ĞqËIy’Â¼´	é$gzã¾´>é4„¡@d¬s°)>jûµ F§B;Ó7l†<¨h…ap[º\c¨?D÷½ß=0
+MàÖ¹4ˆu±H¥(‡"TÜ¤èäD‚¡—IŠpÙñøK¤}||êá/¿h½RîúP~YğÿËıïl×5èŒ†[–@Ú­I79²©{%ê\İô¬¡Üµ¦ú¥¢Õ¢•›öfê´z-è¨ƒ;Àx+Ó"&~p/§İÜFÄ³çI¨¬««ª²×µp‰_ZìöæF¥KÁ%w,ü?şr+
+.“ü£2Bp#‰=Wğ–¹Ò(ë6«Ø#©m“—è*JAŠòZ*£ÑOôİ5k8oÀ¾R~?M–[a›÷púpúTé	˜‚Á¦®P Ğ°·#ÖW&‡ÑJÅA½Y	uTª“mä·‚
+İ…yİ•ÓğúÇÀÜUs™2B,Ñº®`/S%û$L·ÅFc£m3pNÉf3Æ3Æ÷´o…­°·„—Æ»eÁş=±±3¥' #ì7!Ç/‰UvÕÃ)8amîjõù'aúdA¾§Ğo 	Ÿ}‚Ã$s”!â±ÎÄèlrVFE³¬+xßÇ†ö|´5ÕQàªtUºêZÀ½¿ b}õôgYÖë,Z' —Õáå~Ãğiµ%T•×ÖI<"G<¯fÂ³ l‡¤½âhı)%b]8£ˆŠ!væŠ_…p`¼ìK[cSRÖ×–qI6£Ì¢rrL`1ÙmŞ–:×*ê«tííÉ¿q™äGOÃë»â1÷Gv¾¬$¿  	s› Ñìp c¶ÊvgğÔuÚzĞB­Yã 46z==3ğš)ŸIã0—VügNÄÛãqâÍÇÙPcU6ª~œ\ìo#ïÀOĞÕJk5È¡¼äˆInÁèd<¾ANıŠ{‹Ş¤3íŠ¥ŸŞQõ)|‚¾gÀ'ÍŸ†¾è¹1vşHÌdj0å6îµ 3ô›÷ï^Ç{ñ—Ë†gÑoğ¬ÿéáå±Ç¯;³ß¨7Ì€˜§\2bÁû4â·ã‰äZv0rÁ¢³k\%c5oÁ9è7;Æ^’0àk
+ù«\"î<JÈAE¶P¡¨®¬’WÉë ¥MÓv°™­öÈX¬mĞl‚lmÆcÛH–N­Óz•A:ºk‚Ğ^osŸÉaïlGÇq^ ô’'kÖÁ´£ùÙ13şFtÄOá…Xş„u/&V³#íí.ô•ù²mSgà¯ptüŞ¬HËM¯**U*DÖ’5tEMƒ
+±è¬¯ºñ «÷Ô‰TjN¤ßˆ\“pöØÉ™cc½‘îÖNÄºl†œ,™LéãEw{¶@2¤Vòóy¹¥`÷­B‚C}İÉøËäûÌÔá÷bßí¿
+ŸQßá3ÙUş×¼ov¿·yÊĞ 3jÿ‹P4:“îol}ÏïPhUósğ<õ¯zN¼Jø»ôõ»x:^šÛ„b“ÑHJÅíæ6¸Í&j…Â®ş•2lîÆ{—™1Â5JÃæ/âñ‘›O²y[d« `ƒ	GŸÍk 0Ôé´eA}2 >/o0ã×µã=
+¬õ.½Ù`7"FZ‹ˆÃÄ%‡iø—Ãñ7·à0›ŒàHB‹ÒUY©TVrÈaP£J—²…‹#d$µ¸\-Á5rW7)¸ÌXm/qOoâÁïğ'ßnaİ >"hìC{ƒ»9é]Zx d4³-²AP)Èãe¹J[½\`³ZÜÈ{xòÔiè¯ø PÉHHş†®ÊÊNãAT™jl­oP{™§DX\ Ü?S|˜3ım£íKgaFÛzFë«Ğ`s|àª·*@	uj­¢bÏ¾­[!ÊZaš=ï÷à‘çL8:Èa 7Bã­LrC¢¬)‡bTâ«hçôÃ=\æ2ƒŒøğSÚlÔØ}x.($n°m“¼ˆÔ$l YíĞ™t6½‰@HæFî<b[-&SwÃ1@x<Bş;ıE’‘IŞäCHĞR¶ø9‡€ŸlÇ&Î"ªÃw…r>x)ÿxó¶
+ê4õ*DÎÎ 7¼@§
+1µF­)Óç’BãÆ“pÆ!=”0ò ¬AmQ[´T!vynğ	"áTÛœ?“w³ÉïÉ2³Ô.»ùB˜ö¹‚í‚F›»áj¢÷ş¾c½'Å%²•[Ô®*_] ‚Óh1ƒôf­EmS7×™F£WLòÛ7C¨5Pj«Æ¥kÒ:4–z[SîÊG×ÈV2@¶ÑŠz%¨ ¼¹Êˆ¹¬´ï?àWÂøÎ«yâÔÉXtEâEø¶¬f‹-<6Ü6½Ğ)÷ò]EV>$ÃÖºUÅ¾PÆ´ö,Ÿ6Œf@¬ÿa.‹ì–ø8¬ÿÈ­*Ë~ìãgÿÁ=Óm#£#£~ª)<Z1%ŒeO¤vb‘©À¯Ê+@x£³®CÛ	ã0äê	tûü¾F¯Õn²‚	œTá‘,KUfJƒïÓ4hZ@*ªŒK1d òr˜ä½dF¯ìpbóÿVşuíû¬Íä#lÖuŞ˜ì*gF£½®Â4b½Ái¤,´*2@¬k¥P]£––öx³aìÌOÙ’¾]º6ÃªCë>…AèóD£¨€\DoHÏİ
+ÅPÚPnF¬~—ÓÄú*Xí.âäKÄù\ü5f³®·ÊœrƒÁ Ñ«Q*ùgz½´¢¤¨´¨´X)…L‡à(Ìö`fk_÷[½]Ãà…fu£âv‰‰F9^Œé‰Ÿàø?g¹ñb–t‹Âœî`G7wßü5ö÷Ts™ò†z3b×›õ.ğ" âé¬äok ‹¿Î¦±iLTIúş¥¿Ä²ƒ4‚v0şæ6ÜÉ&ğ@BK½²²®®’CjTIJx€H F-v{à5rS5O;ra®;š8òw¼oîÕ¿³æ	adG[<=çw®ã>›)«y¯ËÖÀ* Yg&ö¥K©À˜
+#ÖÏı£>êîDùtN,k<¥}ì…LqÑ.de ¦wııøh‡¯ÓÑ	}ĞQë‘!Ö¼°¢¬€[è—uqäólÖÏ.©56ÁfOY*ç‹d<C©³²UÑ¢jÒºjºë'à4‚.s§­Ã=Ñ?:ƒ–û·Ğ@ü3š8ò–h7N‹ŞbÃ¦›O±S€W™“Ÿ“_	)ÀoÎçÙêÚ*ú‹ëÊÊÔ´m°ö´ñbyC¢‰ªY8“Şá¾á>ÿÌÂxåp^?ªq‹)İˆuñâğÀ4œ@_®:¾œƒÙäïÙ°W”şF6"_¢‹Z+; ?ÓúÜ‰”’=¯g³®¼°áØG\8Ûø½a„­¥µçB&Z¿öÍµæÛÌã?Â%©/OŒ°®ãç‰7ØyPT.Ë®–(‹ÕbÒPzŠÑ›ÀF—Åï9èò9ª
+¸ Ô+yh™GWéªÁp»ğA“İÑb²Zı^äÿ+½qÂÖÑ`µw4=‘cÃ³Ğ^ª¡”m<†X?ÔkÊA	»G…‡aÚ;†]Ğ.µUjƒZ£®EèÁ ]#€jJKóC“½£y ±®÷^ñœ†¯Œˆ<’&±M›!¹ğÀ.¤šäõîÄ$¹ÊÎ
+á§C´ñKØ<ïÆl6´[¢Îa4™p¦ì}ÍÑ¦¶VWĞæ1µ€f÷Fv µùšÌ+\€şíØŸ¾áÌÀ„{8Øãú[ü6‡É&pi¬JĞ€F[_—w€_˜ZƒDuRmìÉaxa3–±7mÉ#ÙœÜßÛ]£ş°'èhÔ)Í¹ô]sïw÷SAÿêŞ÷wÖOá$v^e…pí‰œ¹Áé¡‰Ï¶^„Ï³¤WÓfcémû`¤È<Äú™—.ÛMõŞ½}¼´Ié1˜†¡®Î#HÁ ’V¶N)ÊË«ÌƒL;Ê|ˆõSw‹·›Û%ór0ëG¶ Ä­ò!ÄúY¨ƒ3pÆ6ê¶EZ‡aÂß~W‘-â1ÁªÕ€˜9ò>‚è£M_Çëñ„Ÿg¦Ë?ËŸÚÒ¿òA¬‘(Éi9ä½@® aC¾Iä!ï?AÆã' E d	ºğ‚±>|àåˆLÀ¶+Ûº…'´Tüš)¯ƒ$v©G(«;§ÁG®[Î:û<§‡"§à8Œ
+šŞ¤˜4üyéÁDœ€—‘ËÆXçp5™Î^÷óÒ÷XŸ5Ûí--uö*.ë¹ø—*¼ø×9n£²±†óß·áeéc¬sc¤‰ÿ\ERëªnSV3—uî½_–®ûu†KMıª7D¯õ„ˆ?ÈáÄPoõ71eÍ)ñsÄ6v:äJ$ûËµEPu[Åm£ÕÜø024n°© A¥Fªg=Z¶²áå‰ô‹…îÆ®ö\òäMkARWMb}§jhõA
+*ÜEÙ¥¢ìä©Ü£Ì€¯Î¡¯	&İä2ÚÁr;U‚¢NUU/Ó”ëªĞÒI¯ÍÙ“ˆ5§Ì*âÂˆçtôsw¯­šĞdn_
+Õ,†J0¯¯%F>İõ~òƒÓ–œÉ>–¿ƒ!PÊeòš`+ïg@¯¶Cí-9¶¡ï5@k^æ­ÏóTD£--Q.„ª<"S[0ê:9°s37ñ’fG¿±*7Š„<Ø	ÅÎR_bFÄ£ÕGàŒ;!–Ü–Õ•4™å²’}¯°Ó²zÆ¹ğÕõ¡9z’±ñÀ®fŠ2Ü #şÆ©”.úÃl½ÊêÅ‡¨Öv¦-6k›¡ºTùaşl`¤À²l|œÎ’‘ÿş¿Ê[*éÕnFô(=’“ÄêÔ†Ù|ú$ƒ*·¶	Ü`€Ûä²9CÃı­0Qyß[àH‡mˆŒËZù8‡IĞ`øv6‚WÆ_¶°•V›ƒï2ÑÆµ>@T¨9k-2¾ÜLé<6“áˆvºÅït»-Ö¯1(è2¨U\òş1€^Q†HbşĞËÄ8]ÔÅ€È¥”bUªtiü­Ã¦J.èõºZD&Î]•%•æª%º<3ÒJÉupÊäœÖù lvhAàP[ªŒ sC˜6“áûï'ó£›*¬*'ØÁns¸ñ ñ=¹t~„^_Z«¨ÒÔëË"@²Z½ŒË”Á ±N†w&¶÷—z¤Ó¬ğõ›‹Ù 3¨©Í<0¤k«´*V¥j¶U›Š•6›{Î›ctÙ@o‚Y½‡òKEÂİ*‹®Ao+Â#tS“Éa2™­í¦Q˜…­OåS9e „r]±FˆX„¾ÎPOu§–z¥T9LÔ‰×ÒY?-F+XåIÎüXB1èuuehù
+]§Ò×´@	şTCk·4/Ç¾ÿ”ó ÁW£±Ë´—ŞLê£M»„‹?4õÆãñÓlh7µZZ¨*’"y­^¯×hv’ùPy[,³€Íâp¡±zoÚéğ6íœ™é8oÃDåP^¤Ê-wIRK©µÔŠ6yéyI?AÌÓßé¶Äào0¾‡r­*aR[´vêlvs3šÁtJ:ãh@­Q)o/½p,5°¶ÂÎ’ı©{ß,¦D£õ;U¢Šè‡«zÊ`#¤•óssrs2ËÒá	x5×)ÒÂ§ú±»?ñ0¾c^€·}ÿ<¦³®ãñì³§Ág0VÒ—Ú!h;àJàÕfËÒ%Ò\HGY¾²şî@{7º+½"K¨;ÖrÎ@¿ ¶@ª"KRP˜'×üY[¤/7Õ8ë}œ™ÖwŸl~ú™Ÿã¾{Zó†{ÍŞVèEQI0O —ó9°¯ƒH+™¬9'`Æ3Ş3Õ<Ç|õâé?ù“L9ƒ»âq?1Î–@E­J†ÈÕó/–ñt‹Ãä„‹;
+ 1ÿE…Ë–
+endstream
+endobj
+
+794 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /PJPLDX+DejaVuSansMono
+  /Encoding /Identity-H
+  /DescendantFonts [795 0 R]
+  /ToUnicode 798 0 R
+>>
+endobj
+
+795 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType2
+  /BaseFont /PJPLDX+DejaVuSansMono
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 797 0 R
+  /DW 0
+  /CIDToGIDMap /Identity
+  /W [0 17 602.0508]
+>>
+endobj
+
+796 0 obj
+<<
+  /Length 11
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿ  ¾¿
+endstream
+endobj
+
+797 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /PJPLDX+DejaVuSansMono
+  /Flags 131077
+  /FontBBox [49.804688 -176.75781 554.1992 758.78906]
+  /ItalicAngle 0
+  /Ascent 759.7656
+  /Descent -240.23438
+  /CapHeight 759.7656
+  /StemV 95.4
+  /CIDSet 796 0 R
+  /FontFile2 799 0 R
+>>
+endobj
+
+798 0 obj
+<<
+  /Length 844
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+17 beginbfchar
+<0001> <0028>
+<0002> <002D>
+<0003> <0031>
+<0004> <002C>
+<0005> <0020>
+<0006> <0030>
+<0007> <002E>
+<0008> <0029>
+<0009> <0035>
+<000A> <0036>
+<000B> <0032>
+<000C> <0038>
+<000D> <0034>
+<000E> <0039>
+<000F> <0065>
+<0010> <0033>
+<0011> <0037>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+799 0 obj
+<<
+  /Length 5849
+  /Filter /FlateDecode
+>>
+stream
+xœİYtTEšşêş·º“Îëv§;„WÒİ¡y!!!`t" 1äAB2$E@yÈ°`;aGÆ†e4Ì*"£Äqt”qA´EºŠ=U·;ÄÇÙÙ=sÎvŸt×­[õÿßÿı_ıU· KAH-z¨Ú}¡Á	à  ¥–VÎ,¿W›}Ğ 9gaiú=wh3~[YIa±õ:Î‘g )++)kÒt JÚèUV^½ âëx *@ï9E…±-75E^—.¨äMz j) ÷ÜÂò’³})
+ˆÚ¸ÖWVTUc6®IrşÈÊy%•Ã^:b’ ÖîhÂ	õ·‹m@J4a¥¶ZÛ»	/à45®‰`«Ù~œÀN´â–ã³ÑKl(–ã€)º'P‡mjf}ˆ:ˆÓ8·QC²LÚì4<ì,š°ºİÂj¼@‡°ˆÑ–ÈÊ±ƒ=`šX–h‹Ğ¤M@Nê§ œÄJ¬ÄFì@N*dËÙ¼ƒ}¨E6kpöa?éD›>X3®`‰¶K»]+E-¡[±•-G3ªt0ŞãÍZìÀ>l0Ûx3ß,ùàÍ¼™† zZš,Nk;­xÛÉ²AZ>N3aİG?¢·Ù
+=IŸOP§Àƒx7[œ¨³&¡ÎRÊê¨÷"Ÿ6_€íÂ‹Ó:ƒ¾Ä"ÍƒcØ¦"öix>Ï×O¡Û°M}Ö™Ÿ'é*–cƒ&Øh}$e¡‹ô±ØŒ' ôA€
+ÊÀƒ¨À"¾Î|cv!™¯£zm‘ÉK×nÇ6­”Õ¢N»‚“¨ ŠRôä±‚í³8ëbTñfÀ‰ç¬®“Æ0ÀmìÑ|yÅ{üwNq¿<Õ“<à†K·auïÁø=QİM×¯Ÿ¢wçS÷ğ{È¶G÷%½÷M7ßK0füwë’;"h6÷ÉÆLœ²GóÉ«S=ä¹#Ô=éu÷íá¾¼ö¸‹ÊÜkŒ5IÃÖ%Ã’¡¡LÔëe|V$„Îœ ,Ìù,ãË5)GÏÁ88Hµ{ì>İS¦£µŠº·¾/ê­Ñ_^šgé Œí—¨Æâ@ı1–møIt”ä° Şmœ	¤ì™™ƒ`´R™Es9]’zkƒC©fÅòå+¶7lÚÔ`qœ?øà}1ìƒ‹ì…¿eG`¬˜¥rm9ög±]ÓtãÌQ…*•y\V¬…_ûB[¾W }$o†½ıNjĞµ¾ÊŠ†ğ°$K!‰EgG[ƒHk‘Aù<váK·K;Ñl˜x†…i}y—^3¶é«Í»ÌØ6Š÷´K,ñşú°ÎzÂ"™y5Tº‹’bÙ•Öc[‹XÊkb["çV\?§åŸ!]ÄlşnôópGCBdC|}Â–^®„îº{c<‰½ŒÖ@àLÀ¸8Æù–€qñÌÅTÿ)Ha)Z
+¥è)<Å’bM	K	O±¥Dd!‹eiY”¥gñ,K–5+,+<Ë–Q€V Ø
+"¦c:›®M·MhD#kÔ©Qoä–FkcXcx£­1b7v³İÚnÚ­ïæ»-»­»Ãv‡ï¶í8ŒÃì°v˜ë‡ùaËaëá°Ãá‡m‡#F~˜ +š®OçÓ-Ó­ÓÃ¦‡KÇßd¨×46’çrZ’¼½c½šİp¤§9ì†ÖG}&©vnÜ[ÇdŞ:fÅºÚÚuëkk×zùò§Ÿ¶´h‡?ôÖü±Ú6ñº8.^¯³T6„e©ÛÅ±L<*°Uì¶„­R9¼ hï³A Ïâ	õ”:RRHeéö$v¡µ•¯©±÷‰KÔ'¤e«Ô²•E„!^wDDgZiíZNs¸œš5iˆ#c°ÆîS:Ş¾bùr‹# n;û¸-ğ7öâ¹óìE€¡îú9=™7£'n÷{ukÏnV{­±ŞÙ¥5`UÔë®J@—fóÂHL0Z¶êA	âÊECud¦Æz\ûYz\N$y{÷ÉH`éiC2÷NòZ¬¯i-×ö¿{Àß˜!Î}1ÿXş}ûŸüÍ'ïÜ:’7ïŒqñ£€øÌí>™6hÏÛ÷ú|ĞÚt^¸İŸdMìÚ`Kl0l¿ÔY-ÖëqõÆŸ7½£¼VK›è“rm=/Äù–@KÀxß¸h\´g¦2×@&Ó'Jr’Üšİ€'-y-.gœ	”Îf­wäÅÔ]sßü¤åÑz‰%1ç›Ä;Ë6mZöØªU|ß~_qV|X<[|ñù%q…Õ°ìa¶.ñÚœı;vìÿõ¯Ù#s…Í€Ä?CÜéï‡>náñ]»Q—î>‹…çö'£œõ:46ÙºxêÕSR8rÄîÈƒ–WSÇLœb5ø'ö.™ò«KÚT¯ÏãòdÁĞ² µ2&İå´X£«Ñi­9Àâ3ŠGn\zïË•3_*|›EL-¾µy×®]ÇØÀ>ÜP°x}ÎğW¥]xş#ÕÙÈz°üú9=_Õƒ$¤`¸ß‰†>–†„äG}Â–>O¥ÆGöº%ÁÕ+!&<ÁÕİK	1ÄT£õh@iA2,µP‚0.ff¦v¤Õ7e„Ö•5¹œz’·WÆà!±¡I^‹V¶rãã+Vm|\¼²lÃ¥×O]Ú°¬¾QˆóçÅõÆqK>¼tÉ¢…KµckÖliX»zó$Ï¾%{OÚ»dŸÇórã+çÏß~œÍXğÈ#^ºLÖ8M‹ô
+ŞQÈñ'²(ŠQT(ÂÚÀ­
+g‘6$„é–˜È^ÑFkë™Ûä„”ó²åÈ4¹×[~|ª7œy(İîJ²'Ù=ÚYÑıÉóÑK/¿¶’÷lı˜N¶¦ïÛXñaé{ÉõsúHÅg/üÀïµ !î—FTmäz£ÁkièQïİâ‹µKô†'Döî*e{>ĞÊV­©ËJµ!z\Î8RëÉa–:ÎìHw;¤‚½½µIË6n\öØª•ïIõK‘êıü]¦_ïˆó6iõ!i^[½ß×‡yX×âÙÌÖòŸ,\¬b¥¨J”˜]?§OÑÁ…Èõ÷F1[mø:KÜ³Ì²6Šı®ëÚØCQ[z’ÖÃ³ ¯‡ÃİÓh	´Ú*ıç[çeú–‹Lµæ<¦†º¢Y’véi«\ˆ«>¥õÜág¦)ŸõÂ½â+ñsöÆMú†U+6´ûï±<÷ò­™ÏõïÏ2Y,‹d~ñî±'Ú³«¯ŸÓ‡òÏĞ£üıÛà²Õ†ïŒj°$ÖºwöhHª·lq=Õ/.äìšĞÛH o¢3<±ŸÑzôhkàLÀŞ%$Ô Ï3SYP“JV–Ñ^»Ú…mÜ&>¾<ó™¥/ÎØ¹wïæ­[k·mxlê¡²…Ïç½ÅøjJìóÒãø¸w¯ãƒë×=ºeçÃåU‹úöİïv¿ı›Eò 
+†Z@Ê›aA†¿+÷i¤‘OçzoÀ*âÄtæE¢Õ´JVSZ¡" ÿ¦zc=.–Ä<µôôµNka×2xó]W—ñşÒ6 İß´öÈù>Ócn»ŒÄ0é§ßÿËĞ÷Wk®1~(,€yÓÄk¹è	è§¾ZsİÉ)K_L?…2¶‹ã
+Û`»ÀîCV`3–£K°«edòùP†MØ‹½ì!¶–5im†¶ŸzÑ:¨z¥şSÓ'Z$úc6,Ğ``‹DÄïfvpèêélLÔsŠÙfpãP°­!ïÛÔ¡_ïĞæˆÇÁ¶= ‚í0xY·`;ÃØmÁvTloöP°2ç6G*±ó03Q†j¸ÑEè7ÒŠT¤ÃX7r0Õ¨B5æ¡…(Ç ¸‘‡¹(Â@¸‘9˜7&´ÙªRW%¨B	æá!” aÃ”àAâ.ÔÀ"”¡s1St£PÙwcæÂJÔ`æ`ŠàF1*PBuïF;•ia*0ÈA*0w)ÿU˜¥úed‘¡æ‡f‡æv¶]ªzÍˆªƒÑË«Q‰aHA
+ŠƒãB¢
+¨Á<¡DÍ§¢ˆ¹(A5Fv°Š6Äú×Y–÷$ƒrÔ”`*0ıçÿ;LÊœØnêÙd®îN˜¿®’ÿ·ôşP¢û;bdQæ\öÈKÎæa6Ü¨@éwb‘‘WöÊ•µvš¶ËÔ½’`\3•É²Ä'í”ª»%mŞÌ›j’÷«Q¡ÎUó+ƒ:7=T`ªƒ–3ƒ±™Ù¬V(:k¼Ej\9*ƒÖCäh»©¤µjL{;¨Ä«2'ç«o{Š0…ÁøL¡åÊŠÄZİÆO)faNPÇ}Û0¶{ë]â¯Æü Î¥ÇvNdO%æ¡Å¨Q8ÛÑ«dÆfajv¾Ùƒ´.y(ÂÔ(+&'ó•ÊÔš¯2#óİ9¢ıv…Wµ¡­QèÙ–¼´çº}ıV¡LõÜ,mq¦¨ºãV–Íõ`Údµsö¿=ês&ZSgf„U×Ñ|ÅGù÷òZ¥ªfÎFhjÄ´&•"#©Phª¢EÊ9¦£ç«d(C2rÁ¬¶|Ta˜Z“‚³
+1ª2´ç c-jgàë•@îÒ®TYU§±¡µRyÓĞqŒJ®m3S²ÎwÖšÉ†YÉ¿%ŸÒ²Y/dîËÕw{ıø>¹¨ÆB…·TUi{`'¦¾m®äda~é]r.×r¨¢IìR§óÚzL¤’ÓP”2ŸUÚ¿¤“¯ÌQWíÉ¹’Ù™AšñÎÄMY°o^‡*£3‘Tµù¸‘ŸªïŒ©c+î¤0éÍ|;’ÎşnäåfMç*O2’o®êf–ä§ÄWŞÉn¨§ªM™¡usã.R¬wq»§ù*ªb5ß{“}ÑÛ÷3äøĞ®ëí 6síŒ½aŸ‘¼˜{S«TÃœ™x˜uÆJ°@ñlª·•¨îbrõËİ&4£cşMÌß¾bdå=ù]Ä(ı|›^ÌènVÃåİ5ª3ÃŞo=¯x;åğºfeÓ¶g·¯ºĞŠ’'síÉ}ÉÜ_n´(ça6
+ÕiÙÜ¥ª¾~şø¿¨Xß•yÒ2Y”ûbiS£‘«ü “”ŸŒÄ$ÜlLP÷ò0nŒÇà.äar1Bå%[İ‘÷½j5Ş<e± “•-ÓÆd+ÛSáV¶åI5_]Aò1BÍÍÅå#•ÕLP¶Ça<Æ"Où4Ï˜ù±˜Œª=JFMù(Pßrü8…ÅD:	¼vF%-OlC6¹˜€á¼›ä){¿ô?RµóÛp"ÍVIËÒæpLÆXu%{'cÆ£ ŸÒòˆ Ú|ÃHLÆ’«˜™0GÆcª1
+£1I¡&GÊëI*™™qÊëÕk"+fY¶Û­Èç éÓÄ!ù¿«ÍóDÿXŒUÜÊx'*¹ÈÆ¸6»!íŒR$n“É*>‰/OE(mÈ{’EÉçØ¶‘:dEæ4[åM"—óe$’‘‰7$d­svn¦iKæM25VˆñÈÅpeÉì1õ˜§bäÖ´iêŞÔ„9ÖÄ$ó“¯2{'&G˜önŒÂ\!{f²ƒŸÃ;pÖ}iQbá‘j–*û:+rıI$r”T¼
+± 5&³d"7×‹é#”ÇÉA}†V^şü†ÖQhÜ÷©¦­ïÎ”|JL„f%Éÿ^vÍÚ•‹ªîU÷µª¯íÜOí§ÒçÏjmÇ“€Y…G©±å7Œkï5ë³¹gµ?ót<Ãİlç
+=%¸áô:}˜µÛ|6êxú-Vçtó,XÕv*1÷Š¶“‰<ı›'†ĞS‹|”ûKçç½*å×ŒÌôõu[æùR3½Uİ„ÍoÛ¡n|B”X$GÒò|Õ–¿%™'†B5F•ıßğTlÆğısŠå»ø—½Uj•gÑYŠay´;¯íù¬É€ùëVùYoWŸ´6ìkçPÉÁÌÈåóyÆç
+éÓöwü¾–¢øYHQåÜ¨Ná•H¹áD)ÿ? ^×Á=Á_o;¿ê[NÄ€;"®p¡;º F#İ€ßjK™kï¦i<»s¡Ä\XªşÇ/@,V}:à 1»jê3[A,Zµ£ö~<ŠgûXƒX$| 4³){ájT¢AÌªÚ5†«¶®úIõhª‡ù§
+‚®-¦VA_	ºšFÿu€¾\L_\YË¿ôÅıÊå©üÊZº²T¿ÜÒ›_J—ızKoúüR
+ÿü*]J¡ÿô™ OÓè¢“>©§ÀÇ£x@P éú)ÿuıãQôÑ…bşQ=](¦¿	úğƒîüCAt§÷ŸMçıÇzï¯]ù{Wé¯]él=½+èAyÛÅÿ"èm½UO~ÓÅÿ,èÍuüMıi1½1Œš×EğæatFĞé?ÚøiA´Ñ)A¯zm¿ÖƒşG'½ZO'j}ü„ W_L/zIĞ‹‚mâG½ è÷‚~'èÈº~ÄI‡#éĞóø!AÏœÆŸ?@Ï/ÕğñƒÓè _?à£ı‚~[OMuÙü9AÏÖeóg¯Òo¶Fñ}‚ş½˜öÓ¯£iƒvzFø¯Ñ¯=-è—Ú%è©_Dó§ÒèÑôäN;²/í´ÓÏw$óŸ/¦Éô3AOú7AÛ»òíÅÔøSƒ7v¥Ÿô¯6Ú&è'[£øOm¢-›ò-‚6¤†ºlŞPOõàõ‚ß4?~€_ªoú±ošF›üúFAÿ"hÃ}|Ãú±êj}¼.›Ö¯‹àë´.‚ÖÖúøÚbª]cçµ>Zc§Õ‚V	Z)è±vş˜ vúgAË=jÏáN¤e‚–. %,æK=²˜'Ğ?	ZMš/è!A5Õ‘¼&†jšüoéÕ‘T}D¯rP•_Ÿ'èG‚*UÌÈ+êiny_>w"•÷¥9‚f§Ñƒ‚f¥QÙUšy€J•*T4#	šƒÏH BAš.èş{"øıÑ4­˜î{™î½'‚ßë¤{"hª )Nº[Ğ]‚&wïÊ'§Ñ$AMtçb/¨ÀIù‚Æ±d>NĞØ4¦/İ‘ÏïJyÃ</FçÆóÑ‚FwğQÅ427<@¹ñ4b¸ƒJÃsì|¸ƒ†7i~¸“Ãsì”Ó¤Á®gû£yve7±#şpİŸÉıÑäobKıázVd8ÏŠ¤¬&æ÷ë?t;Kæ·_¥Ûı /”iÏá™Åtë nüÖ14TĞd'"(cNíÆ¡ôÔn<]Pš=‡§	”ìäƒºQj7JIvò”xÇ ä±<ÙIÉMšt;À°ó±4@Â­×ûßâãıİÇoñQ?mï'¨¯ >‚zÇ/.‡ûr©W%	òÆÄp¯ ;™{“;™ÇP‚=‡'ê)¨G÷®¼‡ î0x÷®ÔMPWAñ‚ºÄåğ.#)Î•ÌãrÈå4¸+™œÅÂà±NrØs¸C%s{11Ü°“arÉcb(Æä.:ÊÆ£#)Úä.*2œGÙ(ª‰ù÷é‘á)µ5Tdã6AáqfU…%s‹ î$Ò†qºJKæÚ0b08K&ÄšXñŠu¬ÿÿŸşÑ şÎWOü7-¾| 
+endstream
+endobj
+
+800 0 obj
+[/ICCBased 802 0 R]
+endobj
+
+801 0 obj
+[/ICCBased 803 0 R]
+endobj
+
+802 0 obj
+<<
+  /Length 258
+  /N 1
+  /Range [0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœu±JÃPFOŒµUªv¬DœD@¤`]\Ú
+F§ëMkŠIˆ¹‘RŸB|êê&Ø¥n‚à¤‹¸º(¸H¹rëTÅ³üË9ğ`ùÕ¨a”&åÊº»ãî:Ùl
+Œ3Å¬*ŞªnÔ ”h)™&C|>b™û°ä‹ÈëŞìçº«é»“æõAçívØıCÆ«+	ô€y')ğ
+ÌµÒ8+¤/<°ŠÀâa­RkpÂàØ´óA¾mWÓQ”IhÿãŒœ%–Álş½E5VW~ªüdµşX€ì)ôÏ´ş:×ºöôb‘ˆk#&¼_Â¤3÷0±÷ØIì
+endstream
+endobj
+
+803 0 obj
+<<
+  /Length 314
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vİ÷BšË¡©hˆFk	¢ÙÆú‚ !
+¢­Õ †’‹¯ZPÏò~xx^Ş—”ç¼QİŠ¶ùµx"©¹^PñÒÏ cº!ÌåH0
+ ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;Q?V.ø_îtFÀà3LËEÆK¶)y	ğëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ĞŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzçm\‡Ğ8rœÏSÇiœúµ­öşfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
+endstream
+endobj
+
+804 0 obj
+[818 0 R /XYZ 28.346457 795.19684 0]
+endobj
+
+805 0 obj
+[818 0 R /XYZ 28.346457 553.17584 0]
+endobj
+
+806 0 obj
+[820 0 R /XYZ 28.346457 770.84283 0]
+endobj
+
+807 0 obj
+[820 0 R /XYZ 28.346457 473.06186 0]
+endobj
+
+808 0 obj
+[820 0 R /XYZ 28.346457 300.49786 0]
+endobj
+
+809 0 obj
+[820 0 R /XYZ 28.346457 795.19684 0]
+endobj
+
+810 0 obj
+[822 0 R /XYZ 28.346457 485.02518 0]
+endobj
+
+811 0 obj
+[822 0 R /XYZ 28.346457 345.71332 0]
+endobj
+
+812 0 obj
+[822 0 R /XYZ 28.346457 795.19684 0]
+endobj
+
+813 0 obj
+[824 0 R /XYZ 28.346457 770.84283 0]
+endobj
+
+814 0 obj
+[824 0 R /XYZ 28.346457 471.37585 0]
+endobj
+
+815 0 obj
+[824 0 R /XYZ 28.346457 306.04987 0]
+endobj
+
+816 0 obj
+[824 0 R /XYZ 28.346457 795.19684 0]
+endobj
+
+817 0 obj
+<<
+  /Type /ExtGState
+  /ca 0.19607843
+>>
+endobj
+
+818 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 800 0 R
+    >>
+    /Font <<
+      /f0 776 0 R
+      /f1 782 0 R
+      /f2 788 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 0
+  /Parent 1 0 R
+  /Contents 819 0 R
+>>
+endobj
+
+819 0 obj
+<<
+  /Length 2255
+  /Filter /FlateDecode
+>>
+stream
+xœÍ\Ko$Ç¾Ï¯èÜ¼S|Ö0de`«[œƒ-@@‚¬¬äï=î™nÕ{¦«Û¹¨¡‘TúÈ"ù‘,v=|ş÷Ï¯İwßºîáÓãŸ~èğğı÷İÇÿ9P‡vßRÇ	DƒZìb§Ğ=9<<c÷üë»_Ÿ_ŸØ=}=<¼`GÜ=½œèO_ûæ'Dü	‘NO>=åôÔÓÓf?§g<>9~};~}ÿÆ‡¿wO>üøtøëáÇO‡‡?~}ûÇËÏÏoİÇO×d
+	²\Èôøù€İçÇ¿´ûtèıË;&¥ØıëğÙ[š!…(¶ÁÒ* Û,Í¨@‘D7X:d [,-‚$n±´b ¶¼‰B"¤³ñ©³´Ä™8wxãÚª)7\»·lùÍü˜ $Ê•¥9Ì·®rUI¶ÁÒÑ€Ñš>«:A1Éªœ r}ïUh¦Ô~eKlwñ¬k³H–âÍºs¸NÂ‘BM€²¦
+ÓQGTç¹æî›…læÜ5ÇË¼ÄéH6ÚEã©»óÄ€ŸşYA %F'5PÙUŠ'ùĞ}OÊ|¹øù×¥êÓRjC<°^3ğçlD¦;?aÜw
+Â à	c%abx¶0Œğ~Û$™üìår=è¡äv’ÿ=¡Ïşş”§2{"Åºgrå"$bq3Õó~ ƒNG]œ¢›§“\w·õ:ñ‚aİG6PŠÌ>¿úô”GTw’-6töù)ˆqœÊ&®“ÃS¦	Ş[oŞÖ;Dµ‚»÷±¬OÁÅ{ïÕ&à]Pál©Ñ0·À©¦Å×¨C9{˜ÃLˆÑ<Ü´…êä’LŠš;¼)xŞTg—oı ÅS&%¼Ønë4´%vš}?˜ïhn¾_'°=ô>s9YL`\'°°z>ÛÊğ¹‹«…!gP«ê,v<Kü¥Y#’6àe”\b!SPC$^ÁÛAÑ•Vh3"pS¶z,µ<mãÜLİ­õ`ºÂb¯¶Y4¥Åú‹õhº%ø±›/-Ò8ÕÃéš¿?æz<İÑlŞ¹Ÿ[
+
+ÖİNÂ´Ã¹A,Tw»ÆpÆ3ıÅeOŸ„ën·ø‘=İ˜ Rw«5;Zb¸ötÁkİ­¶Ô,—ÆwXŒdÒÕß ¾‡ÄîGà:Ï"è,»^°å‡µÇşnÇùŞ¶8¶ŞÏL5·ÖÅzwlìÃ÷sı»•˜Ö	Ì2NO»6(ÂµN`k ,ÖŸÜJüZ'®=@¿s¾Å­Û.Ÿi~Œz.GhØv?º›Új…wOÆjZÍqÙ;]],%ŠÓbó*,×ãKDe³¨6àeÍZâ›  Ä²pGZ»À¼½3~îÖšëA<Äé\ÁÅ¿a=ˆ¯€°XŸ³¦Éù|Ç=r¦z0ßüµ.ºëÎÆõ`¾ø+–ì[®I=˜ï	ş.øâqÖ8~i¢UÁ¯)ıOC/“ƒş·]êæ3óÙSk5oj Ó…ÀÅiB
+–iÑh„ A7XZ#0óKFĞƒm°tˆã&¨/ÆĞ8€:K‹"(J7Ï¸!CÊ©>ºyãâD@G+Ñ˜A’U'‹@xûÒf"7\zT‰
+ƒXŞH%˜úÿ³…J$ˆÈ*‘@ïQÉ» ]Í¼­—&^Èğ0i¥üœ)¡pêAwdÇÑËæŠ$³!d¶ĞÚ@ÃSŞê	ÉeJ˜+õLh¯®K)¾Á¹¥·Útpsf
+G):w®î¿¦8r7ïÿ/Îî¬î~ \¡¸?\ÉÌøJ.ü®0r1©ºõ›Ip>oœI4ëí.€ëFdJG7Á›gÅÛÀ+«¼z ŠÙ5§Á
+WpİÀênHã†Fô®Ë4{ºLBİö’àª[¸}³kì½>'×ëVPbeè³pkáÅP¢€hjÖ ÀW@,Ñ	pm  yÃXŠç!#5AàeD±#«õ)ü
+ãÂ8F»´yK!:%ˆ9ä=ì¢ ³¦Ôâßû“±xZŒHCFİ%<Äây17Ùdõ”§h	°ïÌ<§h9@½%d‚H¹z Ã]„¸æ1–;à(˜ö1JÀ2®Ã0×ß%G )µ#ŒS÷ß‹jÖ€¢j½”MÅ» Š´ØiAïeœâQ­"Dí³é=q*¾ƒa}E•›hÁ{ı&ßÁØ¿˜©-èÈËL“Ö‹ÅiC©yq¬^¬à)Ô‹ƒí5Pìˆ@lÀµT¯N´ÏtÇÜşæ3ñ”ëÕÉï%Áy¨Æ}ë~HaÚ{mn™êF@ˆiƒNÍ»Ù´+Ÿ»}Ìu#Ø\‚ùĞõÍ#¬YªF Y¦]òæ¡(k5¯àãlÕ`¼€ë¡ê=€€iC#_Ó˜¹Ã8‘àQ¬ºÁæÈ¼Õ:c-æ9U;5«C¡_Šå\ïÔ¬†àuj±ŞªYÀ+É	©Ş«i°î;•ÈÕfM^@XìŒçÜ)PZWŠ7EXŠÊQ@Ô,ôÖ(€F[ƒ(Eæ{—H±Ï+	KÁ9 bZáöÑGÂRœÍ-K…èÂ6Á¥-d°õ	XA4çœ€°sß4“Nèvç‹=bH&m0¸”@Å›2ˆ2°ˆI^rtT¼ò‚X!¶á2Ó•›+úû¦¸Í^¸C¿T¾ºB¬Ÿ›Š7P$˜›èÁ·ÉbÛÚ­IÕèw°¨xo…ş®7i‚Á+Z¨|ùCˆ xU•/ˆ}Ì¥cé¹uõNÅ+(ÀFPÜûdŠW1P/[`p½²x¥¥¾{¿†b„Ì¼[/‡ŠW#PN»j¡ŞY–§syíãBñ"ƒ‹nÆjn\(ŞcpÑÎØAõæòz¾-Ö»Ë0ÛıšuTÆ—eı»ºêíåıD˜¿º}åıóÿKD
+endstream
+endobj
+
+820 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 800 0 R
+      /c1 801 0 R
+    >>
+    /Font <<
+      /f0 776 0 R
+      /f1 782 0 R
+      /f2 788 0 R
+      /f3 794 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 1
+  /Parent 1 0 R
+  /Contents 821 0 R
+>>
+endobj
+
+821 0 obj
+<<
+  /Length 5523
+  /Filter /FlateDecode
+>>
+stream
+xœİ]K$7r¾÷¯È•ö¡YY!Fƒ`±€¥İÃCs³|X	hÀ†5°gçÿÃ`uå«:Š‘UÉd×øÒ¥V×0ƒÁàÇ`<¾üöÇÿùû‡áOz†oøşoÜÓŸÿ<|÷—ïŸş÷	7¸á(ûà%1‰R~ùõéÛ_ÜğË?Üğ_><}÷şÉï?>}ûìd áıó<@ùxÿëÓ¿õ“sî'çğüIçO>úó§œ?Ãù3>?~~¸üÛ»ÿŞÿËÓ_ß?ıÛÓ_øşéÛËa}FÂ}´f„Õù¼Èıñå7<K†/R;r+¹ÏsF^ıuãÓ»!ã°ã ¸€F¥ÅwÃ7qüî8Ü5Q.•ôÏ?ıçóßù4|÷Ã5ÅxœŠùşÇ'7üøı¿>ùá‡§òõ_ŸÜØñğßO?Z#£ äcj>2!	ÅÜ|d&™¹ıÀ2Gí•!Íè‘½# Dwãà„“?fğ0ûtûØ—{Ÿ”½Ïádâaˆì€$çÊÎGkçã»ÁçiÃšxfa+ò¢äqã4ø„)_”_–¿µ$òz’7åµÜ-RÑÚûN*–zıİø—î}¸2«—ÿÍŞšh³‹bæ´irterçip|7¼ÿ¯Š A=œ"P -$@K‚¨I¤(™HğÉx~Ò¶¨óÀÿÁx~VŸÁŸpïããé¨ù[Lé|ì|æÛ5ß‹S }î²¿P=²@öì¥ËCÔ½‹ §st¯ ?[×Ü#ƒkòxk{¡±à‹ûÓÀ‚%B¨zè Lş^	~c=^CXBò’ö?ÿ§gK b} ôñäÊíà£%€†±Bà9·À¡e¤á¬dˆÑ;ôMD°p€40Œœ¢„vxò/44Œ	"¹¼K€ñ°y¹œ~1%Æù@4f.qÃ$ÑÄœBl°&_ZhèˆÈ"I£Ğà	ÙïÄÇÉ,Ü*’áˆLËĞ@9BHRîÇ›Fª!3xù¸ÇkéBö÷?şäV`0c¹÷Iˆ$`´$Ğğ2$,KXƒU´Dà6Xkà=pÙ»ÿ[ëé4Æ\¼–Oÿõt“4š»y'e³k4ùŸ‹%€9€ _a¯Ö­”Ó•sÑµy¾i|úa¹2µyş†KƒwWNæF*0ïm^ƒ?ÄÔLÖ&ğü!ù~P£¡”O8½¯c]€èCº;4ó›³/tÓ9XLçxÓÚgb¾ğ¡LïÚK=v{ğÆDÕ8‘q<9ƒæB58v”üt1¸Yáj,uÊ¨…à!J¨:­u‰?EíÎ¡;>Éü‡wCpë$Ä°ÎAˆ³#şÕíéÀ Næİ¦¦©02‘M0ù˜‘s",Nzã©D¥‰™]OR{™ç¤š H}dJ.Fº9_ÇœçtÄĞ 9IrÀØ’3HˆGhDSN|ÄØAÀe¬¦^ïÛGHÂ‡¨„]IyÏè×rldàS<`lŸ çCÔíc‚ìîYÊWG®à1\ÁyµAï¸,[·u¯,òò¶7§®7'y5W>:È!zÙ¯+”#jÜ·DRòii0Õ"Ä«üŞz¾êÇ;?’­Væ€ã»ÍK¬^‚LÔbíD£¨·…ÓAH`æD%'Úº÷İE#ç¨mò|+^&jÈ83¤Ÿmçó­˜‰hL..ãÿ‹m¦<…”¸Åo¨—QëSK
+K}mÔzÒì€CXA‘ ¡9ezl²ÀWÊ…òËõe¿X¹à«áú¾pÃ>% K©»:;DX&x˜`gíÏêGıJëèø†’Õ=gçWwÄÛÍ‰¬L[0<çû%¨jf
+Ï]äf§ßÇï›öÑÕ­î¨	ŒÒIĞ+qF3Ù±nœ?ªÙ°¤¸FÜaÄVÂ*rÕˆ÷ˆPÖ†^³j6uè«VÜn—…—µúÈ,R5ãÏa¡jÇÑ­_wØ±Æˆ±nÇ;DØ”t¸L–Lß›’¦Sİ›\¤KFWB5s¹nÇ?ƒäªv,´
+²ŞaÆ–“œ°nÆ÷KPÕà´ãÃú÷é“6k°´:|P6mO3g™¸n¼+xõ^%,ëèı÷*gmı^µG„ºîXÿœu·Ùjë÷¯Ãfp™ªj.OÛ
+ê÷´ÏaÕûœ`ZgŠî _+B”êº="lÃ€_bÒ­éåúMî0É_İ|&ñâü0W?×¯rŸÃêw9‡ëlä8l$²q—Û!Â6uÅkNgš­Cã.wÔ®•>MÖ±¹v+w¹Ï`Õ»œO¼Î|ßÃVœ6×ïr{DèTÁ—ëw¹Ãg°¿„/×ïrŸÁĞÕ)Q¼äZˆÌñİ0Q{Œ.ĞÈxB—_>3‡¬HBFu„uLÿÖv7Å{>¦û/b\¿ü?“f^
+ÿxúåùİğM€œsYÎZz¾ĞÑİu"Ä˜ª¥DnH¥gíIaú”¥ùÈDÁã#ÏJŒ‘1 ,>ß\ıäJÙ «V?İ=8{d”„]üõV¨Òˆx¤õ4€G_ëŸ{±Å2ÇÕF•dñHÎ›óãeÃz²/F_¯öïùÚ³õµâL°îô[U–ÏŒN^ÄR}ÓB³ËÛi—àœx‘˜mŞNs¸„rl#İçNs™‚ƒÀä°‰&ßƒÓ|H@¾0>ìáÖóUN‘ci›áJeõà®*…,4ï!	xÂ€M¶¤Ù?Š*÷GàÉ»Ğc?¨Ìè08é¤õ&\è7Nç@Ì6ZT)@ft"¢a;ÑY¥ Y ónLtÖY@ftŞ-É£Ò€´’À¤‚Ñy@$ğÉe;^*H@p­$ØÀF£ò€„ğ¢…ı"Xm¨“€Ğ‹º,‚ÚØ[)à§¯L4PLÜLÜ•ø£‘æTÜ”ı"˜¨ó~8„,¡ô÷îÂªG•åc>$@pr¬ß®ò|,N†İ2˜'ƒNõ1Ÿûµ`»	:ÛÇŒÌ»e0AAgû˜‘y·æé¤Ò}”’S¬u· åª|!Chóü-G“Nú!­T°Á
+TŞ×U,¦ĞQ*÷¶Ó}:©ü¥È_B9ö‹`ŸN::ôZÀ¢é&è SS‚ähWíUIğeÊóZ)š¶ĞùCféƒGõ´Å®ºòi
+Sš3ŠöÔ^?…½w§ úó)øÛbö…†-ûmAûà€<fß~hÆŞ 5—şDçb:@!']›YO ’ÒÖîyp—!9fğŸªs¸ß?x ”\8YÜšî$ä*—ÀıƒƒÄ£Ô`Ubˆ+ƒ¿†GµÔÔ§aĞ¯ó€®TI’(ÈEd¨Cô?ÍyßW(ûZµj&•Wp˜!_•²ˆRŠrÒGÉ»%ƒî¸|gŠ 3ºš”ZX…ÑÙ(\„ürŠì–Á&½Viİ‰Çs¬¯]ªÄ0y=ìR%¡`_˜ØÃIÇÛ¥ÊCÁâA(S»Ti"8*lŠ-ÖaC¨E%Š8ÅÚ^Ü ã÷†J1ŸœãÚç8 …U²ˆùÜh ƒÙw‹*aÄŒ{d¸¸!Ù ‘êK’ÜÚS;D¹¾$;d0¯»ë7]-:.6_wUbˆÅbî–Şh~´?í)`İBygC=¿·uz‰ÙvÈpsÌcü]6o#•ba»¥ßó¸¨şŸşnVü¢Jo±0‚RÖ¶¼ùĞ‹*ÁÅÂvÈĞ!ğ¥’`,Œ`·ôÇ¾t¶ŒÙ(­o¨t¢Ê‹±0‚2ô0‚ºÿ¿_úã@¥ÕXâ:’p@G&êÌ³ì¡ƒè´³ì–¾ƒ¨1©Z½CZ¯OÚÚ|0*zıbQVß^:ÖÙO‹±~‹é8Ã±/Ÿpñä%SÙ«Woƒ½hõeº*ËXh,æi>e}ZÃe÷…#³EUÂ “›V´ñ[xP'a.…"m¬P‰?ˆËË.¤‰f€D%ş ï Hl"Á†´«JİA>BÎä¨‰fˆD'ß\’­ÒB—EAvK•<×ß5ëŠÓ	oÊ‚m‰şˆÁËÎaô918çÈ"¹„ ™2£–©7‡J´Ë\8ƒ$Š·öıPyGá1cSäÆœÁqrùˆ±KØC©™¸uğWàPçµ¡@kÕ·Gi•×&”Z¹RÃ^ğ¹úF­«“±rMxthÕÑd·c©t6Ä2âD;ÁY”²…y6ë/—òÈivÏ«ï~Z¹CŸnjÇR9p¼ã¸ZÍö›µëU]±»æQ¥Ä! ŠÕ;‘®ZûMcWû&
+ËéÅ¡{Ÿ¿%Y¡Ú”w—z:â^Ì\…ÊGS"8ØW	e|Î9æ*P»&¸Ñó¿6ßİêªë„%×Bª<$H»ªTV—HÀ®¼#üB<É É3r¤08 b¡R5Tr §ÿ–[E4Z*mKŒç®È‹„"ƒç8–×³8`ƒO·ÊhZ²JìRzGÃ¾µ|Ee`_;U––òR¯œDcj›F‚˜Ã[(LïØ(PD$‡jl’vLçª-µÊËO¥ö,pî¯D•S…R"ŸLÔâg€É	?èB“J”‚Á^ÓÖy¡I%0)7Ö]ìƒÈö[ÉUšËHCJØâtµÜR™"W“&«vÍ:3fO*•C"#ºğÛ“T®rù1.RÉ Hˆ‹%¼Ó{/ªÑÕ“•©Ñ×xbÍ¡6ğõó¥â¶o5,›$óÕSëÍO•‰âô²Ãô7B•“‚©¤98>†ª”Lœ°«ßÔU:‹RC*‘³XÔ¹|H®¿W¢“aÄÒ|î1=ˆª41¢cŒĞÖ[¬»)Ì‹ĞüARù3NBäÕóÆòsİ¸[ew˜½J¼±p Rßf›WY9§ÿ^eİ»*_Çâè@ËS>æs¿«áùê¡ÿöv'õ¿İılë)Ôs6¯*3Hé L¯ï/osÔ©C0ƒ`Àq(uròĞ¿¾x¾UÏ?È=Pe")½æQ»'t>T’²s§|Øì•ÈÄ—³¾ô_<Æk§‚/§}á¶…JZ©2½¾ö=Ê)¯2¥øB’Bj0±O/•3eÎÔca½¨K²'SO*_Ê"S¿óù&‘©l)œ›	`‘'‘Ê•²(Ø)€õòeRÙNu{`×	ÊV2×	ì•Àä«t sÀÎç[u¤2ÌuÀ{ï½¢«ıÿsÀZ†0úÉD.•0 ğ8WÒ{ÔvÇA¤rÌùî¸ùèö×Ş‰á²§ş
+Óiª<„ì(_ÑXgLe@ÌS*Nwÿm1’¿XR¿/(áÃâ¯Ï7’Êp°H¥v6•í`†Ãb¯sÁo'n¥ísñ*ßâÕ{4Ì^[R¹–¿áñúöõ*Uá½7¢v<!;ä½ïbÓrOÀ/ÛkıW\×9oØ|¡¾ùöÃF÷GŒ
+¤ŒùşÏ/6V¿ğÇ}y[=õòŸßÿz9ÄËrKÈ¿=Aç²"ıÓºö™¼½~©ıÛ­<ØWªı*Êµ+&¦ÒPìñ¨¦No1İ0w>~C)8©ìóo¯æşV™)æŞŞç›7\•[Â'páD½óùæWå…jôø-÷[•BqÌÖ_;bJ_b‹Ç›·[•‘arç0E`!Œ‡ŞnUF†év{!ÃÛx8*íÂ\¯ËØØíåoà*ÏÂT†¾kiïğcUÆ…éz{¤7ßÀUZ…¹½»Æ¸z½}ˆ}ë·“.ûB¿‚\»dçÀÒIšüX{%ÔûML@§÷cv7ŒPÅìèË›`©oéÄÚ%=~Xü×ã%UşlO2Ö­=ËãuªW\]é½7c®v€t0Œ+³» »ù®vg/¶ßSØè¤©ıÙó%¼Ÿd4[·Ù²yK¨İĞsGCƒeÙ¢_kYxˆm©¶;ÏåŠ]ğúVßQí«›¬­õ®ER{¤©xİ9ï=&s7…P«cKsi|,¨nv\ÕNê9w–×‡Ó! ©vSÏÅœ}Fm§^ d ï(uHµuz{ÄÙjoôkŞ Õ~é@ª2¾1@ªÔ€l±¶¶½‡:@¶ÂHµzaa©=,ìøkªÚ]ÍOïhhaÖ)Àj§ôÜIÕeW°3Nq€ìÙ÷9Ø§Àq¶ìê§ÀZ†!ƒu2ñY#L»ÂÖµÚá<`Ê%›ÔB×¶ıI­I¤‰(³Ú&ÍåIÂ+E¼	(³Ú;=u°¼‰M6ÇdV›¯ç¶ÈÖ`ƒr®u=öÙjÃô“9B¤Ô’Õ†é$ïf3"«Ñ3"¯Dx›ı©¶E/ÜrMÄ>aæWŸ\¯·³ÂW!»=Ø;Dêˆİ@óÔĞû£'D~›ŒÕ®Â·°Éög†Ú=önK0OµÁšCÅyï²È81Êš	v:2È82öˆ³ùÌ ú™±–áëÿ¨Y^ft6¼Â€ÕNêEÔ …>móõ°@!LĞU¥‘SuU;Ã®ÚDM9•âIéax=`WmÍfAHs“4Wí¼f‰€Ñ9ßkWä:ò"]ğn ½ŸzªÛí’oe½az¢o¾•õé‰: K¾•õè‰à®¬7AOÜ ˜pe½SzjÎï’?c½ñÙp.tÊ·²Úñì÷ñ!ò­¬¶E{	\©<>İÊj_ôL—ĞÇ\ôŞèû¦[Yo•ñ±Gº•õfé ÆjCõ0ßÊjö»d–Ô6ì{¤[Yí«^àãCX¬âãd[Çv@ÛÎThb~­İC ]í¼9SúXºĞŞ9‡*´wÉ¡ŠíSÚ{$Õn…v1 ½K‚JêĞŞ%i+´?„Õ¡½ÒöyU\¾ÁÚR^;$dÕ[Ÿpv½Š‚ğ}²ÁÀ÷	Ù`Àûd¿‚î²_·‚{0À½G*)Ô±½Gf5ĞşÆUGöî¶uÁÜ²àÕnâ]Ïª½Â>3„”’ïcòÑ€÷ÎÙÓhà{—ìi4 şmÑ@ø™¶[!>ß%iëß%“«£|ûs·™ÜÍp¯6æ.Ğ¶CÖ6ê€?òÅöÙ j“ìñ›gmÿ}ÿî¾
+endstream
+endobj
+
+822 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 800 0 R
+      /c1 801 0 R
+    >>
+    /ExtGState <<
+      /g0 817 0 R
+    >>
+    /Font <<
+      /f0 776 0 R
+      /f1 782 0 R
+      /f2 788 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 2
+  /Parent 1 0 R
+  /Contents 823 0 R
+>>
+endobj
+
+823 0 obj
+<<
+  /Length 16195
+  /Filter /FlateDecode
+>>
+stream
+xœí½],½‘xß¿¢ì]#ìLˆñÅ ÃÀ<60ŒÖå[Öx5ğjøï/fVef»OfŸ®î·«)@ï9ÅSÅÌdò‰>ñõÛçÿõßÿùôïşİÓéôÛüİü§ôôïÿıéïÿÃïş¿'>¥S:ıŸ¤Z6SD¦\¤äÓÿüôÛ?¦Óÿå)şåÿüô÷¿J§ßÿåé·J'V’Óïÿ´L€?~ÿç§ÿú7H)ı!%™ÿÔùO›şŸÿäùÏy<åí÷’_Ísş÷hşöß¿¶ÿşóyÆßü·ÓïÿÓÓ?üşé¿<ıÃ?şîé·×ÏÍ¯?wfâjå•ÇæóËıoñŸÓÕíúfşÒ}¨ö¿ıÍ©œşfı«6>¥?$µÕÏ³h¬.È±Z‹Í×Î+:M1/;ëoNóõşÔùÑ|ÿÒ®/?ZYé¬¬N+›O¡‰Âs±7¯¬®W¶­M{–imÿæúæşï¿üõÿıÓÿã_Oÿ›ÊB¥D)rÊ5Q¨s´;ú§tú§yúí¹İiö\â´ú+·ÛM'«$µp‰ÓŸŸ0ë/ø~â"çO9iv–ùSMnÑæ:ıòÄ$)4‰ÏŸ<U–Âó§Â©ºNßb–ˆjó'cËiú™Pp6MÓ•¦‹O×SRI©œ?dášbú™RÕéßŒDÜ½”ù“Kh1?©2İ•+'ÍÉTJæékN¡v~²LÓSO÷›Iµ¨–ó§l‰óùC5®e~° 1-<İa›g›3¨XXÎÓ§BlUêtó…Ì™y~°BáRç{¯ÔÖ»ÎÔ³Ï—ª”½Ø4A¥š“ØôTœH²¤˜ş‰yÖRç–¨d™&g&Îá6-3Y®ÓôÌÁ\§+³ĞúEiX¹|È‘sÌªQ<ÍW’’Tæ(yöùâJ¥hùF\¼¤ùâFV"Ï_4ŠRÍıêÓ²syúÓA9Bí”3S¤Gq"‰\ñ$&&_	&—»%UÈrzÊY0µûa˜0%Oî2p2pòµprÙ¹;€Â)»ÊO9–±ŠPåZ†>8ùb89oÜ01&ÏÙØNÙ˜L§ÓÉÓéwÏOéôü»ÿü$§ÿıd§løó'¡¤Z¦}ş!
+5¨*'9eS¬÷¦wÊ¹Je?	±xÅ{üg çŠãÜKíµsDdSÒ$zÊÊ”JÕ×8yáˆ8aÿò›ÓïÿçC Jx”8EªTd9ïw–!”r	»H®±9Õ3İ3û²À~Z–xó/ß9´ØÖ;W*¡QNÁ‰’iyëZÿíkKİ½ÈR)‡¼ùÍÿuï›7²Ä)Oû_“ªı` 	¬†˜„Ã­!@É"Õjqb*ÊUj“Ë’²U9	fNay#v•Ô´dÅk*YÀ^œŒT:ìÕwû#[¤ZŸrÅŞò,A"7SÁÃ
+±'­€½D-"o9Im›6±+W=ITç©ç
+ÇI*(@ƒ¬deÓ“2i-	KXI„óI›äöŠuáDÕCS=©RJ™Ûï!Î«””1j,\gy,E“a0gUÁÛâLœµ$ÆhIŒÁ R«ÔÒ³X{]\)«Em³¯mP˜4’T~_
+U”8yÔ6iHŠv¬£b,¥Íšñ›6A&¥İ–eNm‚BÊ"¥Í*µ:îJËˆös.Ø,ÊEƒBUŒ“_TÉ¹DdŒ†w,µ:‰›„`Ô9×¶ š©–A©Ñ¶ 
+qÉí÷)8µ=h‰,§È‚·R´&Å]™×,ÓhNÂÒFº7À¤™SaG…¸c”9«ãf-È’„ËI¡ØLª_¬k‘i4sÆzj2Ê1¨Ù=ã¾›¬ŠµQæT¸‘š…MËBÚ`¦T’´A¯‘¼öé›ª…Û¶¬äÎ¢ÁEÚjg&)9¬pápÅf¥$"mĞ=§ŒÍFá1}Sª%¬IÎdUEƒIÙ"öèŒ—hÉ5(×€†ï0|­†ï;nö[ªıy?mùNs¿ş(‰’«´ËÁ®{m½åïû–ìÈu¶†û­Ç~>‰=¤êª'U÷nõ·Ìóû=f~ı)`?KÆµŒJ²ª÷@‡®ó3èÁçÇ¨C¢>œDİ½×o]xÏGÜ!ï3ù«—+ 5„q5'a»:tŸCö</xÇ†XbõáÄêî½~ãğıñÔ"”Çù>3ÿà1À5s>åÄÀù]$Ğ‘Ëü” úòOÓõ:å×)'bø'*Ìüf—ãßvƒEÏÊ…j‰øùû¡«û¹¾zé]=ƒ'‡»ò}bt/ÎS0ñ§û­cŠír5bõĞ‹8tèwĞ¡o‹E”T¨"h`# |; 	FQ
+¶<‚N¾N#Šòd	
+%#Ú¤†‰S*\”NN¾N.;wOp{àÜ†€Ò»DíJ®ÄQJşœ¨İÚK™#÷„8åÛå¨½SØ.G‚Ø>7l—{™ÙŒpÀ¬Ÿ¸ËüiğQ‘»NÙJåo¹Û˜êÉGèîİ¡»¿†ĞİÈÉáºÖïW³~ßo¯2[“—wœz-ˆ>4D÷oö7D-­yÓ»N>b`J¥{÷úñ˜5i{Ç©W|ğ@è@èã!tï^¿uqüxnk îï5wŸ·ëäãÊ¤¥YğûÄ½úâ‰D‹qïè'î–DH	©ün5
+oëRwRqÒ¢^&	6‡ÉtOkHZøï!‡8ş*şéiçîğ»©%âĞ4ñ¥¾)0Ğ\u< |5 \vî ¸QBî•Ôãx¼S•T}<œ|1œ\vîœäJá\§„/“Tóa¤(UÜğ0½R¾R.;wR’QÊ¨!vˆ'K‰Lr|NÀ÷jÕYrŠZ>0ŞI±Õª±Ü%ŞIS!Ë…í³ãz)Zš„4£Ã'Ä;Å«,ÁG<iÊTjü­À…˜IñN#ŞiÄ;ıâ^b'‡hØ¾_Íö}ÇÍ~Ë¸?a/ßgò<K¥jš§ä{IÈ'¸K’ÿ±ıDÑ‚|¢>¡=dë­'[÷îõ[Íó¾û]¦şÁƒFMÃ²»:p™ŸAõ4]ÇÇ§C><İ¹Õo]yÏGÜ"ï2÷¤’‹4£;Wñ¸“:t¡Ÿ’B÷D/8Ê†d’õñ$ëîÍ~ëüıñäÅÈ[Ã¯wšûõ«…ÊM¸\!q¿×‰ùÈu~F=ÂóôİP½Z}
+†6>êÂw{… ´0YAÙù{GïJ¯0‚Á#Pß±tá¹g»n»´oz¥_:ºóªwû¥ıúÿxCÈ¯y&x˜ìNmÉÉK$-U7ê—‰ÃRDİªa¦Èx‘±QÇBj…İc£–AL:WózV!¢Íy³¨i#NU&ÏÇE]åš•:µí$eúù¢¼¦gXëğLæa­<Ş¢Êƒ’™µÛ_4z`}=åb/¿U»ùE¿*É½ÅœÕ|ÅrOnÃ‹¶¯T£æÌ¥ßTc»òEõC#º†Ö	 ]ˆ¥/S ZPîÇ•I ıÇVšÏk1 ù—êkR)Umc*°Q¯¡“$kbY›ìT<¥æß[LÎˆğh^Ï‹%ÁAIà>\[ÔvNY[\ˆk‘¶ôgƒEq˜+Kƒ+iˆ´•_,®T~ªå,`ËšecÃO¾¶C„áò4Û˜#¿wX[şÅ,!XÍã¶˜'¢Ô6~^›)‚è—2;}/æŠÁ8İÁÅl'A0‹mÌql®hë¿˜1’ÉpãkF‚RÒÓÅ¨‘ ¯©´p1n¤G”öV=…"[moàİà-ÆI‰w«-IÎ!¡m7’*åà¶V«sYÍœîí€‹ëisr O®Û#Y6«©Êö,
+°ªéöLAfªÌËá¢!]&·şê”A&"yòË¯dÌ‘br_ÎhAÉM
+l ¤5Á‹¯Û“iIIK’í‘d
+i¾:šz©åYQ ·5OBe9«jæ¶«W‡Èqkbe9½rÎZ~sŒ!M™›`YgMáÅY7€¡´xåÕ	‡$Ì¢ED,'H¦
+8lN<$ jÛ~]|€­’¤½‘åD¢"æí…¬ÎBˆÙÈ¥4³ŠH˜Yá3_ŸHRòÀ{\“ˆkJ\›ır^"j¹½ĞåÜDœKM>É˜å EìE­¶×±:IüïuŠ®Y©P©ZÔÛûX­ˆ)š†\²ÅÀ"í…¬N[ˆşğœy‚Érî¢T=áÿÑ–(3—¦iWG1ü¬Ô<	œåLF)«j¬…åpFÉ%Š¦É^Xi”f¨lE\BBÛcy{t£4¿Ùâ(Ÿé½j‚ZÉ$œTß§&(SÉU%ûF¼µ,ÆöÚÚaQ5É,ôÖv˜[™Ì³E¸1¤N g-Û˜ré]D}&sÔY´µ¸DD­%úNÃ³lLX¿T6rp÷+±ÆdVó®²H5†ôI{/BAJªEb#Ó˜à‰Á¿¯e#(Mûâ,Ó˜ÄaæğZ¤1Ê·E±ØZdÄE²6‹f±ÉˆÍ.&ÕÅ&#Æ^n&İÊ&ƒ¢çÒ^äb“QR¨ä+YV+—Ò”ÔJ–áMh¹e•ñÈÍ*YË²a ÙV–­‚lEYIÌZ7FY¢ÈRkKZ	²+ÈdİÈ±\r®ÜDú"Ç²·ö
+WrA`UT¯ä˜‡@ô^‰1WKØ÷WbÌ*ªÅÅµ3Çœ°½cÆ5[{‘k)¦…­60¯e˜šªù$~¦	Q©“]‰0É‘,7»a"¥Ô˜dÉJ„a[ä+Æ$Öò‹§-ÕB¸6òky%kñµz˜w¨Ôê	›ÑÉïR¨Uˆ3Wo
+q^ €ıFvµ7©)¨•ìJRê­èªÅÛNßŠ®j¬W'HxmCğ¶•\ÅÑ½·’«¤R]¹•\Í\ùJr!üQÛ;]I.ìn¸_K®¬bˆ›İJ./Ec–Q‹äB°-í[Éå)±Î–ÛYr™ç”ÚÂ¬$—1‡^I.Í¹ÅJ®$—Šf4—ßJ.‰êÒÀ¸–\¢n¨Ñ¹‘\\Y¢ÉÕiæO‡Şå4Iœ4iSV«Ó$%/_ÛÓ$%¶)Ús%¸j$X^	®*Ù"V’«1©~%ºŠM ÒFvE5.-Ør]á)å&æW¢+`QkŞ(eDp¢™ÓVveHSÄîJtyÀá%W’·íqh‹ä*®:Y‚kÑeˆú,7²«Fª“`]‰.Ç±°È•èÒTŠ§Éâ[‹®l!¥ÅkÑ%’ršH‡ìZ@±‘]Ó¦²kÑ5¿“|%»æ§)ïU>×ÔIS­w*ŸëˆóO*Ÿ+½ú©®`© ¸Ë'1cD|×r—|ÓJÁ^ã“óI¤WöÂâÎèúñù$¢/óÖ•Lb
+©lß;—¤‘ì5¡ÏÒH&É$#™äó“I^ò{ı0Œd8´†Ck8´†Cë]eÌ­ıùˆ_ìË¿ärëÈÆÅ—v%$‡/møÒ†/møÒŞêKûTù·rÈ½{±é¼}·s/~¼µh~¼áÇ~¼áÇ{Ù÷¹âmå|çà}Ocgæ‹q-7‡q¸‡q¸_v!~¦hcÇÈ}Ë²K¯¹9–²qŸ×!½rwÎB¡,ù;ºà
+z}Âc•@ÂËO&vL)¹Jò˜Ó8’õ’>NoÈãÈB¥D)rò,ÄçãĞO¥q¬”TbÂb¬uWPõv[«iÇ²(kk[”²37|üâÄ!ÍºˆmÉ$6ˆ©ÒN95[ç,3%(§<ikÙ\ ùêˆ¿yj2wÅ g*ğBú…*º\şòÄN¹$ü–&Ÿ#gª©év)°´æ f'İQmîõæÚR†CylŠ§Q18á0Èi¢¸Á¬‚(l³–œÇ_ZñÖf-É&w‰Më›•˜LTT¯Ò®•µH3ÁáË)Ãü)ä ŠÚwƒ"R¥¥I”¦bp;áÒ¾ª©ÂsÓœc³ñ:´hm‡FxŸJ…Ãz;O®!¸¿j€±– ÍC¦9ÍJ‚%«çf©Sb˜^£˜s³i`–Â`Æ¨…ZÓ§¨Ç	«G‚–FÅSêt-Î3¦µ½',8hŞÔ¬tcJV¤dì­¢áÍsc‚T:¯Ì!³W!¬[²Ú¶»òOÍÁ
+ëÄ§sœÁ…`Ø®Nç¶-ÀºHu§Ze¢¨Î* À©pÕæÏ¶JVkÃ ÇÆ²9T~Ô~m¹”Æ§9c1Sû¹TI“·ù*µâØ0ÙYF³õ%FU3üÍ¿<¹“«·˜’æ=KíN=S˜Âı'Fp©á¦€ÌÄšv/íÈ[‰=JDàöR.ƒÇR9@dğ¼ñ%„õ}ãmXÒ$'g£ZpÀM¯€'·ÀÑ“'ö—ğ”ûÅÛ$N^˜$¿k´SÿÃ¹ïkÓÍQ­Í]ÚÙR*â"mêk†„'œF‚Ëı£mn‰/Œ[-–¿a¸MªÂ'ÏAœÒ¤À·á6#Üæ®á6/OÖ˜Ô+¹4Îãì1Îãìq}öxYóæ¨Aô|´0z¾ïÀÓ½øp¿«¨<;Á˜ºK™#—ù‰z9ğ4¯ï®ˆ@Iùä–(îVøĞu~â}=ÄótkÚ+ç“[NÉHÀõa4¸öòt˜ÕñÓ÷ó#\»İZ3lKÓw"Á/ÕŒOHêëÏù„7W#Vô“„÷0:‡Ñ9ŒÎ_áÍfãaïCxK®ÄMg~á­İ¾ÚaäĞc¼9*ÈÖ»0Ş©ŸÊxkÏ{ÏÁÀEÖ§¼Õ_3>òæ€D)•¿5åİ¬!È²ÁyÎ{pŞ¿
+Îû…Êà¼Çñc?Æñã]9ï²æÍœ·8T™º¿'é}cNöB1¹bç·§úxR®Ë#œD¤hÜ•+¯÷~Zn¦ãşº”GÁñÍ¿ıi¿:dê–V†ïÂÔ]²7ÖGñEunGÏ)ëÑ¥`ÂjpI³ØÕìztÉØNÊw=¶$D¬G•¼³ÖƒE½<g.¬Gı½½¤#l'¥¾Y«KŠÁÕè¬ê7£—¤ÍèÅ ¸Ó 6£³àjtëßŒ­…Í Óœ‚s5:Û›ÑŒ¿ÃF¸-‹Íh'£²½ØW£ÁP‘ÛÑ³r5X%á$¹Ù‰ãd3Š3ıTæc;:›,›QDë«ÑÙÙŒ*¹‰Öíí^Ì›«Á°zõó‹És5Z¡ä®~1„6£°šr5:›G›ÑBœÓv+\Œ¦Í`%ä­rv¼En‰*k›õÈ|s!œ"JX³!V6[¥RlJ^\ ÇiÇƒåaÑBéKë…ieÖxª°,b3êÔš!t^nÄ4Ët¼<¿œÙ,áô¹~…ÊT«{³–×­BœĞ+d½30è ;Ö›ƒ¹ävZ6F¥4}Ù›8J"K6û7d:uŸw<µœ­ep(²}‘«¸N’5æ¢Ğµ“¤³mªÈMRØyk0ãXí:gä-‡¼x«!Ã ÅtÎX>04UøXW)æSóêğÄÁ2Õ¢XŠ”d2ƒBŞÿ^¦‹-uRl¡IV(´Ö	-×X”R®-örşjovN›E:Ò3K°9½!Û^¦ÕUNO%×IrAHOm‡Œ%É.ãè’Úa•¥ç$F'Û4?¥š«êd£ŸÓ…2‹NtÂ’f}Îã>«Õ©½QKÃ^40[¼r.ºÔ2˜ôµVÇëË\,€’ÙT¯a“L³v›LÓ?ínj·6zßZ×vÉ8]U§\„ÚŒŸn=zY‡õà²bÛÑ5°]^Ävt&VcËÛ]nh„Õè¼iÖƒ¹°<ïÄõèj×®F—¾œ°^«1ÛÑ3ºÖ£×£kÔ®GÏ_®­GÏ’c=z2ëÁEmGÏ¢k=zsW£g6d=zŸ›Ñ…#ÙÎby3zaN¶ƒ³¬ßìÄ…PY^TÈÕè™fY^4ÓÕè™|Y^ŞfôBÉl›İŒ-4ÍvtVÍ›Ñ…¼Y^TşÕèÙ<X.¦Ävt6:Öƒó¤7˜Ö?CEmÆ¹,× U†„Şõı BO2O¹ù„z`Õñõ“¶bJµ AëeIàCïx½„(î>±¼çÅ†ÁSâfıZ)\'ÛæòQ³"bªd±¼mû_rËé^v7Ér}½‹PŠC½6Â²ã@Î¢W»“QEIAå¯w2jŒxÒ)™ù¼é™Ö¦„ÿ>˜2jÿ4È‚%¦Høªmp2?GmÙæF™Jpâ‰ò¼à™¡MÂ'ÎtÁ>¡,ÙÄì­ä±¤Øæ0IB­—­ì!)Vx²99Eš3§ÉBZd™åÉÿ¸Èü
+ı,¢’rŠ”…·«(ıa<ÕXD0EnÕÖÂš
+2Øçâtg©NĞ•I^Éx¯kË=_T…R
+/:ÎZEQ?C|.c5ëEªµ-ªªUœÍÚÖjQkJsùYÿ)ª‡!mf­(Qz1’µÇ\”*<@É¯,¥<ù×ªZ)àv™
+w¬
+:.œ&{e´”R³Í=‰ÎÖ¬«@„‹>)ƒ=Şe½$TÕC
+Ì},¡ZZÏŠ;èå[YrBM¢‹:P`¨Ær‡¨M¤4¢(>1êÀz±’š Xª}B¢ñ«´èÇ…hÊTjü­Ã@íš!2fDŒ¨ƒuğ+ˆ:xÁÛ²Æd¢r…ÊOÒcTºÔK£é’9]Ú§Ïõ¸¤h§>GÕ¥³ºÄWŸ#ëói]ê­CÑu©¼X¿>CØgûÌcŸ¥ì3š]ò³K“öÕ>ûÚgjû¬nŸî³Å]b¹GA÷Ùê>±İçÀ»ty—Xïsğ]º¾Çë÷= }oAß³Ğ÷Bô=}ïFÏÒs˜¼İ8&‘Ş› †º`ØÛ}˜^Nø¯zÒÿvJ§ÿçMõ`WT0ŠéIüd¹Ä¬–[©rß<¹#—ù‰,²xš×/¬ÑJ–“#œÊî÷„‡.ô3oì1è€†:€KŒîóˆG®ó3ïìá§ã{{É‚]x±?÷©³>ËÖgäºä]ŸçëR‚}ö°C3véÈ>sÙ%9»thŸ9í’¬=6¶ÇÚöùİ¸à>oÜç˜»ttŸ¹î³Ü=>¼Kœ÷9ö>ßçîû<ß'Ğ÷t]]¯Dßƒñ‚·£ïé{Qú—¾w¦ëÈéº|úŞ¡¾'é·ÓNª\Z}ÿ×Î²µCí}lÙw6×SçéTŒ¹AdË-ÙÃ…fµy+Àwÿò§”ày~°3„ ÎR…²¼Ş§ğgğÈu~æ=Âóü ÏĞ=Íq×"‡®ó3oì§ï¸êUÙÀ±5#Çåò¬—ºu1tˆºwzƒÙ+­i?3·á)Åü™ç?å9Kë·‘ó0rFÎÃÈyøüœ‡ û!SŒÒâ@ŸÑ4y‘|¬&Ó±o	€4ÉÛ`É@—£éP¿
+¬l¨)Wy„$èR¶^nŒE©kí%®3Hk†bÜ„€¢‘K€ãß„‹… Åú6´4.ı­ÃIµ›ˆU,FL}Z6éÂ™M'ŸÕ	[¨8sÙÍVJEòä!]âk+8œ©¥á*·’§à©cĞ·[	§^/KŒ/òk%Z“°U<0ZÄ(ëûÍÛo65Ş»È	ŒNm."ƒ9dòI.ÜJ¥Zcj\¹âa*Ò£Ó™È9S6yk;aEï ·oN“óx¡‚àRÌÉëuâxf®åŠb*hÛÒ&Xå[.­ÓÜBY!™¶ ²â*‚¼J;o¢Í*tÔF±Àÿ*>·:G°…ùÔkrìÎdê3+÷3–Š§Ş´Gu!K¹Î­</.md;çëv†n}“GwÕİIĞ¬¥\Ö)ÿàOemÖŠ©ásKÆ‹	à”Õ§fAëşV¼f‹;Ø™ö°4y#ïaä=Œ¼‡OÌ{(U7rMûŠR4I»!‰s1m‹5¥ì%Ac_Ğÿ™ôÏ†­F{¼¦İ7Ì¶äjS¤ÖŠçìiXñåÉk±°åÖKuÍµ¹3–¨ËS¸Î†´i=Ô6–ìW›mLÑ×ÅMÜ¤>|'ùÊÁ9åÉY».ÚØbPÖn\¯]"Q·”û$Û¤7·–1uoßxe2^øµÿ†ËÔA|ãéÉ-vğÊ)„nàÛV‹ùÌSÌåÆÕäQÓ¹©üâ–²4yÀ6,o~‹µ³+Z#Ó«lMŠbÙšA¶r¡eËÑvÒÚÕf–&iÑ -Ğ§.xk'´Dßäk*ZÒÛ´Vk¯ k9‰så@”š¦¨µµ¯ÑŠ“l}’pd\9/Q.¥^»9…C›¥¾q‰Ös¯ñµ÷4Ëœe³ö³*3‚4®|²µÔÜ:`nİ·ÕÃ©¦‚:õnEá\aşYE­Û5O…Éá5ø¸6C†X7FÊÅû·ÒJ8¼ÏMèU¥1Äcs€%ığô‡x™6ıÀ.CŠs´}ïÔ‡ÆğVÔ|¹#÷aä>ür^ğºìË}X“%]^¥GÀt™š>©Ó'€º\QTêÓO]¦ªËiõÈ¯>MÖ§Ôºì[‡¥ë²y/}’°O(öÉÇ>QÙ'5»ügŸ*íÓª}
+¶O×ö©İ>Ü§Œ»ìr—ˆî“Ö/Ü}2¼Ë›÷)ö>ßeî{ßĞwô}‡DßyÑõst="wKØ!”Şœş`MP¶æ)Ší½#ûa‰Œí¸ÿ"‘I=¡ç‘’óÍÈ=p‘ïüŞ‘u}Nûx<ñù@Ú?¼öº½#qÿğÜ?hwÏä³{÷Œß§ºÌA—cèÓ}ê¢Ërôè>qòÉÒåcºÌMŸäéB]î¨Ë2õ	©.wÕ§¹ºŒXŸ<ëm}R®Ëßu©¾>-ø…Ø§ûÔdŸÆ|óì¤].õŞµOÒ¾Àè¾Àÿ¾À¿À-÷‰èw)¾«ä«é§`h•‹±=wD‹i¸î¿Œ'Šm(
+© ys9¼Wa§(UîZ‡ØzuwÍ!1š
+ÿø8½^©0›¡,ùîzŞ+ Ò
+¼g´A´ŒëéUÒ)½­÷‡¤6ŞÍ=Á.=ÃÎŸ[{°?$‰^ï°Õ÷æczŸçÕüÂïò*@0é<{Šßœ8Î÷Æïs-¾ÿÏW¡…Ë5wÆÖf^£à¾‰ÔMşù¶g‰<iBâ~"a/îM\¶<‘Tš$6.y9ğY'Â:*U[â“Pba$\!6²ÎgVHíê®ÎMK¬ÈÄ,¹Ér$L±Ô
+”£¼LcÂÄÔºGgâÜF¤¥i4G |K#qšŸ[;múµØÕrm9:Yxb1V¨äˆÜ,-Ô	@67ôwÎ³ë%ehzz#qÿÖø|Pz-i¦ î=J
+ãh×ÍÁ£h<÷v¡•¥¤Y$	İ£4Â`ç´eœTÛ²"^§–
+‰<kÁÁŠ\'£¥™J)çª˜Ö‹Ø”bÄäÿ-OK|:Õ¬í§œÍÓ”/ ×PîŒ`•vWŒ<²Ê0Bs3Yq¼I°ş¿™O©€loV]ÊyÊ3òR¤İTI)çÖgamUÕÉÖóÖ:T¸§f@¥ŠŞ ¹NxFÊá\GèTd<¬Z»±â*“AÁ­sEk@ÅÕ¶Gqp^‚BKm4³àIÅñÏ“Y…t¢f™s))­‚jËÓ}),ÖÙ;£@¨¬Èy4‹¶kíÀ·³üê|NØYs–J¤¢Ó:
+vÏdl±*ê OcòµèñŒ3ğ<ÊÜŠ\€QÕ
+B<ïœè‹§fTéP™’Í.Çv4]˜ÊlˆQ¶Šl+¡l‚¬®Íè¡h†˜aPi(lµuóSÎ8†) œä¤hU²”õÆy·y§!Sô¤YIÛàîÎ¸BhÅ!ÑÜrÕ KŞÓçTCa»óôş9.9ï&RÔFv—“cÏ?á;î“ó~"E³òI3STĞßw÷ÊYbdkU~õıo½r‰
+#×´ÉÀµ[N9î•_áïĞÚ¨ÚÅ/'ğwœ#r4zVa(ÌEz ó88‡Â^RS$ïé«[-D)Mc|p3ıÈ1—Öÿƒü/­ÇÇ.`”Šìß²çj/_ç'Ò,+¬7L´ÿqÃSFÕd÷jL~WyÒéà‘J£÷A>qc¾¦¶Ú9œÑ\ÉÈàøk'î ‘ÕRÆGëÉ‹Rn€Tjó¼5‹„³f­§LZüÑd|”ZA¨gd¾NA×"ÜPë>×:Êğ!²Ê)Z¿G(ûY™{–z
+rñsàìñSPvi–rS¯9&µ4UR¸sÂœ¸	‡13¦ŒÕ;G¸=L™Í“Sà\`”µÜì©;R‚‘×GJr¦axs
+Ü¨ÍÁğ{:’ÚƒM3†Ñ‘(e<eòTÚ-)HğŒù8O®CEŸ+Æ·RÒÒVíù­'ˆ—Û’ãÁ8ŒãÁ8¼v<x±óf7Š¾’IDõk'¤“eÊîx­o ½—³Z±í¹4£ÜOÄİç½Ûƒe¢T~ö†®¹Á—¿05:ı=I)(ê±²Õ:(wã†>­ƒ84…Kj­t2)§R«n”œ¾TÚêœJ–V¶Ò8™ÖTüZåÀÑ$µøJç0ºïVo*cÑ9à«§GX+jf·n”^Êı¬U\7ğÙFç`¯ƒŒŞ* 8{AÍJé ‡á²Ò:èË(¬M.,jœn­©M»èD:Dn#WŠG™ÚKˆâA¬•
+BÙVzGÚi"¯õê}•È±V;Šp¾¦Ê¥£•Ì”§2Cg¥ƒ“‚¶­cè†Y<ÖJÇŒ8²\)Cª.®u¡Ã¶Ö9Ö
+‚¶+-*ÇQâ2¸	ÀEå¸P;ÉFå¸Î2r£rÜÑO|Ö-gƒ‘ßËãğMA­4Wª®>İëEãä©´PlN†ß¶´Æ—+…“DIlõMÎ~«n2<À­kåJÛäJíÔ·Q6‘iƒ”¬•®	(MµV5aÄ®Wš&ï²¬MÀö-M+.zæ2xˆ…bˆaŞ‰„’`R+õÓ8¨^˜²DÆªsù@Š‚¥ú}H¨ÖëÆO'¡zqØœ)Ù²{’Pıåi.G(‰œxŠÙ[(ŸV%ItÍù$ŠÀY¹Iº…ôä!ëš¨»Ğ>-:v:‹:3¢RD¦ ¨(rƒ¶,®¥Éš%*ƒ)Üy>Ú;e® Ğ—W%ŸÆÍ:b–şlt§š,Z´F‘—# 9¼¶“‹ŠÁ¦´¨g¶f ›	tL³m¥B(AY9,ı9ì8©XÆ´ÙQ,oo†KÑ©`/ÂúZ#å¦1ª4-¬L¢ˆ†@lLª^ZD¢Á®a°qb±Q—
+şA´I\8ÕÍÁ®@gt‚n‡.	ûM‰sj…¢šÊ¬¦$©ò|$fôG5B~ÄÀL·Àcp(ÂÔÖÛœX¤¶Aã<•ãÎÍ¬kÅ
+Ñæ³vôªğÇ£„aL‰'D!vEa)·ğÀE;"ÈÜÊvŒ(ğdmL"ÛTñÒ>YÉœÔ^#‚­E<™Lª½‚€@à8™Ù””…Éü=E4aRµÅ`™Ö:mÍŒöÊŠu2E³ó8ë*µİ*"š
+„m[Û¯9UØ(+ˆ§tÄbıòÛTÛX…˜­4}Ñ‹N±V†È–é‹hİ[Fğw)m1™‘ÀƒQú¨É‡8&+¸ß_¢RÑOeÖâˆòh·İªDºLA¤¥Õ‘,IãŠ:ì-e\Hmqjè4r?{dïFşkíì‡?,øaÁşS´GĞüD/ûBX›;3E½ 2<×g0E½(2qÇ}@9½7Ut}ıüz™¶Ä8±ŞFvÉ:‡b]‚«6a^ç .ñ×‚ÊN½è¯Õü×½Áÿ£7Øæü?{ÿòoÚì{CÀ²P)Q Q †j3Ôh¹‰$]BÚÓ:h=mâÒÓ*ô<m%iA61âi6ŞiãlH›pí´ÈN›˜ë´	«N²>­c£Ó&ú9mâ›Ó6‚y¢¼BŞFo£ˆ7QÂ“Ëov\µOèïQa¬·OPoLÎö	¶¯Í—V§Äİ>!¸ÂhiŸ}ö4æI
+êEç€‡1Ó‹­SàˆnŸ„6P§È–”20hä–¶ON%Şö)j!Ù“î¼¼j«„äƒöwO­v&¢«ñ	ç2díµ-İRçÖ\É<]i1ìÛ'$‘)ôRû„pŞäÓó{mféÕ‡eËŠ:Exl1¾WÔ‘(<ÒØRÊøäW£9~)-Êí¢Ğıûí˜ıtO~5æ÷Vpù¸˜£üjÌ‘Œz]ì¦ˆ9GšïW	 #ã)PM¬ ©#£À¨0*|b%€—ŒäÛƒŞ$•†õ;¬ß_ŸõûÛüÉƒ—¨š÷š»oÊô¢jr"Öé¹ĞÿR )?Œ+É¯FÕüôíª©F¬ğêˆEË=>zÎ¿nu¸ä³ßú—üõ<döDâ9AıZ@.)é·âò’ƒ~#;—œó$C#;buÎ)ïÙKyGä^²Æ;øâì‰ãsŒkO8ÏyàQ}IüîîK¢÷_»»B}ìŠø9q»#ğ—DíñNË¾UKvO1œs®{jâœa}­4¶µ?/E8ÎwÇa‡İ`kvqE÷Z¸i¤4p2pò%prŞ¸»‚ š³ş¥ûb’k«Ÿ?ë‡A¹'pÆŠqÔ–rVQ?"8~2+Ö‚B„ âÙgĞbåµ°¬£ÅZœš5€~_Z¬Ù¯8Ø^lğbƒûuğb/*û¼Ø0ƒ‡ü+6ƒßq·ß0%ÏG÷œ{}¤((}<”îßíÇ^‹ÃäAÌë;Íİ?wô¢ë¸ÂÒ„ÏÇsØÑ·óDÒ*N|‰­Økå€ÛúÏñrN¡ü;‡Šs8ÎLŸÖâ/Qmâsu¤á¥6AG6òskI)¨OyAÁµÜTiœÂ­E1GUéŠÔs‘‚[ËÊIsGÚ"ÂÖÎOv-zU‹jéâU¾Î­X>W*è	iFyéHìBá‚uG|«gŸ/µ–å(˜Är_°Ïõ
+ºbs8Rn…>Š§2×ÚWVºú i7Å“ôµÃ\º «+¸8ŠhßjèÿjsÅ˜åÓ²swĞsj¨>ªi¶UZL÷qwA®/~¸””/”ËÎİƒ7ª¹µ.ß‚L¦ãñÏUˆ7€2€òµ€rÙ¹{€’+…#c	i/‚ä×ÃHQª¸áa|¤|1¤\vî¤$£”Â{×¨¥„@¶ø,ÏhôÒ,9?Ğ/ªØnÕĞNã~QM]ˆPŠéSı¢ÑÍHHÊEò'øE£›.RKıÈ|M™Ğ&gÇ(83©Ã/:ü¢Ã/úëğ‹¾ÄS¾äq6ğ°­6ğ;nö[îıùy×É×$é€é€éãÁt÷f¿%şŸ¨÷œ{MĞ>H÷îõ[ŸÃóşö®“¯ÉáÒÒÇCéîÍ~ëğøñäÅÈ[±™wš»ÏáõòdµÕøo–ü'Äõòdµpã?.ÄhÉfTUô?êå
+”8”ê+/Orkş´•~¶–$×Â0Ö ¿‘i¼+I©k$\ÉÍŒ†=!ŠÂ’S§‰H•Ö‚{Ös+Èy+mÑ¬9ÔÔº²—s«Õ“Ä—"Â¹h<K€k)®v–S×"[#Ç÷x‚Şí×Ò¥¾*NvD»Ô íz/ŠÍ7Rß©÷:\^ë .aó¼V†^µÜÓQ9¡xfOW`Îët¥8Uff‘º|Zöî?W$’"¥¢‚P€àxŒ6mâº4×PPù"P¹ìİ=P	4W;±áşDŞR}AÁT¯ÃñTT¾T.{wTPP¸•"(ş~*‘$¯Z¶¨¨|¨Ì{wT*¥fô¸°@ï>®Up"W÷< 2 òÕ rÙ»{ R	iåÄh4¢Ç‹\YBÃË““/†“óÖİSÖ'ÚÀˆŸØ*yr)è–ƒè×””/†”óÖİƒt÷TË‰=¡!–ûa¤à-TôPPùbP¹ìİCX2a½Ü«ƒ#zÓÂó§Dä×:(pëü¥Uò¶P@¹Oy¾K…=Óß3-"^k¢€›)ö‘Yåµ&
+ĞêyI"ù€&
+,"ÃXÚoÜFK"µš”ƒ5Ò"FZÄH‹ø 6
+ÛØŠ—‚Ä†-<lá_¯-üÛı6bèyìÅ=çŞÄu˜˜> LwïöÛ`¥ça÷œ{R2P:Púˆ(İ»Ûoã¤EœÜsî%še t ôQº{·ß†h=v¹çÜë@šÒÒDéîİ~ö| Îæs/1<££ˆÑ}{ı&,íùH„Ïıf^Ç„„> B÷o÷›ˆ¸çÁE÷œ{¸4`:`úˆ0İ½İoÃñö7µ~¯¹û¡%õÕ¦ÖÌAV=êÇ%ë—ôZSëŸ¾¡ãM­Ù+\ß‡{õ"~¡"Tb‰ÀL“Üš?m¥ŸLbDºÂP×Ğ¾‘>AÎº¢2¯p#9‹¦$}9š€ñªçÆBWRÍ‚,sWÆJ‘˜{Ú_\SÍ1·“¿¿^ÌË¹ÈVŸƒˆz¢¹”l<7¶¿ÔICg)u-µ¹A=ŠW­|®r%Ñ­"€¦+ß³¥çÆHWÒ>*—Òıˆ%’¨s'¤kE°æ^E×j7çr¥$´ºkÑ®ÊpË6KÌkı‘khÖzõé²÷D.× ¢
+×q¢’RÎo\ÎQÓ&pyÀfÀæËÁfÙÈ{ZÃ'&×„hNªõx^2S‰dIll¾4l.ylœDp‚…ã¦&có&ô®ÃLÀùâÀ¹lä]À)„ƒóäñtq9^Š,‘%Íë¬å››¯ˆ›iïr&D|
+B"Ç[J-QÇ››¯›y#ïÂM&ek€›\ìMÀñŒ]1p3póµq3íã=°‘D‰	·8ŞT«=›’søº`ìÀÍÀÍWÄÍ¼‘wG)Ø2üçAhİr¼Ô“x²M¡¿œœ¯œËFŞœ@*xƒMIõ¬ £êÃ¶”ì€Í€ÍW„Í¼‘÷À©ú©*bª
+IQK@ÎŒj88_8—¼8F%¡X€•Q'gQœœ/œy#ïN!O–àÀ©¨V7ÈPâÂCãà|mà\6òà˜$n‘6•Šú\Èíp‚µ”œœ¯œy#ïS©SÉ¡¶móqJ3fNƒŒÀùÚÀ¹lä]ÀA½ŒXOT%—ã¦NI¢ˆ88_8óFŞ“LB…[½áû”v–\‰úï“J;îä:I¹'T´ş¸ÚÎå„ïUÛ™#HN?¹¶s‘^vY0¶WÖÏ(î\´wG:¥°?¬¸3‡S¶Rù{wnyÕ“êÎ£ºó¨îüë¨îüB2îKe†i<Lã/b¿ßÖ¿I7>¬{¿™×iÀ¯¯×[ÿ6Ñıù@–ğ]'_¥ ÈÈ>:d÷îüÛûç#	Êwœzû<;ûøˆİ»÷oÓûŸåFßuò%ñz v öñQ»wïßÔx>˜™}Ï¹ÏYß²²Ù½[ÿ¶®Áó±¤ğ{Î½$œÌÌ>>f÷îı›š
+ÏÇ2Òï9÷’í>0;0ûğ˜İ½÷o:<É†¿ëäëTûÚÚÇGíŞ½[MâùH*ş§^²übb±ûvşm‹ç#5 î:ùºÀÀÀìÀìÃcv÷Ş¿­¡ñ|¬ Á]'_ªÔÔ>>j÷îıÛÏGªÜuòui…ÚÚÇGíŞ½[=äùXé…»N¾Ôu¨¨}xÔîŞû·¥KÔ}¸ëä›¢µµÚ½{ÿ¶nÊó±¢w|©h1P;Pûø¨İ»÷o‹¶üxrGª³º¿Ûäı’Ö+9P™´´DÃOhúë½BHÔ±ÕõWÅIğÁ½«‘'}´í/6%o
+`Orìüi+×åZ8òä7²R&ä½ :×`¸•¤ì‰ñp]Áj5YÎÙûrÖ³WA®Ø5Ö¨ş‚æŒµÍ}™U¤ÎRëZB—a‹€¾’×¦’<å¾ø†\œ×µ0OÕ˜£vE;çêg©v#èÍ“¦Òû’¬w•€V”ôğ®J°`­µö„åâYûêBDÏûåJyä
+­/]U$|ï++¹p½útÙÖ;
+÷(ª[¨ šÅ3‰#Qã(ŠĞ‚<KÚÔX00úê0ºìë]8ª¨ÕQ‘û/”*ëñ~N5×(C=–}½G
+cº¢¾(,F‘«ã5qLØ´×00úê0:oë](
+TÚjNWËR Rc”*00z ]öõ.eÉu
+Ì\ôxz&«96u´ŒŒ¾:ŒÎÛzŠ2¡`ï„¢TâM½Qkv$İ=Œ.ûz
+©À-ƒä°ÈòeK,ãp4pô`8š÷õY"MàPÎ8ŞĞ»Ò«®nàèÁp4ïë]8JÂ-nÅ¢ßĞ[VÕ0`4`ôP0š÷õ.i«(9¡¨ät¼çÊË›ªn èÑPÔ¶õ.9£#
+Lº7Æb²iÛ5040ôõ14ïë] 
+ò1UŸÉâ¦oÀ‘'-K¿©££‡€Ñ´­w¡¨’q¶™¦óTßDÓIU4İ€ÑƒÁhŞ×{päL’Í7Å½áèªê÷ÀÑÀÑCàhŞ×»p¤ØØ³÷5ŞÂ.T‡:z(MÛz„Œj–©x Dš»üb+yÕˆw h èPtÙ×»`”©0óÔ½É"ø¸ã«çƒê0z4MÛzŠ
+e¯eÒF¹ú\›çŠ°ü#óuÀèÑ`4ïë=8Ê õJk˜T¯î8JRÉ#,uàèÁp4ïë]8R)×ˆ³ğq	%KG’Ä€ÑCÁè²¯wÁÈH’OuR-åãÁtBR¬›n€èÁ@4më]Ê”¼WÄ)?	¹ºÈĞDD¢y_ïBQÀİ*Œ*¿Í¢‹:,º£ÇÃÑ¼¯wá¨R8Wu•88ÛtJÉ~8p4pô@8ºìë=8
+¦œRÊZã™£HY-àî¢CÑ¼¯w¡HÉê¬R$>Ú­äQcä=Šæ}½ENh†ÕHrœaĞva@E†¢y_ïBQ[Î¨:œHŒçë1×’ŒŒ
+F—}½F…juÍFÎöi•¢ãd4`ô`0š÷õ•DÅ,Mİ}¢Ôt<¼Û(çÀû88z(Íûz„rD9Ó["ouÕ z4MÛz†’QÊÂ'–L,ì·]¥äô¿W-Û8¡‡˜Î;ã‡m«,%2ö±TeıÁüN9W©ì'!¯¥=G:¡×ÜRâô³ÊîQ–œ¤
+;–·ÎéUohõ‡¿ìíÅ‰¼Ë‰«aÓØkJ¹¬r·~¸ÌšPv½ wyÇôËÿùiYe\hYåå;ÇÖ;:ë­IHsµÒî.¤,}B.øßïVºwLÄFê9ë›·À_÷n”©ÔùÄTK`q ¶‹,`·†¥SQ®‚4'IaKBš4…¡L¦j\Kµ“’š–¬xA%KJÉOFªEôê;~‡‘«>jfRO\©ÕÌ?X„Dn¦‚Ç(]tto
+£‘ÖÆ=IntªQbW®zB›©êœa;Šb“T*Pc3”>S6=)Ä}iÚ+‰paÜ$i˜W¬#q3PÁ]•Ğê°ı›íQRÆ¨±0~ÏF&
+W•rV¼/ÎÄYKBE]Ä9·4j*µ‚ÚÅ`FëBŒVÊjQÛ¬Åã_¬IªN¿/Š>ØÉ£¶ICRÜzÿ£÷n ¿i êhÒnË2§6A!e‘Òf•Zw¥‰’E´Ÿ³pÁvQ&´vÀ PÕ„†‘¿<©’s‰È)îXju7˜d*ähÍØ6l¦Zj¥FÛ„Z(Ä%·ß§àÔv¡%²œ"ŞJÑšweB\³L£9	·Bw¦T•qLš95äV@_*sÖF"û/I¸ ÉRÉÍ+yB„™F3Äıòä‰Jh85»gÜ—c“U±6Êœjó$»‘š…MË¢…;yFc&iƒ^#y*ìÓ7U·mYÉEƒ)Š´ÕÎ°RrèI
+W,`VJ"ÒİsjòÙ(<¦oJµ„5É¨‹	{ƒIÙ"v©z¾ØµuXÉÃJş’Vò;Bá¦›çóæ‡÷œ{ÓXq@x@øÛAx/n[‰>i¼x×É×]ˆˆ¿ˆ÷Bá¶éó®w|ÓRr€x€ø»x7nš¨>é9yÏ¹×ı,„„¿„÷Bá¶ƒëó‘~—w|İLs€x€øÛx/nÚÇ>ë¶yÏ¹—NÂÂßÂ{¡pÛ»öùH§Ï»N¾n#:@<@üí@¼
+·sŸµ½ëäKÓââïâİP¸íÚû|¬Çé]'¿4PşvŞ‰„ÛÁÏÇú«ŞqêKëÖààoàH¸éUü|¨µë§>wèèıvèİ…ƒÛ&ÉÏÇZÊŞqê¥[íÀïÀï·Ãï^(Üôg~>ÖÎös/­r„„¿„÷Bá¶9ôó±Vºw|éÓ;@<@üİ@¼
+·©Ÿôñ½çÜKàààoà]8¸i‰ı|¨ƒğİ&^Zìì~;ìîDÂm/îçc‹ï:ùÒy`x`øÛax/n?ë›|Ï¹—ÌÂÂßÂ{¡pÛ…üùXÏæ»N¾4„  şn Ş…ÛèÏFßsîu3êááoáH¸í¾ş|¨Wõ=ç¾ôÁ  şv Ş„›¾ïÏ‡ÚdßoæKîŞŞoŞ}@¸m8ÿ|¬=÷=ç^Z;ï…Âm³ûç#­Áï:ùºïø ñ ñ·ñ^(,É÷ãlÓ—ü®“Ÿ›7ïÂÒı ÆV-Ñï7ó¥Ùú@ï@ï·Cï> ,MØ`liÅ~¿™—&ï½½ß½û€°4?€±Kø»N¾î/?<üí¼	Kãù([·Ÿ¿çÜ—ÖöÁÁßÁ;‘°ô¼ß²Mçû{Î¥¦‘™4 ü=!¼
+bh—Š>€³Öù6î>9ÓÆş¶Ş1¼¦CE`‹‘Ãv~—‰û-×k¯å:ukk¬ÊAV=.½^¶\ÿ»ÃMàkêİQa²‚bÜ?{C´¹¡ÿe|l
+endstream
+endobj
+
+824 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 800 0 R
+    >>
+    /Font <<
+      /f0 776 0 R
+      /f1 782 0 R
+      /f2 788 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 3
+  /Parent 1 0 R
+  /Contents 825 0 R
+>>
+endobj
+
+825 0 obj
+<<
+  /Length 4183
+  /Filter /FlateDecode
+>>
+stream
+xœÍ]¯Ü¶†ï÷W¨Hã¤¡9Ãï4Ğ8¹h(â»¦‰-š uòÿQhÏŠ”¨Ù!W$uÎ>>GCòÑğÕëïşûÃÏÓ_\¦éõ·oşòõ$/_~9}õõ›Ëÿ.0ÉINŸÁ„^(mµq“sVXŞNï~º¼~'§w¿\äôË»Ÿ/_½½Èéí‡Ëë÷r%pzû>˜?ŞştùÇÇßK)¿—nŸxûT·O}û´×ÏŸŸş¦nÿŠËÿr¯ş9½ıëå›·—¿_¾ùöÍåu~À_ƒQÂiWºà® \vOKùôó¯şº¾ŠÅ{œK~ôjÒaú¸p™ÈÛïHµùï«P™GI¿Q
+#aTêF;9¥š˜ Ä³+¸úõéõ/ï_MŸYB6˜M˜–p\/ÿ1·¿DP¯¦ÏÜíÿ½_ıû‡õW™üúÿüá×½ÿáİ¯ÓWßŞ¹f”Â¬®ùÍw9}÷æo=}{™ù§‹œ@já¤šşsù®dØ(aœÕÆw·æÛÔjcº[£J3 ¬P0Â²Báã JŞ0X%‚“|Ì°Da´íoØz#”ô^÷·l½N¦2ØÏ²‘Â+¥„	Ú›ş–Á
+e¿¼d*ªd>Í<s’¸M’%ï”Ì8q¾šŞş›)Ùšø~ãc•itàuáÛñí6¼]½ƒWì·;áî~ıG…¯·Ä×ƒ„X	¥!İJOY>M%!›¼Ô«É/sõí‡·ÉF-K…İ|“ûï(ÿ_Êm³ûŸK…§™ñ}É9Ïe¶r[¥ğí4T…Ñlj·x°,êÔ-0¨·k®ø¹¬Ğn+(Å…¨d£æÔ¶ˆš)D€[ƒ¥°¡Ë>ëÃ†üÜîõoî¸¾ü}¹Ut•­øÖ˜ÍLx`€mi€ù’ßàAñ¶¸mE³q·Å ™Âø¶:]Şø©¶W¢dÑsËÖèÑF³½{–Ô|ÀgÇ¦¨òÛ5ÕÅRz>G\¨MÒ8Ôqè‹a…$möº2Kq™vª]GÉgé€xçiçÊ¥øcÑi`Óa³@?àrŒc| Ÿ¯í¾kª«öUÒ´ÕÙÚZŠy=×|–öò’¤1Êr+Ï\HÍ\(#¸x)Pìi«ˆÆŸ"AÈâ·ÁzG°0Îbe«Xt†8ˆV=Ä²Âš1àÉ
+pZ»ş–ç}µ×º?àCi„#Ø“–­,wÆeÉrw^¶2İ˜­Lw&f+Ë½‘ÙÊt'f†Ôš–:2š!µBFK½iô@–¾Z£rÂª0ßàÃÁRK]tz©Š/œ)³(Xjïó’3l~ŸÁÎ²	>¥İJ¶æ‚ÚR|ÜN gJóqIÏrŠfk×¨Ê°wó§1s6Ûm—·1ŠŸN iŠŸÎ i_®ˆšç‡z€Ï”ˆ|eùy¹X¶XŸ€Ğ¢Ï‘ï—|Ö’ÏÎš>=Ï`h²vŒ5òy9ÂÙœCìÚV|bAÍÊ™¨ùL<“iÃ§ä‰˜¬~-Ÿ™|¾Êê—hÇ'æKeš|^ì"´x ìóÕ"şf–ë”«Ö±ëŸí¨æ]@ã4Ş	mMù	Fx¯kiU½a­¼a€Ç:a@õ÷ØÌpCúş!v^¸8v%fŒ@Ô•GÉr;f¹
+4]ƒÀš®@`-× 0Êô®¦‘+W¯—û|<¨2Ô:TK¹„FŠ_O­AµtÂ¢»r–VPu]u| ––PHéİ]f†Z&j­–ÚùÒa™!F¤\JôóÂ2cØ{ìXf,{“í4ËÖµ÷Æñq;–ÏÇm ,ÛíªB›ÀŞÍÃ;Íîm[Ë{l+ùOÌ,ğ~1ËÇ»Øe‘ï³:Ïòa/·bËöHÔçòMaÑWÍ§æ	¸Ì>7OÀe’ÓòÉÙ7UŒ›ãÓìHt°œÁ2!€¦é·SÍ!~Oæ­„;Œf¼¼ï­·åt­·åt­»åx­·åxæÈx#oøØa&c½ĞÒô?e°nÀù«™äp0Ï€6@Ã:¡p|N{æñ(ï
+)Í+–úáÔ&Kà
+'Ù>ÚVŠ_O­O­
+Âõú¥°ŸHxRPšÈµÖ´A8)]ï/‘
+WhãoıÌO_(ªp|‡p»ÿM¨Âöö2v[+
+gùû«Á…ÚÃ]¹jAù©¡c£˜ù!Äj"À)¥ÁƒêéùÁÂ"Şq…Ã(ÍN?xb*=]/e@„Íô<€Rxşdƒ=JG¸ŠA+€lvºöèQş¸xw{Å—ìşÑNÏ¤ï¤hqÛí5›¢Rozh…7|6¸p9—¾úÂyûv¯…i‹ëÅ……çÚˆwlõÉOõUS5ÏÁ×ŞmwC[<¿‡3Õ	[İ•$Ÿ°í^?
+û«ï`vD¼cÂ’¼ªÊidu¸´™0¿|çu¸ş°Ù^<Ñ¶(µŞÜSë2'(t-L°“—õò]îg\ê…RÂlI™ãõ’?ÅäãğS#V:t­TÎP´éo`L@=À¶“"89" ZH?Ät"]sÛVÁ2xNÕ6ıDËr~nXVŞ¯a„eë…•Šç~Ç,Ê¾#ì˜e¥ ó®¿e°ÂûU#O­å]dW÷Zúm¢À ¥–¥@­î]
+N»óinŞj©îQ8„9s÷”ã§D¿ŸZoÏÏU¨cğ¾ôıÔÒ9HáŒìòıJßO-—ƒRc—ï—P”	’äâBœ›¤Êè†=Ï`’\;³Ì€ÍĞDƒA"WgTÛic ©¸BÓâÂİMYv@ ş{lg*Ç­ÏjfüëI±‹Óe§Ø’=Æ©ìç»íWÙiËßâín×bÃê®&ìÓ eìváÒõlKÙ9ÏfÁ çò,È{°jœ…,hvûAİ*U}âH½ÄTâG¦C„óÂRc1å°
+Û%r§†‡@j*¦\àäİ\®¦Œ@ª+®s¹Ùí£êVåjL
+3®ryDZÜa«n‡Rš1å2ÂvSö¬m¦@ª1¦œá¬,åGÙiWÈéf·RèŠÙšr\åô€ˆïêów )kƒ‘k=;ımÜ6Õë«%÷»?;c £İ â' }RÑİ´áä|º»i=Ÿ%ƒ¹óº¬Q	sÆÎteº7M¦»SĞ•éŞteº7]™îBW¦{‘P uaÃRQN`¡@Ê¼¢uKé9†©ïŠs7ª1ZŸÀCTmEçæç¹Êœ@DT_EB{­ô	Lh-Uï„sV¹s¨(©=¨@.³Õ‹‡¢¤t¡²v™ŸŠÒÒ†±âœBEiuÃXqF`Ñ¸HÅ“ÖoÄHMÃUä‡‹ÒZ†)–¼Êş»}by#@Ê¦»|H,s`ğ8¥õS</¥¥S&Œğ.ÇùgE&>F İè/y\HqÄTä‡ÄÚÑy›d<Ë^;>_¥%Sğ2Ë€/Ÿ·#ğm‡òş¿òFÊ&®òv$tÎ^NS`h¥Å”·/‹ÒR‹)G ¹ˆà²ÊVİq´ÖbÊç1¾{”¥ÂkÍçó@àœV;yìË^¶½ÁhÖëê×ánß>K¿wvÉ–å¶8¤ívËd.•ŸD‘º‘±ç×Ö¶ì!:‰\‘òïæ?~¬³ÎZ¿=FQƒ·Lëm:(!Í§AaœÑf€é€Â^«\wÓ±yr¶ŒË`¥PêÑÃéók	œQ#,Ï OPY–J s<@=d¼Rû1ËÖ/Kê‡,ÆªÂRËûšÈöî Æm¦ RfÖèXqš}(RLRÒ‚@åŸ<B*Ë®qÛNù)
+üRµ}Ã"{4Â$U%Áè¥ 7_@Â$'S–£ÙV­“”œ\eù)>°mš(ı¶Ä8·¤6ä*>”Şbr¯;¬b;IÊI¦Û³Ùé;İù œ;š’·!‡ Û¹ïÀë;©)™†¼Å‡»;®|ˆs9·ŠŠ¸!owºÔàsï½¯·•l-ïiÜqş²×l&8µ]J™ RWr•¨>—½¶^fHQÉ”¨ÍN—^³½ÓX¸ì¹æu@¼w¯Îo·
+¯ÙîJ0v»2? ®Xz×“«Dmğ¡”¨‘aåï*O¢¤,eJÔf§K5?œ¸ì¹çu@¼w¯\[n³j& ¥ãæ}´E9¯É_ïú¤z­.¨7Š™iâü¼ ¿i«„RRë 	‚ğzVÇëoÚ¢&ŒğzFˆÃØ•{­L÷_+Ó½É×Êtoô•Lwg_+Ó½á×Êt7úEŠ[ÎÛ¹[E9‘
+—3¸•ñø‹Ô¸¼¾ğ…áø‹T¹œ'¨[|ñü‹T¹T¨—JüÌü‹”¹\åùğ‰º\åù)>8>g0Rºr‡,È¿{|^n_"Å+Wwè(–»ºëW(¯ƒIõÊ4è§00RÀ2ú&ƒ….šòV—”°Lƒ>‚å›ÎÚ<HËT‡BÇÜûúsß¤Šå*UÏ `¤å*UGP°;m=Ik·9Ë§êh¶§e—Ÿ¢½R_M=Ÿ¢gğ/R¹r•¢yÌN±²ZjHéÊUŠ`‘)ïš˜Ë®Ÿª#€c6]íæ‚ò¢œÔ®ŒMR ´PxlÁÙ—ı1n3&[â–¶6»ÍS\¶#x’¨üôŞ»ko"ƒYæ7ºÛ+d# îm:Ì¯W‚Yÿµ»i03Ø¹–¶î¦Ã‚.»›NBJ–aîuqªûÁL^G˜öV(§ìèˆa([ GG>xoMwËJk¥Ç‡ƒ±¯‡Š}r5Ïá›áA»H%ÇÕ£«v'Š¸‹”rLİ^ ğÁx7î¥.@j9‹˜ôÂ{×°ôÍ»H1ÈùÌ·RÙ|m¼‹ÔŠŒ™`[]F&R-2åù	. ©ƒàô¶@]Hª=¦ 4¸À/x³óCõ˜IÈtcöò8î:xÌuc³ii ÜBRı1s‹µ‡­ò·òÔÎ°C=Âë{<ğÚ²…wˆ×»Èlc]¦3XPˆÙ
+g ÖBR2%i‹»ÊQl†wy0«O;#-Ó´İuæÜğ.=kÙ’"©ÁäåƒÏ1ø,!ƒí»'>¬¿â@;M÷=ij§éoÚ¡®'{ì¤çíÀÜóÒß´BÊ0$ ©Y¢ X¡üãuàí*pÈr8d¹2]GÓû"‡<À? )
+»"øã1 ’Ú®©ëå€¤P+:½Ô²—oUJ.óy1 ’2­)ÕÏØ„“j«)ÑOq!°Q8Ü-\¢Ğ¼­>¢ƒ…´Ša¼ûÆÑ‰²g|‰>eSO«Æ!kßhÎ¼íöÊÕZ‘–EŒ;Îu×îºají}ôª¤©RÏ HÆ”¯§ìïIÅ”¯#vœ÷„åë~ÖVŒ©zÆ>ó\å}2©Æ˜²tˆ×yß_¥òXÿv¿M”
+endstream
+endobj
+
+826 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 800 0 R
+    >>
+    /Font <<
+      /f0 788 0 R
+      /f1 782 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 4
+  /Parent 1 0 R
+  /Contents 827 0 R
+>>
+endobj
+
+827 0 obj
+<<
+  /Length 545
+  /Filter /FlateDecode
+>>
+stream
+xœÕVMkÛ@½ï¯˜^J\èhvf?!j'‡\(Ö-î!-uhÿŠm}YÈ•\K¹xØE~ófæ-o’O›íÕS¶…é|¦ş(5ˆ gø@è¢²µJ2‚ÙB,f_•¹Ú}½VbÑ[¿ÔB}Só™JN›ˆÑ8cıàÈQ0Fm¬Y[B«ÉŒ€,Œ¡ î ÖN#{t²ctAÆ@6±Á†
+9;Ì9{Q/Ù³š¦Š İ¨dE 5¤«êß»®ÕÍ’ˆ–DzéOõv%µ¦”úÅY7UÎZ†]$2ŒÎUkÍàÑŸLñ¾gU1”ÏÌyŒ6ü3§>QÕã>gØ×¶İıÆ¼¹62 7G—›ÃI|q;ùé—”µµÅû½˜ò‡<9çÑU%,WMB‹ßOÏp{« ’ùìó=º»ƒéı	iZ:ıÜòF	5†Ø$ [Ôd: î`À-j’º€ÁcIáÙŸ›‘¥k\ÒÂµ¦¥¹²=¢ó³î«y¦±œ…™™FØØE”0²°Å£1Ã#»ˆDqŒn .'Ømá%Ä~vXƒîåáÿİËÄÏ‚…¤¯èâÌ¶ûH.Î¢ÑjŞ×u-goŠ§öV\\„Š7üº.nZl¡¦Í+Ø¸mcPéôbczw“V®ÕÕ:×F¼’âµˆóaŞÄ¹¥sğm›[%È1WÆJPŞ7V¿º8o•
+endstream
+endobj
+
+828 0 obj
+<<
+  /Creator (Typst 0.14.1)
+  /ModDate (D:20251218075347Z)
+  /CreationDate (D:20251218075347Z)
+>>
+endobj
+
+829 0 obj
+<<
+  /Length 996
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.14.1</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2025-12-18T07:53:47+00:00</xmp:ModifyDate><xmp:CreateDate>2025-12-18T07:53:47+00:00</xmp:CreateDate><xmpTPg:NPages>5</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>o2b6CWztArCaIBGPLYltNA==</xmpMM:InstanceID><xmpMM:DocumentID>YcjSBXb6GWbZEjl0N5dzBA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+830 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 829 0 R
+  /Lang (en)
+  /StructTreeRoot 16 0 R
+  /MarkInfo <<
+    /Marked true
+    /Suspects false
+  >>
+  /ViewerPreferences <<
+    /Direction /L2R
+  >>
+  /Outlines 2 0 R
+>>
+endobj
+
+xref
+0 831
+0000000000 65535 f
+0000000016 00000 n
+0000000114 00000 n
+0000000195 00000 n
+0000000288 00000 n
+0000000399 00000 n
+0000000545 00000 n
+0000000646 00000 n
+0000000755 00000 n
+0000000884 00000 n
+0000001038 00000 n
+0000001153 00000 n
+0000001263 00000 n
+0000001396 00000 n
+0000001505 00000 n
+0000001637 00000 n
+0000001745 00000 n
+0000003816 00000 n
+0000004875 00000 n
+0000007942 00000 n
+0000008689 00000 n
+0000010510 00000 n
+0000010585 00000 n
+0000010877 00000 n
+0000010978 00000 n
+0000011064 00000 n
+0000011230 00000 n
+0000011339 00000 n
+0000011438 00000 n
+0000011626 00000 n
+0000011814 00000 n
+0000012002 00000 n
+0000012190 00000 n
+0000012289 00000 n
+0000012479 00000 n
+0000012669 00000 n
+0000012859 00000 n
+0000013049 00000 n
+0000013148 00000 n
+0000013338 00000 n
+0000013528 00000 n
+0000013718 00000 n
+0000013908 00000 n
+0000014007 00000 n
+0000014180 00000 n
+0000014370 00000 n
+0000014560 00000 n
+0000014750 00000 n
+0000014849 00000 n
+0000015022 00000 n
+0000015195 00000 n
+0000015385 00000 n
+0000015575 00000 n
+0000015656 00000 n
+0000015755 00000 n
+0000015971 00000 n
+0000016187 00000 n
+0000016392 00000 n
+0000016490 00000 n
+0000016695 00000 n
+0000016789 00000 n
+0000016877 00000 n
+0000016963 00000 n
+0000017129 00000 n
+0000017238 00000 n
+0000017337 00000 n
+0000017525 00000 n
+0000017713 00000 n
+0000017901 00000 n
+0000018089 00000 n
+0000018188 00000 n
+0000018378 00000 n
+0000018568 00000 n
+0000018758 00000 n
+0000018948 00000 n
+0000019047 00000 n
+0000019237 00000 n
+0000019427 00000 n
+0000019617 00000 n
+0000019807 00000 n
+0000019906 00000 n
+0000020079 00000 n
+0000020269 00000 n
+0000020459 00000 n
+0000020649 00000 n
+0000020748 00000 n
+0000020921 00000 n
+0000021094 00000 n
+0000021284 00000 n
+0000021474 00000 n
+0000021555 00000 n
+0000021654 00000 n
+0000021870 00000 n
+0000022086 00000 n
+0000022291 00000 n
+0000022389 00000 n
+0000022594 00000 n
+0000022688 00000 n
+0000022776 00000 n
+0000022863 00000 n
+0000023031 00000 n
+0000023146 00000 n
+0000023251 00000 n
+0000023443 00000 n
+0000023635 00000 n
+0000023827 00000 n
+0000024019 00000 n
+0000024124 00000 n
+0000024316 00000 n
+0000024508 00000 n
+0000024700 00000 n
+0000024892 00000 n
+0000024997 00000 n
+0000025189 00000 n
+0000025381 00000 n
+0000025573 00000 n
+0000025765 00000 n
+0000025870 00000 n
+0000026045 00000 n
+0000026237 00000 n
+0000026429 00000 n
+0000026621 00000 n
+0000026726 00000 n
+0000026901 00000 n
+0000027076 00000 n
+0000027268 00000 n
+0000027460 00000 n
+0000027543 00000 n
+0000027648 00000 n
+0000027866 00000 n
+0000028084 00000 n
+0000028292 00000 n
+0000028392 00000 n
+0000028600 00000 n
+0000028696 00000 n
+0000028785 00000 n
+0000028874 00000 n
+0000029044 00000 n
+0000029160 00000 n
+0000029265 00000 n
+0000029457 00000 n
+0000029649 00000 n
+0000029841 00000 n
+0000030033 00000 n
+0000030138 00000 n
+0000030330 00000 n
+0000030522 00000 n
+0000030714 00000 n
+0000030906 00000 n
+0000031011 00000 n
+0000031203 00000 n
+0000031395 00000 n
+0000031587 00000 n
+0000031779 00000 n
+0000031884 00000 n
+0000032059 00000 n
+0000032251 00000 n
+0000032443 00000 n
+0000032635 00000 n
+0000032740 00000 n
+0000032915 00000 n
+0000033090 00000 n
+0000033282 00000 n
+0000033474 00000 n
+0000033558 00000 n
+0000033663 00000 n
+0000033881 00000 n
+0000034099 00000 n
+0000034307 00000 n
+0000034407 00000 n
+0000034615 00000 n
+0000034711 00000 n
+0000034801 00000 n
+0000034924 00000 n
+0000035013 00000 n
+0000035103 00000 n
+0000035273 00000 n
+0000035389 00000 n
+0000035494 00000 n
+0000035686 00000 n
+0000035878 00000 n
+0000036070 00000 n
+0000036262 00000 n
+0000036367 00000 n
+0000036559 00000 n
+0000036751 00000 n
+0000036943 00000 n
+0000037135 00000 n
+0000037240 00000 n
+0000037432 00000 n
+0000037624 00000 n
+0000037816 00000 n
+0000038008 00000 n
+0000038113 00000 n
+0000038288 00000 n
+0000038480 00000 n
+0000038672 00000 n
+0000038864 00000 n
+0000038969 00000 n
+0000039144 00000 n
+0000039319 00000 n
+0000039511 00000 n
+0000039703 00000 n
+0000039787 00000 n
+0000039892 00000 n
+0000040110 00000 n
+0000040328 00000 n
+0000040536 00000 n
+0000040648 00000 n
+0000040856 00000 n
+0000040952 00000 n
+0000041042 00000 n
+0000041132 00000 n
+0000041302 00000 n
+0000041418 00000 n
+0000041523 00000 n
+0000041715 00000 n
+0000041907 00000 n
+0000042099 00000 n
+0000042291 00000 n
+0000042396 00000 n
+0000042588 00000 n
+0000042780 00000 n
+0000042972 00000 n
+0000043164 00000 n
+0000043269 00000 n
+0000043461 00000 n
+0000043653 00000 n
+0000043845 00000 n
+0000044037 00000 n
+0000044142 00000 n
+0000044317 00000 n
+0000044509 00000 n
+0000044701 00000 n
+0000044893 00000 n
+0000044998 00000 n
+0000045173 00000 n
+0000045348 00000 n
+0000045540 00000 n
+0000045732 00000 n
+0000045816 00000 n
+0000045921 00000 n
+0000046139 00000 n
+0000046357 00000 n
+0000046565 00000 n
+0000046672 00000 n
+0000046880 00000 n
+0000046975 00000 n
+0000047064 00000 n
+0000047195 00000 n
+0000047316 00000 n
+0000047391 00000 n
+0000047466 00000 n
+0000047556 00000 n
+0000047726 00000 n
+0000047842 00000 n
+0000047947 00000 n
+0000048138 00000 n
+0000048329 00000 n
+0000048520 00000 n
+0000048711 00000 n
+0000048816 00000 n
+0000049007 00000 n
+0000049198 00000 n
+0000049389 00000 n
+0000049580 00000 n
+0000049685 00000 n
+0000049876 00000 n
+0000050067 00000 n
+0000050258 00000 n
+0000050449 00000 n
+0000050554 00000 n
+0000050729 00000 n
+0000050920 00000 n
+0000051111 00000 n
+0000051302 00000 n
+0000051407 00000 n
+0000051582 00000 n
+0000051757 00000 n
+0000051948 00000 n
+0000052139 00000 n
+0000052223 00000 n
+0000052328 00000 n
+0000052545 00000 n
+0000052762 00000 n
+0000052970 00000 n
+0000053071 00000 n
+0000053279 00000 n
+0000053374 00000 n
+0000053463 00000 n
+0000053553 00000 n
+0000053723 00000 n
+0000053831 00000 n
+0000053936 00000 n
+0000054127 00000 n
+0000054318 00000 n
+0000054509 00000 n
+0000054700 00000 n
+0000054805 00000 n
+0000054996 00000 n
+0000055187 00000 n
+0000055378 00000 n
+0000055569 00000 n
+0000055674 00000 n
+0000055849 00000 n
+0000056040 00000 n
+0000056231 00000 n
+0000056422 00000 n
+0000056527 00000 n
+0000056702 00000 n
+0000056877 00000 n
+0000057068 00000 n
+0000057259 00000 n
+0000057343 00000 n
+0000057448 00000 n
+0000057665 00000 n
+0000057882 00000 n
+0000058090 00000 n
+0000058191 00000 n
+0000058399 00000 n
+0000058494 00000 n
+0000058583 00000 n
+0000058673 00000 n
+0000058843 00000 n
+0000058959 00000 n
+0000059064 00000 n
+0000059254 00000 n
+0000059444 00000 n
+0000059634 00000 n
+0000059824 00000 n
+0000059929 00000 n
+0000060119 00000 n
+0000060309 00000 n
+0000060499 00000 n
+0000060689 00000 n
+0000060794 00000 n
+0000060984 00000 n
+0000061174 00000 n
+0000061364 00000 n
+0000061554 00000 n
+0000061659 00000 n
+0000061833 00000 n
+0000062023 00000 n
+0000062213 00000 n
+0000062403 00000 n
+0000062508 00000 n
+0000062682 00000 n
+0000062856 00000 n
+0000063046 00000 n
+0000063236 00000 n
+0000063320 00000 n
+0000063425 00000 n
+0000063641 00000 n
+0000063857 00000 n
+0000064064 00000 n
+0000064162 00000 n
+0000064369 00000 n
+0000064464 00000 n
+0000064553 00000 n
+0000064643 00000 n
+0000064813 00000 n
+0000064929 00000 n
+0000065034 00000 n
+0000065224 00000 n
+0000065414 00000 n
+0000065604 00000 n
+0000065794 00000 n
+0000065899 00000 n
+0000066089 00000 n
+0000066279 00000 n
+0000066469 00000 n
+0000066659 00000 n
+0000066764 00000 n
+0000066954 00000 n
+0000067144 00000 n
+0000067334 00000 n
+0000067524 00000 n
+0000067629 00000 n
+0000067803 00000 n
+0000067993 00000 n
+0000068183 00000 n
+0000068373 00000 n
+0000068478 00000 n
+0000068652 00000 n
+0000068826 00000 n
+0000069015 00000 n
+0000069204 00000 n
+0000069288 00000 n
+0000069393 00000 n
+0000069608 00000 n
+0000069823 00000 n
+0000070030 00000 n
+0000070126 00000 n
+0000070333 00000 n
+0000070427 00000 n
+0000070515 00000 n
+0000070637 00000 n
+0000070742 00000 n
+0000070863 00000 n
+0000070977 00000 n
+0000071124 00000 n
+0000071271 00000 n
+0000071418 00000 n
+0000071565 00000 n
+0000071712 00000 n
+0000071826 00000 n
+0000071973 00000 n
+0000072120 00000 n
+0000072267 00000 n
+0000072414 00000 n
+0000072561 00000 n
+0000072675 00000 n
+0000072822 00000 n
+0000072969 00000 n
+0000073116 00000 n
+0000073263 00000 n
+0000073410 00000 n
+0000073524 00000 n
+0000073671 00000 n
+0000073818 00000 n
+0000073965 00000 n
+0000074112 00000 n
+0000074259 00000 n
+0000074373 00000 n
+0000074520 00000 n
+0000074667 00000 n
+0000074814 00000 n
+0000074961 00000 n
+0000075108 00000 n
+0000075222 00000 n
+0000075369 00000 n
+0000075516 00000 n
+0000075663 00000 n
+0000075810 00000 n
+0000075957 00000 n
+0000076082 00000 n
+0000076179 00000 n
+0000076254 00000 n
+0000076360 00000 n
+0000076507 00000 n
+0000076654 00000 n
+0000076801 00000 n
+0000076948 00000 n
+0000077062 00000 n
+0000077209 00000 n
+0000077356 00000 n
+0000077503 00000 n
+0000077650 00000 n
+0000077797 00000 n
+0000077927 00000 n
+0000078064 00000 n
+0000078186 00000 n
+0000078333 00000 n
+0000078480 00000 n
+0000078627 00000 n
+0000078774 00000 n
+0000078921 00000 n
+0000079010 00000 n
+0000079132 00000 n
+0000079279 00000 n
+0000079426 00000 n
+0000079573 00000 n
+0000079720 00000 n
+0000079867 00000 n
+0000079956 00000 n
+0000080078 00000 n
+0000080225 00000 n
+0000080372 00000 n
+0000080519 00000 n
+0000080666 00000 n
+0000080813 00000 n
+0000080902 00000 n
+0000081024 00000 n
+0000081171 00000 n
+0000081318 00000 n
+0000081465 00000 n
+0000081612 00000 n
+0000081759 00000 n
+0000081848 00000 n
+0000081970 00000 n
+0000082117 00000 n
+0000082264 00000 n
+0000082411 00000 n
+0000082558 00000 n
+0000082705 00000 n
+0000082794 00000 n
+0000082916 00000 n
+0000083063 00000 n
+0000083210 00000 n
+0000083357 00000 n
+0000083504 00000 n
+0000083651 00000 n
+0000083740 00000 n
+0000083862 00000 n
+0000084009 00000 n
+0000084156 00000 n
+0000084303 00000 n
+0000084450 00000 n
+0000084596 00000 n
+0000084684 00000 n
+0000084806 00000 n
+0000084952 00000 n
+0000085098 00000 n
+0000085244 00000 n
+0000085390 00000 n
+0000085536 00000 n
+0000085624 00000 n
+0000085711 00000 n
+0000085823 00000 n
+0000085992 00000 n
+0000086092 00000 n
+0000086197 00000 n
+0000086378 00000 n
+0000086671 00000 n
+0000086852 00000 n
+0000087137 00000 n
+0000087318 00000 n
+0000087463 00000 n
+0000087644 00000 n
+0000087768 00000 n
+0000087873 00000 n
+0000088064 00000 n
+0000088255 00000 n
+0000088436 00000 n
+0000088577 00000 n
+0000088758 00000 n
+0000088878 00000 n
+0000088983 00000 n
+0000089164 00000 n
+0000089297 00000 n
+0000089478 00000 n
+0000089659 00000 n
+0000089840 00000 n
+0000089981 00000 n
+0000090162 00000 n
+0000090278 00000 n
+0000090362 00000 n
+0000090467 00000 n
+0000090684 00000 n
+0000090901 00000 n
+0000091118 00000 n
+0000091325 00000 n
+0000091421 00000 n
+0000091576 00000 n
+0000091692 00000 n
+0000091781 00000 n
+0000091871 00000 n
+0000092041 00000 n
+0000092165 00000 n
+0000092262 00000 n
+0000092453 00000 n
+0000092644 00000 n
+0000092835 00000 n
+0000092932 00000 n
+0000093123 00000 n
+0000093314 00000 n
+0000093505 00000 n
+0000093602 00000 n
+0000093793 00000 n
+0000093984 00000 n
+0000094175 00000 n
+0000094272 00000 n
+0000094463 00000 n
+0000094654 00000 n
+0000094845 00000 n
+0000094942 00000 n
+0000095133 00000 n
+0000095324 00000 n
+0000095515 00000 n
+0000095612 00000 n
+0000095803 00000 n
+0000095994 00000 n
+0000096185 00000 n
+0000096269 00000 n
+0000096366 00000 n
+0000096591 00000 n
+0000096703 00000 n
+0000096928 00000 n
+0000097036 00000 n
+0000097243 00000 n
+0000097339 00000 n
+0000097429 00000 n
+0000097519 00000 n
+0000097689 00000 n
+0000097773 00000 n
+0000097862 00000 n
+0000098057 00000 n
+0000098238 00000 n
+0000098474 00000 n
+0000098558 00000 n
+0000098647 00000 n
+0000098864 00000 n
+0000099081 00000 n
+0000099171 00000 n
+0000099284 00000 n
+0000099517 00000 n
+0000099622 00000 n
+0000099838 00000 n
+0000100054 00000 n
+0000100270 00000 n
+0000100486 00000 n
+0000100591 00000 n
+0000100807 00000 n
+0000101023 00000 n
+0000101239 00000 n
+0000101455 00000 n
+0000101560 00000 n
+0000101776 00000 n
+0000101992 00000 n
+0000102208 00000 n
+0000102424 00000 n
+0000102529 00000 n
+0000102745 00000 n
+0000102961 00000 n
+0000103177 00000 n
+0000103393 00000 n
+0000103498 00000 n
+0000103714 00000 n
+0000103930 00000 n
+0000104146 00000 n
+0000104362 00000 n
+0000104467 00000 n
+0000104683 00000 n
+0000104899 00000 n
+0000105115 00000 n
+0000105331 00000 n
+0000105436 00000 n
+0000105652 00000 n
+0000105868 00000 n
+0000106084 00000 n
+0000106300 00000 n
+0000106405 00000 n
+0000106621 00000 n
+0000106837 00000 n
+0000107053 00000 n
+0000107269 00000 n
+0000107374 00000 n
+0000107590 00000 n
+0000107806 00000 n
+0000108022 00000 n
+0000108238 00000 n
+0000108343 00000 n
+0000108567 00000 n
+0000108674 00000 n
+0000108898 00000 n
+0000109005 00000 n
+0000109229 00000 n
+0000109327 00000 n
+0000109534 00000 n
+0000109629 00000 n
+0000109717 00000 n
+0000109886 00000 n
+0000109970 00000 n
+0000110075 00000 n
+0000110265 00000 n
+0000110455 00000 n
+0000110645 00000 n
+0000110826 00000 n
+0000111002 00000 n
+0000111086 00000 n
+0000111191 00000 n
+0000111415 00000 n
+0000111522 00000 n
+0000111745 00000 n
+0000111847 00000 n
+0000112062 00000 n
+0000112277 00000 n
+0000112394 00000 n
+0000112501 00000 n
+0000112670 00000 n
+0000112794 00000 n
+0000112891 00000 n
+0000113082 00000 n
+0000113273 00000 n
+0000113454 00000 n
+0000113562 00000 n
+0000113659 00000 n
+0000113849 00000 n
+0000114039 00000 n
+0000114220 00000 n
+0000114321 00000 n
+0000114426 00000 n
+0000114616 00000 n
+0000114806 00000 n
+0000114987 00000 n
+0000115082 00000 n
+0000115278 00000 n
+0000115472 00000 n
+0000115569 00000 n
+0000115759 00000 n
+0000115949 00000 n
+0000116130 00000 n
+0000116234 00000 n
+0000116331 00000 n
+0000116521 00000 n
+0000116711 00000 n
+0000116892 00000 n
+0000116993 00000 n
+0000117098 00000 n
+0000117288 00000 n
+0000117478 00000 n
+0000117659 00000 n
+0000117754 00000 n
+0000117950 00000 n
+0000118093 00000 n
+0000118177 00000 n
+0000118282 00000 n
+0000118498 00000 n
+0000118714 00000 n
+0000118921 00000 n
+0000119016 00000 n
+0000119232 00000 n
+0000119346 00000 n
+0000119515 00000 n
+0000119655 00000 n
+0000119768 00000 n
+0000119958 00000 n
+0000120148 00000 n
+0000120338 00000 n
+0000120528 00000 n
+0000120718 00000 n
+0000120831 00000 n
+0000121021 00000 n
+0000121211 00000 n
+0000121401 00000 n
+0000121591 00000 n
+0000121781 00000 n
+0000121894 00000 n
+0000122084 00000 n
+0000122274 00000 n
+0000122464 00000 n
+0000122654 00000 n
+0000122844 00000 n
+0000122965 00000 n
+0000123155 00000 n
+0000123345 00000 n
+0000123535 00000 n
+0000123725 00000 n
+0000123915 00000 n
+0000124128 00000 n
+0000124229 00000 n
+0000124342 00000 n
+0000124532 00000 n
+0000124722 00000 n
+0000124912 00000 n
+0000125102 00000 n
+0000125292 00000 n
+0000125405 00000 n
+0000125595 00000 n
+0000125785 00000 n
+0000125975 00000 n
+0000126165 00000 n
+0000126355 00000 n
+0000126468 00000 n
+0000126658 00000 n
+0000126848 00000 n
+0000127038 00000 n
+0000127228 00000 n
+0000127418 00000 n
+0000127539 00000 n
+0000127729 00000 n
+0000127919 00000 n
+0000128108 00000 n
+0000128297 00000 n
+0000128486 00000 n
+0000128699 00000 n
+0000128797 00000 n
+0000128881 00000 n
+0000129002 00000 n
+0000129217 00000 n
+0000129432 00000 n
+0000129647 00000 n
+0000129862 00000 n
+0000130069 00000 n
+0000130163 00000 n
+0000130378 00000 n
+0000130487 00000 n
+0000130669 00000 n
+0000131240 00000 n
+0000131331 00000 n
+0000131583 00000 n
+0000132821 00000 n
+0000137361 00000 n
+0000137546 00000 n
+0000138280 00000 n
+0000138371 00000 n
+0000138626 00000 n
+0000140148 00000 n
+0000146780 00000 n
+0000146956 00000 n
+0000147647 00000 n
+0000147738 00000 n
+0000147985 00000 n
+0000149443 00000 n
+0000156197 00000 n
+0000156362 00000 n
+0000156630 00000 n
+0000156719 00000 n
+0000157005 00000 n
+0000157930 00000 n
+0000163859 00000 n
+0000163897 00000 n
+0000163935 00000 n
+0000164294 00000 n
+0000164717 00000 n
+0000164772 00000 n
+0000164827 00000 n
+0000164882 00000 n
+0000164937 00000 n
+0000164992 00000 n
+0000165047 00000 n
+0000165102 00000 n
+0000165157 00000 n
+0000165212 00000 n
+0000165267 00000 n
+0000165322 00000 n
+0000165377 00000 n
+0000165432 00000 n
+0000165492 00000 n
+0000165802 00000 n
+0000168137 00000 n
+0000168483 00000 n
+0000174086 00000 n
+0000174457 00000 n
+0000190733 00000 n
+0000191043 00000 n
+0000195306 00000 n
+0000195598 00000 n
+0000196222 00000 n
+0000196339 00000 n
+0000197425 00000 n
+trailer
+<<
+  /Size 831
+  /Root 830 0 R
+  /Info 828 0 R
+  /ID [(YcjSBXb6GWbZEjl0N5dzBA==) (o2b6CWztArCaIBGPLYltNA==)]
+>>
+startxref
+197663
+%%EOF

--- a/packages/preview/irif/0.0.2/examples/examples.typ
+++ b/packages/preview/irif/0.0.2/examples/examples.typ
@@ -1,0 +1,187 @@
+#import "irif.typ" : *
+#set page(margin: (top:2cm,x:1cm,bottom:1cm))
+== \#nm-integrate
+#let test-params-1 = (f_x:x=>4 / (1 + x*x),x0:0,x1:1,accuracy:6)
+#let test-params-2 = (f_x:x=>1/x,x0:1,x1:2,accuracy:6)
+#table(columns:6,inset:8pt,
+table.header([Target],$n$,[-midpoint],[-trapezium],[-simpsons], [-simpsons-38]),
+table.cell(rowspan:4,[$pi approx $ #calc.round(calc.pi,digits:8)]),
+[1],[#nm-integrate-midpoint(..test-params-1,n:1)],
+  [#nm-integrate-trapezium(..test-params-1,n:1)],
+  [#nm-integrate-simpsons(..test-params-1,n:1)],
+  [#nm-integrate-simpsons-38(..test-params-1,n:1)],
+[2],[#nm-integrate-midpoint(..test-params-1,n:2)],
+  [#nm-integrate-trapezium(..test-params-1,n:2)],
+  [#nm-integrate-simpsons(..test-params-1,n:2)],
+  [#nm-integrate-simpsons-38(..test-params-1,n:2)],
+[4],[#nm-integrate-midpoint(..test-params-1,n:4)],
+  [#nm-integrate-trapezium(..test-params-1,n:4)],
+  [#nm-integrate-simpsons(..test-params-1,n:4)],
+  [#nm-integrate-simpsons-38(..test-params-1,n:4)],
+[8],[#nm-integrate-midpoint(..test-params-1,n:8)],
+  [#nm-integrate-trapezium(..test-params-1,n:8)],
+  [#nm-integrate-simpsons(..test-params-1,n:8)],
+  [#nm-integrate-simpsons-38(..test-params-1,n:8)],
+table.cell(rowspan:4,[$ln 2 approx $#calc.round(calc.ln(2),digits:8)]),
+[1],[#nm-integrate-midpoint(..test-params-2,n:1)],
+  [#nm-integrate-trapezium(..test-params-2,n:1)],
+  [#nm-integrate-simpsons(..test-params-2,n:1)],
+  [#nm-integrate-simpsons-38(..test-params-2,n:1)],
+[2],[#nm-integrate-midpoint(..test-params-2,n:2)],
+  [#nm-integrate-trapezium(..test-params-2,n:2)],
+  [#nm-integrate-simpsons(..test-params-2,n:2)],
+  [#nm-integrate-simpsons-38(..test-params-2,n:2)],
+[4],[#nm-integrate-midpoint(..test-params-2,n:4)],
+  [#nm-integrate-trapezium(..test-params-2,n:4)],
+  [#nm-integrate-simpsons(..test-params-2,n:4)],
+  [#nm-integrate-simpsons-38(..test-params-2,n:4)],
+[8],[#nm-integrate-midpoint(..test-params-2,n:8)],
+  [#nm-integrate-trapezium(..test-params-2,n:8)],
+  [#nm-integrate-simpsons(..test-params-2,n:8)],
+  [#nm-integrate-simpsons-38(..test-params-2,n:8)],)
+
+== \#nm-differentiate
+#let test-params-cos = (f_x:x=>calc.cos(x),x0:calc.pi/2,accuracy:6)
+#let test-params-ln = (f_x:x=>1 / (1 + calc.ln(x)),x0:2,accuracy:6)
+#table(columns:4,inset:8pt,
+table.header([Target],$h$,[-forward],[-central]),
+table.cell(rowspan:3,[$f(x)=cos x, quad f`(pi/2)=-1$]),
+$1$,[#nm-differentiate-forward(..test-params-cos, h:1)],
+      [#nm-differentiate-central(..test-params-cos, h:1)],
+$0.1$,[#nm-differentiate-forward(..test-params-cos, h:0.1)],
+      [#nm-differentiate-central(..test-params-cos, h:0.1)],
+$0.01$,[#nm-differentiate-forward(..test-params-cos, h:0.01)],
+      [#nm-differentiate-central(..test-params-cos, h:0.01)],
+table.cell(rowspan:3,[$f(x)=1/(1+ln x),quad f`(2) approx -0.174414$]),
+$1$,[#nm-differentiate-forward(..test-params-ln, h:1)],
+  [#nm-differentiate-central(..test-params-ln, h:1)],
+$0.1$,[#nm-differentiate-forward(..test-params-ln, h:0.1)],
+  [#nm-differentiate-central(..test-params-ln, h:0.1)],
+$0.01$,[#nm-differentiate-forward(..test-params-ln, h:0.01)],
+  [#nm-differentiate-central(..test-params-ln, h:0.01)])
+
+#pagebreak()
+== \#nm-iterate
+=== -FPI and -relaxed-FPI
+#let test-params-gx = (g_x:x=>2 * calc.sin(x) + 2 * calc.cos(x),accuracy:6,x0:-1.5,n-max:8)
+#table(columns:4, inset:8pt,
+table.header([Target],[-FPI],[-relaxed-FPI $lambda=0.5$],[-relaxed-FPI $lambda=1.4$]),
+[$g(x)=2sin x + 2 cos x \ x approx -2.68075641016$],
+  [#nm-iterate-FPI(..test-params-gx)],
+  [#nm-iterate-relaxed-FPI(..test-params-gx, lambda:0.5)],
+  [#nm-iterate-relaxed-FPI(..test-params-gx, lambda:1.4)])
+All Values:
+#let FPI = nm-iterate-FPI(..test-params-gx,return-all:true)
+#let RFPI1 = nm-iterate-relaxed-FPI(..test-params-gx, return-all:true, lambda:0.5)
+#let RFPI2 = nm-iterate-relaxed-FPI(..test-params-gx, return-all:true)
+
+#let table-rows = ()
+#for i in range(FPI.len()) {
+  table-rows.push([#i])
+  table-rows.push([#FPI.at(i)])
+  table-rows.push([#RFPI1.at(i)])
+  table-rows.push([#RFPI2.at(i)])
+}
+
+  #table(columns:4,inset:5pt,
+  table.header($n$,[-FPI $x_n$],[-relaxed-FPI, $lambda=0.5$],[-relaxed-FPI, $lambda=1.4$],
+  ..table-rows
+  )
+)
+=== -newton-raphson
+#let test-params-nr = (f_x:x=>calc.pow(calc.e,x) - x - 2,accuracy:6)
+#grid(columns:2,column-gutter: 20pt,[
+  Finding Roots:
+  #table(columns:2,inset:8pt,
+table.header([Target],[-newton-raphson]),
+[$f(x)=e^x-x-2 \ f(1.14619) approx 0 \ f(-1.84141) approx 9$],
+[
+  #nm-iterate-newton-raphson(..test-params-nr,x0:1) \ \
+  #nm-iterate-newton-raphson(..test-params-nr,x0:-1)])
+],
+[
+  All Values:
+#let NR1 = nm-iterate-newton-raphson(..test-params-nr,x0:1, return-all: true)
+#let NR2 = nm-iterate-newton-raphson(..test-params-nr,x0:-1, return-all: true)
+#let table-rows = ()
+#for i in range(NR1.len()) {
+  table-rows.push([#i])
+  table-rows.push([#NR1.at(i)])
+  table-rows.push([#NR2.at(i)])
+}
+#table(columns:3,inset:5pt,
+table.header([$n$],[NR:$x_0 = 1$],[NR:$x_0 = -1$]),
+..table-rows
+)
+]
+)
+
+=== -secant, -false-position, -bisection for $sin(x)=0$
+#table(columns:(0.2fr,1fr,1fr,1fr),inset:5pt,
+table.header($x$,[-secant],[-false-position],[-bisection]),
+text(size:8pt)[$[-1,1]$],
+  [#nm-iterate-secant(x0:-1,x1:1,return-all:true,accuracy:8)],
+  [#nm-iterate-false-position(x0:-1,x1:1,return-all:true,accuracy:8)],
+  [#nm-iterate-bisection(x0:-1,x1:1,return-all:true,accuracy:8)],
+text(size:8pt)[$[0.5,1]$],
+[#nm-iterate-secant(x0:0.5,x1:1,return-all:true,accuracy:8)],
+  [ False Position should panic.
+  //#nm-iterate-false-position(x0:0.5,x1:1,return-all:true,accuracy:8)
+],
+  [ Bisection should panic.
+  //#nm-iterate-bisection(x0:0.5,x1:1,return-all:true,accuracy:8)
+],
+text(size:8pt)[$[-1.5,1]$],
+  [#nm-iterate-secant(x0:-1.5,x1:1,return-all:true,accuracy:8)],
+  [#nm-iterate-false-position(x0:-1.5,x1:1,return-all:true,accuracy:8)],
+  [#nm-iterate-bisection(x0:-1.5,x1:1,return-all:true,accuracy:8)],
+)
+
+#pagebreak()
+== nm-plot-integral
+Alternatively including 'points'
+#grid(columns:4, inset:10pt,
+["left": #plot-integral(size-x:3,size-y:2,method:"left",show-points:true)], 
+["right": #plot-integral(size-x:3,size-y:2,method:"right")],
+["mid": #plot-integral(size-x:3,size-y:2,method:"mid",show-points:true)], 
+["trapezium": #plot-integral(size-x:3,size-y:2,method:"trapezium")],
+["integral":#plot-integral(size-x:3,size-y:2,method:"integral",show-points:true)],
+["asfsf":#plot-integral(size-x:3,size-y:2,method:"asfsf")],  
+["simpsons":#plot-integral(size-x:3,size-y:2,method:"simpsons",n-strips:2,show-points:true)],
+["simpsons-38":#plot-integral(size-x:3,size-y:2,method:"simpsons-38",n-strips:2)]
+)
+
+=== Limits: inc-0: true, inc-0: false
+#grid(columns:3,inset:10pt,
+plot-integral(size-x:3,size-y:2,method:"integral",x0:2,x1:3), 
+plot-integral(size-x:3,size-y:2,method:"integral",x0:2,x1:3,inc-0:false),
+)
+=== n-strips: 1, 2, 4, 8, 16, 32
+#grid(columns:3, inset:10pt,
+..range(6).map(n=>
+plot-integral(size-x:3,size-y:2,n-strips:calc.pow(2,n)))
+)
+
+#pagebreak()
+== \#nm-table
+=== Integral Table, -integrate
+#grid(columns:3,inset: 5pt,
+[method: "Midpoint" #nm-table-integrate()],
+[method: "Trapezium" #nm-table-integrate(method:"Trapezium")],
+[method: Simpsons" #nm-table-integrate(method:"Simpsons",n-rows:4)],
+[method: "Simpsons-38" #nm-table-integrate(method:"Simpsons-38")]
+)
+
+=== Differential Table, -differentiate
+#grid(columns:2,inset: 5pt,
+[method:"CD" #nm-table-differentiate()],
+[method:"FD" #nm-table-differentiate(method:"FD")],
+)
+
+=== Iteration Table, -iterate
+#grid(columns:2,inset: 5pt,
+[method: "FPI" #nm-table-iterate(method:"FPI",ratio-order:1)],
+[method: "RFPI" #nm-table-iterate(method:"RFPI",ratio-order:1)],
+[method: "Newton-Raphson" #nm-table-iterate(method:"Newton-Raphson",ratio-order:2)],
+[method: "Secant" #nm-table-iterate(method:"Secant",ratio-order:1.6)]
+)

--- a/packages/preview/irif/0.0.2/irif.typ
+++ b/packages/preview/irif/0.0.2/irif.typ
@@ -1,0 +1,560 @@
+#import "@preview/cetz:0.4.2"
+#import "@preview/cetz-plot:0.1.3"
+
+#let plot-integral(f_x: x => x / calc.ln(calc.abs(x)),
+                  x0: 1.2,
+                  x1: 6,
+                  inc-0: true,
+                  shade-color: rgb(100,100,255,50),
+                  method:"mid",
+                  n-strips:4,
+                  show-points:false,
+                  show-labels:true,
+                  label-a: "a",
+                  label-b:"b",
+                  size-x:6,size-y:6
+) = {
+  // Mistaken plot type:
+  if (not ("integral","mid","left","right","trapezium","simpsons","simpsons-38").contains(method)) {method = "integral"}
+  // Fix incorrect bounds:
+  if (x0 > x1) {(x0,x1) = (x1,x0)}
+  else if (x0==x1){x1 = x0 + 1}
+  //Create variables
+  let min-x = 0
+  let max-x = 0
+  let min-y = 0
+  let max-y = 0
+  let h = (x1 - x0) / n-strips // Strip width, if used.
+  if (inc-0) { //Actually calculate X-min/max
+    let width = x1
+    max-x = width * 1.1
+    min-x = - width * 0.05 
+  } else {
+    let width = x1 - x0
+    max-x = x1 + 0.05 * width
+    min-x = x0 - 0.05 * width
+  }
+  //Largest found y-value
+  let f-max = calc.max(..range(0,1001).map(x=>f_x(x0 + x*(x1 - x0)/1000)))
+  //values for plot
+  let min-y = -0.05 * f-max
+  let max-y = 1.1 * f-max
+  
+  
+  cetz.canvas({
+    import cetz.draw: *
+    import cetz-plot: *
+    set-style(stroke:2pt)
+    plot.plot(size:(size-x,size-y),x-tick-step: none,y-tick-step: none, axis-style:"school-book",
+    x-min:min-x,x-max:max-x,y-min:min-y,y-max:max-y,
+    {
+
+      plot.add(domain:(min-x,max-x), f_x,style:(stroke:black))
+      
+      if (method=="integral") {
+        plot.add(domain:(x0,x1),f_x,fill-type:"axis",fill:true,style:(fill:shade-color,stroke:3pt))
+        plot.add-vline(x0,min:0,max:f_x(x0),style:(stroke:1pt+black))
+        plot.add-vline(x1,min:0,max:f_x(x1),style:(stroke:1pt+black))
+        if (show-points) {
+            plot.add(((x0,f_x(x0)),(x0,f_x(x0))),mark:"*",mark-style:(stroke:black))
+            plot.add(((x1,f_x(x1)),(x1,f_x(x1))),mark:"*",mark-style:(stroke:black))
+          }
+      } else if (method=="left"){
+        let n = 0
+        let x = x0
+        while n < n-strips {
+          plot.add(domain:(x,x+h),p=>f_x(x),style:(fill:shade-color,stroke:1pt+black),fill:true)
+          plot.add-vline(x,min:0,max:f_x(x),style:(stroke:1pt+black))
+          plot.add-vline(x+h,min:0,max:f_x(x),style:(stroke:1pt+black))
+          if (show-points) {
+            plot.add(((x,f_x(x)),(x,f_x(x))),mark:"*",mark-style:(stroke:black))
+          }
+          x += h
+          n += 1
+        }
+      } else if (method=="right"){
+       let n = 0
+        let x = x0
+        while n < n-strips {
+          plot.add(domain:(x,x+h),p=>f_x(x+h),style:(fill:shade-color,stroke:1pt+black),fill:true)
+          plot.add-vline(x,min:0,max:f_x(x+h),style:(stroke:1pt+black))
+          plot.add-vline(x+h,min:0,max:f_x(x+h),style:(stroke:1pt+black))
+          if (show-points) {
+            plot.add(((x+h,f_x(x+h)),(x+h,f_x(x+h))),mark:"*",mark-style:(stroke:black))
+          }
+          x += h
+          n += 1
+        }
+      } else if (method=="mid") {
+        let n = 0
+        let x = x0
+        while n < n-strips {
+          plot.add(domain:(x,x+h),p=>f_x(x+h/2),style:(fill:shade-color,stroke:1pt+black),fill:true)
+          plot.add-vline(x,min:0,max:f_x(x+h/2),style:(stroke:1pt+black))
+          plot.add-vline(x+h,min:0,max:f_x(x+h/2),style:(stroke:1pt+black))
+          if (show-points) {
+            plot.add(((x+h/2,f_x(x+h/2)),(x+h/2,f_x(x+h/2))),mark:"*",mark-style:(stroke:black))
+          }
+          x += h
+          n += 1
+        }
+      } else if (method=="trapezium"){
+        let n = 0
+        let x = x0
+        while n < n-strips {
+          plot.add(domain:(x,x+h),n=>(n - x)*(f_x(x+h)-f_x(x))/(h)+f_x(x),style:(fill:shade-color,stroke:1pt+black),fill:true)
+          plot.add-vline(x,min:0,max:f_x(x),style:(stroke:1pt+black))
+          plot.add-vline(x+h,min:0,max:f_x(x+h),style:(stroke:1pt+black))
+          if (show-points) {
+            plot.add(((x,f_x(x)),(x,f_x(x))),mark:"*",mark-style:(stroke:black))
+          }
+          x += h
+          n += 1
+        }
+        if (show-points) {plot.add(((x,f_x(x)),(x,f_x(x))),mark:"*",mark-style:(stroke:black))}
+      } else if (method == "simpsons") {
+        let h = (x1 - x0)/(2*n-strips)
+        let n = 0
+        let x-0 = x0
+        while n < n-strips {
+          let x-1 = x-0 + h
+          let x-2 = x-1 + h
+          let (y-0, y-1, y-2) = (f_x(x-0), f_x(x-1), f_x(x-2))
+          plot.add(x=> y-0 
+              + (x - x-0)*(y-1 - y-0)/h 
+              + (x - x-0)*(x - x-1)*(y-2 - 2*y-1 + y-0)/(2*h*h),
+            domain:(x-0,x-0+2*h),style: (stroke: 0.8pt + black))
+          plot.add-fill-between(
+            x=>0,
+            x=> y-0 
+              + (x - x-0)*(y-1 - y-0)/h 
+              + (x - x-0)*(x - x-1)*(y-2 - 2*y-1 + y-0)/(2*h*h),
+            domain:(x-0,x-0+2*h),
+            style: (stroke: none, fill: shade-color)
+          )
+          plot.add-vline(x-0,min:0,max:y-0,style:(stroke:1pt+black))
+          plot.add-vline(x-1,min:0,max:y-1,style:(stroke:(thickness:1pt, paint:black,dash:"dashed")))
+          plot.add-vline(x-2,min:0,max:y-2,style:(stroke:1pt+black))
+
+          if (show-points) {
+            plot.add(((x-0,f_x(x-0)),(x-0,f_x(x-0))),mark:"*",mark-style:(stroke:black))
+            plot.add(((x-1,f_x(x-1)),(x-1,f_x(x-1))),mark:"*",mark-style:(stroke:black))
+            plot.add(((x-2,f_x(x-2)),(x-2,f_x(x-2))),mark:"*",mark-style:(stroke:black))
+          }
+          
+          x-0 += 2*h
+          n += 1
+        }
+        
+      } else if (method == "simpsons-38") {
+        let h = (x1 - x0)/(3*n-strips)
+        let n = 0
+        let x-0 = x0
+        while n < n-strips {
+          let x-1 = x-0 + h
+          let x-2 = x-1 + h
+          let x-3 = x-2 + h
+          let (y-0, y-1, y-2, y-3) = (f_x(x-0), f_x(x-1), f_x(x-2), f_x(x-3))
+          plot.add(x=> y-0 
+              + (x - x-0)*(y-1 - y-0)/h 
+              + (x - x-0)*(x - x-1)*(y-2 - 2*y-1 + y-0)/(2*h*h)
+              + (x - x-0)*(x - x-1)*(x - x-2)*(y-3 - 3*y-2 + 3*y-1 - y-0)/(6*h*h*h),
+            domain:(x-0,x-0+3*h),style: (stroke: 0.8pt + black))
+          plot.add-fill-between(
+            x=>0,
+            x=> y-0 
+              + (x - x-0)*(y-1 - y-0)/h 
+              + (x - x-0)*(x - x-1)*(y-2 - 2*y-1 + y-0)/(2*h*h)
+              + (x - x-0)*(x - x-1)*(x - x-2)*(y-3 - 3*y-2 + 3*y-1 - y-0)/(6*h*h*h),
+            domain:(x-0,x-0+3*h),
+            style: (stroke: none, fill: shade-color)
+          )
+          plot.add-vline(x-0,min:0,max:y-0,style:(stroke:1pt+black))
+          plot.add-vline(x-1,min:0,max:y-1,style:(stroke:(thickness:1pt, paint:black,dash:"dashed")))
+          plot.add-vline(x-2,min:0,max:y-2,style:(stroke:(thickness:1pt, paint:black,dash:"dashed")))
+          plot.add-vline(x-3,min:0,max:y-3,style:(stroke:1pt+black))
+
+          if (show-points) {
+            plot.add(((x-0,f_x(x-0)),(x-0,f_x(x-0))),mark:"*",mark-style:(stroke:black))
+            plot.add(((x-1,f_x(x-1)),(x-1,f_x(x-1))),mark:"*",mark-style:(stroke:black))
+            plot.add(((x-2,f_x(x-2)),(x-2,f_x(x-2))),mark:"*",mark-style:(stroke:black))
+          }
+          
+          x-0 += 3*h
+          n += 1
+        }
+      }
+      
+      if (show-labels){
+        plot.annotate({
+          content((x0,2*min-y),text(font:"New Computer Modern Math",[$#label-a$]))
+          content((x1,2*min-y),text(font:"New Computer Modern Math",[$#label-b$]))
+        })
+      }
+    })
+  })  
+}
+
+#let nm-integrate-midpoint(f_x:x=>x*x,
+x0:0,x1:1,accuracy:12,n:1) = {
+  let h = (x1 - x0) / n
+  let total = 0
+  for i in range(n) {
+    total += h * f_x(h/2 + x0 + h * i)
+  }
+  return calc.round(total,digits:accuracy)
+}
+#let nm-integrate-trapezium(f_x:x=>x*x,
+x0:0,x1:1,accuracy:12,n:1) = {
+  let h = (x1 - x0) / n
+  let total = 0.5 * (f_x(x0)+f_x(x1))
+  let strip = 1
+  while strip < n {
+    total += f_x(x0 + strip * h)
+    strip += 1
+  }
+  return calc.round(h*total,digits:accuracy)
+}
+#let nm-integrate-simpsons(f_x:x=>x*x,
+x0:0,x1:1,accuracy:12,n:1) = {
+  let T_n = nm-integrate-trapezium(f_x:f_x,x0:x0,x1:x1,accuracy:accuracy+5,n:n)
+  let T_2n = nm-integrate-trapezium(f_x:f_x,x0:x0,x1:x1,accuracy:accuracy+5,n:2*n)
+
+  let total = (4 * T_2n - T_n) / 3
+  
+  return calc.round(total,digits:accuracy)
+}
+
+#let nm-integrate-simpsons-38(f_x:x=>x*x,
+x0:0,x1:1,accuracy:12,n:1) = {
+  let i-max = 3 * n
+  //Simpsons for S_3n
+  //3h/8 [ f(x0) + 3f(x1) + 3f(x2) + 2f(x3) + ... + f(x_n-max)]
+  //For i = 1 to i = n
+  let h = (x1 - x0) / i-max
+  let x_i = range(0,i-max).map(i => x0 + h*i)
+  let total = f_x(x_i.at(0)) + f_x(x_i.last())
+  let strip = 1
+  while strip < i-max {
+    let val = f_x(x_i.at(strip))
+    if calc.rem(strip, 3) == 0 {
+      total += 2 * val
+    } else {
+      total += 3 * val
+    }
+    strip += 1
+  }
+  total *= h * 3 / 8
+  return calc.round(total,digits:accuracy)
+}
+
+#let nm-differentiate-forward(f_x:x=>x*x,x0:1,h:1,accuracy:12) = {
+  let d = (f_x(x0+h) - f_x(x0)) / h
+  return calc.round(d,digits:accuracy)
+}
+#let nm-differentiate-central(f_x:x=>x*x,x0:1,h:1,accuracy:12) = {
+  let d = (f_x(x0 + h/2) - f_x(x0 - h/2)) / h
+  return calc.round(d,digits:accuracy)
+}
+
+
+
+#let nm-iterate-relaxed-FPI(g_x:calc.cos,x0:1,lambda:0.5,n-max:5,accuracy:12,return-all:false) = {
+  let n = 0
+
+  if not return-all {
+    let x = x0
+    while n < n-max {
+      x = lambda * g_x(x) + (1 - lambda) * x
+      n += 1
+    }
+    return calc.round(x,digits:accuracy)
+  }
+  
+  let x = ()
+  x.push(x0)
+  while n < n-max {
+    x.push(lambda * g_x(x.last()) + (1 - lambda)*x.last())
+    n += 1
+  }
+  return x.map(n=>calc.round(n,digits:accuracy))
+  
+}
+#let nm-iterate-FPI(g_x:calc.cos,x0:1,n-max:5,accuracy:12,return-all:false) = {
+  let result = nm-iterate-relaxed-FPI(g_x:g_x,x0:x0,n-max:n-max,lambda:1,accuracy:accuracy,return-all:return-all)
+  return result
+}
+#let nm-iterate-newton-raphson(f_x:calc.cos,x0:1,n-max:5,accuracy:12,return-all:false) = {
+  let n = 0
+
+  if not return-all {
+    let x = x0
+    while n < n-max {
+      x = x - (f_x(x)) / (nm-differentiate-central(f_x:f_x,
+                                            x0:x,
+                                            h:0.0000001,
+                                            accuracy:15))
+      n += 1
+    }
+    return calc.round(x,digits:accuracy)
+  }
+  let x = ()
+  x.push(x0)
+  while n < n-max {
+    let xn = x.last()
+    x.push(xn - (f_x(xn)) / (nm-differentiate-central(f_x:f_x,
+                                            x0:xn,
+                                            h:0.0000000001,
+                                            accuracy:15)))
+    n += 1
+  }
+  return x.map(n=>calc.round(n,digits:accuracy))
+}
+
+#let nm-iterate-secant(f_x:calc.sin,x0:1,x1:0.5,n-max: 5,accuracy:5,return-all:false) = {
+  let n = 0
+  if not return-all {
+    let (a,b) = (x0,x1)
+    while n < n-max {
+      let next = (a * f_x(b) - b * f_x(a))/(f_x(b) - f_x(a))
+      a = b
+      b = next
+      n += 1
+    }
+    return calc.round(b,digits:accuracy)
+  }
+  let xn = ()
+  xn.push(x0)
+  xn.push(x1)
+  while xn.len() < n-max {
+    let (a,b) = (xn.at(xn.len()-2),xn.last())
+    if (f_x(b) - f_x(a))==0 {
+      xn.push(0)
+    } else {
+    let next = (a * f_x(b) - b * f_x(a))/(f_x(b) - f_x(a))
+    xn.push(next)
+    }
+  }
+  return xn.map(n=>calc.round(n,digits:accuracy))
+}
+
+#let nm-iterate-false-position(f_x:calc.sin,x0:1,x1:0.5,n-max: 5,accuracy:5,return-all:false) = {
+  if f_x(x0) * f_x(x1) > 0 {panic("Error, no change of sign.")}
+  let n = 0
+  if not return-all {
+    let (a,b) = (x0,x1)
+    while n < n-max {
+      let next = (a * f_x(b) - b * f_x(a))/(f_x(b) - f_x(a))
+      if f_x(a)*f_x(next) > 0 { //Same sign, so replace b
+        b = next
+      } else {a = next}
+      n += 1
+    }
+    return (calc.round(a, digits: accuracy), 
+            calc.round(b, digits: accuracy))
+  }
+
+  let xn = ()
+  xn.push((x0,x1))
+  while xn.len() < n-max {
+    let (a,b) = xn.last()
+    let next = (a * f_x(b) - b * f_x(a))/(f_x(b) - f_x(a))
+    if f_x(a)*f_x(next) > 0 { //Same sign, so replace b
+        xn.push((a,next))
+      } else {xn.push((next,b))}
+    n += 1
+  }
+  return xn.map(n=>(calc.round(n.at(0), digits: accuracy),
+                        calc.round(n.at(1), digits: accuracy)))
+}
+#let nm-iterate-bisection(f_x:calc.sin,x0:1,x1:0.5,n-max: 5,accuracy:5,return-all:false) = {
+  if f_x(x0) * f_x(x1) > 0 {panic("Error, no change of sign.")}
+  let n = 0
+  if not return-all {
+    let (a,b) = (x0,x1)
+    while n < n-max {
+      let next = (a+b)/2
+      if (f_x(next)==0) {
+      xn.push((a,next))
+      break
+    }
+      if f_x(a)*f_x(next) > 0 { //Same sign, so replace b
+        b = next
+      } else {a = next}
+      n += 1
+    }
+    return (calc.round(a, digits: accuracy), 
+            calc.round(b, digits: accuracy))
+  }
+
+  let xn = ()
+  xn.push((x0,x1))
+  while xn.len() < n-max {
+    let (a,b) = xn.last()
+    let next = (a+b)/2
+    if (f_x(next)==0) {
+      xn.push((a,next))
+      break
+    }
+    if f_x(a)*f_x(next) > 0 { //Same sign, so replace b
+        xn.push((a,next))
+      } else {xn.push((next,b))}
+    n += 1
+  }
+  return xn.map(n=>(calc.round(n.at(0), digits: accuracy),
+                        calc.round(n.at(1), digits: accuracy)))
+}
+
+#let nm-table-integrate(f_x:calc.sin,x0:1,x1:2,start-strips:1,strip-ratio:2,method:"Midpoint", n-rows:5,show-diffs:true,show-ratio:true,accuracy:5) = {
+  //method must be from the array. If not, do mid.
+  if not ("Midpoint","Trapezium","Simpsons","Simpsons-38").contains(method) {
+    method = "Midpoint"
+  }
+  let strip-array = ()
+  strip-array.push(start-strips)
+  while strip-array.len() < n-rows {
+    strip-array.push(strip-array.last() * strip-ratio)
+  }
+
+  let integrals = ()
+  let header = $M_n$
+  if method == "Midpoint" {
+    integrals = strip-array.map(n=>nm-integrate-midpoint(f_x:f_x,x0:x0,x1:x1,n:n,accuracy:accuracy))
+  } else if method=="Trapezium" {
+    integrals = strip-array.map(n=>nm-integrate-trapezium(f_x:f_x,x0:x0,x1:x1,n:n,accuracy:accuracy))
+    header = $T_n$
+  } else if method == "Simpsons" {
+    integrals = strip-array.map(n=>nm-integrate-simpsons(f_x:f_x,x0:x0,x1:x1,n:n,accuracy:accuracy))
+    header = $S_(2n)$
+  } else {
+    integrals = strip-array.map(n=>nm-integrate-simpsons-38(f_x:f_x,x0:x0,x1:x1,n:n,accuracy:accuracy))
+    header = $S_(3n)$
+  }
+  let diffs = ()
+  diffs.push([])
+  for i in range(integrals.len()-1) {
+    diffs.push(calc.round(integrals.at(i+1) - integrals.at(i),digits:accuracy))
+  }
+  let ratios = ([],[])
+  for i in range(diffs.len()-2) {
+    ratios.push(calc.round(diffs.at(i+2) / diffs.at(i+1),digits:accuracy))
+  }
+
+  let table-rows = () 
+  for i in range(strip-array.len()) {
+    table-rows.push([#strip-array.at(i)])
+    table-rows.push([#integrals.at(i)])
+    if show-diffs {
+      table-rows.push([#diffs.at(i)])
+      if show-ratio {table-rows.push([#ratios.at(i)])}
+    }
+  }
+  let headers = ($n$,[#header])
+  if show-diffs {
+    headers.push([Difference])
+    if show-ratio {headers.push([Ratio])}
+  }
+  return table(columns:headers.len(),
+              table.header(..headers),
+              ..table-rows)
+}
+
+#let nm-table-differentiate(f_x:x=>calc.ln(x),x0:2,start-h:1,h-ratio:2,n-rows:5,accuracy:5,method:"CD",show-diffs:true,show-ratio:true) = {
+  //Default to Central Difference if bad name
+  if not ("CD","FD").contains(method) {
+    method = "CD"
+  }
+
+  let differentials = ()
+
+  let h-array = ()
+  h-array.push(start-h)
+  while h-array.len() < n-rows {
+    h-array.push(calc.round(h-array.last() / h-ratio,digits:8)) 
+    //Rounds due to floating point division
+  }
+  
+  let differentials = h-array.map(h=>nm-differentiate-central(f_x:f_x,x0:x0,h:h,accuracy:accuracy))
+  if method == "FD" {
+    differentials = h-array.map(h=>nm-differentiate-forward(f_x:f_x,x0:x0,h:h,accuracy:accuracy))
+  }
+
+  let diffs = ()
+  diffs.push([])
+  for i in range(differentials.len()-1) {
+    diffs.push(calc.round(differentials.at(i+1) - differentials.at(i),digits:accuracy))
+  }
+  let ratios = ([],[])
+  for i in range(diffs.len()-2) {
+    ratios.push(calc.round(diffs.at(i+2) / diffs.at(i+1),digits:accuracy))
+  }
+
+  let table-rows = () 
+  for i in range(h-array.len()) {
+    table-rows.push([#h-array.at(i)])
+    table-rows.push([#differentials.at(i)])
+    if show-diffs {
+      table-rows.push([#diffs.at(i)])
+      if show-ratio {table-rows.push([#ratios.at(i)])}
+    }
+  }
+  let headers = ($h$,$f'(x)$)
+  if show-diffs {
+    headers.push([Difference])
+    if show-ratio {headers.push([Ratio])}
+  }
+  return table(columns:headers.len(),
+              table.header(..headers),
+              ..table-rows)
+  
+}
+
+#let nm-table-iterate(f_x:calc.sin,x0:1,x1:0.5,lambda:0.5,n-rows: 5,accuracy:5,ratio-order:2,method:"FPI",show-diffs:true,show-ratio:true) = {
+  //Default to NRaphson
+  if not ("FPI","RFPI","Secant","Newton-Raphson").contains(method) {
+    method = "Newton-Raphson"
+  }
+
+  let n-array = range(n-rows).map(n=>n+1) //Start at 1.
+
+  let headers = ($n$,$x_n$)
+  if show-diffs {
+    headers.push([Difference])
+    if show-ratio {
+      headers.push([Ratio])
+    }
+  }
+  let x-array = ()
+  if method=="FPI" {
+    x-array = nm-iterate-FPI(g_x:f_x,x0:x0,n-max:n-rows,return-all:true,accuracy:accuracy)
+  } else if method=="RFPI" {
+    x-array = nm-iterate-relaxed-FPI(g_x:f_x,x0:x0,n-max:n-rows,return-all:true,accuracy:accuracy,lambda:lambda)
+  }else if method == "Secant" {
+    x-array = nm-iterate-secant(f_x:f_x,x0:x0,x1:x1,n-max:n-rows,return-all:true,accuracy:accuracy)
+  } else {
+    x-array = nm-iterate-newton-raphson(f_x:f_x,x0:x0,n-max:n-rows,return-all:true,accuracy:accuracy)
+  }
+  let diffs = ()
+  diffs.push([])
+  for i in range(x-array.len()-1) {
+    diffs.push(calc.round(x-array.at(i+1) - x-array.at(i),digits:accuracy))
+  }
+  let ratios = ([],[])
+  for i in range(diffs.len()-2) {
+    ratios.push(calc.round(calc.abs(diffs.at(i+2)) / calc.pow(calc.abs(diffs.at(i+1)),ratio-order),digits:accuracy))
+  }
+  
+  let table-rows = ()
+  for i in range(n-array.len()) {
+    table-rows.push([#n-array.at(i)])
+    table-rows.push([#x-array.at(i)])
+    if show-diffs {
+      table-rows.push([#diffs.at(i)])
+      if show-ratio {table-rows.push([#ratios.at(i)])}
+    }
+  }
+
+  return table(columns:headers.len(),
+              table.header(..headers),
+              ..table-rows)
+}

--- a/packages/preview/irif/0.0.2/typst.toml
+++ b/packages/preview/irif/0.0.2/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name        = "irif"
+version     = "0.0.2"
+description = "Numerical methods for integration, differentiation and root finding"
+license     = "MIT-0"
+authors     = ["TGGrace"]
+entrypoint  = "irif.typ"
+exclude     = [
+    ".git*",
+    "examples"
+]
+


### PR DESCRIPTION
Introduces Simpson's Composite 3/8ths rule.
Adds integral plotting for Simpson's rule and Simpson's 3/ths rule
Updated examples to demonstrate.

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Changes:
- Introduces Simpson's Composite 3/8ths rule, another numerical method for integration.
- Added integral plotting for Simpson's rule and Simpson's 3/ths rule
- Updated examples to demonstrate.