### PR TITLE
patstdlib:0.3.0

### DIFF
--- a/packages/preview/patstdlib/0.3.0/LICENSE
+++ b/packages/preview/patstdlib/0.3.0/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/preview/patstdlib/0.3.0/README.md
+++ b/packages/preview/patstdlib/0.3.0/README.md
@@ -1,0 +1,54 @@
+<h1 align='center'>patstdlib</h1>
+
+Some standard pieces I find useful: fonts, subfigures, algorithms, labeled enums, etc.
+
+## Documentation
+
+Please see the inline documentation attached to each object. A full list of all available functionality can be found in [`src/lib.typ`](https://github.com/patrick-kidger/patstdlib/blob/main/src/lib.typ).
+
+## Functionality
+
+Here's a few highlights:
+
+**Labeled enums**
+
+```typst
+#show: enable-referable-enums
+
+#referable-enum("step")[
+  + Foo
+  + Bar
+  + Baz <step:baz>
+]
+
+In @step:baz then ...
+// Renders as 'In step 3 then ...'
+```
+
+**Subfigures**
+
+```typst
+#show: enable-referable-subfigures
+#set enum(full: true)
+
+#figure(
+  caption: [Main caption],
+  grid(
+    columns: 2,
+    subfigure(
+      caption: [Caption for subfigure '(a)'],
+      image(...)
+    ),
+    subfigure(
+      caption: [Caption for subfigure '(b)'],
+      image(...)
+    ),
+  )
+)
+```
+
+**Significant figures**
+
+```typst
+#sigfig(3.141592653, digits: 3)  // 3.14 as a `decimal`
+```

--- a/packages/preview/patstdlib/0.3.0/src/algorithms.typ
+++ b/packages/preview/patstdlib/0.3.0/src/algorithms.typ
@@ -1,0 +1,72 @@
+#import "@preview/algorithmic:1.0.7"
+
+#import "./figure.typ": labeled-figure
+#import "./style.typ": as-math
+
+#let _algorithm_kind = "a8e95559e94540e4b1ddaf2bdba11fc4"
+#let _algorithm_counter(loc2) = {
+    let x = counter(figure.where(kind: _algorithm_kind)).at(loc2)
+    assert.eq(x.len(), 1)
+    x.at(0)
+}
+#let _algorithm-show-state = state("8444c8b2f07542b697529bc3e603ac9c", false)
+#let enable-referable-algorithms(doc) = {
+    _algorithm-show-state.update(true)
+    show ref: it => {
+        let el = it.element
+        if type(el) == content and el.func() == figure and el.kind == _algorithm_kind {
+            link(el.location(), [Algorithm #_algorithm_counter(el.location()) (#el.supplement)])
+        } else {
+            it
+        }
+    }
+    doc
+}
+#let algorithm(title, code, width: none, placement: none, clearance: 1em, label: none) = {
+    assert.ne(width, none, message: "`width` is a required argument to `algorithm`")
+    context assert(_algorithm-show-state.get(), message: "Please `#show: enable-referable-algorithms`")
+    let algo = box(width: width, grid(
+        columns: 1,
+        stroke: none,
+        inset: 0.5em,
+        grid.hline(),
+        align(start, [*Algorithm #context { _algorithm_counter(here()) }:* #title]),
+        grid.hline(),
+        align(start, algorithmic.algorithm(inset: 0.25em, indent: 1em, line-numbers: false, code)),
+        grid.hline(),
+    ))
+
+    labeled-figure(algo, supplement: title, caption: none, kind: _algorithm_kind, placement: placement, clearance: clearance, label: label)
+}
+#let Input(doc) = algorithmic.Line([*input* #doc])
+#let Output(doc) = algorithmic.Line([*output* #doc]) + algorithmic.Line[$quad$]
+#let Sample(var, val) = algorithmic.Line([#var $~$ #val])
+#let ForIn(x, xs, code) = algorithmic.For($#x #[*in*] #xs$, code)
+#let Case(pattern, code) = (pattern: pattern, code: code)
+#let Match(x, ..cases) = {
+    if cases.named().len() > 0 {
+        panic("`Match` takes only positional arguments.")
+    }
+    algorithmic.iflike(kw1: "match", kw2: "", kw3: "end", x, {
+        for case in cases.pos() {
+            if type(case) != dictionary or case.keys() != ("pattern", "code") {
+                panic("`Match` should be called with `Case` arguments.")
+            }
+            algorithmic.iflike(kw1: "case", kw2: "then", kw3: "", case.pattern, case.code)
+        }
+    })
+}
+#let Loop(code) = algorithmic.iflike(kw1: "loop", kw3: "end", [], code)
+
+// Fixed to print the comment symbol using the math font
+#let CommentInline(c) = as-math(text(size: 0.8em, sym.triangle.stroked.r)) + " " + c
+// Its wrappers
+#let Comment(c) = (CommentInline(c),)
+#let LineComment(l, c) = {
+  let l = algorithmic.arraify(l).flatten()
+  ([#l.first()#h(1fr)#CommentInline(c)], ..l.slice(1))
+}
+#let LastLineComment(l, c) = {
+  let l = algorithmic.arraify(l).flatten()
+  (..l.slice(0, l.len() - 1), [#l.last()#h(1fr)#CommentInline(c)])
+}

--- a/packages/preview/patstdlib/0.3.0/src/enum.typ
+++ b/packages/preview/patstdlib/0.3.0/src/enum.typ
@@ -1,0 +1,79 @@
+#import "@preview/typsy:0.2.1": safe-counter
+
+//
+// Referable enums
+// Adapted from https://github.com/typst/typst/issues/779#issuecomment-2595880447
+//
+
+#let _state-referable-enum = state("254062f63911459cb0ff8f4d1bd47553", none)
+#let _counter-referable-enum = safe-counter(() => {})
+// Both arguments assumed to be strings.
+#let _get-greatest-suffix(sample1, sample2) = {
+    let suffix = ("",)
+    for (c1, c2) in sample1.rev().split("").zip(sample2.rev().split("")) {
+        if c1 == c2 {
+            suffix.push(c1)
+        } else {
+            break
+        }
+    }
+    suffix.rev().join("")
+}
+#let _remove-suffix(x, suffix) = {
+    assert(x.ends-with(suffix))
+    x.slice(0, x.len() - suffix.len())
+}
+
+/// *Example:*
+///
+/// ```typst
+/// #show: enable-referable-enums
+///
+/// #set enum(numbering: "a.", full: true)
+/// #referable-enum("Step")[
+/// + foo
+/// + bar <baz>
+/// ]
+///
+/// @baz  // Renders as 'Step b'
+/// ```
+///
+/// - supplement (str): The name to use when referencing this enum, e.g. the 'Step' in 'Step 1'.
+/// - doc (content): Content
+/// -> content
+#let referable-enum(supplement, doc) = context {
+    let current-numbering = enum.numbering
+    assert(enum.full, message: "Only `enum.full = true` is supported right now. Add `#set enum(full: true)`.")
+    let wrap-numbering(..it) = {
+        _counter-referable-enum.update(it.pos())
+        numbering(current-numbering, ..it)
+    }
+    set enum(numbering: wrap-numbering)
+
+    let sample1 = numbering(current-numbering, 1)
+    let sample2 = numbering(current-numbering, 2)
+    let suffix = _get-greatest-suffix(sample1, sample2)
+
+    _state-referable-enum.update((supplement, suffix, current-numbering))
+    doc
+}
+
+
+/// Referable enums.
+/// Use as e.g. `#show: enable-referable-enums`
+#let enable-referable-enums(doc) = {
+    show ref: it => {
+        let el = it.element
+        if el != none and el.func() == text and _state-referable-enum.at(el.location()) != none {
+            let loc = el.location()
+            let (supplement, suffix, current-numbering) = _state-referable-enum.at(loc)
+            let numbers = numbering(current-numbering, .._counter-referable-enum.at(loc))
+            // Override enum references.
+            link(loc, supplement + [~] + _remove-suffix(numbers, suffix))
+        } else {
+            // Other references as usual.
+            it
+        }
+    }
+    doc
+}

--- a/packages/preview/patstdlib/0.3.0/src/figure.typ
+++ b/packages/preview/patstdlib/0.3.0/src/figure.typ
@@ -1,0 +1,105 @@
+// Fix https://github.com/typst/typst/issues/4359
+/// Prefer this to `figure`. It adds a `label` argument, which fixes an issue with hyperlinks.
+#let labeled-figure(..args, placement: none, clearance: 1em, label: none) = {
+    assert(placement in (none, auto, bottom, top))
+    let out = figure(..args)
+    out = if label == none { out } else [#out #label]
+    if placement != none {
+        placement = if placement == auto { placement } else { placement + center }
+        out = place(placement, clearance: clearance, float: true, out)
+    }
+    out
+}
+
+#let _subfigure-enabled = state("cff4409cca2e4ba580b2343755cdc628", none)
+#let _subfigure-supplement = state("a9a416beff354362a74ef2e7710d7d61", none)
+#let _subfigure-subsupplement = state("a1522481a72c4586ae634bd2646bb602", none)
+#let _subfigure-kind = "20bead2ae82843c1bae51d6c208631e8"
+
+/// Creates a subfigure. For use within the body of a `figure`. This adds a counter, a caption, and makes it referable.
+///
+/// Arguments are largely as `figure`. Differences:
+/// - `placement` and `kind` are all superfluous and removed.
+/// - `outlined` defaults to `false`, `supplement` defaults to nothing, and `numbering` defaults to `"(a)"`.
+/// - New argument `label`. When referred to from outside the enclosing figure, it will render as e.g. `Figure 3(a)`.
+///     The word 'Figure' in this example is inherited from the enclosing figure. When referred to from inside the
+///     enclosing figure (e.g. from its caption), it will render as e.g. `Panel (a)`.
+/// - New argument `subsupplement`. This defines the word 'Panel' when referred to this figure, as above.
+/// - New argument `gap-below`. This adds vspace below the caption, which is often useful to add space between the
+///     caption of the subfigure and the caption of the figure.
+#let subfigure(
+    body,
+    ..args,
+    supplement: _ => none,
+    numbering: "(a)",
+    gap: 0.65em,
+    outlined: false,
+    label: none,
+    subsupplement: "Panel",
+    gap-below: 0.65em,
+) = {
+    context assert.ne(
+        _subfigure-enabled.get(),
+        none,
+        message: "Call `#show: enable-referable-subfigures` before using `subfigure`.",
+    )
+    _subfigure-subsupplement.update(subsupplement)
+    set par(spacing: 0em)
+    [#body#v(gap)#figure(
+            [],
+            ..args,
+            placement: none,
+            kind: _subfigure-kind,
+            supplement: supplement,
+            gap: 0em,
+            outlined: outlined,
+            numbering: numbering,
+        )#label#v(gap-below)]
+}
+/// Enables the use of subfigures. Set up the relevant show rules.
+#let enable-referable-subfigures(doc) = {
+    context assert.eq(_subfigure-enabled.get(), none, message: "Cannot call `enable-referable-subfigures` twice.")
+    _subfigure-enabled.update(true)
+    show figure.where(kind: image): fig => {
+        counter(figure.where(kind: _subfigure-kind)).update(0)
+        _subfigure-supplement.update((fig.supplement, fig.numbering))
+        show ref: it => {
+            let el = it.element
+            if type(el) == content and el.func() == figure and el.kind == _subfigure-kind {
+                let subsupplement = _subfigure-subsupplement.at(el.location())
+                let subfigcounter = counter(figure.where(kind: _subfigure-kind)).at(el.location()).at(0)
+                link(
+                    el.location(),
+                    {
+                        subsupplement
+                        [~]
+                        numbering(el.numbering, subfigcounter)
+                    },
+                )
+            } else {
+                it
+            }
+        }
+        fig
+    }
+    show ref: it => {
+        let el = it.element
+        if type(el) == content and el.func() == figure and el.kind == _subfigure-kind {
+            let (figsupplement, fignumbering) = _subfigure-supplement.at(el.location())
+            let figcounter = counter(figure.where(kind: image)).at(el.location()).at(0)
+            let subfigcounter = counter(figure.where(kind: _subfigure-kind)).at(el.location()).at(0)
+            link(
+                el.location(),
+                {
+                    figsupplement
+                    [~]
+                    numbering(fignumbering, figcounter)
+                    numbering(el.numbering, subfigcounter)
+                },
+            )
+        } else {
+            it
+        }
+    }
+    doc
+}

--- a/packages/preview/patstdlib/0.3.0/src/lib.typ
+++ b/packages/preview/patstdlib/0.3.0/src/lib.typ
@@ -1,0 +1,5 @@
+#import "algorithms.typ"
+#import "enum.typ": enable-referable-enums, referable-enum
+#import "figure.typ": enable-referable-subfigures, labeled-figure, subfigure
+#import "misc.typ": CITE, TODO, dd, partial, sigfig
+#import "style.typ": appendix, as-bio, as-code, as-math, as-normal, composition, font-info, fonts, numberings, topmatter

--- a/packages/preview/patstdlib/0.3.0/src/misc.typ
+++ b/packages/preview/patstdlib/0.3.0/src/misc.typ
@@ -1,0 +1,91 @@
+/// Indicates a task that is still to-do. Renders like `TODO(author)[text here]`, all in red.
+///
+/// *Examples:*
+///
+/// ```typst
+/// #TODO[]                      // renders as: TODO
+/// #TODO[foo]                   // renders as: TODO[foo]
+/// #TODO(author: patrick)[]     // renders as: TODO(patrick)
+/// #TODO(author: patrick)[foo]  // renders as: TODO(patrick)[foo]
+/// ```
+///
+/// *Arguments:*
+///
+/// - doc (content): the text to render.
+/// - author (content): the author of the to-do.
+/// -> content
+#let TODO(author: none, doc) = {
+    set text(font: "DejaVu Sans Mono", size: 0.9em, fill: red)
+    if author == none {
+        if doc == [] [TODO] else [TODO\[#doc\]]
+    } else {
+        if doc == [] [TODO(#author)] else [TODO(#author)\[#doc\]]
+    }
+}
+
+/// Indicates a citation that needs filling in. Renders like `CITE[text here]`, all in red.
+///
+/// *Examples:*
+///
+/// ```typst
+/// #CITE[]     // renders as: CITE
+/// #CITE[foo]  // renders as: CITE[foo]
+/// ```
+///
+/// *Arguments:*
+///
+/// - doc (content): the text to render.
+/// -> content
+#let CITE(doc) = {
+    set text(font: "DejaVu Sans Mono", size: 0.9em, fill: red)
+    if doc == [] [CITE] else [CITE\[#doc\]]
+}
+
+/// Creates either a fraction `dx/dy`, or just a `dx` e.g. for use at the end of an integral.
+///
+/// *Constructors:*
+///
+/// There are two valid constructors:
+///
+/// 1. `dd(x)` to create a single-line `dx`.
+/// 2. `dd(x, y)` to create a fraction `dx/dy`.
+///
+/// In addition both forms consumes a `d:` keyword argument, defaulting to `math.dif`, indicating how to render the `d`.
+///
+/// -> content
+#let dd(..x, d: math.dif) = {
+    if x.named().len() > 0 { panic }
+    x = x.pos()
+    if x.len() == 1 { $#d#x.at(0)$ } else if x.len() == 2 { $(#d#x.at(0)) / (#d#x.at(1))$ } else { panic }
+}
+
+/// As `dd`, but uses `d: math.diff`.
+///
+/// -> content
+#let partial(..x) = dd(..x, d: math.diff)
+
+/// Rounds a number to a specified number of significant figures.
+///
+/// - x (str, int, float, decimal): a number to round.
+/// - digits (int): the number of significant digits to round to.
+/// -> decimal
+#let sigfig(x, digits: none) = {
+    assert(digits != none, message: "Must provide `digits` keyword argument.")
+    assert(digits > 0, message: "`digits` must be positive.")
+
+    // Convert to a decimal with enough zeros, so that we get the right number of trailing zeros out.
+    if type(x) == float {
+        x = str(x)  // Suppress decimal conversion warning
+    }
+    x = str(decimal(x))
+    if "." not in x {
+        x = x + "."
+    }
+    x = decimal(x + "0" * digits)
+
+    let trunc = calc.trunc(x)
+    let trunc_len = if trunc == 0 { 0 } else { str(calc.abs(trunc)).len() }
+    let decimal_digits = digits - trunc_len
+    assert(decimal_digits >= 0, message: "Cannot truncate to fewer significant digits than the integer component has.")
+    calc.round(x, digits: decimal_digits)
+}

--- a/packages/preview/patstdlib/0.3.0/src/style.typ
+++ b/packages/preview/patstdlib/0.3.0/src/style.typ
@@ -1,0 +1,317 @@
+#let _font-info-state = state("7e79ee62c4164f44af4c01f139a93236", none)
+#let font-info() = {
+    let x = _font-info-state.get()
+    assert.ne(x, none, message: "Must call `#show: style` first.")
+    x
+}
+#let _as-font(font-type, body) = context {
+    let fi = font-info()
+    let font = fi.at(font-type)
+    let size = 1em * (fi.scaling.at(font) / fi.scaling.at(text.font))
+    text(font: font, size: size, body)
+}
+#let as-normal(body) = _as-font("normal-font", body)
+#let as-math(body) = _as-font("math-font", body)  // Not useful, $..$ exists.
+#let as-code(body) = _as-font("code-font", body)  // Not useful, `..` exists.
+#let as-bio(body) = _as-font("bio-font", body)
+
+/// Sets fonts and sizes across the document.
+///
+/// By default this just recapitulates Typst defaults. However my own favourite choices for academic writing are:
+/// ```typst
+/// #show: fonts.with(
+///     title-font: "New Computer Modern",
+///     heading-font: "New Computer Modern",
+///     normal-font: "New Computer Modern",
+///     title-size: 20pt,
+///     heading-sizes: (13pt, 12pt, 11pt, 10pt),
+///     text-size: 10pt,
+///     fallback-fonts: false,
+/// )
+/// ```
+#let fonts(
+    title-font: "Libertinus Serif",
+    heading-font: "Libertinus Serif",
+    normal-font: "Libertinus Serif",
+    math-font: "New Computer Modern Math",
+    code-font: "DejaVu Sans Mono",
+    bio-font: "DejaVu Sans Mono",
+    scaling: (
+        "Libertinus Serif": 100%,
+        "New Computer Modern": 100%,
+        "New Computer Modern Math": 100%,
+        "DejaVu Sans Mono": 80%,
+    ),
+    title-size: 18.7pt, // 1.7em * 11pt
+    heading-sizes: (15.4pt, 13.2pt, 11pt), // 1.4em * 11pt, 1.2em * 11pt, 1em * 11pt
+    text-size: 11pt,
+    fallback-fonts: true,
+    fallback-smallcaps: false,
+    doc,
+) = {
+    // Normalize to lower, which is how `context text.font` is stored.
+    title-font = lower(title-font)
+    heading-font = lower(heading-font)
+    normal-font = lower(normal-font)
+    math-font = lower(math-font)
+    code-font = lower(code-font)
+    bio-font = lower(bio-font)
+    let scaling2 = (:)
+    for (k, v) in scaling.pairs() {
+        scaling2.insert(lower(k), v)
+    }
+    scaling = scaling2
+    let font-info-to-set = (
+        title-font: title-font,
+        heading-font: heading-font,
+        normal-font: normal-font,
+        math-font: math-font,
+        code-font: code-font,
+        bio-font: bio-font,
+        title-size: title-size,
+        heading-sizes: heading-sizes,
+        text-size: text-size,
+        scaling: scaling,
+    )
+    // Poor man's set-rule.
+    context {
+        assert.eq(_font-info-state.get(), none, message: "Cannot call `fonts` twice.")
+        _font-info-state.update(font-info-to-set)
+    }
+
+    // Font sizes
+    set text(font: normal-font, size: text-size * scaling.at(normal-font))
+    show title: set text(font: title-font, size: title-size * scaling.at(title-font))
+    show heading: set text(font: heading-font, size: heading-sizes.last() * scaling.at(heading-font))
+    show: body => heading-sizes
+        .slice(0, -1)
+        .enumerate(start: 1)
+        .fold(body, (body, (level, size)) => {
+            show heading.where(level: level): set text(size: size * scaling.at(heading-font))
+            body
+        })
+    show math.equation: set text(font: math-font, size: 1em * scaling.at(math-font))
+    // 1.25em default because the default `raw` size is `0.8em`, see https://github.com/typst/typst/issues/1331
+    show raw: set text(font: code-font, size: 1.25em * scaling.at(code-font))
+
+    // Misc
+    set text(fallback: fallback-fonts)
+    show title: set par(justify: false)
+    show title: set text(hyphenate: false)
+    show smallcaps: it => if fallback-smallcaps { text(size: 0.8em, upper(it)) } else { it }
+
+    doc
+}
+
+// Sets the page composition – the spacing of all the text.
+//
+/// By default this just recapitulates Typst defaults. However my own favourite choices for academic writing are:
+/// ```typst
+/// #show: composition.with(
+///     justify: true,
+///     par-spacing: 1.3em,
+///     margin: (top: 40pt, x: 40pt, bottom: 60pt),
+///     heading-spacings: (
+///         (above: 24pt, below: 8pt),
+///         (above: 16pt, below: 8pt),
+///         (above: 10pt, below: 8pt),
+///     )
+/// )
+/// ```
+#let composition(
+    justify: false,
+    par-spacing: 1.2em,
+    margin: 2.5cm,
+    // Defaults taken from
+    // https://github.com/typst/typst/blob/6b9b78596a6103dfbcadafaeb03eda624da5306a/crates/typst-library/src/model/heading.rs#L313-L314
+    heading-spacings: (
+        (above: 1.8em / 1.4, below: 0.75em / 1.4),
+        (above: 1.44em / 1.2, below: 0.75em / 1.2),
+        (above: 1.44em, below: 0.75em),
+    ),
+    doc,
+) = {
+    set par(justify: justify, spacing: par-spacing)
+    set page(margin: margin)
+
+    let last-heading-spacing = heading-spacings.at(-1)
+    show heading: set block(above: last-heading-spacing.above, below: last-heading-spacing.below)
+    show: body => heading-spacings
+        .slice(0, -1)
+        .enumerate(start: 1)
+        .fold(body, (body, (level, heading-spacing)) => {
+            show heading.where(level: level): set block(above: heading-spacing.above, below: heading-spacing.below)
+            body
+        })
+    doc
+}
+
+/// Sets the numberings for various elements in the document.
+///
+/// By default this just recapitulates Typst defaults. However my own favourite choices for academic writing are:
+/// ```typst
+/// #show: numberings.with(page: "1", heading: "1.1")
+/// ```
+#let numberings(
+    page: none,
+    heading: none,
+    footnote: "1",
+    doc,
+) = {
+    set std.page(numbering: page)
+    set std.heading(numbering: heading)
+    set std.footnote(numbering: footnote)
+    doc
+}
+
+/// A simple style for the top matter.
+///
+/// *Example:*
+///
+/// ```typst
+/// #show: style.with(
+///   title: [How to foobar],
+///   authors: (
+///     (
+///       name: "Tom Smith",
+///       affiliation: "ShallowMind",
+///       email: "foo@bar.com",
+///     ),
+///   ),
+///   abstract: [We show to really baz things up.],
+/// )
+/// ```
+///
+/// *Arguments:*
+///
+/// Arguments are list in the order they render from top-to-bottom down the page.
+///
+/// - header (content): header of the first page.
+/// - topline (bool): whether to place a line after the header.
+/// - title (content): the title.
+/// - logo-left (none, content): placed to the left of the title.
+/// - logo-right (none, content): placed to the right of the title.
+/// - authors (array): an array of dictionaries `(name: str, affiliation: str, email: str)`.
+/// - authors-maxcols: the number of columns to organize the authors into.
+/// - abstract (content): the abstract.
+/// - bottomline (bool): placed after the abstract.
+#let topmatter(
+    header: [],
+    topline: true,
+    title: [],
+    logo-left: none,
+    logo-right: none,
+    authors: (),
+    author-maxcols: 3,
+    abstract: [],
+    bottomline: true,
+    doc,
+) = {
+    // Metadata
+    set document(title: title)
+
+    // Header
+    set page(
+        header: context {
+            if counter(page).get().at(0) == 1 {
+                set text(size: 0.85em)
+                header
+                v(-5pt)
+                if topline { line(length: 100%) }
+            }
+        },
+        header-ascent: 0%,
+    )
+    // Title
+    /* This alignment is set up so that we get the following behaviour:
+
+    With a short title, it is centered relative to the larger logo:
+
+                              ╔═╗
+    Short title on one line.  ║ ║
+                              ╚═╝
+
+    With a long title, the logo remains at the top of the page:
+
+    Long title that covers    ╔═╗
+    multiple lines: lorem     ║ ║
+    ipsum dolor sit amet      ╚═╝
+    consectetur adipiscing
+    elit sed do eiusmod
+    */
+    v(20pt)
+    let title-columns = ()
+    let title-aligns = ()
+    let title-pieces = ()
+    if logo-left != none {
+        title-columns.push(15fr)
+        title-aligns.push(top)
+        title-pieces.push(logo-left)
+    }
+    title-columns.push(85fr)
+    title-aligns.push(horizon)
+    title-pieces.push(_title(title))
+    if logo-right != none {
+        title-columns.push(15fr)
+        title-aligns.push(top)
+        title-pieces.push(logo-right)
+    }
+    grid(columns: title-columns, column-gutter: 4fr, align: title-aligns, ..title-pieces)
+    v(10pt)
+    // Authors
+    {
+        set align(center)
+        let count = authors.len()
+        let ncols = calc.min(count, author-maxcols)
+        grid(
+            columns: (1fr,) * ncols,
+            row-gutter: 24pt,
+            ..authors.map(author => [
+                *#author.name* \
+                #if author.affiliation != none [#author.affiliation#linebreak()]
+                #if author.email != none { as-code(author.email) }
+            ]),
+        )
+    }
+    // Abstract
+    if abstract != [] {
+        v(10pt)
+        set align(center)
+        text(size: 1.3em, smallcaps("Abstract", all: true))
+        parbreak()
+        set align(left)
+        abstract
+    }
+    // Bottomline
+    if bottomline {
+        v(15pt)
+        line(length: 100%)
+        v(10pt)
+    } else {
+        v(20pt)
+    }
+    doc
+}
+
+/// Marks the transition to the appendix, for example meaning that:
+///
+/// - Heading numbering shifts to "A.1.".
+/// - A new title is provided.
+///
+/// *Usage:*
+///
+/// ```typst
+/// #show: appendix.with(title: "Supplementary")
+/// ```
+///
+/// - title (none, content): the title to place at the start of the appendix.
+/// -> content
+#let appendix(title: auto, doc) = {
+    place.flush()
+    pagebreak()
+    set heading(numbering: "A.1", supplement: "Appendix")
+    counter(heading).update(0)
+    assert.ne(title, auto, message: "Must specify a title: `#show appendix.with(title: ...)`.")
+    if title != none { std.title(title) }
+    doc
+}

--- a/packages/preview/patstdlib/0.3.0/typst.toml
+++ b/packages/preview/patstdlib/0.3.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "patstdlib"
+version = "0.3.0"
+entrypoint = "src/lib.typ"
+authors = ["Patrick Kidger <contact@kidger.site>"]
+license = "Apache-2.0"
+description = "Some standard pieces I find useful: fonts, subfigures, algorithms, labeled enums, etc."
+repository = "https://github.com/patrick-kidger/patstdlib"
+keywords = []
+categories = ["components", "scripting"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Changes
- Breaking change: `fonts` now uses Typst defaults by default.
- Breaking change: `topmatter` no longer sets numberings or page margin.
- Introduced `composition` to set justification, heading around spacings etc.
- Introduced `numberings` to set numberings for page, heading, etc.
