### PR TITLE
pf2e-style:0.2.0

### DIFF
--- a/packages/preview/pf2e-style/0.2.0/LICENSE
+++ b/packages/preview/pf2e-style/0.2.0/LICENSE
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright 2026 Wexel Wingding
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/pf2e-style/0.2.0/README.md
+++ b/packages/preview/pf2e-style/0.2.0/README.md
@@ -1,0 +1,243 @@
+# Typst Package for Pathfinder 2nd Edition
+
+Have full control over your Pathfinder 2nd Edition (PF2e) content with this easy-to-use [Typst](https://typst.app/docs) template. With print-friendly design, customizable themes, and Pathfinder specific elements like the Three Action Economy icons, this kit provides almost everything you need to get your adventure documents looking perfect for next session.
+
+Check out the example [document](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/examples/pf2e.typ) and the resulting [PDF file](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/examples/pf2e.pdf).
+
+This was made to really capture the look and feel of PF2e Remastered. While sites like [scribe](https://scribe.pf2.tools/) offer incredible markdown formatting for PF2e materials, its color set is still based on the prior version of PF2e, it doesn't offer any means of extension, and it doesn't have an option to self-host. ***By no means is this a jab at scribe. It is a much more rich and feature complete way to make official looking materials, but it just wasn't quite what I was looking for***. This project provides that updated color scheme as well as takes advantage of Typst's superior markup language. 
+
+## Example
+
+If you are familiar with Markdown or the MediaWiki syntax, typst won't feel too different. You can check out the [typst syntax](https://typst.app/docs/tutorial/) for reference. Here is what a very simple document might look like:
+
+```typst
+#import "@preview/pf2e-style:0.2.0": *
+#show: pf-stylization
+
+= Getting Started
+
+Read or paraphrase the following to begin the adventure. <s>
+
+#aloud[The autumn wind carries the scent of woodsmoke and baked goods as you crest the hill overlooking Palo Monte. Below, the city's lanterns flicker to life against the twilight, their glow reflecting in the River Sable that cuts through the city like a silver scar. But the journey has been long, and the chill bites deeper with each passing mile.]
+
+== Palo Monte
+```
+
+This would render like this:
+
+![A render of the above example. "Getting Started" is assigned its own font as the main header. The text in `#aloud` have a line above and below it to indicate it should read or paraphrased to players.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/snippet.png)
+
+## Usage
+
+To use the template, simply import and use it in your Typst document:
+
+```typst
+#import "@preview/pf2e-style:0.2.0": *
+#show: pf-stylization // These two lines apply the template
+```
+
+## Models
+
+This is what Typst calls different elements in the document. This package includes several tailored towards PF2e materials, but there are bunch of additional functions that Typst offers.
+
+### Action Icons
+
+The staple iconography for the Pathfinder combat. These can be triggered at any time using their corresponding variable.
+
+```typst
+Single Action = #A
+Double Action = #AA
+Triple Action = #AAA
+Reaction = #R
+Free Action = #F
+```
+
+![Each action type is displayed to show its corresponding action icon. A single action is square turned 45° with a portion taken out. A double action is two of those squared next to each other; triple action, three. A reaction is an arrow curved in a clockwise circle. A free action is the outline of a single action.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/action-chart.png)
+
+### Creature Statblock
+
+The best way to show off what those actions can do is by putting them against an enemy. Pathfinder has a very unique way of displaying combatants, and this style can be achieved with `encounter`
+
+```typst
+#encounter((
+  name: [Griznik Sizzlepaw],
+  type: [Creature 1],
+  traits: ([Unique], [small], [goblin], [humanoid]),
+  details: (
+  [_Male goblin baker and entrepreneur_],
+  [*Perception* +7],
+  [*Languages* Goblin, Common],
+  [*Skills* Crafting +9, Deception +6, Stealth +8, Survival +7],
+  [*Str* +5, *Dex* +2, *Con* +4, *Int* -5, *Wis* +0, *Cha* -5],
+  [*Items* flour-dusted apron, rolling pin (improvised club), bag of special spices, 3 hot cross buns, small ledger],
+  [---], //This bar invokes the line that separates portions of a stat block like in the picture below
+  [*AC* 16, *Fort* +4, *Ref* +9, *Will* +7],
+  [*HP* 18],
+  [*Goblin Scuttle* #R *Trigger* A creature ends its movement within 10 feet of Griznik. *Effect* Griznik Strides up to 10 feet without triggering reactions. He must end this movement farther from the triggering creature.],
+  [*Culinary Alchemist* Griznik can identify any edible substance with a successful DC 15 Crafting check. He gains a +2 circumstance bonus to Crafting checks related to baking or cooking.],
+  [---],
+  [*Melee* Rolling Pin #A +9 (agile, nonlethal), *Damage* 1d4+1 bludgeoning],
+  [*Ranged* Hot Bun Toss #A +9 (range 30 ft.), *Damage* 1d6+1 fire plus 1 persistent fire],
+  [*Flour Bomb* #AA Griznik throws a handful of specially prepared flour that explodes in a 10-foot burst within 20 feet. Creatures in the area must attempt a DC 17 Fortitude save. \ *Critical Success* No effect \ *Success* The creature is dazzled for 1 round. \ *Failure* The creature is dazzled for 1 minute and sneezes uncontrollably for 1 round, becoming off-guard \ *Critical Failure* Same as failure, plus the creature is blinded for 1 round],
+    [*Knead Dough* #AAA Griznik prepares special dough. At the start of his next turn, the dough animates as a Tiny dough golem under his control for 1 minute. The dough golem has AC 14, 10 HP, and can make a Slam Attack #AA (+8, 1d4 bludgeoning). Once the golem is defeated or its time runs out, it deflates.])
+))
+```
+
+![A statblock for Griznik Sizzlepaw, a goblin baker.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/giznik-stats.png)
+ 
+All you have to do is make a content array and aspect of the encounter be its own item. With how flexible it is, you can have most any sort of **hazard**, **complication**, or **obstacle** be written with the `encounter` function.
+
+#### Hazard Example
+
+```typst
+#encounter((
+  name: [Poisoned Lock], 
+  type: [Hazard 1],
+  traits: ([Simple],[Mechanical], [Trap]), //Make sure blocks without traits are written like this; otherwise, you might get a error
+  details: (
+    [*Stealth* DC 17 (trained)],
+    [*Description* A spring-loaded poisoned spine is hidden near the keyhole of a lock. Disabling or breaking the trap does not disable or break the lock.],
+    [---],
+    [*Disable* DC 17 Thievery (trained) on the spring mechanism], 
+    [*AC* 15, *Fort* +8, *Ref* +4], 
+    [*Hardness* 6, *HP* 24 (BT 12); *Immunities* Critical hits, object immunities, precision damage], 
+    [*Spring #R Trigger* A creature tries to unlock or Pick the Lock; *Effect* A spine extends to Strike the triggering creature.],
+    [*Melee* spine +13, *Damage* 1 piercing plus cladis poison],
+    [*Cladis Poison* (poison) *Saving Throw* DC 19 Fortitude; *Maximum Duration* 4 hours; *Stage 1* 1d6 poison damage and drained 1 (1 hour); *Stage 2* 2d6 poison damage and drained 2 (1 hour); *Stage 3* 3d6 poison damage and drained 2 (1 hour)]),
+)) 
+```
+
+![An example of a hazard statblock from the above `encounter` block](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/808bea2df563c6c9b9f059f28211bb7fb5d30e76/docs/img/hazard.png)
+
+### Feats
+
+Aside from the action economy, one of the other pinnacle aspects of PF2e is its feats which allow you to build almost whatever possible character you wanted to. 
+
+```typst
+#feat((
+  name: [Battle Medicine #A],
+  level: 1,
+  trait: ("General",),
+  reqs: ([*Prerequisites* trained in Medicine], [*Requirements* You're holding or wearing a healer's toolkit (page 288).],),
+  effect: [You can patch up wounds, even in combat. Attempt a Medicine check with the same DC as for Treat Wounds and restore the corresponding amount of HP; this doesn't remove the wounded condition. As with Treat Wounds, you can attempt checks against higher DCs if you have the minimum proficiency rank. The target is them immune to your Battle Medicine for 1 day. This does not make them immune to, or otherwise count as, Treat Wounds.],
+  special: [],
+))
+```
+
+![A render of the "Battle Medicine" feat.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/feat.png)
+
+### Spells
+
+Depending on your class, spells can be just as important as feats.
+
+```typst
+#spell((
+    name: [Fireball #AA],
+    level: 3,
+    trait: ("Concentrate", "Fire", "Manipulate"),
+    reqs: ([*Traditions* arcane, primal], [*Range* 500 feet; *Area* 20-foot burst], [*Defense* basic Reflex]),
+    effect: (
+        [A roaring blast of fire detonates at a spot you designate, dealing 6d6 fire damage.],
+        [---],
+        [*Heightened (+1)* The damage increases by 2d6.]),
+))
+```
+
+![A render of the "Fireball" spell.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/spell.png)
+
+### Chapter Headers
+
+To really make the title of your work or section stand out since the document will be two columns, you can use `chap-header`.
+
+```typst
+#chap-header("Chapter 1", "The Introduction", [An excellent way to draw in a reader's attention when they're flipping through your work.])
+```
+
+![A header that single columned and stretches across the top of the page in question. Each of the three elements of it are stacked atop each other and the description is italicized.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/header.png)
+
+### Tables
+
+PF2e, like other games, have a certain way to lay out tables. While you honestly can put whatever table you want and have it work great, I figured I might as well add an extra component to get that official sort of feel.
+
+```typst
+#pftab(
+  "General Feats",
+  columns: 4,
+  [*Non-Skill Feats*], [*Level*], [*Prerequisites*], [*Benefits*],
+  [Adopted Ancestry], [1], [—], [Gain access to ancestry feats from another ancestry],
+  [Armor Proficiency], [1], [—], [Become trained in a type of armor],
+  [Breath Control], [1], [—], [Hold your breath longer and gain benefits against inhaled threats],
+  [Canny Acumen], [1], [—], [Become an expert in a saving throw or Perception],
+  [Diehard], [1], [—], [Die at dying 5, rather than dying 4],
+)
+```
+
+![A simple document table but assigned a green header and a pattern for the lines.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/056d68c92cb2644a1bbcd46daeb25db4ed5fcfc0/docs/img/pfTable.png)
+
+### Note
+
+A little comment never hurts to add to clear things up.
+
+```typst
+#note[
+    ===== Where did all of this come from?
+  A local goblin baker, Griznik Sizzlepaw, has recently set up shop in the city. He has been in steep competition with another baker across the street, and the two have essentially been at war since. As of late, the tensions have been getting more heated. If the players make fun of how burnt the rolls are, Griznik will become enraged and hostile towards the party. 
+]
+```
+
+![A simple box element to serve as a note for the reader.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/note.png)
+
+### Attention
+
+Sometimes a note's not enough. For then, it might be important to have something a little more in your face.
+
+```typst
+#attention[
+    ===== The Bag of Special Spices
+The bag contains Griznik's proprietary "Dragon's Breath Blend"—a mixture of powdered fire-pepper, crushed glow-moss, and crystallized lightning bug extract. When sprinkled on food, the spices cause the meal to crackle with harmless crimson sparks and emit a soft, coppery glow. The consumer feels a warming sensation spreading from their core, gaining resistance 2 to cold damage for the next hour. However, the blend is potent; anyone consuming more than a pinch must succeed at a DC 14 Fortitude save or become Stupefied 1 for 1 minute, seeing harmless flames dance across surfaces and friendly faces appear as grinning devils.
+]
+```
+
+![Similar to the note, it is a box element, however, this is made to draw more attention.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/attention.png)
+
+### Read Aloud
+
+When you write, there might be things you need to tell directly to your players. When you do, having a way to distinguish it will make running things a lot easier.
+
+```typst
+#aloud[The autumn wind carries the scent of woodsmoke and baked goods as you crest the hill overlooking Palo Monte. Below, the city's lanterns flicker to life against the twilight, their glow reflecting in the River Sable that cuts through the city like a silver scar. But the journey has been long, and the chill bites deeper with each passing mile.
+
+As you approach the city gates, a most peculiar scent cuts through the evening damp: the warm, yeasty fragrance of fresh bread, but laced with something else—cinnamon that crackles like static, and sugar that glows faintly in the gathering dark. It emanates from a narrow storefront in the Undermarket district, where a hand-painted sign swings in the breeze: "Griznik's Glowing Buns." Perhaps a moment's respite, a warm meal, and a local's knowledge might guide your search better than cold suspicion alone.]
+```
+
+![A block paragraph with a line at the top and bottom of it to indicate that it should be read or paraphrased to players.](https://gitlab.com/Jed_Hed/pf2e-typst/-/raw/0c532bdc12176011494e4d46329814148c3f2e63/docs/img/readAloud.png)
+
+---
+
+## Known Limitation
+
+### ~Chapter Header does not reach the top of the page~
+
+Resolved. The header now sit atop the page in question. Make sure to account for size when and laying out your document. You don't want it pushing images or tables off the page.
+
+### First line of the text indents
+
+If you look at official Paizo materials, you'll notice that the first line of text following anything but another paragraph is not indented. Typst doesn't have consistent way to generate this sort of a stylization. To circumvent such, I added a [label](https://typst.app/docs/reference/foundations/label/), `<s>` that you can apply onto a paragraph that you **don't** want to indent. 
+
+If an update to Typst offers an easier way to do this, I'll be swift to get it implemented here.
+
+## Contributing
+
+Feel free to open an Issue to report any bugs, suggest new features, general comments, or help requests. Don't be afraid to share your work either. I would love to see people using this toolkit or making their own tweaks to it!
+
+## License
+
+This project is licensed under the [MIT-0 License](https://fedoraproject.org/wiki/Licensing/MIT-0). As such, you are welcome to use this toolkit to your heart's content:
+
+- Change it however you see fit
+- Fork it and redistribute it as you like
+- No attribution towards me is necessary (but I wouldn't mind the appreciation 🤣)
+
+Seeing that I am specifically using Paizo's *Pathfinder 2nd Edition Remastered* as influence and a guideline for producing this template, this particular project is created under their [Community Use Policy](https://paizo.com/licenses/communityuse). This use of the policy applies specifically to this toolkit and, as such, does not *directly* extend to material generated with it. Please consult [Paizo's licenses](https://paizo.com/licenses) to see which extends to your content generated.
+
+`pf2e-style` uses trademarks and/or copyrights owned by Paizo Inc., used under Paizo's Community Use Policy (paizo.com/licenses/communityuse). We are expressly prohibited from charging you to use or access this content. `pf2e-style` is not published, endorsed, or specifically approved by Paizo. For more information about Paizo Inc. and Paizo products, visit paizo.com.

--- a/packages/preview/pf2e-style/0.2.0/lib.typ
+++ b/packages/preview/pf2e-style/0.2.0/lib.typ
@@ -1,0 +1,246 @@
+#import "style/formatting.typ": *
+
+// Pulled from https://github.com/typst/typst/issues/2196
+#let to-string(it) = {
+  if type(it) == str {
+    it
+  } else if type(it) != content {
+    str(it)
+  } else if it.has("text") {
+    it.text
+  } else if it.has("children") {
+    it.children.map(to-string).join()
+  } else if it.has("body") {
+    to-string(it.body)
+  } else if it == [ ] {
+    " "
+  }
+}
+
+#let roll-result(it) = {
+  let output = false
+  if to-string(it).starts-with("Critical Success") {output = true}
+  else if to-string(it).starts-with("Success") {output = true}
+  else if to-string(it).starts-with("Failure") {output = true}
+  else if to-string(it).starts-with("Critical Failure") {output = true}
+  else if to-string(it).starts-with("Heightened (") {output = true}
+  return output
+}
+
+#let pftraits(traits) = {
+  if traits != ([],) {
+  for trait in traits [
+#let style = if trait == "tiny" or trait == "small" or trait == "medium" or trait == "large" {
+      rgb("#3a7a58") // Size Green
+    } else if trait == "uncommon" {
+        orange
+    } else if trait == "rare" {
+        navy
+    } else if trait == "unique" {
+        rgb("#871F78") // Dark Purple
+    } else {
+    colors.pfmaroon
+  }
+#box(
+      fill: style,
+    stroke: (
+      left: colors.pfyellow + 2pt,
+      right: colors.pfyellow + 2pt,
+      top: colors.pfyellow + 1pt,
+      bottom: colors.pfyellow + 1pt,
+    ),
+      inset: 4pt
+    )[#text(weight: "semibold", size: .8em, fill: white)[#upper[#trait]]]
+]}}
+
+// Action Icons
+#let A = (
+  box(image("style/action-icons/single.svg", height: 1em))
+)
+#let AA = (
+  box(image("style/action-icons/double.svg", height: 1em))
+)
+#let AAA = (
+  box(image("style/action-icons/triple.svg", height: 1em))
+)
+#let R = (
+  box(image("style/action-icons/reaction.svg", height: 1em))
+)
+#let F = (
+  box(image("style/action-icons/free.svg", height: 1em))
+)
+
+#let box-top(info) = [
+  #text(size: 1.3em, weight: "extrabold")[#align(center)[#info\ ]]
+]
+
+#let pftab(name, columns: (1fr, 4fr), breakable: false, ..contents) = [
+  #v(1em)
+  #block(breakable: breakable)[
+  *#smallcaps(text(size: 1.3em)[#upper(name)])*
+  #v(-.5em)
+  #table(
+  columns: columns,
+  align: (col, row) =>
+   if col == 0 { center }
+    else { center },
+  fill: (col, row) => if row == 0 {rgb("002a16") } else if calc.odd(row+1) { colors.pfwhite } else { colors.otherRow },
+  inset: 5pt,
+  stroke: none,
+  // align: horizon,
+  ..contents
+  )
+  #v(1em)
+]]
+
+#let chap-header(num, title, desc) = place(
+  center + top,
+  // dx: 55%,
+  dy: -5%,
+  scope: "parent",
+  float: true,
+  clearance: -0.5em,
+)[
+  #set text(fill: colors.pfgreen)
+  #layout(size => {
+    let content = text(weight: "extrabold")[
+      #text(1.5em, font: "Taroca")[#upper(num)] \ 
+      #text(2em, font: "Taroca")[#upper(title)] \ 
+      #text(1.2em, style: "italic")[#desc]
+    ]
+    
+    block(
+      fill: rgb("#f4eee0"),
+      stroke: (
+        bottom: 3pt + rgb("#664200"),
+        rest: none,
+      ),
+      width: 115%,
+      inset: 1em,
+      outset: 1em,
+      align(center, content)
+      // outset: (x: 200%, y: (m.height / 2)),
+    )
+  })
+]
+
+#let note(info) = [
+  #v(1em)
+  #box(
+    fill: rgb("#e2d7d3"),
+    inset: 7pt,
+    // outset: 2pt,
+  )[
+    #show heading: it => align(center)[#it] 
+    #info
+  ]
+]
+
+#let attention(content) = [
+  #v(1em)
+  #box(
+    fill: rgb("#eadcb7"),
+    stroke: (1pt + black),
+    inset: 4pt,
+  )[
+    #show heading: it => align(center)[#it] 
+    #content
+  ]
+]
+
+#let aloud(content) = [
+  #v(.5em)
+  #line(stroke: 1pt + colors.pfbrown, length: 100%)
+  #text(fill: colors.pfbrown)[#content]
+  #line(stroke: 1pt + colors.pfbrown, length: 100%)
+  #v(.5em)
+]
+
+#let spell(spl) = [
+  #v(1em)
+    #set par(spacing: .6em, first-line-indent: 0em) // hanging-indent: 1em)
+    #let creature_header(body) = {
+      box(
+        text(weight: "extrabold",size: 1.4em, stretch: 50%)[#upper(spl.name)]
+      )
+      h(1fr)
+      sym.wj
+      box(text(weight: "extrabold",size: 1.4em, stretch: 50%)[#upper(body)])
+    }
+    #creature_header[#spl.type]
+    #line(stroke: 1pt, length: 100%)
+    #pftraits(spl.traits)
+  
+  #for req in spl.reqs {
+    par(hanging-indent: 1em)[#req\ ]
+  }
+  #line(stroke: 1pt, length: 100%)
+  #for effect in spl.effect {
+  if to-string(effect).starts-with("•") {
+    par(hanging-indent: 1.7em, first-line-indent: 1em)[#effect]
+  } else if roll-result(effect){
+    par(hanging-indent: 1em, first-line-indent: 0em)[#effect]
+  } else if effect == [---] or effect == [line] {line(stroke: 1pt, length: 100%)
+  } else {par(hanging-indent: 0em, first-line-indent: 1em)[#effect]}}
+]
+
+#let feat(feat) = [
+  #v(1em)
+    #set par(spacing: .6em, first-line-indent: 0em) // hanging-indent: 1em)
+    #set text(size: 10pt) 
+    #let creature_header(body) = {
+      box(
+        text(weight: "extrabold", size: 1.4em, stretch: 50%)[#upper(feat.name)]
+      )
+      h(1fr)
+      sym.wj
+      box(text(weight: "extrabold",size: 1.4em, stretch: 50%)[FEAT #body])
+    }
+    #creature_header[#feat.level]
+    #line(stroke: 1pt, length: 100%)
+  #pftraits(feat.traits)
+  
+  #for feat in feat.reqs {
+    par(hanging-indent: 1em)[#feat\ ]
+  }
+  #if feat.reqs != () {
+    line(stroke: 1pt, length: 100%)
+  }
+  #for effect in feat.effect {
+  if roll-result(effect) {
+    par(hanging-indent: 1em)[#effect]
+  } else {
+  par(hanging-indent: 0pt, first-line-indent: 1em)[#effect]}}
+  #if feat.special != [] {
+    line(stroke: 1pt, length: 100%)
+    par(hanging-indent: 1em)[#feat.special\ ]
+  }
+]
+
+#let encounter(comp) = [
+  #v(1em)
+    #set par(spacing: .6em, first-line-indent: 0em) // hanging-indent: 1em)
+    #let creature_header(body) = {
+      box(
+        text(weight: "extrabold", size: 1.3em, stretch: 50%)[#upper(comp.name)]
+      )
+      h(1fr)
+      sym.wj
+      box(text(weight: "extrabold",size: 1.3em, stretch: 50%)[#upper(comp.type)])
+    }
+    #creature_header[]
+    #line(stroke: 1pt, length: 100%)
+  #pftraits(comp.traits)
+  #for entry in (comp.details) {
+  if entry == [---] or entry == [line] {line(stroke: 1pt, length: 100%); continue}
+  if roll-result(entry) {par(hanging-indent: 1em)[#entry]; continue}
+  if comp.type == [Complication] or comp.type == [Opportunities] or comp.type == [] or comp.type == [Obstacle]  {par(hanging-indent: 0em)[#entry]; continue}
+  if comp.type == [Background] {par(hanging-indent: 0em, first-line-indent: 1em)[#entry]; continue}
+  // if entry.has(<r>) {entry;continue}
+    par(hanging-indent: 1em)[#entry] 
+  }
+    // #line(stroke: 1pt, length: 100%)
+    // #comp.trigger
+    // #line(stroke: 1pt, length: 100%)
+    // #comp.effect
+]

--- a/packages/preview/pf2e-style/0.2.0/style/action-icons/double.svg
+++ b/packages/preview/pf2e-style/0.2.0/style/action-icons/double.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="34.072403mm"
+   height="21.682438mm"
+   viewBox="0 0 34.072403 21.682438"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"><inkscape:page
+       x="0"
+       y="0"
+       width="34.072403"
+       height="21.682438"
+       id="page2"
+       margin="0"
+       bleed="0" /></sodipodi:namedview><defs
+     id="defs1" /><g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Double Action"
+     transform="translate(-72.678811,-131.03732)"><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 76.314992,138.13014 3.905533,3.72596 -3.815749,3.86064 -3.725968,-3.72596 z"
+       id="path3" /><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 83.362907,152.71977 10.728989,-10.77388 -10.77388,-10.90856 -5.072703,5.20738 5.656289,5.70118 -5.656289,5.70118 z"
+       id="path4" /><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 97.189389,151.14858 9.561821,-9.33737 -9.516931,-9.56181 -4.534009,4.44422 4.982922,5.02781 -4.93803,5.1176 z"
+       id="path5" /></g></svg>

--- a/packages/preview/pf2e-style/0.2.0/style/action-icons/free.svg
+++ b/packages/preview/pf2e-style/0.2.0/style/action-icons/free.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="21.727324mm"
+   height="21.862005mm"
+   viewBox="0 0 21.727324 21.862005"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   sodipodi:docname="single.svg"
+   inkscape:export-filename="free.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"><inkscape:page
+       x="0"
+       y="0"
+       width="21.727324"
+       height="21.862005"
+       id="page2"
+       margin="0"
+       bleed="0" /></sodipodi:namedview><defs
+     id="defs1" /><g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Single Action"
+     transform="translate(-72.589026,-86.86442)"><path
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke-width:0.841999"
+       d="M 83.45394,108.75286 94.318855,97.782205 83.40107,86.785114 72.562591,97.782205 Z"
+       id="path3"
+       sodipodi:nodetypes="ccccc"
+       transform="translate(1.125e-6)" /><path
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.558099"
+       d="m 78.082282,95.346004 2.558932,2.499425 -2.529179,2.558941 -2.588688,-2.529187 z"
+       id="path1" /><path
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.598214"
+       d="m 79.609474,93.768502 3.731575,-3.699682 7.750195,7.750195 -7.718302,7.782095 -3.699681,-3.73157 4.050514,-4.050525 z"
+       id="path2" /></g></svg>

--- a/packages/preview/pf2e-style/0.2.0/style/action-icons/reaction.svg
+++ b/packages/preview/pf2e-style/0.2.0/style/action-icons/reaction.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="21.386112mm"
+   height="17.648407mm"
+   viewBox="0 0 21.386112 17.648407"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"><inkscape:page
+       x="0"
+       y="1.9380785e-14"
+       width="21.386112"
+       height="17.648405"
+       id="page2"
+       margin="0"
+       bleed="0" /></sodipodi:namedview><defs
+     id="defs1" /><g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="Reaction"
+     transform="translate(-72.94815,-221.57667)"><path
+       style="opacity:1;fill:#000000;stroke-width:0.841999"
+       d="m 84.844315,231.77312 -8.798669,5.29716 9.876057,2.15478 -1.750755,-2.51391 c 0,0 4.05025,-0.33232 7.339707,-2.53635 1.272073,-0.85232 3.01966,-2.95639 2.805697,-5.16249 -0.258835,-2.66876 -1.167395,-4.11181 -4.06265,-5.74607 -2.187089,-1.23452 -4.290002,-1.75315 -7.451935,-1.68342 -2.504955,0.0552 -5.073127,0.82217 -7.160143,2.10989 -1.22518,0.75596 -2.693469,2.89548 -2.693469,2.89548 0,0 1.710074,-1.53662 4.399334,-2.08744 2.510224,-0.51415 5.364474,-0.7008 7.676391,0.40402 1.959922,0.9366 3.871771,2.04274 4.354443,4.84825 0.174386,1.01361 0.09453,2.5739 -2.087439,4.46668 -1.935995,1.6794 -3.389282,1.68341 -3.389282,1.68341 z"
+       id="path10"
+       sodipodi:nodetypes="ccccssssscsssscc" /></g></svg>

--- a/packages/preview/pf2e-style/0.2.0/style/action-icons/single.svg
+++ b/packages/preview/pf2e-style/0.2.0/style/action-icons/single.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="21.727324mm"
+   height="21.862005mm"
+   viewBox="0 0 21.727324 21.862005"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"><inkscape:page
+       x="0"
+       y="0"
+       width="21.727324"
+       height="21.862005"
+       id="page2"
+       margin="0"
+       bleed="0" /></sodipodi:namedview><defs
+     id="defs1" /><g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Single Action"
+     transform="translate(-72.589026,-86.86442)"><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 76.449668,93.957223 3.860638,3.770861 -3.815749,3.860636 -3.90553,-3.815747 z"
+       id="path1" /><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 78.155532,92.071795 5.252267,-5.207376 10.908554,10.908554 -10.863665,10.953447 -5.207375,-5.25227 5.701181,-5.701177 z"
+       id="path2" /></g></svg>

--- a/packages/preview/pf2e-style/0.2.0/style/action-icons/triple.svg
+++ b/packages/preview/pf2e-style/0.2.0/style/action-icons/triple.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="45.295181mm"
+   height="21.502888mm"
+   viewBox="0 0 45.295181 21.502888"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"><inkscape:page
+       x="0"
+       y="1.7928863e-21"
+       width="45.295181"
+       height="21.502888"
+       id="page2"
+       margin="0"
+       bleed="0" /></sodipodi:namedview><defs
+     id="defs1" /><g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Triple Action"
+     transform="translate(-72.7237,-175.52448)"><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 72.7237,186.34326 3.770857,-3.81575 3.77086,3.81575 -3.681076,3.77086 z"
+       id="path6" /><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 83.49758,197.02736 -5.072702,-4.98292 5.656289,-5.79097 -5.790962,-5.47672 5.117594,-5.25227 10.908554,10.81878 z"
+       id="path7" /><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 97.503627,195.68062 -4.489117,-4.44423 4.982919,-5.0727 -5.02781,-4.84824 4.534008,-4.62379 9.561823,9.42714 z"
+       id="path8" /><path
+       style="fill:#000000;stroke-width:0.841999"
+       d="m 110.3425,193.79519 -3.68108,-3.63618 4.0851,-4.04021 -4.0851,-3.95042 3.72597,-3.63619 7.6315,7.6315 z"
+       id="path9" /></g></svg>

--- a/packages/preview/pf2e-style/0.2.0/style/formatting.typ
+++ b/packages/preview/pf2e-style/0.2.0/style/formatting.typ
@@ -1,0 +1,93 @@
+#let colors = (
+  pfgreen: rgb("#002a16"),
+  pfred: rgb("#4e1b0e"),
+  pfmaroon: rgb("#5d0000"),
+  lightgreen: rgb("#015d4e"),
+  pfwhite: rgb("#ede3c7"),
+  pfnavy: rgb("#002b6f"),
+  otherRow: rgb("#f4eee0"),
+  pfyellow: rgb("#dac285"),
+  pfbrown: rgb("#644117"),
+)
+
+#let pf-stylization(doc) = {
+  // General page layout
+  set page(
+    paper: "a4",
+    columns: 2,
+    margin: (left: 12mm, right: 12mm, top: 12mm, bottom: 12mm),
+  )
+  set text(
+    font: ("Roboto", "Liberation Sans"), // General font family
+    size: 10pt,
+    stretch: 80%,
+  )
+  set par(
+    spacing: .6em,
+    justify: true,
+    first-line-indent: 1em,
+  )
+  show <s>: set par(first-line-indent: 0em)
+
+  /// Headers
+  show heading.where(level: 1): it => {
+    set par(first-line-indent: 0em)
+    text(
+      font: ("Taroca", "Liberation Sans"), // Staple Pathfinder font
+      size: 1.6em,
+      fill: colors.pfgreen,
+      weight: "extrabold",
+      it.body
+    )
+  }
+  show heading.where(level: 2): it => {
+    set par(first-line-indent: 0em)
+    text(
+      size: 1.4em,
+      fill: colors.pfred,
+      weight: "bold",
+      it.body
+    )
+  }
+  show heading.where(level: 3): it => {
+    set par(first-line-indent: 0em)
+    text(
+      size: 1.3em,
+      fill: colors.lightgreen,
+      weight: "bold",
+      it.body
+    )
+  }
+  show heading.where(level: 4): it => block(
+    width: 100%, 
+    rect(
+      width: 100%, 
+      radius: (
+        top-left: 10pt,
+        top-right: 5pt,
+      ),
+      fill: colors.pfnavy,
+      stroke: none,
+      inset: 6pt,
+      align(left, text(
+        fill: white,
+        weight: "bold",
+        size: 1.3em,
+        it.body
+      )+ v(-9pt) + line(length: 100%, stroke: (white + 0.5pt)))
+    )
+  ) 
+  show heading.where(level: 5): it => {
+    text(
+      size: 1.3em,
+      weight: "bold",
+      it.body
+    )
+  }
+
+  // Struggled to get this. Work around found here -> https://github.com/typst/typst/issues/3640
+  show table.cell.where(y: 0): it => (
+    text(fill: white, weight: "bold")[#it]
+  )
+  doc
+}

--- a/packages/preview/pf2e-style/0.2.0/typst.toml
+++ b/packages/preview/pf2e-style/0.2.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pf2e-style"
+version = "0.2.0"
+entrypoint = "lib.typ"
+license = "MIT-0"
+description = "Pathfinder 2.1 Edition Toolkit."
+authors = ["Jed_Hed <jed_hed@proton.me>"]
+repository = "https://gitlab.com/Jed_Hed/pf2e-typst"
+categories = ["components", "layout", "book"]
+keywords = ["dnd", "pathfinder", "rpg", "ttrpg", "tabletop", "game"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Pathfinder 2nd Edition Remastered template. Adds styling, functions, and icons to enable third party and independent role-playing game material creation using Typst. **Better optimized functions and styling**

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [X] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.

### Changelog

- Created an `encounter` function which acts as a single, more simplistic way to create stat blocks, hazards, complications, and whatever else an adventuring party might run into
- Turned the operation to stylize traits into a single function, `pftraits` to reduce redundancy
- Fixed `chap-header` so that it attaches to the head of the page
- Condensed `feat` and `spell` so that they have similar syntax
- Adjusted the spacing in `aloud` to look cleaner
- Corrected the Paizo license from Fan Content to Community Use