### PR TITLE
Remove the unmaintained showman from “Tools that can be useful”

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -95,8 +95,12 @@ The community created some tools that can help when developing your package:
 - [tytanic], to test your packages.
 - [typship], to easily install your package locally or submit it to Typst Universe.
 
+A more comprehensive list can be found in [Package development — Best of Typst (TCDM)][tcdm-pkg]
+maintained by the community.
+
 [cetz]: https://typst.app/universe/package/cetz/0.3.4
 [typst-package-check]: https://github.com/typst/package-check
 [tytanic]: https://typst-community.github.io/tytanic/
 [typship]: https://github.com/sjfhsjfh/typship
+[tcdm-pkg]: https://ydx-2147483647.github.io/best-of-typst/#pkg
 [manifest]: manifest.md


### PR DESCRIPTION
showman ([GitHub](https://github.com/ntjess/showman), [Universe](https://typst.app/universe/package/showman)) has not been updated since 2024.

`pip install showman && touch a.typ && showman md a.typ` throws an error:
```log
FileNotFoundError: [Errno 2] No such file or directory: '…/Lib/site-packages/showman/runner.typ'
```

If I `git clone` and manually install it in a venv, `showman md a.typ` exits with warnings.

```log
warning: `json.decode` is deprecated, directly pass bytes to `json` instead
  ┌─ …\showman\arrsmc_dz\a.typ:2:47
  │
2 │ #formatter._content-printer("../a.typ", ..json.decode("{}"))
  │                                                ^^^^^^
  │
  = hint: it will be removed in Typst 0.15.0

warning: `json.decode` is deprecated, directly pass bytes to `json` instead
  ┌─ …\showman\arrsmc_dz\a.typ:2:47
  │
2 │ #formatter._content-printer("../a.typ", ..json.decode("{}"))
  │                                                ^^^^^^
  │
  = hint: it will be removed in Typst 0.15.0
```

If I fill `a.typ` with the first example in its README, then this error occurs:

```log
error: unknown variable: style
    ┌─ @preview/cetz:0.1.2\src\canvas.typ:224:47
    │
224 │             debug: false, body) = layout(ly => style(st => {
    │                                                ^^^^^
```

So unfortunately, showman is not really useful at present…

---

Besides, I recommend [🚀 Package development — Best of Typst (TCDM)](https://ydx-2147483647.github.io/best-of-typst/#pkg) (which was created by myself).
It is more comprehensive and projects that have not been updated for 8 months will be automatically hidden.
Additionally, all projects are ranked based on metrics collected from GitHub and different package managers.

However, I'm not sure if self-promotion is appropriate, so I didn't add TCDM in this PR.