### PR TITLE
to-stuff:0.5.1

### DIFF
--- a/packages/preview/to-stuff/0.5.1/LICENSE.md
+++ b/packages/preview/to-stuff/0.5.1/LICENSE.md
@@ -1,0 +1,10 @@
+Copyright 2025 Nik Mennega
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/packages/preview/to-stuff/0.5.1/README.md
+++ b/packages/preview/to-stuff/0.5.1/README.md
@@ -1,0 +1,1060 @@
+# To-Stuff
+
+To-Stuff is a small package of [Typst](https://typst.app/) functions for converting string values to native types. This is most useful when loading layout data from an external configuration source, such as a YAML file.
+
+- Avoids any use of [`eval()`](https://typst.app/docs/reference/foundations/eval/).
+- All conversion functions optionally accept a default value to return on failure.
+- Where no default value is specified, a failed conversion panics with a sensible error message.
+
+
+## How to use
+
+Import the package into the current scope, optionally renamed using the `as` keyword:
+
+```typ
+#import "@preview/to-stuff:0.5.1"
+// Bindings available as to-stuff.alignment(), to-stuff.angle(), etc.
+
+// …or…
+
+#import "@preview/to-stuff:0.5.1" as to
+// Bindings available as to.alignment(), to.angle(), etc.
+```
+
+The package’s `let` bindings have the same names as their return types, and rely on Typst’s `import` syntax to scope safely. It is not recommended to load the individual bindings into the current scope, as that may cause collisions with the types themselves.
+
+```typ
+#assert(type(42pt) == length) // Expected behaviour
+
+#import "@preview/to-stuff:0.5.1": * // NOT RECOMMENDED
+
+#assert(type(42pt) != length) // To-Stuff bindings collide with standard types
+#assert(type(42pt) == std.length) // Workaround
+```
+
+
+## Localisation
+
+All conversions involving numeric values assume the number strings to be in a format understood by Typst code; specifically:
+
+- All numeric digits must be ASCII characters 0-9 and/or A-F (case non-sensitive).
+- Decimal separators must be a full stop/period; commas, apostrophes, etc. are not supported.
+- Thousands separators are not supported.
+
+
+## Functions
+
+### `alignment()`
+
+Attempts to convert a value to an `alignment`.
+
+```typ
+#alignment(
+	value, // str | alignment | dictionary
+	default: auto, // auto | none | alignment
+	quiet: false, // bool; DEPRECATED
+) -> none | alignment
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `alignment` or `dictionary` (positional, required)
+
+The value that should be converted to an `alignment`.
+
+- An `alignment` is returned unchanged.
+- A string representation of any of the eight `alignment` values is converted to that value.
+	- The string must not contain any scoping prefix, e.g. `alignment.…`, or the conversion will fail.
+- A string consisting of two `alignment` representations joined by a plus sign is converted to the corresponding 2D alignment.
+	- The two alignments must be on different axes, or the conversion will fail.
+- A `dictionary` containing one or more of the keys `x` and `y`, and no other keys, is converted.
+	- The value of `x`, if present, must be either a horizontal `alignment` or a value that would convert to one.
+	- The value of `y`, if present, must be either a vertical `alignment` or a value that would convert to one.
+
+#### `default`
+
+`auto` or `none` or `alignment`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.alignment("top + right")
+// -> right + top
+
+#let b = to.alignment(top + right)
+// -> right + top
+
+#let c = to.alignment((x: "right", y: "top"))
+// -> right + top
+
+#let d = to.alignment("turnwise")
+// panics with: "could not convert to alignment: \"turnwise\""
+
+#let e = to.alignment("top + bottom")
+// panics with: "cannot add two vertical alignments: \"top + bottom\""
+
+#let f = to.alignment(default: top + right, "top + bottom")
+// -> right + top
+
+#let g = to.alignment(default: none, "top + bottom")
+// -> none
+
+#let h = to.alignment(quiet: true, "top + bottom")
+// -> none
+```
+</details>
+
+
+### `angle()`
+
+Attempts to convert a value to an `angle`.
+
+```typ
+#angle(
+	value, // str | angle
+	default: auto, // auto | none | angle
+	quiet: false, // bool; DEPRECATED
+) -> none | angle
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `angle` (positional, required)
+
+The value that should be converted to an `angle`.
+
+- An `angle` is returned unchanged.
+- A string representation of a number followed by the letters `deg` or `rad` is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `default`
+
+`auto` or `none` or `angle`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.angle("45deg")
+// -> 45deg
+
+#let b = to.angle(45deg)
+// -> 45deg
+
+#let c = to.angle("42")
+// panics with: "could not convert to angle: \"42\""
+
+#let d = to.angle(default: 45deg, "42")
+// -> 45deg
+
+#let e = to.angle(default: none, "42")
+// -> none
+
+#let f = to.angle(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `color()`
+
+Attempts to convert a value to a `color`.
+
+```typ
+#color(
+	value, // str | color
+	default: auto, // auto | none | color
+	quiet: false, // bool; DEPRECATED
+) -> none | color
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `color` (positional, required)
+
+The value that should be converted to a `color`.
+
+- A `color` is returned unchanged.
+- A string representation of a predefined color value is converted to that built-in color.
+- A string representation of a hash symbol followed by a 6- or 8-digit hexadecimal code is converted to the corresponding RGB or RGBA value.
+- A string representation of a color space function followed by parentheses and arguments is converted.
+	- The string must not contain any scoping prefix, e.g. `color.…`, or the conversion will fail. This includes the `hsl`, `hsv`, and `linear-rgb` functions.
+
+#### `default`
+
+`auto` or `none` or `color`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.color("red")
+// -> rgb("#ff4136")
+
+#let b = to.color(red)
+// -> rgb("#ff4136")
+
+#let c = to.color("#FF4136FF")
+// -> rgb("#ff4136")
+
+#let d = to.color("rgb(255, 65, 54)")
+// -> rgb("#ff4136")
+
+#let e = to.color("hsv(135deg,75%,127,100)")
+// -> color.hsv(135deg, 75%, 49.8%, 39.22%)
+
+#let f = to.color("indigo")
+// panics with: "could not convert to color: \"indigo\""
+
+#let g = to.color(default: red, "indigo")
+// -> rgb("#ff4136")
+
+#let h = to.color(default: none, "indigo")
+// -> none
+
+#let i = to.color(quiet: true, "indigo")
+// -> none
+```
+</details>
+
+
+### `direction()`
+
+Attempts to convert a value to a `direction`.
+
+```typ
+#direction(
+	value, // str | direction
+	default: auto, // auto | none | direction
+	quiet: false, // bool; DEPRECATED
+) -> none | direction
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `direction` (positional, required)
+
+The value that should be converted to a `direction`.
+
+- A `direction` is returned unchanged.
+- A string representation of any of the four `direction` values is converted to that value.
+	- The string must not contain any scoping prefix, e.g. `direction.…`, or the conversion will fail.
+
+
+#### `default`
+
+`auto` or `none` or `direction`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.direction("rtl")
+// -> rtl
+
+#let b = to.direction(rtl)
+// -> rtl
+
+#let c = to.direction("btf")
+// panics with: "could not convert to direction: \"btf\""
+
+#let d = to.direction(default: rtl, "btf")
+// -> rtl
+
+#let e = to.direction(default: none, "btf")
+// -> none
+
+#let f = to.direction(quiet: true, "btf")
+// -> none
+```
+</details>
+
+
+### `float()`
+
+Attempts to convert a value to a `float`.
+
+While the standard [`float` constructor][typst_float] throws an error on failure, this function [panics][typst_panic] instead, which may be suppressed if desired via the `default` and `quiet` arguments.
+
+```typ
+#float(
+	value, // str | float
+	default: auto, // auto | none | float
+	quiet: false, // bool; DEPRECATED
+) -> none | float
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `float` (positional, required)
+
+The value that should be converted to a `float`.
+
+- A `float` is returned unchanged.
+- A string representation of a number is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `default`
+
+`auto` or `none` or `float`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.float("2.5")
+// -> 2.5
+
+#let b = to.float(2.5)
+// -> 2.5
+
+#let c = to.float("25e-1")
+// -> 2.5
+
+#let d = to.float("42%")
+// panics with: "could not convert to float: \"42%\""
+
+#let e = to.float(default: 2.5, "42%")
+// -> 2.5
+
+#let f = to.float(default: none, "42%")
+// -> none
+
+#let g = to.float(quiet: true, "42%")
+// -> none
+```
+</details>
+
+
+### `fraction()`
+
+Attempts to convert a value to a `fraction`.
+
+```typ
+#fraction(
+	value, // str | fraction
+	default: auto, // auto | none | fraction
+	quiet: false, // bool; DEPRECATED
+) -> none | fraction
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `fraction` (positional, required)
+
+The value that should be converted to a `fraction`.
+
+- A `fraction` is returned unchanged.
+- A string representation of a number followed by the letters `fr` is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `default`
+
+`auto` or `none` or `fraction`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.fraction("2.5fr")
+// -> 2.5fr
+
+#let b = to.fraction(2.5fr)
+// -> 2.5fr
+
+#let c = to.fraction("42")
+// panics with: "could not convert to fraction: \"42\""
+
+#let d = to.fraction(default: 2.5fr, "42")
+// -> 2.5fr
+
+#let e = to.fraction(default: none, "42")
+// -> none
+
+#let f = to.fraction(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `int()`
+
+Attempts to convert a value to an `int`.
+
+While the standard [`int` constructor][typst_int] throws an error on failure, this function [panics][typst_panic] instead, which may be suppressed if desired via the `default` and `quiet` arguments.
+
+This function can also parse correctly-prefixed strings in hexadecimal, octal and binary.
+
+```typ
+#int(
+	value, // str | int
+	default: auto, // auto | none | int
+	quiet: false, // bool; DEPRECATED
+) -> none | int
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `int` (positional, required)
+
+The value that should be converted to an `int`.
+
+- An `int` is returned unchanged.
+- A string representation of a number is converted.
+	- The number may be positive or negative, but may *not* contain decimal places.
+	- Hexadecimal numbers, prefixed with `0x`, are permitted.
+	- Octal numbers, prefixed with `0o`, are permitted.
+	- Binary numbers, prefixed with `0b`, are permitted.
+
+#### `default`
+
+`auto` or `none` or `int`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.int("42")
+// -> 42
+
+#let b = to.int(42)
+// -> 42
+
+#let c = to.int("0x2a")
+// -> 42
+
+#let d = to.int("2.5")
+// panics with: "could not convert to int: \"2.5\""
+
+#let e = to.int(default: 42, "2.5")
+// -> 42
+
+#let f = to.int(default: none, "2.5")
+// -> none
+
+#let g = to.int(quiet: true, "2.5")
+// -> none
+```
+</details>
+
+
+### `length()`
+
+Attempts to convert a value to a `length`.
+
+```typ
+#length(
+	value, // str | length
+	default: auto, // auto | none | length
+	quiet: false, // bool; DEPRECATED
+) -> none | length
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `length` (positional, required)
+
+The value that should be converted to a `length`.
+
+- A `length` is returned unchanged.
+- A string representation of a number followed by the letters `pt`, `mm`, `cm`, `in`, or `em`, is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `default`
+
+`auto` or `none` or `length`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.length("45pt")
+// -> 45pt
+
+#let b = to.length(45pt)
+// -> 45pt
+
+#let c = to.length("42")
+// panics with: "could not convert to length: \"42\""
+
+#let d = to.length(default: 45pt, "42")
+// -> 45pt
+
+#let e = to.length(default: none, "42")
+// -> none
+
+#let f = to.length(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `number()`
+
+Attempts to convert a value to a `float` or an `int` as appropriate.
+
+
+```typ
+#number(
+	value, // str | float | int
+	default: auto, // auto | none | float | int
+	quiet: false, // bool; DEPRECATED
+) -> none | float | int
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `float` or `int` (positional, required)
+
+The value that should be converted to a `float` or `int`.
+
+- A `float` or `int` is returned unchanged.
+- A string representation of a `float` (see [above](#float)) is converted.
+- A string representation of an `int` (see [above](#int)) is converted.
+
+#### `default`
+
+`auto` or `none` or `float` or `int`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.number("42")
+// -> 42
+
+#let b = to.number(42)
+// -> 42
+
+#let c = to.number("0x2a")
+// -> 42
+
+#let d = to.number("2.5")
+// -> 2.5
+
+#let e = to.number(2.5)
+// -> 2.5
+
+#let f = to.float("25e-1")
+// -> 2.5
+
+#let g = to.number("45%")
+// panics with: "could not convert to int or float: \"45%\""
+
+#let h = to.number(default: 42, "45%")
+// -> 42
+
+#let i = to.number(default: none, "45%")
+// -> none
+
+#let j = to.number(quiet: true, "45%")
+// -> none
+```
+</details>
+
+
+### `ratio()`
+
+Attempts to convert a value to a `ratio`.
+
+```typ
+#ratio(
+	value, // str | ratio
+	default: auto, // auto | none | ratio
+	quiet: false, // bool; DEPRECATED
+) -> none | ratio
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `ratio` (positional, required)
+
+The value that should be converted to a `ratio`.
+
+- A `ratio` is returned unchanged.
+- A string representation of a number followed by a percent sign is converted.
+	- The number may be positive or negative, and may contain decimal places.
+
+#### `default`
+
+`auto` or `none` or `ratio`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.ratio("45%")
+// -> 45%
+
+#let b = to.ratio(45%)
+// -> 45%
+
+#let c = to.ratio("42")
+// panics with: "could not convert to ratio: \"42\""
+
+#let d = to.ratio(default: 45%, "42")
+// -> 45%
+
+#let e = to.ratio(default: none, "42")
+// -> none
+
+#let f = to.ratio(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `relative()`
+
+Attempts to convert a value to a `relative`.
+
+```typ
+#relative(
+	value, // str | relative | ratio | length | dictionary
+	default: auto, // auto | none | relative | ratio | length
+	quiet: false, // bool; DEPRECATED
+) -> none | relative
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `relative` or `ratio` or `length` or `dictionary` (positional, required)
+
+The value that should be converted to a `relative`.
+
+- A `relative` is returned unchanged.
+- A `ratio` is returned as a `relative` with a `length` of `0pt`.
+- A `length` is returned as a `relative` with a `ratio` of `0%`.
+- A string representation of a `ratio` (see [above](#ratio)) is converted.
+- A string representation of a `length` (see [above](#length)) is converted.
+- A string consisting of multiple `ratio`s and `lengths` joined by plus signs or minus signs is converted to a single `relative` length.
+	- All `length`-like substrings are added.
+	- All `ratio`-like substrings are added.
+- A `dictionary` containing one or more of the keys `ratio` and `length`, and no other keys, is converted.
+	- The value of `ratio`, if present, must be either a `ratio` or a value that would convert to one.
+	- The value of `length`, if present, must be either a `length` or a value that would convert to one.
+
+#### `default`
+
+`auto` or `none` or `relative` or `ratio` or `length`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.relative("45pt + 3%")
+// -> 3% + 45pt
+
+#let b = to.relative(45pt + 3%)
+// -> 3% + 45pt
+
+#let c = to.relative((ratio: "3%", length: "45pt"))
+// -> 3% + 45pt
+
+#let d = to.relative("42")
+// panics with: "could not convert to relative: \"42\""
+
+#let e = to.relative(default: 45pt + 3%, "42")
+// -> 3% + 45pt
+
+#let f = to.relative(default: none, "42")
+// -> none
+
+#let g = to.relative(quiet: true, "42")
+// -> none
+```
+</details>
+
+
+### `scalar()`
+
+Alias of [`number()`](#number)
+
+*Deprecated*: `scalar()` will be removed in To-Stuff version `1.0.0`.
+
+
+### `stroke()`
+
+Attempts to convert a value to a `stroke`.
+
+```typ
+#stroke(
+	value, // str | stroke | color | length | array | dictionary
+	default: auto, // auto | none | stroke | color | length
+	quiet: false, // bool; DEPRECATED
+) -> none | stroke
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `stroke` or `color` or `length` or `array` or `dictionary` (positional, required)
+
+The value that should be converted to a `stroke`.
+
+- A `stroke`, `color` or `length` is returned unchanged.
+- A string representation of a `color` (see [above](#color)) is converted.
+- A string representation of a `length` (see [above](#length)) is converted.
+- A valid [dash pattern](https://typst.app/docs/reference/visualize/stroke/#constructor-dash) is converted.
+- A string representation of one or more valid `color`s, `length`s and/or predefined dash patterns joined by plus signs is converted.
+	- All `color`-like substrings are combined via `color.mix()`.
+	- All `length`-like substrings added.
+- A `dictionary` that would otherwise be accepted as a valid `stroke` is converted.
+
+#### `default`
+
+`auto` or `none` or `stroke` or `color` or `length`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+
+#### `quiet`
+
+`bool`
+
+Setting to `true` is equivalent to setting `default: none`.
+
+Default: `false`
+
+*Deprecated*: `quiet` will be removed in To-Stuff version `1.0.0`.
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:0.5.1" as to
+
+#let a = to.stroke("red")
+// -> rgb("#ff4136")
+
+#let b = to.stroke(45pt)
+// -> 45pt
+
+#let c = to.stroke("densely-dashed")
+// -> (dash: (array(3pt, 2pt), phase: 0pt))
+
+#let d = to.stroke((3pt, 2pt))
+// -> (dash: (array(3pt, 2pt), phase: 0pt))
+
+#let e = to.stroke((paint: red, thickness: 2pt, dash: "densely-dashed"))
+// -> (paint: rgb("#ff4136"), thickness: 2pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let f = to.stroke("2pt + red + densely-dashed + silver + 5pt")
+// -> (paint: oklab(77.85%, 0.1, 0.054), thickness: 7pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let g = to.stroke("deep-dish")
+// panics with: "could not convert to stroke: \"deep-dish\""
+
+#let h = to.stroke(default: red + 45pt, "deep-dish")
+// -> 45pt + rgb("#ff4136")
+
+#let i = to.stroke(default: none, "deep-dish")
+// -> none
+
+#let j = to.stroke(quiet: true, "deep-dish")
+// -> none
+```
+</details>
+
+
+## Development
+
+### Requirements
+
+Local development of To-Stuff relies on the following software:
+
+- [`tytanic`](https://github.com/typst-community/tytanic)
+- [`task`](https://github.com/go-task/task)
+- [`direnv`](https://github.com/direnv/direnv)
+- [`yq`](https://github.com/mikefarah/yq)
+
+
+### Setup
+
+1. Fork the [Typst Packages][setup_universe] repository and clone it locally. A [sparse checkout][setup_sparse] is recommended.
+
+	For demonstration purposes, we assume your local clone of your Typst Packages fork is at `~/my-typst-dev/universe`.
+
+2. Clone this repository.
+
+	```sh
+	cd ~/my-typst-dev
+	git clone https://codeberg.org/boondoc/typst-to-stuff
+	```
+
+3. Create and activate an environment file to link To-Stuff’s `taskfile` to your local copy of Typst Packages. You may need to edit your `direnv` settings to recognise `.env` files.
+
+	```sh
+	cd ~/my-typst-dev/typst-to-stuff
+	echo "LOCAL_UNIVERSE=${HOME}/my-typst-dev/universe/packages/preview" > .env
+	direnv allow
+	```
+
+	Note that the above command should write an **absolute path** to `.env`; `task` seems not to parse shell variables inside `.env` files, even when `direnv` itself expands them correctly.
+
+4. Initialise tests.
+
+	```sh
+	cd ~/my-typst-dev/typst-to-stuff
+	task
+	```
+
+	The default `task` operation runs all unit tests once.
+
+5. Begin monitoring the repository for file edits.
+
+	```sh
+	cd ~/my-typst-dev/typst-to-stuff
+	task watch
+	```
+
+	Running the `watch` task in a clean repository can incorrectly skip several tests, taking multiple refreshes to successfully compile the entire suite; running a single pass first (see step 4) seems to solve the problem.
+
+
+### Updating the project version
+
+To set a new project version:
+
+1. Edit the `package.version` setting in `typst.toml`
+2. Run `task docs` to automatically update the `README.md` file to reflect the correct version number.
+
+
+### Packaging for Universe
+
+Running `task package` will copy selected files to the the path specified in `$LOCAL_UNIVERSE` (set in `.env`), under a subdirectory structure according to the project name and version specified in `typst.toml`. The list of files copied is defined in `taskfile.yml` under `vars.MODULE` and `vars.IGNORE`.
+
+Only files [relevant][setup_exclude] to Typst Universe itself should be packaged in this way; for instance, Universe has no use for the `tests` subdirectory.
+
+
+[typst_panic]: https://typst.app/docs/reference/foundations/panic/
+[typst_float]: https://typst.app/docs/reference/foundations/float/#constructor
+[typst_int]: https://typst.app/docs/reference/foundations/int/#constructor
+[setup_universe]: https://github.com/typst/packages
+[setup_sparse]: https://github.com/typst/packages/blob/main/docs/tips.md#sparse-checkout-of-the-repository
+[setup_exclude]: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude
+

--- a/packages/preview/to-stuff/0.5.1/exports.typ
+++ b/packages/preview/to-stuff/0.5.1/exports.typ
@@ -1,0 +1,9 @@
+
+#import	"/internals/numbers.typ"	:   float, int, number, number as scalar
+#import	"/internals/units.typ"		:   angle, fraction, length, ratio
+#import	"/internals/alignment.typ"	:   alignment
+#import	"/internals/color.typ"		:   color
+#import	"/internals/direction.typ"	:   direction
+#import	"/internals/relative.typ"	:   relative
+#import	"/internals/stroke.typ"		:   stroke
+

--- a/packages/preview/to-stuff/0.5.1/internals/alignment.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/alignment.typ
@@ -1,0 +1,107 @@
+
+#import	"/internals/utils.typ"		:   *
+
+#let	alignment(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.alignment,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+	if type(value) == dictionary and value.len() > 0 {
+		let	original			=   repr(value)
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			x				:  "horizontal",
+			y				:  "vertical",
+		)
+
+		if keys_this.all(x => x in keys_valid.keys()) {
+			for (field, axis) in keys_valid {
+				if field in value {
+					value.insert(field, alignment(default : none, value.at(field)))
+
+					if none == value.at(field) or value.at(field).axis() != axis {
+						return mild-panic(
+							quiet				:   quiet,
+							default				:   default,
+							types				:   types,
+							"could not convert “{field}” component to {axis} alignment: "
+							.replace("{axis}",	axis)
+							.replace("{field}",	field)
+							+ original,
+						)
+					}
+				}
+			}
+
+			return value.values().sum()
+		}
+
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   keys_this,
+				valid				:   keys_valid.keys(),
+				repr(value),
+			),
+		)
+	}
+
+
+	let	panic-message			=  "could not convert to alignment: " + repr(value)
+
+	if type(value) != std.str {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	let	value				=   value.trim()
+	let	constants			=   list-predefined(std.alignment)
+
+	if value in constants {
+		return constants.at(value)
+	}
+
+
+	let	parts				=   value.split("+").map(std.str.trim)
+
+	if not parts.all(x => x in constants) {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+	let	axes				=   parts.map(x => constants.at(x).axis())
+
+	if axes.at(0) == axes.at(1) {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			"cannot add two {axis} alignments: "
+			.replace("{axis}", axes.at(0))
+			+ repr(value),
+		)
+	}
+
+
+	return parts.map(alignment).sum()
+}
+

--- a/packages/preview/to-stuff/0.5.1/internals/color.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/color.typ
@@ -1,0 +1,222 @@
+
+#import "/internals/numbers.typ"	:   int, number
+#import "/internals/units.typ"		:   angle, ratio
+#import	"/internals/utils.typ"		:   *
+
+
+#let	color(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.color,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	panic-message			=  "could not convert to color: " + repr(value)
+
+	if type(value) != std.str {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	let	value				=   value.trim()
+	let	constants			=   list-predefined(std.color)
+	let	constructors			= (
+		rgb				: (
+			constructor			:  std.color.rgb,
+			args				: (
+				red				: (optional: false,	types: (ratio, int)),
+				green				: (optional: false,	types: (ratio, int)),
+				blue				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		linear-rgb			: (
+			constructor			:  std.color.linear-rgb,
+			args				: (
+				red				: (optional: false,	types: (ratio, int)),
+				green				: (optional: false,	types: (ratio, int)),
+				blue				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		luma				: (
+			constructor			:  std.color.luma,
+			args				: (
+				lightness			: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+		cmyk				: (
+			constructor			:  std.color.cmyk,
+			args				: (
+				cyan				: (optional: false,	types: (ratio,)),
+				magenta				: (optional: false,	types: (ratio,)),
+				yellow				: (optional: false,	types: (ratio,)),
+				black				: (optional: false,	types: (ratio,)),
+			),
+		),
+		hsl				: (
+			constructor			:  std.color.hsl,
+			args				: (
+				hue				: (optional: false,	types: (angle,)),
+				saturation			: (optional: false,	types: (ratio, int)),
+				lightness			: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		hsv				: (
+			constructor			:  std.color.hsv,
+			args				: (
+				hue				: (optional: false,	types: (angle,)),
+				saturation			: (optional: false,	types: (ratio, int)),
+				value				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		oklab				: (
+			constructor			:  std.color.oklab,
+			args				: (
+				lightness			: (optional: false,	types: (ratio,)),
+				A				: (optional: false,	types: (ratio, number),	clamp: false),
+				B				: (optional: false,	types: (ratio, number),	clamp: false),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+		oklch				: (
+			constructor			:  std.color.oklch,
+			args				: (
+				lightness			: (optional: false,	types: (ratio,)),
+				chroma				: (optional: false,	types: (ratio, number), clamp: false),
+				hue				: (optional: false,	types: (angle,)),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+	)
+
+	let	clamps				= (
+		int 				: (
+			fails				:   x => 0 > x or x > 255,
+			error				:  "component must be between 0 and 255",
+		),
+		ratio				: (
+			fails				:   x => 0% > x or x > 100%,
+			error				:  "component must be between 0% and 100%",
+		),
+	)
+
+
+	if value in constants {
+		return constants.at(value)
+	}
+
+	if value.contains(regex("^#?([[:xdigit:]]{3,4}|[[:xdigit:]]{6}|[[:xdigit:]]{8})$")) {
+		return std.color.rgb(value)
+	}
+
+
+	let	rx-funcs			=   regex( "^(" + constructors.keys().join("|") + ")\(([^)]*)\)$")
+
+	if value.contains(rx-funcs) {
+		let	(func, args)			=   value.match(rx-funcs).captures
+
+		if func not in constructors {
+			return mild-panic(
+				quiet				:   quiet,
+				default				:   default,
+				types				:   types,
+				panic-message,
+			)
+		}
+
+		let	allowed				=   constructors.at(func).args.pairs()
+		let	required			=   allowed.filter(x => not x.last().optional)
+		let	args				=   args
+			.split(",")
+			.map(str.trim)
+			.filter(x => "" != x)
+			.enumerate()
+			.map(((offset, arg)) => {
+				if offset >= allowed.len() {
+					return ("panic", "unexpected argument " + repr(arg))
+				}
+
+				let	(name, rules)			=   allowed.at(offset)
+
+				for	parse in rules.types {
+					let	clamp				=   clamps.at(
+						default				: (:),
+						repr(parse),
+					)
+					let	parsed				=   parse(
+						default				:   none,
+						arg,
+					)
+
+					if none == parsed {
+						continue;
+					}
+
+
+					if repr(parse) in clamps and rules.at(
+						default				:   true,
+						"clamp",
+					) and clamp.at("fails")(parsed) {
+						return ("panic", (name, clamp.error).join(" "))
+					}
+
+					return (name, parsed)
+				}
+
+				return ("panic", (
+					name,
+					"component expected",
+					rules.types.map(repr).join(
+						last				:  ", or ",
+						", ",
+					).replace("number", "float"),
+				).join(" "))
+			})
+			.to-dict()
+
+		if "panic" in args {
+			return mild-panic(
+				quiet				:   quiet,
+				default				:   default,
+				types				:   types,
+				panic-message + "; " + args.panic,
+			)
+		}
+
+		if args.len() < required.len() {
+			return mild-panic(
+				quiet				:   quiet,
+				default				:   default,
+				types				:   types,
+				panic-message + "; missing " + required.at(args.len()).first() + " component",
+			)
+		}
+
+		return	constructors.at(func).at("constructor")(..args.values())
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		panic-message,
+	)
+}
+

--- a/packages/preview/to-stuff/0.5.1/internals/direction.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/direction.typ
@@ -1,0 +1,32 @@
+
+#import	"/internals/utils.typ"		:   *
+
+#let	direction(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.direction,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	constants			=   list-predefined(std.direction)
+
+	if type(value) == std.str and value.trim() in constants {
+		return constants.at(value.trim())
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"could not convert to direction: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/0.5.1/internals/numbers.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/numbers.typ
@@ -1,0 +1,231 @@
+
+#import	"/internals/utils.typ"		:   mild-panic
+
+#let	rx-int-number			=  "[[:digit:]]+"
+#let	rx-flt-number			=  "[[:digit:]]*\.?[[:digit:]]+(e[+-]?[[:digit:]]+)?"
+#let	rx-xob-number			=  "0([xob])(.+)"
+
+#let	rx-int-signed			=  "(([-+\s]*)(" + rx-int-number + "))"
+#let	rx-flt-signed			=  "(([-+\s]*)(" + rx-flt-number + "))"
+#let	rx-xob-signed			=  "(([-+\s]*)"  + rx-xob-number +  ")"
+
+
+#let	int_from_base(value, base)	= {
+	let	digits				=  "0123456789abcdefghijklmnopqrstuvwxyz"
+	let	max				=   digits.len()
+
+	if base != calc.clamp(base, 2, max) {
+		// Intentionally non-suppressible panic.
+		panic("Base must be between 2 and {max}: {base}"
+			.replace("{max}",	max)
+			.replace("{base}",	base)
+		)
+	}
+
+	let	v				=   lower(value)
+	let	d				=   digits.slice(0, base)
+
+	if none != v.match(regex("([^" + d + "]+)")) {
+		let	base				=   std.str(base)
+		let	debug				= (
+			"16"				:  "hexadecimal",
+			 "8"				:  "octal",
+			 "2"				:  "binary",
+		).at(
+			default				:  "base-" + base,
+			base,
+		)
+
+		let	xob				= (
+			"16"				:  "0x",
+			 "8"				:  "0o",
+			 "2"				:  "0b",
+		).at(
+			default				:  "",
+			base
+		)
+
+		return	"invalid {base} number: {value}"
+			.replace("{value}",	repr(xob + value))
+			.replace("{base}",	debug)
+	}
+
+	return	 v
+		.rev()
+		.clusters()
+		.enumerate()
+		.map(((x, c)) => d.position(c) * calc.pow(base, x))
+		.sum()
+}
+
+
+#let	xob(
+	quiet				:   false,
+	default				:   auto,
+	types				:  ( ),
+	value,
+) = {
+	let	(_, signs, xob, num)		=   value.trim().matches(regex("^" + rx-xob-signed + "$")).first().captures
+	let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+	let	v				=   int_from_base(num, (
+			x				:   16,
+			o				:    8,
+			b				:    2,
+		)
+		.at(xob))
+
+	if type(v) == std.str {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			v,
+		)
+	}
+
+	return v * {
+		if negative {
+			-1
+		} else {
+			 1
+		}
+	}
+}
+
+#let	int(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.int,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	if type(value) == std.str {
+		let	rx				=   regex("^" + rx-int-signed + "$")
+
+		if value.trim().contains(rx) {
+			let	(_, signs, num)			=   value.trim().matches(rx).first().captures
+			let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+			return std.int(std.float(num) * {
+				if negative {
+					-1
+				} else {
+					 1
+				}
+			})
+		}
+
+		if value.trim().contains(regex("^" + rx-xob-signed + "$")) {
+			return xob(
+				quiet				:   quiet,
+				default				:   default,
+				types				:   types,
+				value,
+			)
+		}
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"could not convert to int: " + repr(value),
+	)
+}
+
+
+
+#let	float(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.float,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	rx				=   regex("^" + rx-flt-signed + "$")
+
+	if type(value) == std.str and value.trim().contains(rx) {
+		let	(_, signs, num, _)		=   value.trim().matches(rx).first().captures
+		let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+		return std.float(num) * {
+			if negative {
+				-1.0
+			} else {
+				 1.0
+			}
+		}
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"could not convert to float: " + repr(value),
+	)
+}
+
+
+#let	number(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.int,
+		std.float,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	if type(value) == std.str {
+		let	vals				= (
+			int(default : none, value),
+			float(default : none, value),
+		)
+
+		vals				=   vals.filter(x => none != x).dedup()
+
+		if vals.len() > 0 {
+			return vals.last()
+		}
+
+		if value.trim().contains(regex("^" + rx-xob-signed + "$")) {
+			return xob(
+				quiet				:   quiet,
+				default				:   default,
+				types				:   types,
+				value,
+			)
+		}
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"could not convert to int or float: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/0.5.1/internals/relative.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/relative.typ
@@ -1,0 +1,104 @@
+
+#import	"/internals/numbers.typ"	:   rx-flt-signed
+#import	"/internals/units.typ"		:   length, ratio
+#import	"/internals/utils.typ"		:   *
+
+#let	relative(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.relative,
+		std.ratio,
+		std.length,
+	)
+
+	if type(value) in types {
+		return value + 0pt + 0%
+	}
+
+
+	if type(default) in types {
+		default				+=   0pt + 0%
+	}
+
+	if type(value) == dictionary and value.len() > 0 {
+		let	original			=   repr(value)
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			ratio				:   ratio,
+			length				:   length,
+		)
+
+		if keys_this.all(x => x in keys_valid.keys()) {
+			for (field, func) in keys_valid {
+				if field in value {
+					value.insert(field, func(default : none, value.at(field)))
+
+					if none == value.at(field) {
+						return mild-panic(
+							quiet				:   quiet,
+							default				:   default,
+							types				:   types,
+							"could not convert “{field}” component to {field}: "
+							.replace("{field}", field)
+							+ original,
+						)
+					}
+				}
+			}
+
+			return value.values().sum()
+		}
+
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   keys_this,
+				valid				:   keys_valid.keys(),
+				repr(value),
+			),
+		)
+	}
+
+
+	let	rx				=  "^(" + rx-flt-signed + "(pt|mm|cm|in|em|%))"
+
+	if type(value) == std.str and value.trim().contains(regex(rx + "+$")) {
+		let	value				=   value.trim()
+		let	parts				= (
+			ratio				:   0%,
+			length				:   0pt,
+		)
+
+		while value.len() > 0 {
+			let	match				=   value.match(regex(rx))
+
+			if none == match {
+				break
+			}
+
+			if match.captures.at(5) == "%" {
+				parts.ratio			+=   ratio(default : 0%, match.text)
+			} else {
+				parts.length			+=   length(default : 0pt, match.text)
+			}
+
+			value				=   value.slice(match.end)
+		}
+
+		return relative(parts)
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"could not convert to relative: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/0.5.1/internals/stroke.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/stroke.typ
@@ -1,0 +1,448 @@
+
+#import	"/internals/numbers.typ"	:   number
+#import	"/internals/units.typ"		:   length
+#import	"/internals/color.typ"		:   color
+#import	"/internals/utils.typ"		:   *
+
+#let	valid-preset(
+	valid				: ( ),
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	if value.trim() in valid {
+		return value.trim()
+	}
+
+	let	expectations			=   valid.join(
+		last				:  "”, or “",
+		"”, “",
+	)
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"expected “{expected}”, found {value}"
+			.replace("{expected}", expectations)
+			.replace("{value}", repr(value)),
+	)
+}
+
+
+#let	stroke-cap-preset(
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"butt",
+		"round",
+		"square",
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:   types,
+	value,
+)
+
+#let	stroke-join-preset(
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"miter",
+		"round",
+		"bevel",
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:   types,
+	value,
+)
+
+#let	stroke-dash-preset(
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"solid",
+		"dotted",
+		"densely-dotted",
+		"loosely-dotted",
+		"dashed",
+		"densely-dashed",
+		"loosely-dashed",
+		"dash-dotted",
+		"densely-dash-dotted",
+		"loosely-dash-dotted",
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:   types,
+	value,
+)
+
+#let	stroke-dash-array(
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	let	dash				=   value.map(x => {
+		if x == "dot" {
+			return x
+		}
+
+		length(default : none, x)
+	})
+
+	if dash.all(x => none != x) {
+		return dash
+	}
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"expected array of “dot” or length, found " + debug-value(value),
+	)
+}
+
+#let	stroke-dash-dict(
+	strict				:   true,
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	let	dash				= (
+		array				: ( ),
+		phase				:   0pt,
+	)
+
+	let	test				=   x => x in dash.keys()
+	let	maybe				=   value.keys().any(test)
+	let	valid				=   value.keys().all(test)
+
+	if not strict and not maybe { // Not attempting to be a dash: let it through
+		return none
+	}
+
+	if (strict or maybe) and not valid {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   value.keys(),
+				valid				:   dash.keys(),
+				repr(value),
+			),
+		)
+	}
+
+	if "array" in value {
+		dash.array			=   dash.array + stroke-dash-array(value.array)
+	}
+
+	if "phase" in value {
+		dash.phase			=   dash.phase + length(value.phase)
+	}
+
+	dash
+}
+
+#let	stroke(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.stroke,
+		std.color,
+		std.length,
+	)
+
+	if type(value) in types {
+		return std.stroke(value)
+	}
+
+
+	if type(default) in types {
+		default				=   std.stroke(default)
+	}
+
+	// An array of lengths is assumed to be the dash
+	if type(value) == array {
+		let	dash				=   stroke-dash-array(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			value,
+		)
+
+		if type(dash) == array {
+			return std.stroke(dash : dash)
+		}
+
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			dash,
+		)
+	}
+
+	if type(value) == dictionary and value.len() > 0 {
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			"paint",
+			"thickness",
+			"dash",
+			"cap",
+			"join",
+			"miter-limit",
+		)
+
+		// A dictionary containing valid pattern parameters for keys could be the dash
+		let	dash				=   stroke-dash-dict(
+			strict				:   false,
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			value,
+		)
+
+		if none != dash {
+			if type(dash) == str {
+				panic(dash)
+			}
+
+			if type(dash) == dictionary {
+				return std.stroke(
+					dash				:   dash,
+				)
+			}
+		}
+
+		// Any other dictionary must be a whole stroke
+		if keys_this.all(x => x in keys_valid) {
+			if "paint" in value {
+				value.paint			=   color(
+					quiet				:   quiet,
+					default				:   default,
+					value.paint,
+				)
+
+				if none == value.paint { // Implies default:none
+					return none
+				}
+			}
+
+			if "thickness" in value {
+				value.thickness			=   length(
+					quiet				:   quiet,
+					default				:   default,
+					value.thickness,
+				)
+
+				if none == value.thickness { // Implies default:none
+					return none
+				}
+			}
+
+			if "dash" in value {
+				let	funcs				= (
+					array				:   stroke-dash-array,
+					dictionary			:   stroke-dash-dict,
+					str				:   stroke-dash-preset,
+				)
+
+				if repr(type(value.dash)) in funcs {
+					let	key				=   repr(type(value.dash))
+					let	dash				=   funcs.at(key)(
+						quiet				:   quiet,
+						default				:   default,
+						types				:   types,
+						value.dash,
+					)
+
+					if none == dash { // Implies default:none
+						return none
+					}
+
+					if key != "str" and type(dash) == str {
+						panic(dash)
+					}
+
+					if key == "str" and dash != value.dash.trim() {
+						panic(dash)
+					}
+
+					value.dash			=   dash
+				}
+			}
+
+			if "cap" in value {
+				let	cap				=   stroke-cap-preset(
+					quiet				:   quiet,
+					default				:   default,
+					types				:   types,
+					value.cap,
+				)
+
+				if none == cap { // Implies default:none
+					return none
+				}
+
+				if cap != value.cap.trim() {
+					panic(cap)
+				}
+
+				value.cap			=   cap
+			}
+
+			if "join" in value {
+				let	join				=   stroke-join-preset(
+					quiet				:   quiet,
+					default				:   default,
+					types				:   types,
+					value.join,
+				)
+
+				if none == join { // Implies default:none
+					return none
+				}
+
+				if join != value.join.trim() {
+					panic(join)
+				}
+
+				value.join			=   join
+			}
+
+			if "miter-limit" in value {
+				value.miter-limit		=   number(
+					quiet				:   quiet,
+					default				:   default,
+					value.miter-limit,
+				)
+
+				if none == value.miter-limit { // Implies default:none
+					return none
+				}
+			}
+
+			return std.stroke(value)
+		}
+
+
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   keys_this,
+				valid				:   keys_valid,
+				repr(value),
+			),
+		)
+	}
+
+
+	let	panic-message			=  "could not convert to stroke: " + repr(value)
+
+	// We’ve covered full stroke definitions, as well as individual paint, thickness and dash values;
+	// an individual cap, join or miter-limit value isn’t really worth worrying about. That leaves
+	// string depictions of compound paint+length+dash declarations.
+	if type(value) != std.str {
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	// Splitting on `+` and evaluating components separately catches more edge cases than one big regex,
+	// e.g. a non-ridiculous regex would probably pass `invalid + 3pt`, which would be an error.
+	// Allowing addition of multiple paints/thicknesses is a little cheeky; we can’t easily do subtraction
+	// since splitting on `-` breaks dash pattern strings.
+	let	o				= (:)
+
+	for	c in value.split("+").map(std.str.trim).filter(x => x != "") {
+		let	d				=   stroke-dash-preset(
+			default				:   none,
+			types				:  (std.str,),
+			c,
+		)
+		if none != d {
+			if "dash" in o {
+				return mild-panic(
+					quiet				:   quiet,
+					default				:   default,
+					types				:   types,
+					"cannot add two stroke arrays: " + repr(value),
+				)
+			}
+
+			o.insert("dash", d)
+			continue
+		}
+
+		let	k				=   color(default : none, c)
+		if none != k {
+			o.insert(
+				"paint",
+				if "paint" in o {
+					std.color.mix(o.paint, k)
+				} else {
+					k
+				},
+			)
+			continue
+		}
+
+		let	t				=   length(default : none, c)
+		if none != t {
+			o.insert(
+				"thickness",
+				t + o.at(
+					default				:   0pt,
+					"thickness",
+				),
+			)
+			continue
+		}
+
+		// Value cannot be processed
+		return mild-panic(
+			quiet				:   quiet,
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	if o.keys().len() > 0 {
+		return std.stroke(o)
+	}
+
+
+	return mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		panic-message,
+	)
+}
+

--- a/packages/preview/to-stuff/0.5.1/internals/units.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/units.typ
@@ -1,0 +1,106 @@
+
+#import	"/internals/numbers.typ"	:   rx-flt-signed
+#import	"/internals/utils.typ"		:   mild-panic
+
+#let	units(
+	units				: (:),
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	if type(value) in types {
+		return value
+	}
+
+
+	let	rx				=   regex("^" + rx-flt-signed + "(" + units.keys().join("|") + ")$")
+
+	if type(value) == std.str and value.trim().contains(rx) {
+		let	(_, signs, num, _, unit)	=   value.trim().matches(rx).first().captures
+		let	negative			=   calc.odd(signs.split("").filter(x => x == "-").len())
+
+		return std.float(num) * units.at(unit) * {
+			if negative {
+				-1
+			} else {
+				 1
+			}
+		}
+	}
+
+
+	mild-panic(
+		quiet				:   quiet,
+		default				:   default,
+		types				:   types,
+		"could not convert to " + repr(types.first()) + ": " + repr(value),
+	)
+}
+
+
+#let	length(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"pt"				:   1pt,
+		"mm"				:   1mm,
+		"cm"				:   1cm,
+		"in"				:   1in,
+		"em"				:   1em,
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:  (std.length,),
+	value,
+)
+
+
+#let	fraction(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"fr"				:   1fr,
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:  (std.fraction,),
+	value,
+)
+
+
+#let	ratio(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"%"				:   1%,
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:  (std.ratio,),
+	value,
+)
+
+
+#let	angle(
+	quiet				:   false,
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"deg"				:   1deg,
+		"rad"				:   1rad,
+	),
+	quiet				:   quiet,
+	default				:   default,
+	types				:  (std.angle,),
+	value,
+)
+
+

--- a/packages/preview/to-stuff/0.5.1/internals/utils.typ
+++ b/packages/preview/to-stuff/0.5.1/internals/utils.typ
@@ -1,0 +1,79 @@
+
+#let	list-predefined(type)		=   dictionary(std).pairs().filter(
+						x => std.type(x.last()) == type
+					).to-dict()
+
+#let	message-unexpected-keys(
+	found				: ( ),
+	valid				: ( ),
+	value,
+) = {
+	return "unexpected key/s “" + found.filter(x => x not in valid).join(
+		last				:  "”, and “",
+		"”, “",
+	) + "”; valid keys are “" + valid.join(
+		last				:  "”, and “",
+		"”, “",
+	) + "” in " + value
+}
+
+#let	type-unabbreviate(value)	= {
+	let	type-str			=   type(value)
+
+	if type-str == type {
+		type-str			=   repr(value)
+	} else {
+		type-str			=   repr(type-str)
+	}
+
+	(
+		bool				:  "boolean",
+		int				:  "integer",
+		str				:  "string",
+	).at(
+		default				:   type-str,
+		type-str,
+	)
+}
+
+#let	debug-value(value)		= {
+	if value in (none, auto, true, false) or type(value) in (array, dictionary) {
+		repr(value)
+	} else {
+		(
+			type-unabbreviate(value),
+			repr(value),
+		).join(" ")
+	}
+}
+
+#let	mild-panic(
+	quiet				:   false,
+	default				:   auto,
+	types				: ( ),
+	message,
+) = {
+	assert(
+		type(quiet) == std.bool,
+		message				:  "to-stuff: “quiet” argument expected boolean, found {value}"
+							.replace("{value}", debug-value(quiet)),
+	)
+
+	if quiet {
+		default				 =   none
+	}
+
+	if auto != default {
+		assert(
+			none == default or type(default) in types,
+			message				:  "to-stuff: “default” argument expected {types}, or none, found {value}"
+								.replace("{types}", types.map(type-unabbreviate).join(", "))
+								.replace("{value}", debug-value(default))
+		)
+
+		return default
+	}
+
+	panic(message)
+}
+

--- a/packages/preview/to-stuff/0.5.1/typst.toml
+++ b/packages/preview/to-stuff/0.5.1/typst.toml
@@ -1,0 +1,33 @@
+[package]
+name				= 'to-stuff'
+version				= '0.5.1'
+compiler			= '0.13.1'
+repository			= 'https://codeberg.org/boondoc/typst-to-stuff'
+license				= 'BSD-3-Clause'
+entrypoint			= 'exports.typ'
+description			= 'Safely parse string values into native data types: lengths, alignments, colors and more.'
+authors				= [
+	'Nik Mennega',
+]
+categories			= [
+	'scripting',
+	'utility',
+]
+keywords			= [
+	'string',
+	'parse',
+	'parsing',
+	'alignment',
+	'angle',
+	'color',
+	'direction',
+	'float',
+	'fraction',
+	'int',
+	'number',
+	'length',
+	'ratio',
+	'relative',
+	'stroke',
+]
+


### PR DESCRIPTION
I am submitting
- [x] an update for a package

Description:

- Invalid `default` and `quiet` values throw failed assertions instead of panicking.
- Reject empty dictionaries when converting:
	- alignment
	- relative
	- stroke
