### PR TITLE
slate-geometry:0.1.0

### DIFF
--- a/packages/preview/slate-geometry/0.1.0/LICENSE
+++ b/packages/preview/slate-geometry/0.1.0/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2026 Tobias Wölfel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/slate-geometry/0.1.0/README.md
+++ b/packages/preview/slate-geometry/0.1.0/README.md
@@ -1,0 +1,46 @@
+# slate-geometry - Collection Of Tablet Specifications
+
+This package provides information for tablets (e.g. Remarkable).
+The information can be used to set up the page format.
+
+The main intention is to not have to remember the device screen sizes when
+creating documents for the paper tablet and still create files which perfectly
+match the device.
+
+## Usage
+
+Use the `setup()` function to set the page size directly.
+This changes the margin at the `top` to match the toolbar size.
+
+```typst
+#import "@preview/slate-geometry:0.1.0": setup
+
+#show: setup.with(
+  "remarkable",
+  "paper-pro",
+  toolbar-pos: "top",
+)
+```
+
+But it is also possible to retrieve the values directly:
+
+```typst
+#import "@preview/slate-geometry:0.1.0": get-size
+
+#let (width, height) = get-size("remarkable", "paper-pro-move")
+#set page(width: width, height: height)
+
+#width.mm() mm x #height.mm() mm
+```
+
+**Toolbar**
+
+The database also stores the approximate size of the toolbar.
+This can be used to prevent the area from being used so nothing is hidden behind
+it.
+
+```typst
+#import "@preview/slate-geometry:0.1.0": get-toolbar
+
+#let bar-width = get-toolbar("remarkable", "2")
+```

--- a/packages/preview/slate-geometry/0.1.0/slate-geometry.typ
+++ b/packages/preview/slate-geometry/0.1.0/slate-geometry.typ
@@ -1,0 +1,3 @@
+#import "src/device-setup.typ": (
+  brands, devices, get-size, get-toolbar, models, setup,
+)

--- a/packages/preview/slate-geometry/0.1.0/src/device-setup.typ
+++ b/packages/preview/slate-geometry/0.1.0/src/device-setup.typ
@@ -1,0 +1,76 @@
+#import "devices.typ": devices
+
+// Access to the brands
+#let brands() = devices.keys()
+// Access to the models for a given brand
+#let models(brand) = devices.at(brand).keys()
+
+#let get-spec(brand, model) = {
+  let brand-models = devices.at(brand, default: none)
+  assert(
+    brand-models != none,
+    message: "Brand not found: "
+      + brand
+      + ". Available: "
+      + brands().join(", "),
+  )
+  let spec = brand-models.at(model, default: none)
+  assert(
+    spec != none,
+    message: "Model not found: "
+      + model
+      + " for brand "
+      + brand
+      + ". Available: "
+      + models(brand).join(", "),
+  )
+  return spec
+}
+
+
+#let get-size(brand, model) = {
+  let spec = get-spec(brand, model)
+  return (spec.width, spec.height)
+}
+
+#let get-toolbar(brand, model) = {
+  let spec = get-spec(brand, model)
+  return spec.toolbar
+}
+
+#let setup(brand, model, toolbar-pos: none, base-margin: auto, body) = {
+  // Device size
+  let (w, h) = get-size(brand, model)
+
+  // Margin
+  // Create a margin variable with default values
+  let m = if type(base-margin) == dictionary {
+    (top: 0mm, bottom: 0mm, left: 0mm, right: 0mm) + base-margin
+  } else {
+    (
+      top: base-margin,
+      bottom: base-margin,
+      left: base-margin,
+      right: base-margin,
+    )
+  }
+
+  // Update the margin with the toolbar width for the selected sides
+  let toolbar-width = get-toolbar(brand, model)
+  if toolbar-pos != none and toolbar-width != none {
+    let positions = if type(toolbar-pos) == array {
+      toolbar-pos
+    } else {
+      (toolbar-pos,)
+    }
+    for pos in positions {
+      m.insert(str(pos), toolbar-width)
+    }
+  }
+
+  // Page setup
+  set page(width: w, height: h, margin: m)
+
+  body
+}
+

--- a/packages/preview/slate-geometry/0.1.0/src/devices.typ
+++ b/packages/preview/slate-geometry/0.1.0/src/devices.typ
@@ -1,0 +1,28 @@
+#let devices = (
+  "apple": (
+    // 1640 x 2360 resolution (264 PPI)
+    "ipad-11-a16": (width: 157.8mm, height: 227.1mm, toolbar: none),
+  ),
+  "boox": (
+    // 1860 x 2480 resolution (300 PPI) (B/W)
+    "note-air4-c": (width: 157.5mm, height: 210.0mm, toolbar: 13mm),
+    // 1860 x 2480 resolution (300 PPI) (B/W)
+    "note-air5-c": (width: 157.5mm, height: 210.0mm, toolbar: 13mm),
+    // 2400 x 3200 resolution (300 PPI) (B/W)
+    "tab-x-c": (width: 203.2mm, height: 270.9mm, toolbar: 13mm),
+  ),
+  "remarkable": (
+    // 1404 x 1872 resolution (226 PPI)
+    "2": (width: 157.8mm, height: 210.4mm, toolbar: 13mm),
+    // 1620 x 2160 resolution (229 PPI)
+    "paper-pro": (width: 179.7mm, height: 239.6mm, toolbar: 13mm),
+    // 954 x 1696 resolution (264 PPI)
+    "paper-pro-move": (width: 91.8mm, height: 163.2mm, toolbar: 13mm),
+  ),
+  "supernote": (
+    // 1920 × 2560 resolution (300 PPI)
+    "manta": (width: 162.6mm, height: 216.8mm, toolbar: 10mm),
+    // 1404 × 1872 resolution (300 PPI)
+    "nomad": (width: 118.9mm, height: 158.5mm, toolbar: 10mm),
+  ),
+)

--- a/packages/preview/slate-geometry/0.1.0/typst.toml
+++ b/packages/preview/slate-geometry/0.1.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "slate-geometry"
+version = "0.1.0"
+entrypoint = "slate-geometry.typ"
+authors = ["Tobias Wölfel"]
+license = "MIT"
+description = "Collection of device specifications for page setup."
+repository = "https://github.com/towoe/slate-geometry"
+keywords = ["devices", "paper", "remarkable", "epaper", "apple"]
+categories = ["layout", "office"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Collection of screen sizes for tablets. Useful when creating documents for non standard sized devices.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [ ] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [x] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
