### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/packages/ @typst/package-review


### PR DESCRIPTION
This adds a `CODEOWNERS` file so package requests are automatically assigned to the @typst/package-review team.