### PR TITLE
gb7714-bilingual:0.2.1

### DIFF
--- a/packages/preview/gb7714-bilingual/0.2.1/CHANGELOG.md
+++ b/packages/preview/gb7714-bilingual/0.2.1/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - 2026-01-24
+
+### Added
+
+- `usera` field support as biblatex-recommended alias for `mark`
+- `entrysubtype` and `note` field detection for type disambiguation (biblatex-gb7714 compatibility)
+  - `@book` + `entrysubtype/note = "standard"` → `[S]`
+  - `@article` + `entrysubtype/note = "news"/"newspaper"` → `[N]`
+- `medium` field support for custom carrier types (e.g., `medium = {MT}` → `[DB/MT]`)
+- `bookauthor` field support for analytic entries (source document authors)
+- `editor` field fallback for source authors when `bookauthor` is missing
+
+### Fixed
+
+- `@inbook` type identifier position: now correctly placed after analytic title
+  - Before: `章节标题//主书名[M]`
+  - After: `章节标题[M]//主书名`
+- Name suffix formatting: removed comma before suffix (per GB/T 7714-2025 examples)
+  - Before: `King M L, Jr.`
+  - After: `King M L Jr.`
+- Year suffix disambiguation now uses citation order instead of title alphabetical order (per GB/T 7714-2025 9.3.1.3)（[#6](https://github.com/pku-typst/gb7714-bilingual/pull/6)）
+  - Before: suffixes assigned by title sort (could produce a, c, b)
+  - After: suffixes assigned by citation order (always a, b, c in order of appearance)
+- Invisible hidden bibliography title no longer triggers unexpected page break with `pagebreak(weak: true)` ([#4](https://github.com/pku-typst/gb7714-bilingual/pull/4) by [@Coekjan](https://github.com/Coekjan))
+- Numeric style no longer incorrectly displays year suffixes (a, b, c) in bibliography （[#7](https://github.com/pku-typst/gb7714-bilingual/pull/7)）
+
+## [0.2.0] - 2026-01-21
+
+### Added
+
+- `mark` field support for manual type declaration (S, N, G, etc.)
+- Analytic entries (`@inbook`, `@incollection`) now include `//` separator
+- `@collection` type support for compilations (`[G]`)
+- `@periodical` type support for serials
+- Automatic `@standard` detection via `number` field prefix (GB, ISO, IEEE, etc.)
+
+### Changed
+
+- **Breaking**: `init-gb7714` now accepts file content (bytes) instead of file path
+  - Old: `init-gb7714.with("ref.bib", ...)`
+  - New: `init-gb7714.with(read("ref.bib"), ...)`
+  - Reason: Published packages cannot access user project files
+- Hidden `bibliography()` is now automatically included; no manual `#hide(bibliography(...))` needed
+
+## [0.1.0] - 2026-01-12
+
+### Added
+
+- Initial release
+- Support for GB/T 7714—2015 and GB/T 7714—2025
+- Numeric (顺序编码制) and author-date (著者-出版年制) citation styles
+- Automatic Chinese/English language detection
+- Author formatting with proper handling of prefixes, suffixes, and hyphenated names
+- Same-author-same-year disambiguation (a, b, c suffixes)
+- Multi-citation merging with `multicite` function
+  - Dictionary arguments with `supplement` for page numbers
+- Citation form control (`form` parameter): `prose`, `author`, `year`
+- Citation supplement (`supplement` parameter) for page numbers
+- Click-to-jump from citations to bibliography
+- Complete entry type support (article, book, thesis, conference, report, patent, standard, webpage, etc.)
+- Multiple BibTeX file support

--- a/packages/preview/gb7714-bilingual/0.2.1/LICENSE
+++ b/packages/preview/gb7714-bilingual/0.2.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gabriel Wu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/gb7714-bilingual/0.2.1/README.md
+++ b/packages/preview/gb7714-bilingual/0.2.1/README.md
@@ -1,0 +1,414 @@
+# gb7714-bilingual
+
+GB/T 7714 双语参考文献系统，支持中英文术语自动切换。
+
+> 同时支持 **GB/T 7714—2015** 和 **GB/T 7714—2025**（2026-07-01 实施）两个版本
+
+## 特性
+
+- ✅ **双版本支持**：可选择 2015 或 2025 版本标准
+- ✅ 自动检测文献语言（通过 `language` 字段、正则匹配汉字）
+- ✅ 中英文术语自动切换（第X卷/v.X、期/no.、等/et al.）
+- ✅ 支持顺序编码制（numeric）和著者-出版年制（author-date）
+- ✅ 正确处理作者格式化（中文连写、英文姓大写+名首字母）
+- ✅ 支持同作者同年文献消歧（a, b, c 后缀）
+- ✅ 支持多引用合并（`multicite` 函数，支持带页码）
+- ✅ 支持引用形式切换（上标/非上标/仅作者/仅年份）
+- ✅ 支持带页码引用（supplement 参数）
+- ✅ 支持点击引用跳转到参考文献列表
+- ✅ 完整的文献类型标识（支持 `mark` 字段手动声明）
+- ✅ 支持析出文献（`//` 符号）
+- ✅ 支持多个 BibTeX 文件
+
+## 安装
+
+```typst
+#import "@preview/gb7714-bilingual:0.2.1": init-gb7714, gb7714-bibliography, multicite
+```
+
+## 使用方法
+
+### 基本用法
+
+```typst
+#import "@preview/gb7714-bilingual:0.2.1": init-gb7714, gb7714-bibliography, multicite
+
+// 使用 2025 版本（默认）
+#show: init-gb7714.with(read("ref.bib"), style: "numeric", version: "2025")
+
+正文中使用 @wang2010guide 引用文献。
+
+#gb7714-bibliography()
+```
+
+> **注意**：需要使用 `read()` 读取 bib 文件内容传入。
+
+### 选择标准版本
+
+```typst
+// 使用 GB/T 7714—2015
+#show: init-gb7714.with(read("ref.bib"), style: "numeric", version: "2015")
+```
+
+### 著者-出版年制
+
+```typst
+#show: init-gb7714.with(read("ref.bib"), style: "author-date", version: "2025")
+
+这是一个引用 @smith2020。
+
+#gb7714-bibliography()
+```
+
+### 多个 BibTeX 文件
+
+```typst
+// 使用多个 bib 文件（用 + 合并内容）
+#show: init-gb7714.with(read("main.bib") + read("extra.bib"), style: "numeric")
+```
+
+### 引用形式切换
+
+```typst
+// 默认上标形式（numeric 模式自动上标，无需 #super）
+孔乙己提到@smith2020 的重要发现
+
+// 非上标形式（散文引用）
+另见#cite(<smith2020>, form: "prose")的详细分析
+
+// 仅作者
+研究由#cite(<smith2020>, form: "author")完成
+
+// 仅年份
+该研究发表于#cite(<smith2020>, form: "year")年
+```
+
+### 带页码引用
+
+```typst
+// 简写形式
+关于方法论的讨论见@liu2015[第 3 章]
+具体实验步骤见@liu2015[126--129]
+
+// 函数形式（可结合 form）
+详见#cite(<kopka2004>, form: "prose", supplement: [第 5.2 节])
+```
+
+### 多引用合并
+
+```typst
+// 基本用法：同一作者的多篇文献会自动合并年份
+#multicite("smith2020a", "smith2020b", "jones2019")
+// Numeric: [1-3]（上标）
+// Author-date: （Smith，2020a，2020b；Jones，2019）
+
+// 带页码的合并引用
+#multicite(
+  (key: "smith2020a", supplement: [260]),
+  "smith2020b",
+  (key: "jones2019", supplement: [Table 2]),
+)
+// Numeric: [1：260, 2, 3：Table 2]
+// Author-date: （Smith，2020a：260，2020b；Jones，2019：Table 2）
+
+// 非上标形式
+#multicite("smith2020a", "smith2020b", form: "prose")
+// Numeric: [1-2]（非上标）
+```
+
+### 自定义渲染（高级）
+
+```typst
+// 使用 full-control 完全控制输出格式
+#gb7714-bibliography(full-control: entries => {
+  for e in entries [
+    // 自定义编号格式
+    (#e.order)#h(1em)
+    // 使用带 label 的渲染结果（支持点击跳转）
+    #e.labeled-rendered
+    #parbreak()
+  ]
+})
+
+// 或者完全自定义，访问原始字段
+#gb7714-bibliography(full-control: entries => {
+  for e in entries {
+    let f = e.fields
+    [
+      [#e.order]
+      #f.at("author", default: "").
+      #emph(f.at("title", default: "")).
+      #f.at("journal", default: ""),
+      #f.at("year", default: "").
+    ]
+    parbreak()
+  }
+})
+```
+
+## 2015 与 2025 版本差异
+
+| 差异点                    | GB/T 7714—2015    | GB/T 7714—2025    |
+| ------------------------- | ----------------- | ----------------- |
+| 预印本类型标识            | `[A]`（档案）     | `[PP]`（预印本）  |
+| 著者-出版年制正文引用括号 | 英文 `()`         | 统一中文 `（）`   |
+| 正文引用分隔符            | 英文 `; ` 和 `, ` | 中文 `；` 和 `，` |
+
+## BibTeX 文件格式
+
+为获得最佳效果，建议在 BibTeX 条目中添加 `language` 字段：
+
+```bibtex
+@article{wang2010guide,
+  title   = {科技论文中文摘要写作要点分析},
+  author  = {王晓华 and 闫其涛 and 程智强 and 张睿},
+  journal = {编辑学报},
+  year    = {2010},
+  language = {chinese}
+}
+
+@book{kopka2004guide,
+  title     = {Guide to LATEX},
+  author    = {Kopka, Helmut and Daly, Patrick W},
+  publisher = {Addison-Wesley},
+  year      = {2004},
+  language = {english}
+}
+```
+
+如果没有 `language` 字段，系统会通过检测标题/作者中的汉字自动判断语言。
+
+## API 参考
+
+### `init-gb7714(bib-content, style: "numeric", version: "2025", doc)`
+
+初始化 GB/T 7714 双语参考文献系统。
+
+- `bib-content`: BibTeX 文件内容（使用 `read()` 读取）
+  - 单文件：`read("ref.bib")`
+  - 多文件：`read("main.bib") + read("extra.bib")`
+- `show-url`: 是否显示 URL（默认 `true`）
+- `show-doi`: 是否显示 DOI（默认 `true`）
+- `show-accessed`: 是否显示访问日期（默认 `true`）
+- `style`: 引用风格
+  - `"numeric"`: 顺序编码制，如 [1]
+  - `"author-date"`: 著者-出版年制，如（王，2020）
+- `version`: 标准版本
+  - `"2015"`: GB/T 7714—2015
+  - `"2025"`: GB/T 7714—2025（默认）
+
+### `gb7714-bibliography(title: auto, full-control: none)`
+
+渲染参考文献列表。
+
+- `title`: 参考文献标题
+  - `auto`（默认）：根据文献语言自动选择（"参考文献" 或 "References"），一级标题
+  - `none`：不显示标题
+  - 自定义内容：如 `heading(level: 2)[References]`
+- `full-control`: 完全控制渲染的回调函数（高级用法）
+  - 签名：`(entries) => content`
+  - 使用此参数时，用户完全控制输出格式
+
+### `get-cited-entries()`
+
+获取被引用的条目列表（低层 API，需在 `context` 中使用）。
+
+返回数组，每个元素包含：
+
+- `key`: 引用键
+- `order`: 引用顺序
+- `year-suffix`: 消歧后缀（如 "a", "b"）
+- `lang`: 语言（"zh" 或 "en"）
+- `entry-type`: 条目类型
+- `fields`: 原始字段字典
+- `parsed-names`: 解析后的作者名
+- `rendered`: 纯渲染结果（不含 label）
+- `ref-label`: 用于跳转的 label 对象（需手动附加到内容中）
+- `labeled-rendered`: 已附加 label 的渲染结果（推荐使用，或用 `rendered` + `ref-label` 自行组合）
+
+### `multicite(..keys, form: none)`
+
+多引用合并函数。
+
+- `keys`: 引用键列表，支持两种形式：
+  - 字符串：`"smith2020"`
+  - 字典：`(key: "smith2020", supplement: [260])`
+    - `key`: 引用键（必需）
+    - `supplement`: 页码等附加信息（可选）
+- `form`: 引用形式（命名参数）
+  - `none` / `"normal"`: 默认（顺序编码制上标，著者-出版年制整体括号）
+  - `"prose"`: 散文形式（顺序编码制非上标，著者-出版年制仅年份括号）
+
+## 支持的条目类型
+
+| BibTeX 类型                | 2015 标识 | 2025 标识 | 说明            |
+| -------------------------- | --------- | --------- | --------------- |
+| article                    | [J]       | [J]       | 期刊文章        |
+| preprint                   | [A]       | [PP]      | 预印本          |
+| newspaper                  | [N]       | [N]       | 报纸文章        |
+| book, inbook, incollection | [M]       | [M]       | 图书            |
+| inproceedings, conference  | [C]       | [C]       | 会议论文        |
+| phdthesis, mastersthesis   | [D]       | [D]       | 学位论文        |
+| techreport, report         | [R]       | [R]       | 报告            |
+| standard                   | [S]       | [S]       | 标准            |
+| patent                     | [P]       | [P]       | 专利            |
+| dataset                    | [DS]      | [DS]      | 数据集          |
+| map                        | [CM]      | [CM]      | 地图            |
+| software                   | [CP]      | [CP]      | 软件/计算机程序 |
+| online, webpage            | [EB/OL]   | [EB/OL]   | 网页/电子公告   |
+| archive                    | [A]       | [A]       | 档案            |
+| misc                       | [Z]       | [Z]       | 其他            |
+
+带 URL 或 DOI 的条目会自动添加 `/OL` 载体标识，如 `[J/OL]`。
+
+### 特殊类型处理
+
+由于底层库 citegeist 不支持 `@standard` 和 `@newspaper` 等非标准 BibTeX 类型，本库提供多种解决方案：
+
+**方法 1：使用 `mark`/`usera` 字段手动声明类型标识**
+
+```bibtex
+% 报纸文章
+@misc{news2024,
+  mark     = {N},
+  title    = {重要新闻标题},
+  author   = {记者},
+  journal  = {人民日报},
+  date     = {2024-01-15},
+  pages    = {1},
+  year     = {2024}
+}
+
+% 标准文献
+@misc{gb7714,
+  mark     = {S},
+  number   = {GB/T 7714—2015},
+  title    = {信息与文献参考文献著录规则},
+  publisher = {中国标准出版社},
+  year     = {2015}
+}
+
+% 自定义载体（数据库/磁带）
+@misc{dbmt,
+  author   = {Rossmann, K and Rittel, H F},
+  title    = {Database created from magnetic resonance images},
+  year     = {1976},
+  usera    = {DB},
+  medium   = {MT}
+}
+% 输出：Rossmann K，Rittel H F. Database...[DB/MT]. 1976.
+```
+
+**方法 2：使用 `entrysubtype`/`note` 字段（biblatex-gb7714 兼容）**
+
+```bibtex
+% 标准（兼容 Zotero 导入）
+@book{gb7714,
+  title        = {信息与文献参考文献著录规则},
+  number       = {GB/T 7714—2015},
+  publisher    = {中国标准出版社},
+  year         = {2015},
+  entrysubtype = {standard}
+}
+
+% 报纸
+@article{news2024,
+  title    = {重要新闻标题},
+  author   = {记者},
+  journal  = {人民日报},
+  year     = {2024},
+  note     = {newspaper}
+}
+```
+
+**方法 3：标准文献自动检测**
+
+如果 `number` 字段以标准前缀开头（GB, ISO, IEC, IEEE, ANSI, DIN, JIS, BS），会自动识别为标准文献 `[S]`：
+
+```bibtex
+@standard{iso9001,
+  number   = {ISO 9001:2015},
+  title    = {Quality management systems},
+  year     = {2015}
+}
+```
+
+**类型检测优先级**：`mark/usera` > `entrysubtype/note` > `number 前缀` > 原始类型
+
+**支持的 mark 值**：
+
+| mark | 类型标识 | 说明     |
+| ---- | -------- | -------- |
+| S    | [S]      | 标准     |
+| N    | [N]      | 报纸     |
+| J    | [J]      | 期刊     |
+| M    | [M]      | 图书     |
+| C    | [C]      | 会议     |
+| D    | [D]      | 学位论文 |
+| R    | [R]      | 报告     |
+| P    | [P]      | 专利     |
+| G    | [G]      | 汇编     |
+| EB   | [EB/OL]  | 网页     |
+| DB   | [DB]     | 数据库   |
+| CP   | [CP]     | 软件     |
+| CM   | [CM]     | 地图     |
+| DS   | [DS]     | 数据集   |
+
+**自定义载体标识**：使用 `medium` 字段指定载体，如 `medium = {MT}` 生成 `[类型/MT]`。
+
+### 析出文献（书中章节）
+
+使用 `@inbook` 或 `@incollection` 时，会自动添加 `//` 析出符号，类型标识位于析出标题后：
+
+```bibtex
+@inbook{chapter2019,
+  title     = {深度学习基础},
+  author    = {张华},
+  booktitle = {人工智能导论},
+  publisher = {机械工业出版社},
+  address   = {北京},
+  year      = {2019},
+  pages     = {45--78}
+}
+```
+
+输出：`张华. 深度学习基础[M]//人工智能导论. 北京：机械工业出版社，2019：45–78.`
+
+**析出文献来源责任者**：支持 `bookauthor` 和 `editor` 字段表示来源文献的责任者：
+
+```bibtex
+@inbook{weinstein1974,
+  author     = {Weinstein, L and Swartz, M N},
+  title      = {Pathogenic properties of invading microorganisms},
+  booktitle  = {Pathologic physiology: mechanisms of disease},
+  bookauthor = {Sodeman, Jr., W A and Sodeman, W A},
+  edition    = {5},
+  publisher  = {Saunders},
+  address    = {Philadelphia},
+  year       = {1974},
+  pages      = {457--472}
+}
+```
+
+输出：`Weinstein L，Swartz M N. Pathogenic properties...[M]// Sodeman W A Jr，Sodeman W A. Pathologic physiology...`
+
+## 项目结构
+
+```bash
+src/
+├── core/           # 核心模块（状态、工具、语言检测）
+├── versions/       # 版本配置（2015、2025）
+├── renderers/      # 渲染器（期刊、书籍、会议等）
+├── authors.typ     # 作者格式化
+├── types.typ       # 文献类型标识
+└── api.typ         # 公共 API
+lib.typ             # 主入口
+```
+
+## 更新日志
+
+详见 [CHANGELOG.md](CHANGELOG.md)
+
+## 许可证
+
+MIT

--- a/packages/preview/gb7714-bilingual/0.2.1/lib.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/lib.typ
@@ -1,0 +1,51 @@
+// gb7714-bilingual - GB/T 7714 双语参考文献系统
+// 支持 GB/T 7714—2015 和 GB/T 7714—2025 两个版本
+// 基于 citegeist 自定义实现，支持中英文术语自动切换
+//
+// 使用方法：
+//   #import "@preview/gb7714-bilingual:0.2.1": init-gb7714, gb7714-bibliography, multicite
+//   #show: init-gb7714.with(read("ref.bib"), style: "numeric", version: "2025")
+//   正文中使用 @key 引用...
+//   #gb7714-bibliography()
+//
+// 多文件支持：
+//   #show: init-gb7714.with(read("main.bib") + read("extra.bib"), style: "numeric")
+//
+// 版本选择：
+//   - version: "2015" - 符合 GB/T 7714—2015
+//   - version: "2025" - 符合 GB/T 7714—2025（2026-07-01实施，默认）
+
+// 导入内部实现
+#import "src/api.typ": (
+  gb7714-bibliography, get-cited-entries, init-gb7714-impl, multicite,
+)
+
+/// 初始化 GB/T 7714 双语参考文献系统
+///
+/// - bib-content: BibTeX 文件内容（使用 `read("ref.bib")` 读取）
+///                多文件可用 `read("a.bib") + read("b.bib")` 合并
+/// - style: 引用风格，"numeric"（顺序编码制）或 "author-date"（著者-出版年制）
+/// - version: 标准版本，"2015" 或 "2025"（默认）
+/// - show-url: 是否显示 URL（默认 true）
+/// - show-doi: 是否显示 DOI（默认 true）
+/// - show-accessed: 是否显示访问日期（默认 true）
+#let init-gb7714(
+  bib-content,
+  style: "numeric",
+  version: "2025",
+  show-url: true,
+  show-doi: true,
+  show-accessed: true,
+  doc,
+) = {
+  // 调用内部实现
+  init-gb7714-impl(
+    bib-content,
+    style: style,
+    version: version,
+    show-url: show-url,
+    show-doi: show-doi,
+    show-accessed: show-accessed,
+    doc,
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/api.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/api.typ
@@ -1,0 +1,548 @@
+// GB/T 7714 双语参考文献系统 - 公共 API
+
+#import "@preview/citegeist:0.2.1": load-bibliography
+
+#import "core/state.typ": (
+  _bib-data, _cite-marker, _collect-citations, _compute-year-suffixes, _config,
+  _style, _version,
+)
+#import "core/language.typ": detect-language
+#import "core/utils.typ": format-citation-numbers
+#import "versions/mod.typ": get-citation-config, get-version-config
+#import "authors.typ": format-author-intext
+#import "renderers/mod.typ": render-entry
+
+/// 初始化 GB/T 7714 双语参考文献系统（内部实现）
+///
+/// - bib-content: BibTeX 文件内容
+/// - hidden-bib: 隐藏的 bibliography 元素（用于让 @key 语法工作）
+/// - style: 引用风格，"numeric"（顺序编码制）或 "author-date"（著者-出版年制）
+/// - version: 标准版本，"2015" 或 "2025"（默认）
+/// - show-url: 是否显示 URL（默认 true）
+/// - show-doi: 是否显示 DOI（默认 true）
+/// - show-accessed: 是否显示访问日期（默认 true）
+#let init-gb7714-impl(
+  bib-content,
+  style: "numeric",
+  version: "2025",
+  show-url: true,
+  show-doi: true,
+  show-accessed: true,
+  doc,
+) = {
+  // 加载 bib 数据
+  let bib-data = load-bibliography(bib-content)
+  // 创建隐藏的 bibliography（让 @key 语法工作）
+  hide(bibliography(bytes(bib-content), title: none))
+
+  // 设置状态
+  _bib-data.update(bib-data)
+  _style.update(style)
+  _version.update(version)
+  _config.update((
+    show-url: show-url,
+    show-doi: show-doi,
+    show-accessed: show-accessed,
+  ))
+
+  // 拦截 cite 元素
+  show cite: it => {
+    let key = str(it.key)
+
+    // 放置 metadata 标记（用于后续 query 收集）
+    _cite-marker(key)
+
+    // 渲染引用
+    context {
+      let current-style = _style.get()
+      let current-version = _version.get()
+      let bib = _bib-data.get()
+      let citations = _collect-citations()
+      let cite-config = get-citation-config(current-version)
+
+      // 获取 form 参数（nil, "normal", "prose", "full", "author", "year"）
+      let form = it.form
+
+      if current-style == "numeric" {
+        // 顺序编码制
+        let order = citations.at(key, default: citations.len() + 1)
+
+        // 处理 supplement（页码等）
+        let supplement-content = if it.supplement != none {
+          [, #it.supplement]
+        } else {
+          []
+        }
+
+        // 根据 form 决定输出形式
+        if form == "author" or form == "year" {
+          // numeric 模式下 author/year 需要从 entry 获取
+          let entry = bib.at(key, default: none)
+          if entry != none {
+            let lang = detect-language(entry)
+            if form == "author" {
+              let author-text = format-author-intext(
+                entry.parsed_names,
+                lang,
+                version: current-version,
+              )
+              link(label("gb7714-ref-" + key), author-text)
+            } else {
+              // form == "year"
+              let year = entry.fields.at("year", default: "n.d.")
+              link(label("gb7714-ref-" + key), str(year))
+            }
+          } else {
+            text(fill: red, "[??" + key + "??]")
+          }
+        } else if form == "prose" or form == "full" {
+          // 非上标形式（散文引用）
+          link(label("gb7714-ref-" + key), [[#order#supplement-content]])
+        } else {
+          // 默认/normal: 上标形式
+          link(label("gb7714-ref-" + key), super[[#order#supplement-content]])
+        }
+      } else {
+        // 著者-出版年制: （Author，Year）或（Author 等，Year）
+        let entry = bib.at(key, default: none)
+        if entry != none {
+          // 检测语言
+          let lang = detect-language(entry)
+          let author-text = format-author-intext(
+            entry.parsed_names,
+            lang,
+            version: current-version,
+          )
+          let year = entry.fields.at("year", default: "n.d.")
+
+          // 计算年份后缀（消歧）
+          let suffixes = _compute-year-suffixes(bib, citations)
+          let suffix = suffixes.at(key, default: "")
+          let year-with-suffix = str(year) + suffix
+
+          // 处理 supplement（页码等）
+          let supplement-content = if it.supplement != none {
+            [#cite-config.author-year-sep#it.supplement]
+          } else {
+            []
+          }
+
+          // 括号和分隔符
+          let lparen = cite-config.lparen
+          let rparen = cite-config.rparen
+          let sep = cite-config.author-year-sep
+
+          // 根据 form 决定输出形式
+          if form == "author" {
+            // 仅作者
+            link(label("gb7714-ref-" + key), author-text)
+          } else if form == "year" {
+            // 仅年份（带括号）
+            link(label("gb7714-ref-" + key), [#lparen#year-with-suffix#rparen])
+          } else if form == "prose" {
+            // 散文形式: Author (Year) 或 Author（Year）
+            link(
+              label("gb7714-ref-" + key),
+              [#author-text #lparen#year-with-suffix#supplement-content#rparen],
+            )
+          } else {
+            // 默认/normal/full: (Author, Year)
+            link(
+              label("gb7714-ref-" + key),
+              [#lparen#author-text#sep#year-with-suffix#supplement-content#rparen],
+            )
+          }
+        } else {
+          text(fill: red, "[??" + key + "??]")
+        }
+      }
+    }
+  }
+
+  doc
+}
+
+// ============================================================================
+// 低层 API：获取原始数据，用于完全自定义渲染
+// ============================================================================
+
+/// 获取被引用的条目列表（低层 API）
+///
+/// 返回一个数组，每个元素包含：
+/// - `key`: 引用键
+/// - `order`: 引用顺序（用于 numeric 模式编号）
+/// - `year-suffix`: 年份消歧后缀（如 "a", "b"）
+/// - `lang`: 检测到的语言（"zh" 或 "en"）
+/// - `entry-type`: 条目类型（"article", "book" 等）
+/// - `fields`: 原始字段字典（title, author, journal, year, ...）
+/// - `parsed-names`: 解析后的作者/编者名字
+/// - `rendered`: 使用默认渲染器生成的文本
+/// - `ref-label`: 用于链接跳转的 label 对象
+/// - `labeled-rendered`: 已附加 label 的渲染结果（推荐使用）
+///
+/// 使用方法：
+/// ```typst
+/// context {
+///   let entries = get-cited-entries()
+///   for e in entries {
+///     // 方式1：使用已附加 label 的渲染结果
+///     e.labeled-rendered
+///     // 方式2：自定义内容 + label
+///     [自定义内容 #e.ref-label]
+///   }
+/// }
+/// ```
+/// config 参数可选，默认显示所有
+#let get-cited-entries(
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let bib = _bib-data.get()
+  let citations = _collect-citations()
+  let current-style = _style.get()
+  let current-version = _version.get()
+  let suffixes = _compute-year-suffixes(bib, citations)
+
+  let entries = citations
+    .pairs()
+    .map(((key, order)) => {
+      let entry = bib.at(key, default: none)
+      if entry == none { return none }
+
+      let lang = detect-language(entry)
+      // 顺序编码制不需要年份后缀消歧（用编号区分）
+      let year-suffix = if current-style == "numeric" {
+        ""
+      } else {
+        suffixes.at(key, default: "")
+      }
+      let rendered = render-entry(
+        entry,
+        lang,
+        year-suffix: year-suffix,
+        style: current-style,
+        version: current-version,
+        config: config,
+      )
+
+      let ref-label = label("gb7714-ref-" + key)
+      (
+        key: key,
+        order: order,
+        year-suffix: year-suffix,
+        lang: lang,
+        entry-type: entry.at("entry_type", default: "misc"),
+        fields: entry.at("fields", default: (:)),
+        parsed-names: entry.at("parsed_names", default: (:)),
+        rendered: rendered,
+        // 便捷字段：用于链接跳转
+        ref-label: ref-label, // label 对象，用法：[内容 #e.ref-label]
+        labeled-rendered: [#rendered #ref-label], // 已附加 label 的渲染结果
+      )
+    })
+    .filter(x => x != none)
+
+  // 排序
+  if current-style == "numeric" {
+    entries.sorted(key: it => it.order)
+  } else {
+    // CSL: demote-non-dropping-particle="never"
+    // prefix 参与排序："van Beethoven" 排在 V，"de Gaulle" 排在 D
+    // 使用小写进行排序（大小写不敏感）
+    entries.sorted(key: it => {
+      let names = it.parsed-names.at("author", default: ())
+      if names.len() > 0 {
+        let first = names.first()
+        let prefix = first.at("prefix", default: "")
+        let family = first.at("family", default: "")
+        let sort-key = if prefix != "" { prefix + " " + family } else { family }
+        lower(sort-key)
+      } else { "" }
+    })
+  }
+}
+
+// ============================================================================
+// 高层 API：开箱即用，符合 GB/T 7714 标准
+// ============================================================================
+
+/// 渲染参考文献列表（高层 API）
+///
+/// - title: 参考文献标题
+///   - `auto`（默认）：根据文献语言自动选择（"参考文献" 或 "References"），一级标题
+///   - `none`：不显示标题
+///   - 自定义内容：直接显示（可传入 `heading(level: 2)[...]` 控制级别）
+/// - full-control: 完全控制渲染的回调函数（可选）
+///   - 签名：`(entries) => content`
+///   - entries: 由 `get-cited-entries()` 返回的数组
+///   - 使用此参数时，库只负责提供数据，用户完全控制输出
+///
+/// 使用方法：
+/// ```typst
+/// // 标准用法
+/// #gb7714-bibliography()
+///
+/// // 自定义标题级别
+/// #gb7714-bibliography(title: heading(level: 2)[参考文献])
+///
+/// // 完全自定义渲染
+/// #gb7714-bibliography(full-control: entries => {
+///   for e in entries [
+///     [#e.order]#h(0.5em)#e.rendered
+///     #parbreak()
+///   ]
+/// })
+/// ```
+#let gb7714-bibliography(
+  title: auto,
+  full-control: none,
+) = {
+  context {
+    let bib = _bib-data.get()
+
+    // 处理 auto 标题
+    let actual-title = title
+    if title == auto {
+      let has-chinese = bib
+        .values()
+        .any(entry => {
+          let f = entry.at("fields", default: (:))
+          let lang = lower(f.at("language", default: ""))
+          lang.contains("zh") or lang.contains("chinese")
+        })
+      actual-title = heading(numbering: none, if has-chinese {
+        "参考文献"
+      } else { "References" })
+    }
+
+    // 显示标题
+    if actual-title != none {
+      actual-title
+    }
+
+    let current-config = _config.get()
+    let entries = get-cited-entries(config: current-config)
+    let current-style = _style.get()
+
+    // 如果用户提供了 full-control，完全交给用户
+    if full-control != none {
+      full-control(entries)
+    } else if current-style == "numeric" {
+      // 顺序编码制：悬挂缩进
+      set par(hanging-indent: 2em, first-line-indent: 0em)
+      for e in entries {
+        [[#e.order]#h(0.5em)#e.labeled-rendered]
+        parbreak()
+      }
+    } else {
+      // 著者-出版年制：悬挂缩进
+      set par(hanging-indent: 2em, first-line-indent: 0em)
+      for e in entries {
+        e.labeled-rendered
+        parbreak()
+      }
+    }
+  }
+}
+
+/// 多引用合并：按作者分组，同作者年份用逗号，不同作者用分号
+///
+/// 用法：
+/// ```typst
+/// // 简单形式（字符串）
+/// #multicite("smith2020a", "smith2020b", "jones2019")
+///
+/// // 混合形式（字符串 + 字典）
+/// #multicite(
+///   (key: "smith2020a", supplement: [260]),
+///   "smith2020b",
+///   (key: "jones2019", supplement: [Ch. 3]),
+/// )
+///
+/// // 非上标形式
+/// #multicite("smith2020a", "smith2020b", form: "prose")
+/// ```
+///
+/// 参数：
+/// - keys: 引用键列表，每个元素可以是：
+///   - 字符串：引用键
+///   - 字典：(key: 引用键, supplement: 页码)
+/// - form: 引用形式（可选）
+///   - none/"normal": 默认（numeric 上标，author-date 带括号）
+///   - "prose": 非上标形式
+///
+/// 输出：
+/// - numeric 模式：[1, 260; 2-3]（带 supplement 的单独显示，其他压缩）
+/// - author-date 模式：（Smith，2020a, 260，2020b；Jones，2019, Ch. 3）
+#let multicite(..args) = {
+  let raw-list = args.pos()
+  let form = args.named().at("form", default: none)
+
+  // 边界情况：空引用列表
+  if raw-list.len() == 0 {
+    return []
+  }
+
+  // 规范化参数：将字符串转为字典形式
+  let normalized = raw-list.map(item => {
+    if type(item) == str {
+      (key: item, supplement: none)
+    } else {
+      (
+        key: item.at("key"),
+        supplement: item.at("supplement", default: none),
+      )
+    }
+  })
+
+  // 放置所有 metadata 标记（用于收集引用顺序）
+  for item in normalized {
+    _cite-marker(item.key)
+  }
+
+  context {
+    let bib = _bib-data.get()
+    let citations = _collect-citations()
+    let suffixes = _compute-year-suffixes(bib, citations)
+    let current-style = _style.get()
+    let current-version = _version.get()
+    let cite-config = get-citation-config(current-version)
+
+    if current-style == "numeric" {
+      // 顺序编码制：保持原始顺序，连续的无 supplement 引用压缩
+      // 格式：[1：250, 2-4]（整体在一个方括号内，用逗号分隔）
+      let parts = ()
+      let pending-orders = () // 待压缩的编号
+
+      for item in normalized {
+        let order = citations.at(item.key, default: 0)
+        if item.supplement != none {
+          // 有 supplement：先输出之前积累的无 supplement 编号，再输出当前
+          if pending-orders.len() > 0 {
+            let formatted = format-citation-numbers(pending-orders)
+            parts.push(formatted)
+            pending-orders = ()
+          }
+          // 编号：页码
+          parts.push([#order#cite-config.locator-sep#item.supplement])
+        } else {
+          // 无 supplement：累积待压缩
+          pending-orders.push(order)
+        }
+      }
+
+      // 处理剩余的无 supplement 编号
+      if pending-orders.len() > 0 {
+        let formatted = format-citation-numbers(pending-orders)
+        parts.push(formatted)
+      }
+
+      let first-key = normalized.first().key
+      let result = parts.join(", ")
+      let linked = link(label("gb7714-ref-" + first-key), [[#result]])
+
+      // 根据 form 决定是否上标
+      if form == "prose" or form == "full" {
+        linked
+      } else {
+        super(linked)
+      }
+    } else {
+      // 著者-出版年制：按作者分组
+      // 收集引用信息
+      let cite-info = normalized
+        .map(item => {
+          let entry = bib.at(item.key, default: none)
+          if entry == none {
+            return none
+          }
+          let names = entry.parsed_names.at("author", default: ())
+          let first-author = if names.len() > 0 {
+            names.first().at("family", default: "")
+          } else {
+            "?"
+          }
+          let lang = detect-language(entry)
+          let year = str(entry.fields.at("year", default: "n.d."))
+          let suffix = suffixes.at(item.key, default: "")
+          (
+            key: item.key,
+            author: first-author,
+            author-count: names.len(),
+            year: year + suffix,
+            lang: lang,
+            supplement: item.supplement,
+          )
+        })
+        .filter(x => x != none)
+
+      // 按作者分组
+      let groups = (:)
+      for info in cite-info {
+        if info.author not in groups {
+          groups.insert(
+            info.author,
+            (
+              author: info.author,
+              author-count: info.author-count,
+              lang: info.lang,
+              years: (),
+              first-key: info.key,
+            ),
+          )
+        }
+        // 年份带 supplement
+        let year-entry = if info.supplement != none {
+          (year: info.year, supplement: info.supplement)
+        } else {
+          (year: info.year, supplement: none)
+        }
+        groups.at(info.author).years.push(year-entry)
+      }
+
+      // 括号
+      let lparen = cite-config.lparen
+      let rparen = cite-config.rparen
+
+      // 渲染每个作者组
+      let parts = ()
+      for (author, group) in groups.pairs() {
+        // 格式化作者名
+        let author-text = if group.author-count >= 2 {
+          author + " " + (if group.lang == "zh" { "等" } else { "et al." })
+        } else {
+          author
+        }
+        // 连接年份（带 supplement）
+        let years-parts = group.years.map(ye => {
+          if ye.supplement != none {
+            [#ye.year#cite-config.locator-sep#ye.supplement]
+          } else {
+            ye.year
+          }
+        })
+        let years-content = years-parts.join(cite-config.author-year-sep)
+
+        // 根据 form 决定格式
+        if form == "prose" {
+          // prose: Author (2020a, 2020b)
+          parts.push([#author-text #lparen#years-content#rparen])
+        } else {
+          // normal: Author, 2020a, 2020b（整体加括号）
+          parts.push([#author-text#cite-config.author-year-sep#years-content])
+        }
+      }
+
+      // 用分号连接不同作者
+      let result = parts.join(cite-config.multi-sep)
+      let first-key = normalized.first().key
+
+      if form == "prose" {
+        // prose: 各组已经带括号，直接连接
+        link(label("gb7714-ref-" + first-key), result)
+      } else {
+        // normal: 整体加括号
+        link(label("gb7714-ref-" + first-key), [#lparen#result#rparen])
+      }
+    }
+  }
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/authors.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/authors.typ
@@ -1,0 +1,143 @@
+// GB/T 7714 双语参考文献系统 - 作者格式化模块
+
+#import "versions/mod.typ": get-author-format-rules, get-terms
+
+/// 格式化作者列表
+/// - parsed-names: citegeist 解析的 parsed_names
+/// - lang: 语言 ("zh" | "en")
+/// - version: 标准版本 ("2015" | "2025")
+/// - max-authors: 最多显示的作者数量，超过则显示 "等" / "et al."
+/// - allow-anonymous: 是否允许返回 "佚名"（默认 true）
+#let format-authors(
+  parsed-names,
+  lang,
+  version: "2025",
+  max-authors: 3,
+  allow-anonymous: true,
+) = {
+  let names = parsed-names.at("author", default: ())
+  if names.len() == 0 {
+    // 尝试 editor
+    names = parsed-names.at("editor", default: ())
+  }
+  if names.len() == 0 {
+    // 无作者时返回 "佚名" 或空
+    if allow-anonymous {
+      let terms = get-terms(version, lang)
+      return terms.anonymous
+    } else {
+      return ""
+    }
+  }
+
+  let terms = get-terms(version, lang)
+  let rules = get-author-format-rules(version)
+
+  // 作者分隔符：根据版本选择（CSL 规范）
+  // 2015: 默认英文逗号 ", "
+  // 2025: 中文逗号 "，"（<name delimiter="，"/>）
+  let delimiter = if version == "2025" { "，" } else { ", " }
+
+  // 格式化单个名字
+  let format-name(name) = {
+    let family = name.at("family", default: "")
+    let given = name.at("given", default: "")
+    let prefix = name.at("prefix", default: "") // 如 "van", "de"
+    let suffix = name.at("suffix", default: "") // 如 "Jr.", "III"
+
+    if lang == "zh" {
+      // 中文：姓名连写，不加空格（通常无 prefix/suffix）
+      family + given
+    } else {
+      // 英文：根据版本规则决定大小写
+      let family-case-fn = if rules.family-uppercase { upper } else { x => x }
+
+      // prefix 作为姓的一部分（demote-non-dropping-particle="never"）
+      // 但 prefix 始终保持原样，不受 text-case 影响
+      let full-family = if prefix != "" {
+        prefix + " " + family-case-fn(family)
+      } else {
+        family-case-fn(family)
+      }
+
+      // 名缩写（始终大写）
+      // hyphen-to-space: true → "Jean-Pierre" → "J P"
+      // hyphen-to-space: false → "Jean-Pierre" → "J-P"
+      let hyphen-sep = if rules.hyphen-to-space { " " } else { "-" }
+      let initials = given
+        .split(" ")
+        .map(part => {
+          part
+            .split("-")
+            .map(g => {
+              if g.len() > 0 { upper(g.first()) } else { "" }
+            })
+            .join(hyphen-sep)
+        })
+        .join(" ")
+
+      // suffix 放在名缩写后面（保留原样，无逗号）
+      // 根据 GB/T 7714-2025 示例：Sodeman W A Jr（无逗号）
+      // 注意：当 given 为空时（如组织名），不添加空格
+      if suffix != "" {
+        if initials != "" {
+          full-family + " " + initials + " " + suffix
+        } else {
+          full-family + " " + suffix
+        }
+      } else {
+        if initials != "" {
+          full-family + " " + initials
+        } else {
+          full-family
+        }
+      }
+    }
+  }
+
+  if names.len() <= max-authors {
+    names.map(format-name).join(delimiter)
+  } else {
+    // 超过 max-authors 时，显示前 3 个 + 等/et al.
+    (
+      names.slice(0, max-authors).map(format-name).join(delimiter)
+        + delimiter
+        + terms.et-al
+    )
+  }
+}
+
+/// 格式化正文引用中的作者（简短形式）
+/// - parsed-names: citegeist 解析的 parsed_names
+/// - lang: 语言 ("zh" | "en")
+/// - version: 标准版本 ("2015" | "2025")
+#let format-author-intext(parsed-names, lang, version: "2025") = {
+  let names = parsed-names.at("author", default: ())
+  if names.len() == 0 {
+    names = parsed-names.at("editor", default: ())
+  }
+  if names.len() == 0 {
+    // 无作者时返回 "佚名"
+    let terms = get-terms(version, lang)
+    return terms.anonymous
+  }
+
+  let terms = get-terms(version, lang)
+  let first = names.first()
+  let family = first.at("family", default: "")
+  let prefix = first.at("prefix", default: "")
+
+  // prefix 作为姓的一部分（如 "van Beethoven"）
+  let first-author = if prefix != "" and lang != "zh" {
+    prefix + " " + family
+  } else {
+    family
+  }
+
+  // 2 个或更多作者时加 "等" 或 "et al."
+  if names.len() >= 2 {
+    first-author + " " + terms.et-al
+  } else {
+    first-author
+  }
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/core/language.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/core/language.typ
@@ -1,0 +1,43 @@
+// GB/T 7714 双语参考文献系统 - 语言检测模块
+
+/// 检测文献条目的语言
+/// 优先级：language 字段 > langid 字段 > 正文汉字检测 > 默认英文
+#let detect-language(entry) = {
+  let fields = entry.at("fields", default: (:))
+
+  // 1. 优先检查 language 字段
+  let lang = fields.at("language", default: "")
+  if lang != "" {
+    let lang-lower = lower(lang)
+    if "zh" in lang-lower or "chinese" in lang-lower or "中" in lang-lower {
+      return "zh"
+    }
+    if "en" in lang-lower or "english" in lang-lower {
+      return "en"
+    }
+  }
+
+  // 2. 检查 langid 字段 (biblatex 风格)
+  let langid = fields.at("langid", default: "")
+  if langid != "" {
+    if "zh" in lower(langid) or "chinese" in lower(langid) {
+      return "zh"
+    }
+    if "en" in lower(langid) or "english" in lower(langid) {
+      return "en"
+    }
+  }
+
+  // 3. Fallback: 检测标题/作者是否含中文
+  let title = fields.at("title", default: "")
+  let author = fields.at("author", default: "")
+  let text-to-check = title + author
+
+  // 检测是否有至少两个连续汉字
+  if text-to-check.find(regex("\p{Han}{2,}")) != none {
+    return "zh"
+  }
+
+  // 默认为英文
+  return "en"
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/core/mod.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/core/mod.typ
@@ -1,0 +1,5 @@
+// GB/T 7714 双语参考文献系统 - 核心模块入口
+
+#import "state.typ": *
+#import "utils.typ": *
+#import "language.typ": *

--- a/packages/preview/gb7714-bilingual/0.2.1/src/core/state.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/core/state.typ
@@ -1,0 +1,79 @@
+// GB/T 7714 双语参考文献系统 - 状态管理模块
+
+// ============================================================
+//                      状态定义
+// ============================================================
+
+#let _bib-data = state("gb7714-bib-data", (:))
+#let _style = state("gb7714-style", "numeric")
+#let _version = state("gb7714-version", "2025")  // "2015" 或 "2025"
+
+// 显示配置
+#let _config = state("gb7714-config", (
+  show-url: true, // 是否显示 URL
+  show-doi: true, // 是否显示 DOI
+  show-accessed: true, // 是否显示访问日期
+))
+
+// 用于标记引用的辅助函数（使用 metadata + query 模式）
+#let _cite-marker(key) = [#metadata(key)<gb7714-cite>]
+
+// 从文档中收集所有引用并建立顺序映射
+#let _collect-citations() = {
+  let cites = query(<gb7714-cite>)
+  let seen = (:)
+  let order = 0
+  for c in cites {
+    let key = c.value
+    if key not in seen {
+      order += 1
+      seen.insert(key, order)
+    }
+  }
+  seen
+}
+
+// 计算年份后缀（用于 author-date 模式消歧）
+// 返回 key -> suffix 的映射，如 ("smith2020a": "a", "smith2020b": "b")
+// 根据 GB/T 7714-2025 9.3.1.3，后缀按引用顺序分配
+#let _compute-year-suffixes(bib, citations) = {
+  // 按 (第一作者姓, 年份) 分组
+  let groups = (:)
+  for key in citations.keys() {
+    let entry = bib.at(key, default: none)
+    if entry == none { continue }
+
+    let names = entry.parsed_names.at("author", default: ())
+    let first-author = if names.len() > 0 {
+      names.first().at("family", default: "")
+    } else { "" }
+    let year = entry.fields.at("year", default: "")
+    let group-key = first-author + "|" + str(year)
+
+    if group-key not in groups {
+      groups.insert(group-key, ())
+    }
+    groups
+      .at(group-key)
+      .push((
+        key: key,
+        order: citations.at(key), // 引用顺序
+      ))
+  }
+
+  // 为每组分配后缀
+  let suffixes = (:)
+  for (group-key, items) in groups.pairs() {
+    if items.len() > 1 {
+      // 按引用顺序排序（根据 GB/T 7714-2025 9.3.1.3）
+      let sorted-items = items.sorted(key: it => it.order)
+      let suffix-chars = "abcdefghijklmnopqrstuvwxyz"
+      for (i, item) in sorted-items.enumerate() {
+        if i < suffix-chars.len() {
+          suffixes.insert(item.key, suffix-chars.at(i))
+        }
+      }
+    }
+  }
+  suffixes
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/core/utils.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/core/utils.typ
@@ -1,0 +1,296 @@
+// GB/T 7714 双语参考文献系统 - 通用工具函数
+
+// ============================================================================
+//                        基础工具函数
+// ============================================================================
+
+// 格式化访问日期：[2024-01-15]
+#let format-accessed-date(entry) = {
+  let f = entry.at("fields", default: (:))
+  let date = f.at("urldate", default: f.at("accessed", default: ""))
+  if date != "" {
+    "[" + str(date) + "]"
+  } else {
+    ""
+  }
+}
+
+// 智能连接：避免 "et al.." 等双标点问题
+#let smart-join(parts, sep: ". ", trailing: ".") = {
+  (
+    parts
+      .map(p => {
+        if p.ends-with(".") or p.ends-with(",") or p.ends-with(";") {
+          p.slice(0, -1)
+        } else {
+          p
+        }
+      })
+      .join(sep)
+      + trailing
+  )
+}
+
+// 统一处理 URL/DOI/accessed（避免重复代码）
+#let append-access-info(
+  result,
+  entry,
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.at("fields", default: (:))
+  let url = f.at("url", default: "")
+  let doi = f.at("doi", default: "")
+  let mut = result
+
+  // 访问日期
+  if config.show-accessed {
+    let accessed = format-accessed-date(entry)
+    if accessed != "" {
+      mut = mut.trim(".") + accessed + "."
+    }
+  }
+
+  // 确保有结尾句号
+  if not mut.ends-with(".") {
+    mut += "."
+  }
+
+  // URL
+  if config.show-url and url != "" {
+    mut += " " + url + "."
+  }
+
+  // DOI
+  if config.show-doi and doi != "" {
+    mut += " DOI:" + doi + "."
+  }
+
+  mut
+}
+
+// ============================================================================
+//                        字段缺失处理函数
+// ============================================================================
+
+/// 带分隔符拼接，自动跳过空字段
+/// join-non-empty(("a", "", "b"), ", ") => "a, b"
+#let join-non-empty(items, sep) = {
+  items.filter(x => x != "").join(sep)
+}
+
+/// 构建出版信息：地址：出版者，年份
+/// 自动处理各字段缺失的情况
+#let build-pub-info(
+  address,
+  publisher,
+  year,
+  punct,
+  include-year: true,
+) = {
+  let parts = ()
+
+  // 地址：出版者
+  if address != "" and publisher != "" {
+    parts.push(address + punct.colon + publisher)
+  } else if address != "" {
+    parts.push(address)
+  } else if publisher != "" {
+    parts.push(publisher)
+  }
+
+  // 年份
+  if include-year and year != "" {
+    if parts.len() > 0 {
+      parts.push(year)
+      return parts.join(punct.comma)
+    } else {
+      return year
+    }
+  }
+
+  parts.join(punct.comma)
+}
+
+/// 追加页码到信息字符串
+/// 如果 info 为空，直接返回 pages；否则用冒号连接
+#let append-pages(info, pages, punct) = {
+  if pages == "" {
+    info
+  } else if info != "" {
+    info + punct.colon + pages
+  } else {
+    pages
+  }
+}
+
+/// 构建作者-年份部分（用于 author-date 风格）
+#let build-author-year(authors, year, punct) = {
+  if authors != "" {
+    (
+      author-part: authors + punct.comma + year,
+      year-in-pub: false,
+    )
+  } else {
+    (
+      author-part: none,
+      year-in-pub: true,
+    )
+  }
+}
+
+/// 构建期刊出版信息：刊名，年，卷（期）：页码
+#let build-journal-info(
+  journal,
+  year,
+  volume,
+  number,
+  pages,
+  punct,
+  include-year: true,
+) = {
+  let result = journal
+
+  if include-year and year != "" {
+    if result != "" {
+      result += punct.comma + year
+    } else {
+      result = year
+    }
+  }
+
+  if volume != "" {
+    if result != "" {
+      result += punct.comma + str(volume)
+    } else {
+      result = str(volume)
+    }
+  }
+
+  if number != "" {
+    result += punct.lparen + str(number) + punct.rparen
+  }
+
+  if pages != "" {
+    if result != "" {
+      result += punct.colon + pages
+    } else {
+      result = pages
+    }
+  }
+
+  result
+}
+
+// ============================================================================
+//                        渲染器公共抽象
+// ============================================================================
+
+/// 渲染器基础框架
+/// 统一处理：作者/年份 -> 内容部分 -> 最终组装
+#let render-base(
+  entry,
+  authors,
+  year,
+  punct,
+  style,
+  config,
+  build-content,
+) = {
+  let parts = ()
+
+  // 1. 处理作者和年份
+  let year-in-pub = true
+  if style == "author-date" {
+    let ay = build-author-year(authors, year, punct)
+    if ay.author-part != none {
+      parts.push(ay.author-part)
+    }
+    year-in-pub = ay.year-in-pub
+  } else {
+    if authors != "" {
+      parts.push(authors)
+    }
+  }
+
+  // 2. 调用类型特定的内容构建函数
+  let content-parts = build-content(year-in-pub)
+  parts += content-parts
+
+  // 3. 组装并添加访问信息
+  let result = smart-join(parts)
+  append-access-info(result, entry, config: config)
+}
+
+/// 简单类型渲染器（适用于结构简单的类型）
+/// 格式：作者. 题名[类型]. 出版信息.
+#let render-simple(
+  entry,
+  authors,
+  title,
+  year,
+  address,
+  publisher,
+  punct,
+  style,
+  config,
+  extra-parts: (),
+) = {
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title)
+      parts += extra-parts
+
+      let pub-info = build-pub-info(
+        address,
+        publisher,
+        year,
+        punct,
+        include-year: year-in-pub,
+      )
+      if pub-info != "" {
+        parts.push(pub-info)
+      }
+      parts
+    },
+  )
+}
+
+// ============================================================================
+//                        引用编号格式化
+// ============================================================================
+
+// 将 [1, 2, 3, 5, 7, 8, 9] 压缩为 "1-3, 5, 7-9"
+#let format-citation-numbers(nums) = {
+  if nums.len() == 0 { return "" }
+  if nums.len() == 1 { return str(nums.first()) }
+
+  let sorted = nums.sorted()
+  let ranges = ()
+  let start = sorted.first()
+  let end = start
+
+  for i in range(1, sorted.len()) {
+    if sorted.at(i) == end + 1 {
+      end = sorted.at(i)
+    } else {
+      ranges.push((start, end))
+      start = sorted.at(i)
+      end = start
+    }
+  }
+  ranges.push((start, end))
+
+  // GB/T 7714: 两篇及以上连续文献用 "-" 压缩
+  ranges
+    .map(((s, e)) => {
+      if s == e { str(s) } else { str(s) + "-" + str(e) }
+    })
+    .join(",")
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/article.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/article.typ
@@ -1,0 +1,70 @@
+// GB/T 7714 双语参考文献系统 - 期刊文章渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation
+#import "../core/utils.typ": build-journal-info, render-base
+
+/// 期刊文章渲染（也用于报纸、连续出版物）
+/// 格式：作者. 题名[J]. 刊名，年，卷（期）：页码.
+/// 报纸格式：作者. 题名[N]. 报纸名，年：页码.
+#let render-article(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+  let entry-type = lower(entry.entry_type)
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let journal = f.at("journal", default: f.at("journaltitle", default: ""))
+  let year = str(f.at("year", default: "")) + year-suffix
+  let volume = f.at("volume", default: "")
+  let number = f.at("number", default: f.at("issue", default: ""))
+  let pages = f.at("pages", default: "").replace("--", "-")
+  let doi = f.at("doi", default: "")
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  // 使用实际条目类型（newspaper → [N]，periodical → [J]，article → [J]）
+  let type-id = render-type-id(
+    entry-type,
+    has-url: url != "" or doi != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+  let punct = get-punctuation(version, lang)
+
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title + type-id)
+
+      let pub-info = build-journal-info(
+        journal,
+        year,
+        volume,
+        number,
+        pages,
+        punct,
+        include-year: if style == "author-date" { year-in-pub } else { true },
+      )
+      if pub-info != "" {
+        parts.push(pub-info)
+      }
+      parts
+    },
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/book.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/book.typ
@@ -1,0 +1,154 @@
+// GB/T 7714 双语参考文献系统 - 书籍渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation, get-terms
+#import "../core/utils.typ": append-pages, build-pub-info, render-base
+
+/// 书籍渲染
+/// 格式：作者. 书名：卷号[M]. 版本. 出版地：出版者，年：页码.
+/// 析出文献格式：作者. 章节标题//主书名[M]. 出版地：出版者，年：页码.
+#let render-book(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+  let terms = get-terms(version, lang)
+  let entry-type = lower(entry.entry_type)
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let booktitle = f.at("booktitle", default: "") // 析出文献的主书名
+  let edition = f.at("edition", default: "")
+  let volume = f.at("volume", default: "")
+  let publisher = f.at("publisher", default: "")
+  let address = f.at("address", default: f.at("location", default: ""))
+  let year = str(f.at("year", default: "")) + year-suffix
+  let pages = f.at("pages", default: "").replace("--", "-")
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  // 使用实际条目类型（collection → [G]，其他 → [M]）
+  let type-id = render-type-id(
+    entry-type,
+    has-url: url != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+  let punct = get-punctuation(version, lang)
+
+  // 判断是否为析出文献（inbook, incollection, chapter）
+  let is-analytic = (
+    entry-type in ("inbook", "incollection", "chapter") and booktitle != ""
+  )
+
+  // 辅助函数：添加卷号后缀
+  let format-volume(base, vol) = {
+    if vol == "" { return base }
+    let vol-str = str(vol)
+    // 检测是否为数值（纯数字或数字+字母如 2a）
+    // 非数值（如 "第2卷"）直接使用，数值则添加前后缀
+    let is-numeric = vol-str.match(regex("^[0-9]+[a-zA-Z]?$")) != none
+    if is-numeric {
+      if lang == "zh" {
+        base + punct.colon + terms.volume-prefix + vol-str + terms.volume-suffix
+      } else {
+        base + punct.colon + terms.volume-prefix + vol-str
+      }
+    } else {
+      base + punct.colon + vol-str
+    }
+  }
+
+  // 获取析出文献来源责任者（bookauthor 优先，其次 editor）
+  let source-authors = ""
+  if is-analytic {
+    // 尝试 bookauthor 字段（原始字符串，citegeist 可能不解析）
+    let bookauthor-raw = f.at("bookauthor", default: "")
+    if bookauthor-raw != "" {
+      source-authors = bookauthor-raw
+    } else {
+      // 尝试 editor
+      let editor-names = entry.parsed_names.at("editor", default: ())
+      if editor-names.len() > 0 {
+        source-authors = format-authors(
+          (author: editor-names),
+          lang,
+          version: version,
+          allow-anonymous: false,
+        )
+      }
+    }
+  }
+
+  // 构建标题部分
+  // 析出格式：章节标题[M]// 来源责任者. 主书名：卷号
+  // 非析出格式：书名：卷号[M]
+  let title-part = if is-analytic {
+    let source-title = format-volume(booktitle, volume)
+    if source-authors != "" {
+      title + type-id + "// " + source-authors + ". " + source-title
+    } else {
+      title + type-id + "//" + source-title
+    }
+  } else {
+    format-volume(title, volume) + type-id
+  }
+
+  // 构建版本信息
+  let edition-part = ""
+  if edition != "" {
+    let edition-str = str(edition)
+    if lang == "zh" {
+      edition-part = "第" + edition-str + "版"
+    } else {
+      let suffix = if (
+        edition-str.ends-with("1") and not edition-str.ends-with("11")
+      ) {
+        "st"
+      } else if edition-str.ends-with("2") and not edition-str.ends-with("12") {
+        "nd"
+      } else if edition-str.ends-with("3") and not edition-str.ends-with("13") {
+        "rd"
+      } else { "th" }
+      edition-part = edition-str + suffix + " " + terms.edition
+    }
+  }
+
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title-part)
+
+      if edition-part != "" {
+        parts.push(edition-part)
+      }
+
+      // 出版信息 + 页码
+      let pub-info = build-pub-info(
+        address,
+        publisher,
+        year,
+        punct,
+        include-year: year-in-pub,
+      )
+      pub-info = append-pages(pub-info, pages, punct)
+      if pub-info != "" {
+        parts.push(pub-info)
+      }
+      parts
+    },
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/conference.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/conference.typ
@@ -1,0 +1,113 @@
+// GB/T 7714 双语参考文献系统 - 会议论文渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation, get-terms
+#import "../core/utils.typ": append-access-info, build-author-year, smart-join
+
+/// 会议论文渲染
+/// - entry: 文献条目
+/// - lang: 语言 ("zh" | "en")
+/// - year-suffix: 年份后缀（用于消歧）
+/// - style: 引用风格 ("numeric" | "author-date")
+/// - version: 标准版本 ("2015" | "2025")
+#let render-inproceedings(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+  let terms = get-terms(version, lang)
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  // 2025 优先使用 eventtitle（会议名称），2015 使用 booktitle
+  let booktitle = if version == "2025" {
+    f.at("eventtitle", default: f.at("booktitle", default: ""))
+  } else {
+    f.at("booktitle", default: f.at("eventtitle", default: ""))
+  }
+  let year = str(f.at("year", default: "")) + year-suffix
+  let pages = f.at("pages", default: "").replace("--", "-")
+  let address = f.at("address", default: f.at("location", default: ""))
+  let publisher = f.at("publisher", default: f.at("organization", default: ""))
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  let type-id = render-type-id(
+    "inproceedings",
+    has-url: url != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+
+  // 使用集中配置
+  let punct = get-punctuation(version, lang)
+
+  let parts = ()
+
+  // 处理作者和年份
+  let year-in-pub = true
+  if style == "author-date" {
+    let ay = build-author-year(authors, year, punct)
+    if ay.author-part != none {
+      parts.push(ay.author-part)
+    }
+    year-in-pub = ay.year-in-pub
+  } else {
+    if authors != "" {
+      parts.push(authors)
+    }
+  }
+
+  // 出处信息：2015 和 2025 格式有差异
+  if version == "2015" {
+    // 2015: 题名[C]//会议名称. 地点：出版者，年：页码
+    parts.push(title + type-id + "//" + booktitle)
+
+    let pub-info = ""
+    if address != "" {
+      pub-info += address
+      // 只有当后面有 publisher 时才加冒号
+      if publisher != "" {
+        pub-info += punct.colon
+      }
+    }
+    if publisher != "" {
+      pub-info += publisher
+    }
+    // 年份（numeric 或作者为空的 author-date）
+    if year-in-pub and year != "" {
+      if pub-info != "" {
+        pub-info += punct.comma
+      }
+      pub-info += year
+    }
+    // 页码前加冒号
+    if pages != "" {
+      pub-info += punct.colon + pages
+    }
+    if pub-info != "" {
+      parts.push(pub-info)
+    }
+  } else {
+    // 2025: 题名[C]//会议名称，日期：页码（全在一个 part 内）
+    let conf-info = title + type-id + "//" + booktitle
+    // 年份（numeric 或作者为空的 author-date）
+    if year-in-pub and year != "" {
+      conf-info += punct.comma + year
+    }
+    if pages != "" {
+      conf-info += punct.colon + pages
+    }
+    parts.push(conf-info)
+  }
+
+  let result = smart-join(parts)
+  append-access-info(result, entry, config: config)
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/misc.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/misc.typ
@@ -1,0 +1,59 @@
+// GB/T 7714 双语参考文献系统 - 其他类型渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation
+#import "../core/utils.typ": render-base
+
+/// 通用渲染 (misc/其他)
+/// 格式：作者. 题名[Z]. 出版方式，年. 注释.
+#let render-misc(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let year = str(f.at("year", default: "")) + year-suffix
+  let note = f.at("note", default: "")
+  let howpublished = f.at("howpublished", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  let type-id = render-type-id(
+    entry.entry_type,
+    has-url: f.at("url", default: "") != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+  let punct = get-punctuation(version, lang)
+
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title + type-id)
+      if howpublished != "" {
+        parts.push(howpublished)
+      }
+      if year-in-pub and year != "" {
+        parts.push(year)
+      }
+      if note != "" {
+        parts.push(note)
+      }
+      parts
+    },
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/mod.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/mod.typ
@@ -1,0 +1,162 @@
+// GB/T 7714 双语参考文献系统 - 渲染器入口
+
+#import "article.typ": render-article
+#import "book.typ": render-book
+#import "conference.typ": render-inproceedings
+#import "thesis.typ": render-thesis
+#import "patent.typ": render-patent
+#import "standard.typ": render-standard
+#import "report.typ": render-report
+#import "webpage.typ": render-webpage
+#import "misc.typ": render-misc
+
+// 类型 -> 渲染函数映射
+#let _renderers = (
+  // 期刊文章
+  "article": render-article,
+  "periodical": render-article, // 连续出版物
+  "newspaper": render-article, // 报纸
+  // 书籍
+  "book": render-book,
+  "inbook": render-book,
+  "incollection": render-book,
+  "collection": render-book, // 汇编
+  // 会议论文
+  "inproceedings": render-inproceedings,
+  "conference": render-inproceedings,
+  // 学位论文
+  "phdthesis": render-thesis,
+  "mastersthesis": render-thesis,
+  "thesis": render-thesis,
+  // 专利
+  "patent": render-patent,
+  // 标准
+  "standard": render-standard,
+  // 报告
+  "techreport": render-report,
+  "report": render-report,
+  // 网页/在线资源
+  "online": render-webpage,
+  "webpage": render-webpage,
+  "www": render-webpage,
+)
+
+// 检测是否为标准（citegeist 不支持 @standard，返回 unknown）
+#let _is-standard-entry(entry) = {
+  let f = entry.at("fields", default: (:))
+  let number = f.at("number", default: "")
+  let std-prefixes = ("GB", "ISO", "IEC", "IEEE", "ANSI", "DIN", "JIS", "BS")
+  std-prefixes.any(p => upper(number).starts-with(p))
+}
+
+// 获取用户指定的 mark/usera 字段（用于手动声明类型标识）
+// biblatex 推荐使用 usera，mark 是为了兼容 gbt7714 宏包
+#let _get-mark(entry) = {
+  let f = entry.at("fields", default: (:))
+  f.at("mark", default: f.at("usera", default: none))
+}
+
+// 获取用户指定的 medium 字段（用于手动声明载体标识）
+#let _get-medium(entry) = {
+  let f = entry.at("fields", default: (:))
+  f.at("medium", default: none)
+}
+
+// 通过 entrysubtype 或 note 字段检测特殊类型
+// 兼容 biblatex-gb7714 的写法：@book + entrysubtype/note = standard
+#let _detect-subtype(entry, raw-type) = {
+  let f = entry.at("fields", default: (:))
+  let subtype = lower(f.at("entrysubtype", default: ""))
+  let note = lower(f.at("note", default: ""))
+
+  // 标准：@book/@inbook + entrysubtype/note = "standard"
+  if raw-type in ("book", "inbook", "unknown") {
+    if subtype == "standard" or note == "standard" {
+      return "standard"
+    }
+  }
+
+  // 报纸：@article + entrysubtype/note = "news"/"newspaper"
+  if raw-type in ("article", "unknown") {
+    if subtype in ("news", "newspaper") or note in ("news", "newspaper") {
+      return "newspaper"
+    }
+  }
+
+  none
+}
+
+/// 根据类型选择渲染函数
+#let render-entry(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let raw-type = lower(entry.entry_type)
+
+  // 智能类型检测（针对 citegeist 不支持的类型）
+  // 优先级：mark/usera > entrysubtype/note > number前缀检测 > 原始类型
+  let mark = _get-mark(entry)
+  let medium = _get-medium(entry)
+
+  let entry-type = if mark != none {
+    // 用户通过 mark/usera 字段手动声明类型标识
+    // mark 值直接映射到类型（S -> standard, N -> newspaper 等）
+    let mark-to-type = (
+      "S": "standard",
+      "N": "newspaper",
+      "J": "article",
+      "M": "book",
+      "C": "inproceedings",
+      "D": "thesis",
+      "R": "report",
+      "P": "patent",
+      "G": "collection",
+      "EB": "online",
+      "DB": "misc", // 数据库，使用 misc 渲染但 mark 会被传递
+      "CP": "misc", // 计算机程序
+      "CM": "misc", // 地图
+      "DS": "misc", // 数据集
+      "A": "misc", // 档案
+      "Z": "misc", // 其他
+    )
+    mark-to-type.at(upper(mark), default: raw-type)
+  } else {
+    // 尝试通过 entrysubtype/note 检测
+    let subtype-detected = _detect-subtype(entry, raw-type)
+    if subtype-detected != none {
+      subtype-detected
+    } else if raw-type == "unknown" and _is-standard-entry(entry) {
+      // 标准文献：通过 number 前缀检测（可靠）
+      "standard"
+    } else {
+      raw-type
+    }
+  }
+
+  // 查找渲染函数，未找到则使用 misc
+  let renderer = _renderers.at(entry-type, default: render-misc)
+
+  // 创建带有正确类型和 medium 的 entry 副本
+  let entry-with-type = entry
+  entry-with-type.entry_type = entry-type
+  // 如果用户指定了 mark，将其存入 fields 以便 render-type-id 使用
+  if mark != none {
+    entry-with-type.fields.insert("_resolved_mark", mark)
+  }
+  if medium != none {
+    entry-with-type.fields.insert("_resolved_medium", medium)
+  }
+
+  renderer(
+    entry-with-type,
+    lang,
+    year-suffix: year-suffix,
+    style: style,
+    version: version,
+    config: config,
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/patent.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/patent.typ
@@ -1,0 +1,70 @@
+// GB/T 7714 双语参考文献系统 - 专利渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation
+#import "../core/utils.typ": render-base
+
+/// 专利渲染
+/// 格式：专利申请者或所有者. 专利题名：专利号[P]. 公告日期：页码[引用日期].
+#let render-patent(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let patent-number = f.at("number", default: f.at("call-number", default: ""))
+  let year = str(f.at("year", default: "")) + year-suffix
+  let date = f.at("date", default: f.at("issued", default: year))
+  let pages = f.at("pages", default: "").replace("--", "-")
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  let type-id = render-type-id(
+    "patent",
+    has-url: url != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+  let punct = get-punctuation(version, lang)
+
+  // 题名：专利号[P]
+  let title-part = title
+  if patent-number != "" {
+    title-part += punct.colon + patent-number
+  }
+  title-part += type-id
+
+  // 使用基础渲染器
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title-part)
+      // 公告日期：页码
+      if year-in-pub and date != "" {
+        let date-part = str(date)
+        if pages != "" {
+          date-part += punct.colon + pages
+        }
+        parts.push(date-part)
+      } else if pages != "" {
+        parts.push(pages)
+      }
+      parts
+    },
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/report.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/report.typ
@@ -1,0 +1,73 @@
+// GB/T 7714 双语参考文献系统 - 报告渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation
+#import "../core/utils.typ": append-pages, build-pub-info, render-base
+
+/// 报告渲染
+/// 格式：作者. 题名：报告编号[R]. 出版地：出版者，出版年：页码.
+#let render-report(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let number = f.at("number", default: "")
+  let year = str(f.at("year", default: "")) + year-suffix
+  let publisher = f.at("publisher", default: f.at("institution", default: ""))
+  let address = f.at("address", default: f.at("location", default: ""))
+  let pages = f.at("pages", default: "").replace("--", "-")
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  let type-id = render-type-id(
+    "report",
+    has-url: url != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+  let punct = get-punctuation(version, lang)
+
+  // 题名：报告编号[R]
+  let title-part = title
+  if number != "" {
+    title-part += punct.colon + number
+  }
+  title-part += type-id
+
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title-part)
+
+      // 出版信息 + 页码
+      let pub-info = build-pub-info(
+        address,
+        publisher,
+        year,
+        punct,
+        include-year: year-in-pub,
+      )
+      pub-info = append-pages(pub-info, pages, punct)
+      if pub-info != "" {
+        parts.push(pub-info)
+      }
+      parts
+    },
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/standard.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/standard.typ
@@ -1,0 +1,95 @@
+// GB/T 7714 双语参考文献系统 - 标准渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-entry-type-rules, get-punctuation, get-terms
+#import "../core/utils.typ": append-access-info, build-pub-info, smart-join
+
+/// 标准渲染
+/// 格式：标准号  标准名称[S]. 出版地：出版者，出版年.
+/// 注意：标准号在最前面
+#let render-standard(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+  let terms = get-terms(version, lang)
+
+  // 标准通常没有个人作者，可能有发布机构
+  let authors = format-authors(
+    entry.parsed_names,
+    lang,
+    version: version,
+    allow-anonymous: false,
+  )
+  let title = f.at("title", default: "")
+  // 标准号
+  let number = f.at("number", default: "")
+  let year = str(f.at("year", default: "")) + year-suffix
+  let publisher = f.at("publisher", default: f.at("organization", default: ""))
+  let address = f.at("address", default: f.at("location", default: ""))
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  let type-id = render-type-id(
+    "standard",
+    has-url: url != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+
+  // 使用集中配置
+  let punct = get-punctuation(version, lang)
+  let type-rules = get-entry-type-rules(version)
+  // 标准号和标题之间用 EM SPACE（CSL 规范 &#8195;）
+  let em-space = "\u{2003}"
+
+  let parts = ()
+
+  // 根据版本规则决定是否显示作者
+  if type-rules.standard-has-author {
+    if style == "author-date" {
+      if authors != "" {
+        parts.push(authors + punct.comma + year)
+      }
+    } else {
+      if authors != "" {
+        parts.push(authors)
+      }
+    }
+  }
+
+  // 标准号 + 标题[S]
+  let title-part = ""
+  if number != "" {
+    title-part = number + em-space
+  }
+  title-part += title + type-id
+  parts.push(title-part)
+
+  // 出版信息（使用公共函数处理字段缺失）
+  // 年份：numeric 模式总是在出版信息中
+  // author-date 模式：如果没有作者（如 2025 标准），年份也放在出版信息中
+  let year-in-pub = (
+    style == "numeric" or not type-rules.standard-has-author or authors == ""
+  )
+  let pub-info = build-pub-info(
+    address,
+    publisher,
+    year,
+    punct,
+    include-year: year-in-pub,
+  )
+  if pub-info != "" {
+    parts.push(pub-info)
+  }
+
+  let result = smart-join(parts)
+  append-access-info(result, entry, config: config)
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/thesis.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/thesis.typ
@@ -1,0 +1,65 @@
+// GB/T 7714 双语参考文献系统 - 学位论文渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation
+#import "../core/utils.typ": append-pages, build-pub-info, render-base
+
+/// 学位论文渲染
+/// 格式：作者. 题名[D]. 地址：学校，年：页码.
+#let render-thesis(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let school = f.at("school", default: f.at("institution", default: ""))
+  let year = str(f.at("year", default: "")) + year-suffix
+  let address = f.at("address", default: f.at("location", default: ""))
+  let pages = f.at("pages", default: "").replace("--", "-")
+  let url = f.at("url", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  let type-id = render-type-id(
+    "thesis",
+    has-url: url != "",
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+  let punct = get-punctuation(version, lang)
+
+  render-base(
+    entry,
+    authors,
+    year,
+    punct,
+    style,
+    config,
+    year-in-pub => {
+      let parts = ()
+      parts.push(title + type-id)
+
+      // 出版信息 + 页码
+      let pub-info = build-pub-info(
+        address,
+        school,
+        year,
+        punct,
+        include-year: year-in-pub,
+      )
+      pub-info = append-pages(pub-info, pages, punct)
+      if pub-info != "" {
+        parts.push(pub-info)
+      }
+      parts
+    },
+  )
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/renderers/webpage.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/renderers/webpage.typ
@@ -1,0 +1,104 @@
+// GB/T 7714 双语参考文献系统 - 网页/电子资源渲染器
+
+#import "../authors.typ": format-authors
+#import "../types.typ": render-type-id
+#import "../versions/mod.typ": get-punctuation, get-terms
+#import "../core/utils.typ": (
+  append-access-info, build-author-year, format-accessed-date, smart-join,
+)
+
+/// 网页/电子资源渲染
+/// 格式：作者. 题名[EB/OL]. (发布日期)[引用日期]. URL.
+#let render-webpage(
+  entry,
+  lang,
+  year-suffix: "",
+  style: "numeric",
+  version: "2025",
+  config: (show-url: true, show-doi: true, show-accessed: true),
+) = {
+  let f = entry.fields
+  let terms = get-terms(version, lang)
+
+  let authors = format-authors(entry.parsed_names, lang, version: version)
+  let title = f.at("title", default: "")
+  let year = str(f.at("year", default: "")) + year-suffix
+  // 发布日期
+  let date = f.at("date", default: "")
+  let url = f.at("url", default: "")
+  let note = f.at("note", default: "")
+  let mark = f.at("_resolved_mark", default: none)
+  let medium = f.at("_resolved_medium", default: none)
+
+  // 网页默认是 EB/OL
+  let type-id = render-type-id(
+    "webpage",
+    has-url: true,
+    version: version,
+    mark: mark,
+    medium: medium,
+  )
+
+  // 使用集中配置
+  let punct = get-punctuation(version, lang)
+
+  let parts = ()
+
+  // 处理作者和年份
+  let year-in-date = false // 年份是否需要放入日期部分
+  if style == "author-date" {
+    let ay = build-author-year(authors, year, punct)
+    if ay.author-part != none {
+      parts.push(ay.author-part)
+    }
+    year-in-date = ay.year-in-pub
+  } else {
+    if authors != "" {
+      parts.push(authors)
+    }
+  }
+
+  // 题名[EB/OL]
+  parts.push(title + type-id)
+
+  let result = smart-join(parts)
+
+  // 发布日期和访问日期：CSL 格式 "题名[EB/OL].（发布日期）[访问日期]"
+  // 发布日期括号使用集中配置
+  let date-part = ""
+  if date != "" {
+    date-part += punct.lparen + str(date) + punct.rparen
+  }
+  // 访问日期
+  if config.show-accessed {
+    let accessed = format-accessed-date(entry)
+    if accessed != "" {
+      date-part += accessed
+    }
+  }
+  // 添加日期部分（用句号分隔）
+  if date-part != "" {
+    result = result.trim(".") + "." + date-part
+  }
+
+  // URL（网页文献的关键信息）
+  if config.show-url and url != "" {
+    result += ". " + url
+  }
+
+  // DOI
+  let doi = f.at("doi", default: "")
+  if config.show-doi and doi != "" {
+    if not result.ends-with(".") {
+      result += "."
+    }
+    result += " DOI:" + doi
+  }
+
+  // 确保以句号结尾
+  if not result.ends-with(".") {
+    result += "."
+  }
+
+  result
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/types.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/types.typ
@@ -1,0 +1,45 @@
+// GB/T 7714 双语参考文献系统 - 文献类型标识模块
+
+#import "versions/mod.typ": get-type-map
+
+/// 渲染文献类型标识 [J] [M] 等
+/// - entry-type: BibTeX 条目类型
+/// - has-url: 是否有 URL 或 DOI
+/// - version: 标准版本 ("2015" | "2025")
+/// - mark: 用户指定的类型标识（覆盖自动检测）
+/// - medium: 用户指定的载体标识（覆盖自动检测）
+#let render-type-id(
+  entry-type,
+  has-url: false,
+  version: "2025",
+  mark: none,
+  medium: none,
+) = {
+  let type-map = get-type-map(version)
+
+  // 类型标识：优先使用用户指定的 mark，否则从 type-map 查找
+  let base = if mark != none {
+    upper(mark)
+  } else {
+    type-map.at(lower(entry-type), default: "Z")
+  }
+
+  // 载体标识：优先使用用户指定的 medium
+  // 否则根据 has-url 自动添加 /OL
+  let carrier = if medium != none {
+    upper(medium)
+  } else if has-url and not base.contains("OL") and base != "EB" {
+    "OL"
+  } else {
+    none
+  }
+
+  // 组合输出
+  if base == "EB" {
+    "[EB/OL]" // 网页默认就是在线
+  } else if carrier != none {
+    "[" + base + "/" + carrier + "]"
+  } else {
+    "[" + base + "]"
+  }
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/versions/mod.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/versions/mod.typ
@@ -1,0 +1,46 @@
+// GB/T 7714 双语参考文献系统 - 版本配置入口
+
+#import "v2015.typ": config-2015
+#import "v2025.typ": config-2025
+
+// 版本 -> 配置映射
+#let _configs = (
+  "2015": config-2015,
+  "2025": config-2025,
+)
+
+/// 获取版本配置
+#let get-version-config(version) = {
+  _configs.at(version, default: config-2025)
+}
+
+/// 根据版本和语言获取术语
+#let get-terms(version, lang) = {
+  let config = get-version-config(version)
+  if lang == "zh" { config.terms-zh } else { config.terms-en }
+}
+
+/// 根据版本获取类型映射
+#let get-type-map(version) = {
+  get-version-config(version).type-map
+}
+
+/// 根据版本获取引用格式配置
+#let get-citation-config(version) = {
+  get-version-config(version).citation
+}
+
+/// 获取标点符号配置
+#let get-punctuation(version, lang) = {
+  get-version-config(version).punctuation
+}
+
+/// 获取作者格式化规则
+#let get-author-format-rules(version) = {
+  get-version-config(version).author-format
+}
+
+/// 获取条目类型相关规则
+#let get-entry-type-rules(version) = {
+  get-version-config(version).entry-type-rules
+}

--- a/packages/preview/gb7714-bilingual/0.2.1/src/versions/v2015.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/versions/v2015.typ
@@ -1,0 +1,95 @@
+// GB/T 7714—2015 版本配置
+
+#let config-2015 = (
+  // 版本标识
+  version: "2015",
+  name: "GB/T 7714—2015",
+  // 标点符号（2015 统一使用英文半角标点）
+  punctuation: (
+    comma: ", ",
+    colon: ": ",
+    lparen: "(",
+    rparen: ")",
+  ),
+  // 作者格式化规则
+  author-format: (
+    family-uppercase: true, // 姓大写（SMITH）
+    hyphen-to-space: true, // 连字符展开（J P）
+    delimiter: ", ", // 作者分隔符
+  ),
+  // 条目类型规则
+  entry-type-rules: (
+    standard-has-author: true, // 标准有作者
+  ),
+  // 文献类型标识映射
+  type-map: (
+    "article": "J",
+    "periodical": "J",
+    "preprint": "A", // 2015 归类为档案
+    "newspaper": "N",
+    "book": "M",
+    "inbook": "M",
+    "incollection": "M",
+    "chapter": "M",
+    "collection": "G", // 汇编
+    "inproceedings": "C",
+    "conference": "C",
+    "proceedings": "C",
+    "phdthesis": "D",
+    "mastersthesis": "D",
+    "thesis": "D",
+    "techreport": "R",
+    "report": "R",
+    "standard": "S",
+    "patent": "P",
+    "dataset": "DS",
+    "map": "CM",
+    "software": "CP",
+    "online": "EB",
+    "webpage": "EB",
+    "archive": "A",
+    "misc": "Z",
+  ),
+  // 正文引用格式
+  citation: (
+    lparen: "(",
+    rparen: ")",
+    author-year-sep: ", ",
+    multi-sep: "; ",
+    locator-sep: ": ", // 页码分隔符（年份和页码之间）
+  ),
+  // 术语（中文）
+  terms-zh: (
+    volume-prefix: "第",
+    volume-suffix: "卷",
+    issue: "期",
+    edition: "版",
+    page: "页",
+    pages: "页",
+    translator: "译",
+    editor: "编",
+    et-al: "等",
+    in-word: "见",
+    accessed: "访问于",
+    online: "在线",
+    no-date: "出版年不详",
+    anonymous: "佚名",
+  ),
+  // 术语（英文）
+  terms-en: (
+    volume-prefix: "Vol.",
+    volume-suffix: "",
+    issue: "no.",
+    edition: "ed",
+    page: "p.",
+    pages: "pp.",
+    translator: "trans",
+    editor: "ed",
+    et-al: "et al.",
+    in-word: "In",
+    accessed: "accessed",
+    online: "online",
+    no-date: "n.d.",
+    anonymous: "Anon",
+  ),
+)

--- a/packages/preview/gb7714-bilingual/0.2.1/src/versions/v2025.typ
+++ b/packages/preview/gb7714-bilingual/0.2.1/src/versions/v2025.typ
@@ -1,0 +1,95 @@
+// GB/T 7714—2025 版本配置
+
+#let config-2025 = (
+  // 版本标识
+  version: "2025",
+  name: "GB/T 7714—2025",
+  // 标点符号（2025 统一使用中文全角标点）
+  punctuation: (
+    comma: "，",
+    colon: "：",
+    lparen: "（",
+    rparen: "）",
+  ),
+  // 作者格式化规则
+  author-format: (
+    family-uppercase: false, // 姓不大写（Smith）
+    hyphen-to-space: false, // 保留连字符（J-P）
+    delimiter: "，", // 作者分隔符
+  ),
+  // 条目类型规则
+  entry-type-rules: (
+    standard-has-author: false, // 标准无作者
+  ),
+  // 文献类型标识映射
+  type-map: (
+    "article": "J",
+    "periodical": "J",
+    "preprint": "PP",
+    "newspaper": "N",
+    "book": "M",
+    "inbook": "M",
+    "incollection": "M",
+    "chapter": "M",
+    "collection": "G", // 汇编
+    "inproceedings": "C",
+    "conference": "C",
+    "proceedings": "C",
+    "phdthesis": "D",
+    "mastersthesis": "D",
+    "thesis": "D",
+    "techreport": "R",
+    "report": "R",
+    "standard": "S",
+    "patent": "P",
+    "dataset": "DS",
+    "map": "CM",
+    "software": "CP",
+    "online": "EB",
+    "webpage": "EB",
+    "archive": "A",
+    "misc": "Z",
+  ),
+  // 正文引用格式
+  citation: (
+    lparen: "（",
+    rparen: "）",
+    author-year-sep: "，",
+    multi-sep: "；",
+    locator-sep: "：", // 页码分隔符（年份和页码之间）
+  ),
+  // 术语（中文）
+  terms-zh: (
+    volume-prefix: "第",
+    volume-suffix: "卷",
+    issue: "期",
+    edition: "版",
+    page: "页",
+    pages: "页",
+    translator: "译",
+    editor: "编",
+    et-al: "等",
+    in-word: "见",
+    accessed: "访问于",
+    online: "在线",
+    no-date: "无日期",
+    anonymous: "佚名",
+  ),
+  // 术语（英文）
+  terms-en: (
+    volume-prefix: "v.",
+    volume-suffix: "",
+    issue: "no.",
+    edition: "ed",
+    page: "p.",
+    pages: "pp.",
+    translator: "trans",
+    editor: "ed",
+    et-al: "et al.",
+    in-word: "In",
+    accessed: "accessed",
+    online: "online",
+    no-date: "n.d.",
+    anonymous: "Anon",
+  ),
+)

--- a/packages/preview/gb7714-bilingual/0.2.1/typst.toml
+++ b/packages/preview/gb7714-bilingual/0.2.1/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gb7714-bilingual"
+version = "0.2.1"
+entrypoint = "lib.typ"
+authors = ["pku-typst"]
+license = "MIT"
+description = "GB/T 7714-2015/2025 bilingual bibliography for Typst with automatic Chinese/English term switching"
+repository = "https://github.com/pku-typst/gb7714-bilingual"
+keywords = ["bibliography", "citation", "gb7714", "chinese", "bilingual", "gb7714-2015", "gb7714-2025"]
+categories = ["paper"]
+disciplines = []
+compiler = "0.14.0"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description:

### Added

- `usera` field support as biblatex-recommended alias for `mark`
- `entrysubtype` and `note` field detection for type disambiguation (biblatex-gb7714 compatibility)
  - `@book` + `entrysubtype/note = "standard"` → `[S]`
  - `@article` + `entrysubtype/note = "news"/"newspaper"` → `[N]`
- `medium` field support for custom carrier types (e.g., `medium = {MT}` → `[DB/MT]`)
- `bookauthor` field support for analytic entries (source document authors)
- `editor` field fallback for source authors when `bookauthor` is missing

### Fixed

- `@inbook` type identifier position: now correctly placed after analytic title
  - Before: `章节标题//主书名[M]`
  - After: `章节标题[M]//主书名`
- Name suffix formatting: removed comma before suffix (per GB/T 7714-2025 examples)
  - Before: `King M L, Jr.`
  - After: `King M L Jr.`
- Year suffix disambiguation now uses citation order instead of title alphabetical order (per GB/T 7714-2025 9.3.1.3)（[#6](https://github.com/pku-typst/gb7714-bilingual/pull/6)）
  - Before: suffixes assigned by title sort (could produce a, c, b)
  - After: suffixes assigned by citation order (always a, b, c in order of appearance)
- Invisible hidden bibliography title no longer triggers unexpected page break with `pagebreak(weak: true)` ([#4](https://github.com/pku-typst/gb7714-bilingual/pull/4) by [@Coekjan](https://github.com/Coekjan))
- Numeric style no longer incorrectly displays year suffixes (a, b, c) in bibliography （[#7](https://github.com/pku-typst/gb7714-bilingual/pull/7)）