### PR TITLE
ferrmat:0.1.0

### DIFF
--- a/packages/preview/ferrmat/0.1.0/LICENSE
+++ b/packages/preview/ferrmat/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Esdras
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/ferrmat/0.1.0/README.md
+++ b/packages/preview/ferrmat/0.1.0/README.md
@@ -1,0 +1,252 @@
+# FerrMat
+
+**Ferramentas Matemáticas** — Caixas decorativas, ambientes matemáticos e código estilizado em português para [Typst](https://typst.app).
+
+---
+
+## Sobre o Projeto
+
+O **FerrMat** é um pacote Typst que oferece componentes visuais e matemáticos com nomes em português. Inclui caixas coloridas estilo tcolorbox, ambientes de teoremas com numeração automática, operadores matemáticos em português, estilização de código e gráficos de Gantt.
+
+Este pacote é o companheiro do **[ABNTyp](https://github.com/3sdras/abntyp)**, que cuida da formatação conforme normas ABNT. O FerrMat fornece componentes independentes de normas, que podem ser usados em qualquer documento Typst.
+
+---
+
+## Instalação
+
+### Via Typst Universe (recomendado)
+
+```typst
+#import "@preview/ferrmat:0.1.0": *
+```
+
+### Via Clone Local
+
+```bash
+git clone https://github.com/3sdras/ferrmat.git
+```
+
+```typst
+#import "caminho/para/ferrmat/lib.typ": *
+```
+
+---
+
+## Módulos
+
+### Caixas Coloridas (`caixas.typ`)
+
+Caixas decorativas estilo tcolorbox com bordas, cores e numeração automática.
+
+```typst
+// Caixa simples
+#caixa(titulo: "Informação", cor: blue)[
+  Conteúdo da caixa.
+]
+
+// Caixa com borda completa
+#caixa(titulo: "Aviso", cor: red, borda: "completa", raio: 4pt)[
+  Conteúdo importante.
+]
+
+// Estilo reutilizável com numeração automática
+#let nota = caixa-estilo(
+  cor: orange,
+  borda: "completa",
+  raio: 3pt,
+  prefixo: "Nota",
+)
+#nota[Lembre-se: $1$ não é considerado primo.]
+```
+
+### Ambientes Matemáticos (`matematica.typ`)
+
+Ambientes de teoremas, definições, exemplos e provas com numeração automática e estilos configuráveis.
+
+**Ambientes disponíveis:** `teorema`, `lema`, `corolario`, `proposicao`, `axioma`, `conjectura`, `afirmacao`, `definicao`, `notacao`, `propriedade`, `exemplo`, `problema`, `observacao`
+
+```typst
+#teorema(titulo: "Pitágoras")[
+  Em todo triângulo retângulo, $a^2 = b^2 + c^2$.
+]
+
+#demonstracao[
+  A demonstração clássica usa a comparação de áreas...
+]
+
+#definicao[
+  Um número $p > 1$ é *primo* se seus únicos divisores são $1$ e $p$.
+]
+
+// Configurar estilo e numeração
+#configurar-ambientes("cinza")          // "colorido", "cinza", "sem-caixa"
+#show: configurar-numeracao("por-tipo", por-secao: true)
+```
+
+**Operadores em português:** `sen`, `tg`, `csc`, `ctg`, `arcsen`, `arctg`, `senh`, `tgh`, `mdc`, `mmc`
+
+**Funções matemáticas:**
+
+```typst
+$fracao(a+b, c+d)$                      // fração vertical
+$matriz(1, 2; 3, 4)$                    // matriz com parênteses
+$colchete(1, 2; 3, 4)$                  // matriz com colchetes
+$binomio(n, k)$                         // coeficiente binomial
+$raiz(2)$  $raiz(3, 8)$                 // raiz quadrada / cúbica
+$leibniz(y, x)$  $leibniz(y, x, 2)$    // derivadas de Leibniz
+$parcial(f, x)$  $parcial(f, x, y)$    // derivadas parciais
+$porPartes(x, se x > 0; -x, se x < 0)$ // função por partes
+```
+
+**Símbolos em português:** `integral`, `somatorio`, `produtorio`, `uniao`, `inter`, `vezes`, `implica`, `sse`, `portanto`, `paraTodo`, `existe`, letras gregas (`alfa`, `gama`, `teta`, etc.)
+
+### Código Estilizado (`codigo.typ`)
+
+```typst
+// Código inline
+O comando #codigo-inline(`print("hello")`) imprime uma saudação.
+
+// Bloco de código com título e numeração de linhas
+#codigo-bloco(
+  lang: "python",
+  titulo: "script.py",
+  numerar-linhas: true,
+  ```python
+  def fatorial(n):
+      if n <= 1:
+          return 1
+      return n * fatorial(n - 1)
+  ```.text
+)
+```
+
+### Cronograma de Gantt (`cronograma.typ`)
+
+Gráficos de Gantt com tarefas, marcos, dependências e progresso (usa CeTZ).
+
+```typst
+#cronograma(
+  hoje: data(15, 3, 2026),
+  mostrar-dependencias: true,
+  (
+    tarefa("Planejamento", data(1, 3, 2026), data(7, 3, 2026),
+      progresso: 100, cor: verde),
+    tarefa("Design", data(5, 3, 2026), data(14, 3, 2026),
+      progresso: 50, cor: azul),
+    tarefa("Entrega", data(28, 3, 2026), data(28, 3, 2026),
+      marco: true, cor: vermelho),
+  ),
+)
+```
+
+### Unidades e Números (`unidades.typ`)
+
+Formatação de números e unidades SI em locale brasileiro, equivalente ao `siunitx` do LaTeX.
+
+```typst
+#num(3.14159)                          // 3,14159
+#num(1234567)                          // 1 234 567
+#num(2.998e8)                          // 2,998 × 10⁸
+#qtd(9.81, "m/s^2")                    // 9,81 m/s²
+#unidade("kg.m/s^2")                   // kg·m/s²
+#faixa-qtd(20, 25, "°C")              // 20 °C a 25 °C
+#ang(45, minutos: 30)                  // 45°30′
+```
+
+**Funções:** `num`, `unidade` (`un`), `qtd`, `faixa-num`, `faixa-qtd`, `lista-num`, `lista-qtd`, `ang`, `tablenum`, `declarar-unidade`, `configurar-numeros`
+
+### Índice Remissivo (`indice.typ`)
+
+Sistema de índice remissivo equivalente ao `makeidx` do LaTeX.
+
+```typst
+A #irem("derivada") derivada de uma função...
+A #irem-def("integral") é definida como...    // exibe "integral" em negrito
+#irem("velocidade", ver: "cinemática")         // remissiva "ver"
+
+// No final do documento:
+#imprimir-indice()
+```
+
+### Provas e Avaliações (`prova.typ`)
+
+Módulo para criação de provas e testes, similar ao `exam.cls` do LaTeX.
+
+```typst
+#cabecalho-prova(
+  instituicao: "UFJ", disciplina: "Cálculo I",
+  professor: "Dr. Silva", data: "22/02/2026",
+)
+#questao(pontos: 2.5)[Calcule a derivada de $f(x) = x^2$.]
+#alternativas("$2x$", "$x^2$", "$2$", "$0$")
+#questao(pontos: 3.0)[Resolva a integral.]
+#espaco-resposta(altura: 5cm)
+#total-pontos()
+```
+
+**Funções:** `cabecalho-prova`, `questao`, `subquestao`, `alternativas`, `verdadeiro-falso`, `preencher-linhas`, `espaco-resposta`, `total-pontos`, `tabela-pontos`
+
+### Anotações e Notas Marginais (`anotacoes.typ`)
+
+Sistema de anotações TODO e notas marginais, similar ao `todonotes` do LaTeX.
+
+```typst
+#registrar-autores(("Alice": blue, "Bob": red))
+#afazer(autor: "Alice")[Revisar esta seção.]
+#urgente[Corrigir erro na fórmula!]
+#nota-margem[Nota explicativa.]
+#lista-de-tarefas()                    // sumário de pendências
+#show: esconder-tarefas               // oculta tudo na versão final
+```
+
+### Formatação de Seções (`secoes.typ`)
+
+Personalização de títulos de seções, equivalente ao `titlesec` do LaTeX.
+
+```typst
+#show heading.where(level: 1): formatar-secao.with(
+  peso: "bold", tamanho: 16pt, forma: "bloco", quebra-pagina: true,
+)
+```
+
+### Colunas e Grades (`colunas.typ`)
+
+Wrappers em português para layout de colunas e grades.
+
+```typst
+#colunas(quantidade: 2)[Texto em duas colunas.]
+#grade(colunas: (1fr, 1fr), [Célula 1], [Célula 2])
+```
+
+### Cores em Português (`cores.typ`)
+
+Constantes de cores: `preto`, `branco`, `azul`, `vermelho`, `verde`, `amarelo`, `laranja`, `roxo`, `cinza`, `prata`, `azul-marinho`, `azul-petroleo`, `bordo`, `oliva`, `lima`, `agua`, `fucsia`, `oriental`
+
+### Configuração de Página (`pagina.typ`)
+
+```typst
+#show: configurar-pagina.with(papel: "a4", margem: margem(superior: 3cm, inferior: 2cm))
+#quebra-pagina()
+```
+
+---
+
+## Dependências
+
+- [CeTZ](https://typst.app/universe/package/cetz) 0.4.0 (para o módulo de cronograma)
+
+---
+
+## Licença
+
+Distribuído sob a licença **MIT**. Veja o arquivo [LICENSE](LICENSE).
+
+---
+
+## Créditos
+
+O FerrMat é uma adaptação do trabalho **"Uma breve introdução ao LaTeX 2e"** do Prof. Dr. **Lenimar Nunes de Andrade** (DM/UFPB), transpondo seu excelente material didático para o contexto do Typst.
+
+---
+
+_FerrMat — Ferramentas Matemáticas para Typst, com nomes em português._

--- a/packages/preview/ferrmat/0.1.0/lib.typ
+++ b/packages/preview/ferrmat/0.1.0/lib.typ
@@ -1,0 +1,12 @@
+#import "src/cores.typ": *
+#import "src/caixas.typ": *
+#import "src/codigo.typ": *
+#import "src/matematica.typ": *
+#import "src/cronograma.typ": *
+#import "src/pagina.typ": *
+#import "src/secoes.typ": *
+#import "src/prova.typ": *
+#import "src/colunas.typ": *
+#import "src/anotacoes.typ": *
+#import "src/unidades.typ": *
+#import "src/indice.typ": *

--- a/packages/preview/ferrmat/0.1.0/src/anotacoes.typ
+++ b/packages/preview/ferrmat/0.1.0/src/anotacoes.typ
@@ -1,0 +1,346 @@
+// Módulo de anotações e notas marginais
+// Notas TODO (afazer) + notas marginais explicativas + sistema de cores por autor
+
+// ---------------------------------------------------------------------------
+// Estado global: mapa de autores → cores
+// ---------------------------------------------------------------------------
+
+#let _anotacoes-autores = state("ferrmat-anotacoes-autores", (:))
+
+// Pool de cores para atribuição automática
+#let _pool-cores = (orange, purple, teal, fuchsia, olive, eastern, blue, red)
+
+/// Registra um autor e sua cor associada.
+///
+/// - nome (str): nome do autor
+/// - cor (color): cor associada ao autor
+#let registrar-autor(nome, cor) = {
+  _anotacoes-autores.update(m => {
+    m.insert(nome, cor)
+    m
+  })
+}
+
+/// Registra vários autores de uma vez a partir de um dicionário nome → cor.
+///
+/// - dict (dictionary): mapeamento de nomes para cores
+///   Exemplo: `("Alice": blue, "Ricardo": red, "Carol": green)`
+#let registrar-autores(dict) = {
+  _anotacoes-autores.update(m => {
+    for (nome, cor) in dict {
+      m.insert(nome, cor)
+    }
+    m
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Funções auxiliares internas
+// ---------------------------------------------------------------------------
+
+/// Resolve a cor de um autor (registrada ou automática do pool).
+/// Se o autor não estiver registrado, atribui uma cor do pool e registra
+/// automaticamente para manter consistência em chamadas subsequentes.
+/// Deve ser chamada dentro de um bloco `context`.
+#let _resolver-cor(autor, cor-manual) = {
+  if cor-manual != auto { return cor-manual }
+  if autor == none { return orange }
+
+  let mapa = _anotacoes-autores.get()
+  if autor in mapa {
+    mapa.at(autor)
+  } else {
+    // Atribuição cíclica do pool baseada na quantidade de autores já registrados
+    let idx = mapa.len()
+    _pool-cores.at(calc.rem(idx, _pool-cores.len()))
+  }
+}
+
+/// Extrai o valor de uma margem (esquerda ou direita) a partir de `page.margin`.
+#let _extrair-margem(margem, lado) = {
+  let chave = if lado == left { "left" } else { "right" }
+  if type(margem) == dictionary {
+    if chave in margem { margem.at(chave) }
+    else if "x" in margem { margem.x }
+    else { 2cm }
+  } else { margem }
+}
+
+/// Normaliza o valor de `lado` aceitando português ou inglês.
+#let _normalizar-lado(lado) = {
+  if lado == left or lado == right or lado == auto { lado }
+  else if lado == "esquerda" { left }
+  else if lado == "direita" { right }
+  else { lado }  // fallback
+}
+
+/// Posiciona conteúdo na margem da página.
+/// Deve ser chamada dentro de um bloco `context`.
+#let _colocar-na-margem(body, lado, largura-nota, dy) = {
+  let lado-norm = _normalizar-lado(lado)
+
+  let margem = page.margin
+  let m-esq = _extrair-margem(margem, left)
+  let m-dir = _extrair-margem(margem, right)
+
+  // Quando auto, detecta qual margem é maior e usa essa.
+  let target = if lado-norm == auto {
+    if m-esq > m-dir { left } else { right }
+  } else { lado-norm }
+
+  let nota-largura = if largura-nota == auto { 3.2cm } else { largura-nota }
+
+  // Centraliza a nota horizontalmente dentro da margem.
+  // place(right) alinha a borda DIREITA do bloco à borda direita do texto,
+  // então dx = (margem + largura) / 2 empurra o centro da nota para o centro da margem.
+  let m-alvo = if target == right { m-dir } else { m-esq }
+
+  // Mede a altura da nota para centralizar verticalmente com a linha do texto
+  let nota-bloco = block(width: nota-largura, body)
+  let nota-alt = measure(nota-bloco).height
+
+  place(
+    target,
+    dx: if target == right { (m-alvo + nota-largura) / 2 } else { -(m-alvo + nota-largura) / 2 },
+    dy: dy - nota-alt / 2 + 0.5em - 0.7cm,
+    nota-bloco,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Notas TODO (afazer)
+// ---------------------------------------------------------------------------
+
+/// Cria uma nota de pendência (TODO).
+///
+/// - body (content): texto da pendência
+/// - autor (str): nome do autor (usa cor registrada ou automática)
+/// - cor (color, auto): cor manual; `auto` usa a cor do autor
+/// - em-linha (bool): se `true`, renderiza inline ao invés de na margem
+/// - lado (alignment, str, auto): `esquerda`, `direita` ou `auto` (margem externa em frente-e-verso)
+/// - destaque (content, none): trecho de texto a destacar com a cor da nota, indicando a que se refere (estilo todonotes)
+#let afazer(
+  body,
+  autor: none,
+  cor: auto,
+  em-linha: false,
+  lado: auto,
+  destaque: none,
+) = context {
+  let cor-final = _resolver-cor(autor, cor)
+
+  // Registra autor não-registrado para manter cor consistente em chamadas futuras
+  if cor == auto and autor != none {
+    let mapa = _anotacoes-autores.get()
+    if autor not in mapa {
+      _anotacoes-autores.update(m => { m.insert(autor, cor-final); m })
+    }
+  }
+
+  // Metadata para coleta na lista de pendências
+  [#metadata((texto: body, autor: autor, cor: cor-final, tipo: "afazer")) <_afazer>]
+
+  // Destaque indicando o trecho referido (estilo todonotes)
+  if destaque != none {
+    highlight(fill: cor-final.lighten(88%), destaque)
+  }
+
+  if em-linha {
+    // Renderização inline — envolvida em figure para que esconder-tarefas funcione
+    [#figure(kind: "_afazer", supplement: none, outlined: false,
+      block(
+        width: 100%,
+        inset: 8pt,
+        radius: 3pt,
+        stroke: 0.8pt + cor-final,
+        fill: cor-final.lighten(85%),
+      )[
+        #set text(size: 9pt)
+        #set par(first-line-indent: 0pt)
+        #if autor != none [#text(weight: "bold", fill: cor-final)[#autor:] ]
+        #body
+      ]
+    )]
+  } else {
+    // Figura invisível para que esconder-tarefas funcione (place não é capturado por show-rules)
+    [#figure(kind: "_afazer", supplement: none, outlined: false, none)]
+    // Renderização na margem
+    _colocar-na-margem(
+      block(
+        inset: 5pt,
+        radius: 2pt,
+        stroke: 0.6pt + cor-final,
+        fill: cor-final.lighten(88%),
+      )[
+        #set text(size: 7.5pt)
+        #set par(first-line-indent: 0pt, leading: 0.5em)
+        #if autor != none [#text(weight: "bold", fill: cor-final)[#autor] \ ]
+        #body
+      ],
+      lado,
+      auto,
+      0pt,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Presets de categoria
+// ---------------------------------------------------------------------------
+
+/// Nota urgente (vermelho).
+#let urgente(body, autor: none, em-linha: false, destaque: none) = afazer(body, autor: autor, cor: red, em-linha: em-linha, destaque: destaque)
+
+/// Nota para revisão (laranja/amarelo).
+#let revisar(body, autor: none, em-linha: false, destaque: none) = afazer(body, autor: autor, cor: orange, em-linha: em-linha, destaque: destaque)
+
+/// Nota de melhoria (azul).
+#let melhorar(body, autor: none, em-linha: false, destaque: none) = afazer(body, autor: autor, cor: blue, em-linha: em-linha, destaque: destaque)
+
+/// Nota de verificação (verde).
+#let verificar(body, autor: none, em-linha: false, destaque: none) = afazer(body, autor: autor, cor: green, em-linha: em-linha, destaque: destaque)
+
+// ---------------------------------------------------------------------------
+// Placeholder de figura ausente
+// ---------------------------------------------------------------------------
+
+/// Renderiza um placeholder para uma figura que ainda não existe.
+///
+/// - descricao (content): descrição da figura faltando
+/// - largura (length): largura do placeholder
+/// - altura (length): altura do placeholder
+/// - cor (color): cor de fundo
+#let figura-faltando(
+  descricao,
+  largura: 100%,
+  altura: 4cm,
+  cor: red.lighten(80%),
+) = {
+  // Registra como pendência
+  [#metadata((texto: descricao, autor: none, cor: red, tipo: "figura-faltando")) <_afazer>]
+
+  // Envolvido em figure para que esconder-tarefas funcione
+  [#figure(kind: "_afazer", supplement: none, outlined: false,
+    block(
+      width: largura,
+      height: altura,
+      inset: 1em,
+      radius: 4pt,
+      stroke: (dash: "dashed", paint: red, thickness: 1.5pt),
+      fill: cor,
+    )[
+      #set align(center + horizon)
+      #set par(first-line-indent: 0pt)
+      #text(size: 20pt)[⚠] \
+      #text(size: 10pt, style: "italic")[#descricao]
+    ]
+  )]
+}
+
+// ---------------------------------------------------------------------------
+// Notas marginais explicativas (estilo livro de cálculo)
+// ---------------------------------------------------------------------------
+
+/// Posiciona uma nota explicativa na margem da página.
+///
+/// - body (content): texto da nota marginal
+/// - lado (alignment, str, auto): `esquerda`, `direita` ou `auto`
+/// - largura (length, auto): largura da nota
+/// - dy (length): deslocamento vertical
+/// - ancora (label, none): label para referência cruzada
+/// - borda (stroke, none): borda opcional
+/// - cor (color, none): cor de fundo opcional
+#let nota-margem(
+  body,
+  lado: auto,
+  largura: auto,
+  dy: 0pt,
+  ancora: none,
+  borda: none,
+  cor: none,
+) = {
+  // Marcador para que esconder-anotacoes possa ocultar notas marginais
+  [#figure(kind: "_nota-margem", supplement: none, outlined: false, none)]
+
+  context {
+    _colocar-na-margem(
+      block(
+        inset: if borda != none or cor != none { 4pt } else { 0pt },
+        radius: if borda != none or cor != none { 2pt } else { 0pt },
+        stroke: borda,
+        fill: cor,
+      )[
+        #set text(size: 8pt)
+        #set par(first-line-indent: 0pt, leading: 0.45em, justify: false)
+        #body
+        #if ancora != none { ancora }
+      ],
+      lado,
+      largura,
+      dy,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lista de pendências
+// ---------------------------------------------------------------------------
+
+/// Gera uma lista de todas as pendências registradas com `afazer()` e `figura-faltando()`.
+///
+/// - titulo (content): título da seção
+#let lista-de-tarefas(titulo: "Lista de Pendências") = context {
+  let itens = query(<_afazer>)
+
+  if itens.len() == 0 {
+    return [_Nenhuma pendência encontrada._]
+  }
+
+  heading(level: 2, numbering: none, titulo)
+
+  set par(first-line-indent: 0pt)
+
+  for item in itens {
+    let dados = item.value
+    let loc = item.location()
+    let pg = counter(page).at(loc).first()
+    let cor-item = if type(dados.cor) == color { dados.cor } else { gray }
+
+    block(
+      width: 100%,
+      inset: (x: 0.5em, y: 0.3em),
+      below: 0.4em,
+    )[
+      #set text(size: 10pt)
+      #box(width: 8pt, height: 8pt, fill: cor-item, radius: 1pt)
+      #h(0.4em)
+      #if dados.autor != none [*#dados.autor* -- ]
+      #if dados.tipo == "figura-faltando" [_(Figura faltando)_ ]
+      #dados.texto
+      #h(1fr)
+      #text(fill: gray)[p. #pg]
+    ]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ocultação global
+// ---------------------------------------------------------------------------
+
+/// Show-rule para ocultar todas as notas de pendência (TODOs).
+/// Oculta tanto as notas visuais (inline e margem) quanto os metadados.
+/// Uso: `#show: esconder-tarefas`
+#let esconder-tarefas(body) = {
+  show figure.where(kind: "_afazer"): none
+  show metadata.where(label: <_afazer>): none
+  body
+}
+
+/// Show-rule para ocultar todas as anotações (TODOs + notas marginais).
+/// Uso: `#show: esconder-anotacoes`
+#let esconder-anotacoes(body) = {
+  show figure.where(kind: "_afazer"): none
+  show figure.where(kind: "_nota-margem"): none
+  show metadata.where(label: <_afazer>): none
+  body
+}

--- a/packages/preview/ferrmat/0.1.0/src/caixas.typ
+++ b/packages/preview/ferrmat/0.1.0/src/caixas.typ
@@ -1,0 +1,152 @@
+// Sistema de caixas coloridas (estilo tcolorbox)
+
+/// Constrói o conteúdo do título formatado para caixas e ambientes.
+///
+/// Retorna `none` se `prefixo` for `none`.
+///
+/// - prefixo: texto do rótulo (ex: "Teorema", "Definição")
+/// - num: número formatado (ou `none` se sem numeração)
+/// - titulo: título descritivo (ou `none` se sem título)
+#let _build-titulo(prefixo, num, titulo) = {
+  if prefixo == none { return none }
+  if num != none {
+    if titulo != none {
+      [*#prefixo #num* --- #titulo]
+    } else {
+      [*#prefixo #num*]
+    }
+  } else {
+    if titulo != none {
+      [*#prefixo* --- #titulo]
+    } else {
+      [*#prefixo*]
+    }
+  }
+}
+
+#let caixa(
+  body,
+  titulo: none,
+  cor: blue,
+  borda: "esquerda",
+  espessura: 2pt,
+  raio: 0pt,
+  preenchimento: auto,
+  titulo-fundo: auto,
+  titulo-cor: black,
+  recuo: 1em,
+  largura: 100%,
+  quebravel: true,
+) = {
+  let bg = if preenchimento == auto { cor.lighten(92%) } else { preenchimento }
+  let titulo-bg = if titulo-fundo == auto { cor.lighten(80%) } else { titulo-fundo }
+
+  let stroke = if borda == "esquerda" or borda == "left" {
+    (left: espessura + cor)
+  } else if borda == "topo" or borda == "top" {
+    (top: espessura + cor)
+  } else if borda == "completa" or borda == "full" {
+    espessura + cor
+  } else {
+    none
+  }
+
+  if titulo != none {
+    // Caixa com título
+    block(
+      width: largura,
+      breakable: quebravel,
+      radius: raio,
+      clip: raio > 0pt,
+      stroke: stroke,
+      {
+        // Barra de título
+        block(
+          width: 100%,
+          fill: titulo-bg,
+          inset: recuo,
+          below: 0pt,
+          text(fill: titulo-cor, weight: "bold", titulo)
+        )
+        // Corpo
+        block(
+          width: 100%,
+          fill: bg,
+          inset: recuo,
+          above: 0pt,
+          body
+        )
+      }
+    )
+  } else {
+    // Caixa sem título
+    block(
+      width: largura,
+      breakable: quebravel,
+      radius: raio,
+      stroke: stroke,
+      fill: bg,
+      inset: recuo,
+      body,
+    )
+  }
+}
+
+#let caixa-estilo(
+  cor: blue,
+  borda: "esquerda",
+  espessura: 2pt,
+  raio: 0pt,
+  preenchimento: auto,
+  titulo-fundo: auto,
+  titulo-cor: black,
+  recuo: 1em,
+  largura: 100%,
+  quebravel: true,
+  prefixo: none,
+  contador: none,
+  numeracao: "1",
+  por-secao: false,
+) = {
+  let counter-key = contador
+
+  assert(not por-secao or counter-key != none,
+    message: "caixa-estilo: por-secao requer contador")
+
+  // Closure auxiliar que renderiza a caixa com o título já resolvido
+  let _render(body, t) = caixa(
+    body,
+    titulo: t,
+    cor: cor,
+    borda: borda,
+    espessura: espessura,
+    raio: raio,
+    preenchimento: preenchimento,
+    titulo-fundo: titulo-fundo,
+    titulo-cor: titulo-cor,
+    recuo: recuo,
+    largura: largura,
+    quebravel: quebravel,
+  )
+
+  // Retorna uma closure
+  (body, titulo: none) => {
+    if prefixo != none and counter-key != none {
+      counter(counter-key).step()
+      context {
+        let num = if por-secao {
+          let sec = counter(heading).get().first()
+          let c = counter(counter-key).at(here()).first()
+          [#sec.#c]
+        } else {
+          numbering(numeracao, ..counter(counter-key).at(here()))
+        }
+        _render(body, _build-titulo(prefixo, num, titulo))
+      }
+    } else if prefixo != none {
+      _render(body, _build-titulo(prefixo, none, titulo))
+    } else {
+      _render(body, titulo)
+    }
+  }
+}

--- a/packages/preview/ferrmat/0.1.0/src/codigo.typ
+++ b/packages/preview/ferrmat/0.1.0/src/codigo.typ
@@ -1,0 +1,87 @@
+// Estilização de código (inline + bloco)
+
+#let codigo-inline(
+  body,
+  fundo: luma(240),
+  raio: 2pt,
+  recuo: (x: 3pt, y: 1pt),
+) = {
+  box(fill: fundo, inset: recuo, radius: raio, body)
+}
+
+#let codigo-bloco(
+  body,
+  lang: none,
+  titulo: none,
+  cor: luma(245),
+  borda: (left: 2pt + luma(180)),
+  raio: 0pt,
+  numerar-linhas: false,
+) = {
+  let code = if lang != none {
+    raw(block: true, lang: lang, body)
+  } else {
+    raw(block: true, body)
+  }
+
+  let code-content = if numerar-linhas {
+    // Adicionar números de linha
+    set par(leading: 0.55em)
+    show raw.line: it => {
+      text(fill: luma(160), size: 0.85em, str(it.number))
+      h(1.2em)
+      it.body
+    }
+    code
+  } else {
+    code
+  }
+
+  if titulo != none {
+    block(
+      width: 100%,
+      radius: raio,
+      stroke: borda,
+      clip: raio > 0pt,
+      {
+        block(
+          width: 100%,
+          fill: luma(220),
+          inset: 0.7em,
+          below: 0pt,
+          text(size: 0.9em, weight: "bold", titulo)
+        )
+        block(
+          width: 100%,
+          fill: cor,
+          inset: 1em,
+          above: 0pt,
+          code-content,
+        )
+      }
+    )
+  } else {
+    block(
+      width: 100%,
+      fill: cor,
+      radius: raio,
+      stroke: borda,
+      inset: 1em,
+      code-content,
+    )
+  }
+}
+
+#let code(
+  body,
+  bloco: false,
+  lang: none,
+  titulo: none,
+  numerar-linhas: false,
+) = {
+  if bloco {
+    codigo-bloco(body, lang: lang, titulo: titulo, numerar-linhas: numerar-linhas)
+  } else {
+    codigo-inline(raw(body))
+  }
+}

--- a/packages/preview/ferrmat/0.1.0/src/colunas.typ
+++ b/packages/preview/ferrmat/0.1.0/src/colunas.typ
@@ -1,0 +1,164 @@
+// Wrappers em português para colunas, quebra de coluna e grade do Typst
+// Traduz nomes de parâmetros de columns(), colbreak(), grid() e sub-elementos
+
+// ---------------------------------------------------------------------------
+// colunas — wrapper para columns()
+// ---------------------------------------------------------------------------
+
+/// Cria um layout de colunas de texto.
+/// - `corpo`: conteúdo a ser distribuído nas colunas
+/// - `quantidade`: número de colunas (padrão: 2)
+/// - `espacamento`: espaçamento entre colunas (gutter)
+#let colunas(
+  corpo,
+  quantidade: 2,
+  espacamento: auto,
+) = {
+  assert(type(quantidade) == int and quantidade >= 1,
+    message: "colunas: 'quantidade' deve ser inteiro >= 1, recebeu " + repr(quantidade))
+  let args = (:)
+  if espacamento != auto { args.insert("gutter", espacamento) }
+  columns(quantidade, ..args, corpo)
+}
+
+// ---------------------------------------------------------------------------
+// quebra-coluna — wrapper para colbreak()
+// ---------------------------------------------------------------------------
+
+/// Insere uma quebra de coluna.
+/// - `fraco`: se `true`, só quebra se não estiver já no topo da coluna
+#let quebra-coluna(fraco: false) = {
+  colbreak(weak: fraco)
+}
+
+// ---------------------------------------------------------------------------
+// grade — wrapper para grid()
+// ---------------------------------------------------------------------------
+
+/// Cria um layout de grade (grid) com parâmetros em português.
+#let grade(
+  ..filhos,
+  colunas: auto,
+  linhas: auto,
+  espacamento: auto,
+  espacamento-coluna: auto,
+  espacamento-linha: auto,
+  alinhamento: auto,
+  preenchimento: auto,
+  borda: auto,
+  recuo: auto,
+) = {
+  let args = (:)
+  if colunas != auto { args.insert("columns", colunas) }
+  if linhas != auto { args.insert("rows", linhas) }
+  if espacamento != auto { args.insert("gutter", espacamento) }
+  if espacamento-coluna != auto { args.insert("column-gutter", espacamento-coluna) }
+  if espacamento-linha != auto { args.insert("row-gutter", espacamento-linha) }
+  if alinhamento != auto { args.insert("align", alinhamento) }
+  if preenchimento != auto { args.insert("fill", preenchimento) }
+  if borda != auto { args.insert("stroke", borda) }
+  if recuo != auto { args.insert("inset", recuo) }
+  grid(..args, ..filhos)
+}
+
+// ---------------------------------------------------------------------------
+// celula — wrapper para grid.cell()
+// ---------------------------------------------------------------------------
+
+/// Cria uma célula de grade com parâmetros em português.
+#let celula(
+  corpo,
+  extensao-coluna: auto,
+  extensao-linha: auto,
+  alinhamento: auto,
+  preenchimento: auto,
+  borda: auto,
+  recuo: auto,
+  quebravel: auto,
+  x: auto,
+  y: auto,
+) = {
+  let args = (:)
+  if extensao-coluna != auto { args.insert("colspan", extensao-coluna) }
+  if extensao-linha != auto { args.insert("rowspan", extensao-linha) }
+  if alinhamento != auto { args.insert("align", alinhamento) }
+  if preenchimento != auto { args.insert("fill", preenchimento) }
+  if borda != auto { args.insert("stroke", borda) }
+  if recuo != auto { args.insert("inset", recuo) }
+  if quebravel != auto { args.insert("breakable", quebravel) }
+  if x != auto { args.insert("x", x) }
+  if y != auto { args.insert("y", y) }
+  grid.cell(..args, corpo)
+}
+
+// ---------------------------------------------------------------------------
+// linha-horizontal — wrapper para grid.hline()
+// ---------------------------------------------------------------------------
+
+/// Insere uma linha horizontal na grade.
+#let linha-horizontal(
+  y: auto,
+  inicio: auto,
+  fim: auto,
+  borda: auto,
+  posicao: auto,
+) = {
+  let args = (:)
+  if y != auto { args.insert("y", y) }
+  if inicio != auto { args.insert("start", inicio) }
+  if fim != auto { args.insert("end", fim) }
+  if borda != auto { args.insert("stroke", borda) }
+  if posicao != auto { args.insert("position", posicao) }
+  grid.hline(..args)
+}
+
+// ---------------------------------------------------------------------------
+// linha-vertical — wrapper para grid.vline()
+// ---------------------------------------------------------------------------
+
+/// Insere uma linha vertical na grade.
+#let linha-vertical(
+  x: auto,
+  inicio: auto,
+  fim: auto,
+  borda: auto,
+  posicao: auto,
+) = {
+  let args = (:)
+  if x != auto { args.insert("x", x) }
+  if inicio != auto { args.insert("start", inicio) }
+  if fim != auto { args.insert("end", fim) }
+  if borda != auto { args.insert("stroke", borda) }
+  if posicao != auto { args.insert("position", posicao) }
+  grid.vline(..args)
+}
+
+// ---------------------------------------------------------------------------
+// cabecalho-grade — wrapper para grid.header()
+// ---------------------------------------------------------------------------
+
+/// Cria um cabeçalho de grade (repete no topo de cada página).
+#let cabecalho-grade(
+  ..filhos,
+  repetir: auto,
+  nivel: auto,
+) = {
+  let args = (:)
+  if repetir != auto { args.insert("repeat", repetir) }
+  if nivel != auto { args.insert("level", nivel) }
+  grid.header(..args, ..filhos)
+}
+
+// ---------------------------------------------------------------------------
+// rodape-grade — wrapper para grid.footer()
+// ---------------------------------------------------------------------------
+
+/// Cria um rodapé de grade (repete no final de cada página).
+#let rodape-grade(
+  ..filhos,
+  repetir: auto,
+) = {
+  let args = (:)
+  if repetir != auto { args.insert("repeat", repetir) }
+  grid.footer(..args, ..filhos)
+}

--- a/packages/preview/ferrmat/0.1.0/src/cores.typ
+++ b/packages/preview/ferrmat/0.1.0/src/cores.typ
@@ -1,0 +1,48 @@
+// Constantes nomeadas em português (wrappers para valores nativos do Typst)
+
+// Valores lógicos e nulo
+#let verdadeiro = true
+#let falso = false
+#let nenhum = none
+
+// Cores
+
+#let preto = black
+#let cinza = gray
+#let prata = silver
+#let branco = white
+#let azul-marinho = navy
+#let azul = blue
+#let agua = aqua
+#let azul-petroleo = teal
+#let oriental = eastern
+#let roxo = purple
+#let fucsia = fuchsia
+#let bordo = maroon
+#let vermelho = red
+#let laranja = orange
+#let amarelo = yellow
+#let oliva = olive
+#let verde = green
+#let lima = lime
+
+// ---------------------------------------------------------------------------
+// Aliases de alinhamento em português
+// ---------------------------------------------------------------------------
+
+// Horizontal
+#let esquerda = left
+#let centro = center
+#let direita = right
+
+// Vertical
+#let topo = top
+#let meio = horizon
+#let inferior = bottom
+
+// Combinados
+#let centralizado = center + horizon   // centro horizontal + vertical
+#let centro-topo = center + top
+#let centro-inferior = center + bottom
+#let esquerda-meio = left + horizon
+#let direita-meio = right + horizon

--- a/packages/preview/ferrmat/0.1.0/src/cronograma.typ
+++ b/packages/preview/ferrmat/0.1.0/src/cronograma.typ
@@ -1,0 +1,885 @@
+// =============================================================================
+// cronograma.typ — Módulo de gráfico de Gantt para ferrmat
+// Usa CeTZ como engine de desenho
+// =============================================================================
+
+#import "@preview/cetz:0.4.0"
+#import "cores.typ": *
+
+// =============================================================================
+// Seção 1: Utilitários de data
+// =============================================================================
+
+/// Cria um dicionário de data. Formato brasileiro: dia, mês, ano.
+#let data(dia, mes, ano) = {
+  assert(type(mes) == int and mes >= 1 and mes <= 12,
+    message: "data: 'mes' deve ser inteiro entre 1 e 12, recebeu " + repr(mes))
+  assert(type(dia) == int and dia >= 1 and dia <= 31,
+    message: "data: 'dia' deve ser inteiro entre 1 e 31, recebeu " + repr(dia))
+  assert(type(ano) == int,
+    message: "data: 'ano' deve ser inteiro, recebeu " + repr(ano))
+  (ano: ano, mes: mes, dia: dia)
+}
+
+/// Retorna true se o ano é bissexto.
+#let _bissexto(ano) = {
+  calc.rem(ano, 4) == 0 and (calc.rem(ano, 100) != 0 or calc.rem(ano, 400) == 0)
+}
+
+/// Retorna o número de dias em um mês.
+#let _dias-no-mes(ano, mes) = {
+  let tabela = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+  if mes == 2 and _bissexto(ano) { 29 } else { tabela.at(mes - 1) }
+}
+
+/// Converte uma data-dict para um número ordinal de dias (desde uma época fixa).
+/// Usa uma fórmula simples: acumula dias por ano e mês.
+#let _data-para-dias(d) = {
+  let dias = 0
+  // Acumular anos completos (simplificado — conta de 1 até ano-1)
+  dias += (d.ano - 1) * 365
+  dias += calc.floor((d.ano - 1) / 4)
+  dias -= calc.floor((d.ano - 1) / 100)
+  dias += calc.floor((d.ano - 1) / 400)
+  // Acumular meses completos do ano corrente
+  let m = 1
+  while m < d.mes {
+    dias += _dias-no-mes(d.ano, m)
+    m += 1
+  }
+  dias += d.dia
+  dias
+}
+
+/// Diferença em dias entre duas datas (d2 - d1).
+#let _diff-dias(d1, d2) = {
+  _data-para-dias(d2) - _data-para-dias(d1)
+}
+
+/// Gera array de meses entre início e fim.
+/// Cada item: (ano: int, mes: int, dia-inicio: int, dia-fim: int, dias-visiveis: int)
+#let _gerar-meses(inicio, fim) = {
+  let meses = ()
+  let ano = inicio.ano
+  let mes = inicio.mes
+
+  while ano < fim.ano or (ano == fim.ano and mes <= fim.mes) {
+    let dim = _dias-no-mes(ano, mes)
+
+    let d-inicio = if ano == inicio.ano and mes == inicio.mes { inicio.dia } else { 1 }
+    let d-fim = if ano == fim.ano and mes == fim.mes { fim.dia } else { dim }
+
+    meses.push((
+      ano: ano,
+      mes: mes,
+      dia-inicio: d-inicio,
+      dia-fim: d-fim,
+      dias-visiveis: d-fim - d-inicio + 1,
+    ))
+
+    mes += 1
+    if mes > 12 {
+      mes = 1
+      ano += 1
+    }
+  }
+  meses
+}
+
+/// Gera subdivisões semanais entre início e fim.
+/// Cada item: (inicio: data, dias: int)
+#let _gerar-semanas(inicio, fim) = {
+  let semanas = ()
+  let d-atual = inicio
+  let total = _diff-dias(inicio, fim) + 1
+
+  let consumidos = 0
+  while consumidos < total {
+    // Dias até domingo (dia 7). Dia da semana é aproximado:
+    // Usamos Zeller simplificado — mas como não precisamos de precisão de dia-da-semana,
+    // vamos simplesmente dividir em blocos de 7 dias.
+    let restantes = total - consumidos
+    let dias-semana = calc.min(7, restantes)
+
+    semanas.push((
+      offset: consumidos,
+      dias: dias-semana,
+    ))
+
+    consumidos += dias-semana
+  }
+  semanas
+}
+
+/// Adiciona n dias a uma data-dict.
+#let _adicionar-dias(d, n) = {
+  let dia = d.dia + n
+  let mes = d.mes
+  let ano = d.ano
+  while dia > _dias-no-mes(ano, mes) {
+    dia -= _dias-no-mes(ano, mes)
+    mes += 1
+    if mes > 12 { mes = 1; ano += 1 }
+  }
+  while dia < 1 {
+    mes -= 1
+    if mes < 1 { mes = 12; ano -= 1 }
+    dia += _dias-no-mes(ano, mes)
+  }
+  (ano: ano, mes: mes, dia: dia)
+}
+
+// Nomes abreviados dos meses em português
+#let _meses-pt = ("Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez")
+#let _meses-en = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+
+// =============================================================================
+// Seção 2: Layout engine
+// =============================================================================
+
+/// Calcula todas as posições e dimensões do gráfico.
+/// Retorna um dicionário com geometria completa.
+#let _calcular-layout(
+  tarefas,
+  inicio,
+  fim,
+  largura-chart,  // largura da área do gráfico (sem nomes) em pt
+  altura-linha,   // altura de cada linha em pt
+  cabecalho,
+  fonte-cabecalho,
+) = {
+  let inicio-dias = _data-para-dias(inicio)
+  let total-dias = _data-para-dias(fim) - inicio-dias + 1
+  assert(total-dias > 0, message: "cronograma: intervalo de datas inválido (fim deve ser após início)")
+
+  let escala-x = largura-chart / total-dias  // pt por dia
+
+  // Calcular posições das tarefas (considerar grupos)
+  let linhas = ()
+  let grupo-atual = none
+  let y-pos = 0
+
+  for t in tarefas {
+    // Separador de grupo
+    if t.at("grupo", default: none) != none and t.grupo != grupo-atual {
+      linhas.push((tipo: "grupo", nome: t.grupo, y: y-pos))
+      grupo-atual = t.grupo
+      y-pos += 1
+    }
+
+    let t-inicio = calc.max(0, _data-para-dias(t.inicio) - inicio-dias)
+    let t-fim = calc.max(0, _data-para-dias(t.fim) - inicio-dias)
+    // Clamp ao range visível
+    let t-inicio-c = calc.min(calc.max(t-inicio, 0), total-dias - 1)
+    let t-fim-c = calc.min(calc.max(t-fim, 0), total-dias - 1)
+
+    linhas.push((
+      tipo: if t.at("marco", default: false) { "marco" } else { "tarefa" },
+      nome: t.nome,
+      x-inicio: t-inicio-c * escala-x,
+      x-fim: (t-fim-c + 1) * escala-x,  // +1 pois o dia é inclusivo
+      y: y-pos,
+      cor: t.at("cor", default: none),
+      progresso: t.at("progresso", default: none),
+      rotulo: t.at("rotulo", default: none),
+      depende-de: t.at("depende-de", default: ()),
+    ))
+    y-pos += 1
+  }
+
+  // Gerar cabeçalhos
+  let meses = _gerar-meses(inicio, fim)
+
+  let cab-nivel1 = ()  // meses
+  let offset-acum = 0
+  for m in meses {
+    let x = offset-acum * escala-x
+    let w = m.dias-visiveis * escala-x
+    cab-nivel1.push((
+      x: x,
+      largura: w,
+      texto: m.mes,  // índice do mês (1-12)
+      ano: m.ano,
+    ))
+    offset-acum += m.dias-visiveis
+  }
+
+  // Nível 2: semanas ou dias
+  let cab-nivel2 = ()
+  if cabecalho == "mes-semana" or cabecalho == "semana" {
+    // Gerar blocos de 7 dias POR MÊS, com labels = dia do mês
+    let offset-global = 0
+    for m in meses {
+      let dia = m.dia-inicio
+      let dias-restantes = m.dias-visiveis
+      while dias-restantes > 0 {
+        let dias-bloco = calc.min(7, dias-restantes)
+        let x = offset-global * escala-x
+        let w = dias-bloco * escala-x
+        cab-nivel2.push((x: x, largura: w, texto: str(dia)))
+        dia += dias-bloco
+        offset-global += dias-bloco
+        dias-restantes -= dias-bloco
+      }
+    }
+  } else if cabecalho == "mes-dia" or cabecalho == "dia" {
+    let d = 0
+    while d < total-dias {
+      let x = d * escala-x
+      cab-nivel2.push((x: x, largura: escala-x, texto: str(d + 1)))
+      d += 1
+    }
+  }
+
+  // Linha do hoje
+  let hoje-x = none
+
+  (
+    total-dias: total-dias,
+    escala-x: escala-x,
+    linhas: linhas,
+    total-linhas: y-pos,
+    cab-nivel1: cab-nivel1,
+    cab-nivel2: cab-nivel2,
+    largura-chart: largura-chart,
+  )
+}
+
+
+// =============================================================================
+// Seção 3: Renderizador CeTZ
+// =============================================================================
+
+/// Altura do cabeçalho em unidades de linha
+#let _alt-cabecalho = 2
+
+/// Renderiza o fundo alternado
+#let _render-fundo(layout, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-base = -_alt-cabecalho * al
+
+  for i in range(layout.total-linhas) {
+    let linha = layout.linhas.at(i)
+    let y = y-base - linha.y * pitch
+
+    if linha.tipo == "grupo" {
+      // Fundo do grupo — tom mais escuro
+      rect(
+        (-config.largura-nomes, y),
+        (layout.largura-chart, y - pitch),
+        fill: config.cor-grade.lighten(50%),
+        stroke: none,
+      )
+    } else if calc.rem(linha.y, 2) == 1 {
+      // Fundo alternado
+      rect(
+        (0pt, y),
+        (layout.largura-chart, y - pitch),
+        fill: config.cor-alternada,
+        stroke: none,
+      )
+    }
+  }
+}
+
+/// Renderiza linhas de grade verticais
+#let _render-grade(layout, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-topo = -_alt-cabecalho * al
+  let y-base = y-topo - layout.total-linhas * pitch
+
+  // Linhas verticais para cada mês
+  for cab in layout.cab-nivel1 {
+    line(
+      (cab.x, y-topo),
+      (cab.x, y-base),
+      stroke: config.espessura-grade + config.cor-grade,
+    )
+  }
+  // Linha final à direita
+  line(
+    (layout.largura-chart, y-topo),
+    (layout.largura-chart, y-base),
+    stroke: config.espessura-grade + config.cor-grade,
+  )
+
+  // Linhas horizontais para cada tarefa
+  for i in range(layout.total-linhas + 1) {
+    let y = y-topo - i * pitch
+    line(
+      (0pt, y),
+      (layout.largura-chart, y),
+      stroke: config.espessura-grade + config.cor-grade,
+    )
+  }
+}
+
+/// Renderiza o cabeçalho com dois níveis
+#let _render-cabecalho(layout, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let nomes-meses = if config.meses-pt { _meses-pt } else { _meses-en }
+  let ct = config.cor-texto
+
+  // Cores do cabeçalho: auto = derivar de cor-padrao; explícito = usar diretamente
+  let cor-n1 = if config.cor-cabecalho != auto {
+    config.cor-cabecalho
+  } else {
+    config.cor-padrao.lighten(80%)
+  }
+  let cor-n2 = if config.cor-cabecalho != auto {
+    config.cor-cabecalho.lighten(15%)
+  } else {
+    config.cor-padrao.lighten(92%)
+  }
+
+  // Nível 1: meses
+  for cab in layout.cab-nivel1 {
+    let x = cab.x
+    let w = cab.largura
+    let nome = nomes-meses.at(cab.texto - 1)
+
+    // Fundo do cabeçalho mês
+    rect(
+      (x, 0pt),
+      (x + w, -al),
+      fill: cor-n1,
+      stroke: config.espessura-grade + config.cor-grade,
+    )
+    // Texto do mês — adapta ao espaço disponível
+    let make-text(corpo) = if ct != auto {
+      text(size: config.fonte-cabecalho, weight: "bold", fill: ct)[#corpo]
+    } else {
+      text(size: config.fonte-cabecalho, weight: "bold")[#corpo]
+    }
+    let texto-completo = make-text[#nome #str(cab.ano)]
+    let texto-curto = make-text[#nome]
+    let larg-completo = measure(texto-completo).width
+    let larg-curto = measure(texto-curto).width
+    let pad = 4pt  // margem mínima de cada lado
+
+    if w >= larg-completo + 2 * pad {
+      content((x + w / 2, -al / 2), texto-completo)
+    } else if w >= larg-curto + 2 * pad {
+      content((x + w / 2, -al / 2), texto-curto)
+    }
+    // Se nem o nome curto cabe, não renderiza texto
+  }
+
+  // Nível 2: semanas ou dias
+  if layout.cab-nivel2.len() > 0 {
+    for cab in layout.cab-nivel2 {
+      let x = cab.x
+      let w = cab.largura
+
+      rect(
+        (x, -al),
+        (x + w, -2 * al),
+        fill: cor-n2,
+        stroke: config.espessura-grade + config.cor-grade,
+      )
+      // Texto — só mostra se couber com margem
+      let txt = if ct != auto {
+        text(size: config.fonte-cabecalho * 0.85, fill: ct)[#cab.texto]
+      } else {
+        text(size: config.fonte-cabecalho * 0.85)[#cab.texto]
+      }
+      if measure(txt).width + 4pt <= w {
+        content(
+          (x + w / 2, -al - al / 2),
+          txt,
+        )
+      }
+    }
+  }
+}
+
+/// Renderiza os nomes das tarefas à esquerda
+#let _render-nomes(layout, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-base = -_alt-cabecalho * al
+  let ct = config.cor-texto
+
+  for linha in layout.linhas {
+    let y = y-base - linha.y * pitch - al / 2
+
+    if linha.tipo == "grupo" {
+      let cor-grupo = if ct != auto { ct } else { config.cor-padrao.darken(20%) }
+      content(
+        (-config.largura-nomes / 2, y),
+        box(
+          width: config.largura-nomes - 4pt,
+          text(size: config.fonte-tarefa, weight: "bold", fill: cor-grupo)[#linha.nome],
+        ),
+      )
+    } else {
+      let nome-content = if ct != auto {
+        text(size: config.fonte-tarefa, fill: ct)[#linha.nome]
+      } else {
+        text(size: config.fonte-tarefa)[#linha.nome]
+      }
+      content(
+        (-config.largura-nomes / 2, y),
+        box(
+          width: config.largura-nomes - 4pt,
+          nome-content,
+        ),
+      )
+    }
+  }
+}
+
+/// Renderiza uma barra de tarefa (pill-shaped)
+#let _render-barra(linha, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-base = -_alt-cabecalho * al
+  let y = y-base - linha.y * pitch
+  let pad = al * 0.15  // padding vertical
+
+  let x1 = linha.x-inicio
+  let x2 = linha.x-fim
+  let largura-barra = x2 - x1
+
+  // Largura mínima para visibilidade
+  let largura-barra = calc.max(largura-barra, 3pt)
+  let x2 = x1 + largura-barra
+
+  let cor = if linha.cor != none and linha.cor != auto { linha.cor } else { config.cor-padrao }
+
+  // Barra principal (arredondada)
+  rect(
+    (x1, y - pad),
+    (x2, y - al + pad),
+    fill: cor.lighten(30%),
+    stroke: 0.5pt + cor,
+    radius: config.raio-barra,
+  )
+
+  // Barra de progresso
+  if config.mostrar-progresso and linha.progresso != none and linha.progresso > 0 {
+    let prog-largura = largura-barra * linha.progresso / 100
+    let prog-largura = calc.max(prog-largura, 2pt)
+
+    let cor-prog = if config.cor-progresso == auto { cor.darken(25%) } else { config.cor-progresso }
+    let raio-prog = calc.min(config.raio-barra, prog-largura / 2)
+
+    rect(
+      (x1, y - pad),
+      (x1 + prog-largura, y - al + pad),
+      fill: cor-prog.lighten(10%),
+      stroke: none,
+      radius: raio-prog,
+    )
+
+    // Se o progresso não cobre toda a barra, redesenhar o contorno
+    if linha.progresso < 100 {
+      rect(
+        (x1, y - pad),
+        (x2, y - al + pad),
+        fill: none,
+        stroke: 0.5pt + cor,
+        radius: config.raio-barra,
+      )
+    }
+  }
+
+  // Rótulo dentro da barra
+  if config.mostrar-rotulo and largura-barra > 20pt {
+    let texto-rotulo = if linha.rotulo != none {
+      linha.rotulo
+    } else if linha.progresso != none {
+      str(linha.progresso) + "%"
+    } else {
+      none
+    }
+    if texto-rotulo != none {
+      content(
+        ((x1 + x2) / 2, y - al / 2),
+        text(size: config.fonte-tarefa * 0.8, fill: white, weight: "bold")[#texto-rotulo],
+      )
+    }
+  }
+}
+
+/// Renderiza um marco (losango / diamond)
+#let _render-marco(linha, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-base = -_alt-cabecalho * al
+  let y-centro = y-base - linha.y * pitch - al / 2
+  let x-centro = (linha.x-inicio + linha.x-fim) / 2
+
+  let cor = if linha.cor != none and linha.cor != auto { linha.cor } else { config.cor-padrao }
+  let tam = al * 0.3  // tamanho do losango
+
+  // Desenhar losango como polígono
+  line(
+    (x-centro, y-centro + tam),
+    (x-centro + tam, y-centro),
+    (x-centro, y-centro - tam),
+    (x-centro - tam, y-centro),
+    close: true,
+    fill: cor,
+    stroke: 0.5pt + cor.darken(20%),
+  )
+}
+
+/// Renderiza a linha "hoje"
+#let _render-hoje(layout, config, inicio) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let offset = _diff-dias(inicio, config.hoje)
+
+  if offset >= 0 {
+    let x = offset * layout.escala-x
+    let y-topo = 0pt
+    let y-base = -_alt-cabecalho * al - layout.total-linhas * pitch
+
+    line(
+      (x, y-topo),
+      (x, y-base),
+      stroke: (paint: config.cor-hoje, thickness: 1.5pt, dash: "dashed"),
+    )
+  }
+}
+
+/// Renderiza dependências como setas em L no espaço entre linhas
+#let _render-dependencias(layout, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-base = -_alt-cabecalho * al
+  let pad = al * 0.15
+
+  // Criar mapa de nomes para linhas
+  let mapa = (:)
+  for linha in layout.linhas {
+    if linha.tipo != "grupo" {
+      mapa.insert(linha.nome, linha)
+    }
+  }
+
+  let cor-seta = config.cor-dependencia
+  let estilo = 0.8pt + cor-seta
+
+  for linha in layout.linhas {
+    if linha.tipo == "grupo" { continue }
+    let deps = linha.at("depende-de", default: ())
+    for dep-nome in deps {
+      if dep-nome in mapa {
+        let dep = mapa.at(dep-nome)
+
+        // Saída: fundo da barra predecessora, a 1/4 do comprimento
+        let largura-dep = dep.x-fim - dep.x-inicio
+        let x1 = dep.x-inicio + largura-dep * 0.25
+        let y1 = y-base - dep.y * pitch - al + pad
+
+        // Entrada: lado esquerdo da barra dependente, meia-altura
+        let x2 = linha.x-inicio
+        let y-dep = y-base - linha.y * pitch - al / 2
+
+        // L puro: desce até a linha do dependente, depois vai pra direita
+        line(
+          (x1, y1),
+          (x1, y-dep),
+          (x2, y-dep),
+          stroke: estilo,
+          mark: (end: ">", size: 3.5pt, fill: cor-seta),
+        )
+      }
+    }
+  }
+}
+
+/// Renderiza borda externa da área de nomes + chart
+#let _render-bordas(layout, config) = {
+  import cetz.draw: *
+
+  let al = config.altura-linha
+  let pitch = al + config.gap
+  let y-base = -_alt-cabecalho * al - layout.total-linhas * pitch
+
+  // Borda externa
+  rect(
+    (-config.largura-nomes, 0pt),
+    (layout.largura-chart, y-base),
+    stroke: 0.8pt + config.cor-grade,
+    fill: none,
+  )
+
+  // Separador vertical entre nomes e chart
+  line(
+    (0pt, 0pt),
+    (0pt, y-base),
+    stroke: 0.8pt + config.cor-grade,
+  )
+
+  // Separador horizontal do cabeçalho
+  line(
+    (-config.largura-nomes, -_alt-cabecalho * al),
+    (layout.largura-chart, -_alt-cabecalho * al),
+    stroke: 0.8pt + config.cor-grade,
+  )
+}
+
+
+// =============================================================================
+// Seção 4: API pública
+// =============================================================================
+
+/// Cria um dicionário de tarefa para uso no cronograma.
+#let tarefa(
+  nome,
+  inicio,
+  fim,
+  cor: auto,
+  progresso: none,
+  grupo: none,
+  marco: false,
+  depende-de: (),
+  rotulo: none,
+) = {
+  assert(type(nome) == str, message: "tarefa: 'nome' deve ser uma string")
+  assert(type(inicio) == dictionary, message: "tarefa: 'inicio' deve ser um dict de data — use data(dia, mes, ano)")
+  assert(type(fim) == dictionary, message: "tarefa: 'fim' deve ser um dict de data — use data(dia, mes, ano)")
+
+  // Validar dias para o mês específico
+  assert(inicio.dia <= _dias-no-mes(inicio.ano, inicio.mes),
+    message: "tarefa '" + nome + "': dia " + str(inicio.dia) + " inválido para mês " + str(inicio.mes))
+  assert(fim.dia <= _dias-no-mes(fim.ano, fim.mes),
+    message: "tarefa '" + nome + "': dia " + str(fim.dia) + " inválido para mês " + str(fim.mes))
+
+  if not marco {
+    assert(
+      _data-para-dias(fim) >= _data-para-dias(inicio),
+      message: "tarefa '" + nome + "': data 'fim' não pode ser anterior a 'inicio'",
+    )
+  }
+
+  (
+    nome: nome,
+    inicio: inicio,
+    fim: fim,
+    cor: cor,
+    progresso: progresso,
+    grupo: grupo,
+    marco: marco,
+    depende-de: depende-de,
+    rotulo: rotulo,
+  )
+}
+
+/// Gráfico de Gantt estilizado com barras arredondadas e cabeçalho multi-nível.
+///
+/// - `tarefas` — array de dicts (use `tarefa()` para criar)
+/// - `inicio` — data de início do gráfico (auto = mais cedo das tarefas)
+/// - `fim` — data de fim do gráfico (auto = mais tarde das tarefas)
+#let cronograma(
+  tarefas,
+  inicio: auto,
+  fim: auto,
+  // --- Dimensões ---
+  largura: 100%,
+  altura-linha: 22pt,
+  largura-nomes: 8em,
+  // --- Cabeçalho ---
+  cabecalho: "mes-semana",
+  meses-pt: true,
+  cor-cabecalho: auto,
+  // --- Visual ---
+  cor-padrao: azul,
+  cor-fundo: branco,
+  cor-alternada: luma(248),
+  cor-grade: luma(220),
+  raio-barra: 4pt,
+  espessura-grade: 0.3pt,
+  // --- Progresso ---
+  mostrar-progresso: true,
+  cor-progresso: auto,
+  // --- Hoje ---
+  hoje: none,
+  cor-hoje: vermelho,
+  // --- Dependências ---
+  mostrar-dependencias: false,
+  cor-dependencia: cinza,
+  // --- Texto ---
+  cor-texto: auto,
+  fonte-tarefa: 0.85em,
+  fonte-cabecalho: 0.8em,
+  mostrar-rotulo: false,
+) = {
+  assert(tarefas.len() > 0, message: "cronograma: 'tarefas' não pode estar vazio")
+
+  // Validar nomes únicos e dependências válidas
+  let _nomes-vistos = (:)
+  for t in tarefas {
+    assert(not (t.nome in _nomes-vistos),
+      message: "cronograma: nome de tarefa duplicado: '" + t.nome + "'")
+    _nomes-vistos.insert(t.nome, true)
+  }
+  for t in tarefas {
+    for dep in t.at("depende-de", default: ()) {
+      assert(dep in _nomes-vistos,
+        message: "cronograma: tarefa '" + t.nome + "' depende de '" + dep + "', que não existe")
+    }
+  }
+
+  // Determinar range de datas
+  let d-inicio = inicio
+  let d-fim = fim
+
+  if d-inicio == auto {
+    let min-dias = _data-para-dias(tarefas.at(0).inicio)
+    let min-data = tarefas.at(0).inicio
+    for t in tarefas {
+      let d = _data-para-dias(t.inicio)
+      if d < min-dias {
+        min-dias = d
+        min-data = t.inicio
+      }
+    }
+    d-inicio = min-data
+  }
+
+  if d-fim == auto {
+    let max-dias = _data-para-dias(tarefas.at(0).fim)
+    let max-data = tarefas.at(0).fim
+    for t in tarefas {
+      let d = _data-para-dias(t.fim)
+      if d > max-dias {
+        max-dias = d
+        max-data = t.fim
+      }
+    }
+    d-fim = _adicionar-dias(max-data, 2)
+  }
+
+  // Usar layout() para medir a largura disponível
+  layout(size => {
+    let largura-total = if type(largura) == ratio {
+      size.width * (largura / 100%)
+    } else {
+      // Resolve relative, length, etc. via measure
+      measure(line(length: largura)).width
+    }
+
+    // Converter largura-nomes e altura-linha para pt absoluto
+    let ln = measure(line(length: largura-nomes)).width
+    let al = measure(line(length: altura-linha)).width
+    let gap = if mostrar-dependencias { al * 0.5 } else { 0pt }
+
+    let largura-chart = largura-total - ln
+
+    // Config dict para passar ao renderer
+    let config = (
+      altura-linha: al,
+      largura-nomes: ln,
+      cabecalho: cabecalho,
+      meses-pt: meses-pt,
+      cor-cabecalho: cor-cabecalho,
+      cor-padrao: cor-padrao,
+      cor-fundo: cor-fundo,
+      cor-alternada: cor-alternada,
+      cor-grade: cor-grade,
+      raio-barra: raio-barra,
+      espessura-grade: espessura-grade,
+      mostrar-progresso: mostrar-progresso,
+      cor-progresso: cor-progresso,
+      hoje: hoje,
+      cor-hoje: cor-hoje,
+      mostrar-dependencias: mostrar-dependencias,
+      cor-dependencia: cor-dependencia,
+      gap: gap,
+      cor-texto: cor-texto,
+      fonte-tarefa: fonte-tarefa,
+      fonte-cabecalho: fonte-cabecalho,
+      mostrar-rotulo: mostrar-rotulo,
+    )
+
+    // Calcular layout
+    let lay = _calcular-layout(
+      tarefas,
+      d-inicio,
+      d-fim,
+      largura-chart,
+      al,
+      cabecalho,
+      fonte-cabecalho,
+    )
+
+    // Altura total do canvas (com margem inferior para descenders)
+    let altura-total = _alt-cabecalho * al + lay.total-linhas * (al + gap) + al * 0.15
+
+    // Desenhar com CeTZ
+    box(width: largura-total, {
+      cetz.canvas(length: 1pt, {
+        import cetz.draw: *
+
+        // Transladar para que (0,0) seja o canto superior esquerdo da área do chart
+        // CeTZ y cresce para cima, mas usamos y negativo para baixo
+        set-origin((ln, 0pt))
+
+        // Fundo geral
+        rect(
+          (-ln, 0pt),
+          (lay.largura-chart, -altura-total),
+          fill: config.cor-fundo,
+          stroke: none,
+        )
+
+        // Fundo alternado
+        _render-fundo(lay, config)
+
+        // Grade
+        _render-grade(lay, config)
+
+        // Cabeçalho
+        _render-cabecalho(lay, config)
+
+        // Nomes das tarefas
+        _render-nomes(lay, config)
+
+        // Barras e marcos
+        for linha in lay.linhas {
+          if linha.tipo == "tarefa" {
+            _render-barra(linha, config)
+          } else if linha.tipo == "marco" {
+            _render-marco(linha, config)
+          }
+        }
+
+        // Dependências
+        if config.mostrar-dependencias {
+          _render-dependencias(lay, config)
+        }
+
+        // Linha "hoje"
+        if config.hoje != none {
+          _render-hoje(lay, config, d-inicio)
+        }
+
+        // Bordas
+        _render-bordas(lay, config)
+      })
+    })
+  })
+}

--- a/packages/preview/ferrmat/0.1.0/src/indice.typ
+++ b/packages/preview/ferrmat/0.1.0/src/indice.typ
@@ -1,0 +1,162 @@
+// ============================================================================
+// ferrmat – Módulo de Índice Remissivo
+// Equivalente ao makeidx/imakeidx do LaTeX.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// irem — marcar um termo no texto (Índice REMissivo)
+// ---------------------------------------------------------------------------
+
+/// Marca um termo para o índice remissivo nesta posição do documento.
+/// O termo é invisível — não aparece no texto.
+///
+/// - `termo`: O termo principal (ex: "derivada").
+/// - `sub`: Subtermo opcional (ex: "parcial" → aparece como "derivada, parcial").
+/// - `ver`: Remissiva "ver" (ex: `irem("velocidade", ver: "cinemática")` → "velocidade, _ver_ cinemática").
+///
+/// ```example
+/// A #irem("derivada") derivada de uma função...
+/// A #irem("derivada", sub: "parcial") derivada parcial...
+/// ```
+#let irem(
+  termo,
+  sub: none,
+  ver: none,
+) = {
+  assert(type(termo) == str and termo.len() > 0,
+    message: "irem: termo deve ser uma string não vazia")
+  [#metadata((
+    tipo: "ferrmat-idx",
+    termo: termo,
+    sub: sub,
+    ver: ver,
+  )) <ferrmat-idx>]
+}
+
+/// Marca um termo e o exibe em negrito no texto (útil para definições).
+///
+/// ```example
+/// #irem-def("integral") é a operação inversa da derivada.
+/// ```
+#let irem-def(
+  termo,
+  sub: none,
+) = [#irem(termo, sub: sub)#strong(termo)]
+
+// ---------------------------------------------------------------------------
+// imprimir-indice — gerar o índice remissivo
+// ---------------------------------------------------------------------------
+
+/// Gera o índice remissivo com todos os termos marcados por `irem()`.
+///
+/// - `titulo`: Título do índice. `auto` = "Índice Remissivo". `none` = sem título.
+/// - `colunas`: Número de colunas. Padrão: 2.
+///
+/// ```example
+/// #imprimir-indice()
+/// ```
+#let imprimir-indice(
+  titulo: auto,
+  colunas: 2,
+) = context {
+  // --- Coletar todas as entradas ---
+  let entradas = query(<ferrmat-idx>)
+
+  if entradas.len() == 0 {
+    return
+  }
+
+  // --- Agrupar por termo → páginas ---
+  // Estrutura: (termo, sub, ver, paginas: dict-como-set para O(1) lookup)
+  let mapa = (:)
+
+  for entrada in entradas {
+    let dados = entrada.value
+    if dados.at("tipo", default: "") != "ferrmat-idx" { continue }
+
+    let termo = dados.termo
+    let sub = dados.sub
+    let ver = dados.ver
+    let pagina = entrada.location().page()
+    let pag-chave = str(pagina)
+
+    // Chave única para agrupar
+    let chave = if sub != none { termo + "\x00" + sub } else { termo }
+
+    if chave not in mapa {
+      let pags = (:)
+      pags.insert(pag-chave, true)
+      mapa.insert(chave, (
+        termo: termo,
+        sub: sub,
+        ver: ver,
+        paginas: pags,
+      ))
+    } else {
+      let existente = mapa.at(chave)
+      existente.paginas.insert(pag-chave, true)
+      if ver != none and existente.ver == none {
+        existente.ver = ver
+      }
+      mapa.insert(chave, existente)
+    }
+  }
+
+  // --- Ordenar chaves alfabeticamente (case-insensitive) ---
+  let chaves = mapa.keys().sorted(key: k => lower(k))
+
+  // --- Título ---
+  let titulo-final = if titulo == auto { "Índice Remissivo" } else { titulo }
+  if titulo-final != none {
+    heading(level: 1, numbering: none, titulo-final)
+  }
+
+  // --- Renderizar ---
+  let conteudo = {
+    let letra-atual = ""
+
+    for chave in chaves {
+      let item = mapa.at(chave)
+      let primeira-letra = upper(item.termo.first())
+
+      // Separador de letra
+      if primeira-letra != letra-atual {
+        letra-atual = primeira-letra
+        v(0.5em)
+        text(weight: "bold", size: 1.1em, primeira-letra)
+        v(0.2em)
+      }
+
+      // Montar linha
+      if item.sub != none {
+        // Subtermo: indentado
+        let linha = h(1.5em) + item.sub
+        if item.ver != none {
+          linha = linha + [, _ver_ #item.ver]
+        } else {
+          let pags = item.paginas.keys().map(k => int(k)).sorted().map(p => str(p)).join(", ")
+          linha = linha + [, #pags]
+        }
+        [#linha \ ]
+      } else {
+        // Termo principal
+        let linha = [#item.termo]
+        if item.ver != none {
+          linha = linha + [, _ver_ #item.ver]
+        } else {
+          let pags = item.paginas.keys().map(k => int(k)).sorted().map(p => str(p)).join(", ")
+          linha = linha + [, #pags]
+        }
+        [#linha \ ]
+      }
+    }
+  }
+
+  set par(first-line-indent: 0pt)
+
+  if colunas > 1 {
+    columns(colunas, gutter: 1em, conteudo)
+  } else {
+    conteudo
+  }
+}

--- a/packages/preview/ferrmat/0.1.0/src/matematica.typ
+++ b/packages/preview/ferrmat/0.1.0/src/matematica.typ
@@ -1,0 +1,1109 @@
+// Ambientes matemáticos (numeração, QED, demonstrações)
+
+#import "caixas.typ": caixa, _build-titulo
+
+#let qed(simbolo: $square$) = {
+  h(1fr)
+  simbolo
+}
+
+#let demonstracao(
+  body,
+  titulo: "Demonstração",
+  simbolo-qed: $square$,
+) = {
+  [*#titulo.*]
+  body
+  qed(simbolo: simbolo-qed)
+}
+
+#let num-equacao(
+  formato: "(1)",
+  por-secao: false,
+  nivel: 1,
+  body,
+) = {
+  if por-secao {
+    set math.equation(numbering: n => {
+      let hd = counter(heading).get()
+      let sec-nums = hd.slice(0, calc.min(nivel, hd.len()))
+      numbering(formato, ..sec-nums, n)
+    })
+    show heading.where(level: nivel): it => {
+      counter(math.equation).update(0)
+      it
+    }
+    body
+  } else {
+    set math.equation(numbering: formato)
+    body
+  }
+}
+
+// ============================================================================
+// Ambientes matemáticos pré-configurados
+// ============================================================================
+
+// Estado global de estilo visual: "colorido" (padrão), "cinza", "sem-caixa"
+#let ambiente-estilo = state("ferrmat-ambiente-estilo", "colorido")
+#let configurar-ambientes(estilo) = ambiente-estilo.update(estilo)
+
+// Estado global de numeração
+#let numeracao-ambientes = state("ferrmat-numeracao-ambientes", (modo: "por-tipo", por-secao: false))
+
+// Contadores dos ambientes pré-configurados
+#let _contadores-ambientes = ("ferrmat-teorema", "ferrmat-lema", "ferrmat-corolario", "ferrmat-proposicao", "ferrmat-axioma", "ferrmat-conjectura", "ferrmat-afirmacao", "ferrmat-definicao", "ferrmat-notacao", "ferrmat-propriedade", "ferrmat-exemplo", "ferrmat-problema", "ferrmat-resultado")
+
+/// Configura o modo de numeração dos ambientes matemáticos.
+///
+/// Parâmetros:
+/// - modo: `"por-tipo"` (padrão) ou `"unificado"`
+/// - por-secao: se `true`, numera como "seção.número" e reinicia a cada heading do nível configurado
+/// - nivel: nível do heading que dispara reinício de contadores (padrão: `1`).
+///   Use `1` para capítulos (TCC/tese) ou `2` para seções em artigos onde `= Título` é nível 1
+///   e `== Seção` é nível 2. A numeração exibe todos os níveis até o configurado
+///   (ex.: `nivel: 2` gera "1.2.1" para capítulo 1, seção 2, ambiente 1).
+///
+/// Uso:
+/// ```typst
+/// #show: configurar-numeracao("por-tipo")
+/// #show: configurar-numeracao("unificado", por-secao: true)
+/// #show: configurar-numeracao("por-tipo", por-secao: true, nivel: 2)
+/// ```
+#let configurar-numeracao(modo, por-secao: false, nivel: 1) = {
+  body => {
+    numeracao-ambientes.update((modo: modo, por-secao: por-secao, nivel: nivel))
+    if por-secao {
+      show heading.where(level: nivel): it => {
+        if modo == "unificado" {
+          counter("ferrmat-resultado").update(0)
+        } else {
+          for key in _contadores-ambientes {
+            counter(key).update(0)
+          }
+        }
+        it
+      }
+      body
+    } else {
+      body
+    }
+  }
+}
+
+#let ambiente-matematico(
+  cor: blue,
+  espessura: 2pt,
+  prefixo: none,
+  contador: none,
+  italico: false,
+  por-secao: false,
+) = {
+  (body, titulo: none) => {
+    let corpo = if italico { emph(body) } else { body }
+
+    // Ambos os contadores são sempre incrementados para que a troca de modo
+    // funcione retroativamente. Trocar de modo no meio do documento NÃO é recomendado.
+    if contador != none {
+      counter(contador).step()
+      counter("ferrmat-resultado").step()
+    }
+
+    context {
+      let estilo-val = ambiente-estilo.get()
+      let config = numeracao-ambientes.get()
+      let modo-num = config.at("modo", default: "por-tipo")
+      let secao-global = config.at("por-secao", default: false)
+
+      let contador-efetivo = if modo-num == "unificado" and contador != none {
+        "ferrmat-resultado"
+      } else {
+        contador
+      }
+
+      let usar-secao = secao-global or por-secao
+
+      let nivel-cfg = config.at("nivel", default: 1)
+      let num = if contador-efetivo != none {
+        if usar-secao {
+          let hd = counter(heading).get()
+          let sec-nums = hd.slice(0, calc.min(nivel-cfg, hd.len()))
+          let sec-str = sec-nums.map(str).join(".")
+          let c = counter(contador-efetivo).at(here()).first()
+          [#sec-str.#c]
+        } else {
+          numbering("1", ..counter(contador-efetivo).at(here()))
+        }
+      }
+
+      if estilo-val == "sem-caixa" {
+        let rotulo = if prefixo != none and num != none {
+          if titulo != none {
+            [*#prefixo #num* (#titulo).]
+          } else {
+            [*#prefixo #num.*]
+          }
+        } else if prefixo != none {
+          if titulo != none {
+            [*#prefixo* (#titulo).]
+          } else {
+            [*#prefixo.*]
+          }
+        }
+        block(above: 0.8em, below: 0.8em)[#rotulo #corpo]
+      } else {
+        let cor-efetiva = if estilo-val == "cinza" {
+          if espessura >= 3pt { luma(35%) }
+          else if espessura >= 2pt { luma(50%) }
+          else { luma(65%) }
+        } else {
+          cor
+        }
+
+        caixa(
+          corpo,
+          titulo: _build-titulo(prefixo, num, titulo),
+          cor: cor-efetiva,
+          borda: "left",
+          espessura: espessura,
+        )
+      }
+    }
+  }
+}
+
+// --- Enunciados (azul — corpo em itálico) ---
+#let teorema = ambiente-matematico(cor: blue, espessura: 3pt, prefixo: "Teorema", contador: "ferrmat-teorema", italico: true)
+#let lema = ambiente-matematico(cor: blue.darken(10%), espessura: 2pt, prefixo: "Lema", contador: "ferrmat-lema", italico: true)
+#let corolario = ambiente-matematico(cor: blue.lighten(10%), espessura: 2pt, prefixo: "Corolário", contador: "ferrmat-corolario", italico: true)
+#let proposicao = ambiente-matematico(cor: eastern, espessura: 2pt, prefixo: "Proposição", contador: "ferrmat-proposicao", italico: true)
+#let axioma = ambiente-matematico(cor: navy, espessura: 3pt, prefixo: "Axioma", contador: "ferrmat-axioma", italico: true)
+#let conjectura = ambiente-matematico(cor: purple, espessura: 2pt, prefixo: "Conjectura", contador: "ferrmat-conjectura", italico: true)
+#let afirmacao = ambiente-matematico(cor: teal, espessura: 2pt, prefixo: "Afirmação", contador: "ferrmat-afirmacao", italico: true)
+
+// --- Definições (verde — corpo normal) ---
+#let definicao = ambiente-matematico(cor: green, espessura: 3pt, prefixo: "Definição", contador: "ferrmat-definicao")
+#let notacao = ambiente-matematico(cor: olive, espessura: 2pt, prefixo: "Notação", contador: "ferrmat-notacao")
+#let propriedade = ambiente-matematico(cor: green.darken(10%), espessura: 2pt, prefixo: "Propriedade", contador: "ferrmat-propriedade")
+
+// --- Exemplos e problemas (cinza/laranja — corpo normal) ---
+#let exemplo = ambiente-matematico(cor: gray, espessura: 2pt, prefixo: "Exemplo", contador: "ferrmat-exemplo")
+#let problema = ambiente-matematico(cor: orange, espessura: 2pt, prefixo: "Problema", contador: "ferrmat-problema")
+
+// --- Informais ---
+#let observacao = ambiente-matematico(cor: maroon, espessura: 1pt, prefixo: "Observação")
+// demonstracao: já definida acima com QED
+
+// ============================================================================
+// Operadores e funções matemáticas em português
+// ============================================================================
+
+/// Seno — exibe "sen" em vez de "sin" no modo matemático.
+///
+/// Uso:
+/// ```typst
+/// $sen(x)$
+/// ```
+#let sen = math.op("sen")
+
+/// Tangente — exibe "tg" em vez de "tan".
+///
+/// Uso: `$tg(x)$`
+#let tg = math.op("tg")
+
+/// Cossecante — exibe "csc".
+///
+/// Uso: `$csc(x)$`
+#let csc = math.op("csc")
+
+/// Cotangente — exibe "ctg" em vez de "cot".
+///
+/// Uso: `$ctg(x)$`
+#let ctg = math.op("ctg")
+
+/// Arco seno — exibe "arcsen" em vez de "arcsin".
+///
+/// Uso: `$arcsen(x)$`
+#let arcsen = math.op("arcsen")
+
+/// Arco cosseno — exibe "arccos".
+///
+/// Uso: `$arccos(x)$`
+#let arccos = math.op("arccos")
+
+/// Arco tangente — exibe "arctg" em vez de "arctan".
+///
+/// Uso: `$arctg(x)$`
+#let arctg = math.op("arctg")
+
+/// Seno hiperbólico — exibe "senh" em vez de "sinh".
+///
+/// Uso: `$senh(x)$`
+#let senh = math.op("senh")
+
+/// Tangente hiperbólica — exibe "tgh" em vez de "tanh".
+///
+/// Uso: `$tgh(x)$`
+#let tgh = math.op("tgh")
+
+// ============================================================================
+// Operadores matemáticos em português
+// ============================================================================
+
+/// Máximo divisor comum — exibe "mdc" em vez de "gcd".
+///
+/// Uso: `$mdc(a, b)$`
+#let mdc = math.op("mdc")
+
+/// Mínimo múltiplo comum — exibe "mmc" em vez de "lcm".
+///
+/// Uso: `$mmc(a, b)$`
+#let mmc = math.op("mmc")
+
+/// Grau/graus — símbolo ° (wrapper para `degree`).
+/// Ambas as formas existem para permitir português correto: `$90 graus$`.
+///
+/// Uso: `$90 graus$`, `$angulo A B C = 45 graus$`
+#let grau = sym.degree
+#let graus = sym.degree
+
+/// Resto (módulo) — exibe "mod".
+///
+/// Uso: `$a resto b$`, `$17 resto 5 = 2$`
+#let resto = math.op("mod")
+
+/// Ângulo — símbolo ∠ com variantes em português.
+///
+/// - `angulo` — ∠ (ângulo padrão)
+/// - `angulo.arco` — ∡ (ângulo com arco)
+/// - `angulo.agudo` — ⦟ (ângulo agudo)
+/// - `angulo.reto` — ∟ (ângulo reto)
+/// - `angulo.esferico` — ∢ (ângulo esférico)
+///
+/// Uso: `$angulo A B C$`, `$angulo.reto$`
+#let angulo = symbol("∠", ("arco", "∡"), ("agudo", "⦟"), ("reto", "∟"), ("esferico", "∢"))
+
+/// Fração com parâmetro `estilo` em português.
+/// Wrapper sobre `math.frac()`.
+///
+/// Parâmetros:
+/// - numerador: conteúdo do numerador
+/// - denominador: conteúdo do denominador
+/// - estilo: "vertical" (padrão), "inclinada" ou "horizontal"
+///
+/// Uso:
+/// ```typst
+/// $fracao(a+b, c+d)$
+/// $fracao(a, b, estilo: "inclinada")$
+/// ```
+#let fracao(numerador, denominador, estilo: "vertical") = {
+  let resolved-style = if estilo == "inclinada" { "skewed" }
+    else if estilo == "horizontal" { "horizontal" }
+    else { "vertical" }
+
+  math.frac(numerador, denominador, style: resolved-style)
+}
+
+/// Matriz com parênteses. Wrapper sobre `math.mat(delim: "(")`.
+///
+/// Uso:
+/// ```typst
+/// $matriz(1, 2; 3, 4)$
+/// ```
+#let matriz(..args) = math.mat(delim: "(", ..args)
+
+/// Matriz com colchetes. Wrapper sobre `math.mat(delim: "[")`.
+///
+/// Uso:
+/// ```typst
+/// $colchete(1, 2, 3; 4, 5, 6)$
+/// ```
+#let colchete(..args) = math.mat(delim: "[", ..args)
+
+/// Matriz com barras (determinante). Wrapper sobre `math.mat(delim: "|")`.
+///
+/// Uso:
+/// ```typst
+/// $barra(a, b; c, d)$
+/// ```
+#let barra(..args) = math.mat(delim: "|", ..args)
+
+/// Matriz com barras duplas (norma). Wrapper sobre `math.mat(delim: "‖")`.
+///
+/// Uso:
+/// ```typst
+/// $norma(a, b; c, d)$
+/// ```
+#let norma(..args) = math.mat(delim: "‖", ..args)
+
+/// Binômio em português.
+/// Wrapper sobre `math.binom()`.
+///
+/// Parâmetros:
+/// - superior: índice superior
+/// - ..inferior: índice(s) inferior(es)
+///
+/// Uso:
+/// ```typst
+/// $binomio(n, k)$
+/// $binomio(n, k_1, k_2, k_3)$
+/// ```
+#let binomio(superior, ..inferior) = {
+  math.binom(superior, ..inferior)
+}
+
+/// Raiz em português.
+/// Com um argumento: raiz quadrada. Com dois: raiz n-ésima.
+///
+/// Uso:
+/// ```typst
+/// $raiz(2)$           // √2
+/// $raiz(3, 8)$        // ∛8
+/// $raiz(n, x)$        // ⁿ√x
+/// ```
+#let raiz(..args) = {
+  let pos = args.pos()
+  assert(pos.len() >= 1 and pos.len() <= 2, message: "raiz() requer 1 ou 2 argumentos: raiz(x) ou raiz(n, x)")
+  if pos.len() == 1 {
+    math.sqrt(pos.at(0))
+  } else {
+    math.root(pos.at(0), pos.at(1))
+  }
+}
+
+/// Estilo de exibição (display) — equivalente ao \displaystyle do LaTeX.
+/// Força o tamanho normal de equações em bloco.
+///
+/// Parâmetros:
+/// - corpo: conteúdo matemático
+/// - compacto: restringe altura de expoentes (padrão: false)
+///
+/// Uso:
+/// ```typst
+/// $destaque(sum_(i=1)^n x_i)$
+/// ```
+#let destaque(corpo, compacto: false) = {
+  math.display(corpo, cramped: compacto)
+}
+
+/// Estilo em linha (inline) — equivalente ao \textstyle do LaTeX.
+/// Força o tamanho normal de equações em linha.
+///
+/// Parâmetros:
+/// - corpo: conteúdo matemático
+/// - compacto: restringe altura de expoentes (padrão: false)
+///
+/// Uso:
+/// ```typst
+/// $ emLinha(sum_(i=1)^n x_i) $
+/// ```
+#let emLinha(corpo, compacto: false) = {
+  math.inline(corpo, cramped: compacto)
+}
+
+/// Estilo de subscrito (script) — equivalente ao \scriptstyle do LaTeX.
+/// Tamanho menor, usado em potências e sub/sobrescritos.
+///
+/// Parâmetros:
+/// - corpo: conteúdo matemático
+/// - compacto: restringe altura de expoentes (padrão: true)
+///
+/// Uso:
+/// ```typst
+/// $subscrito(sum_(i=1)^n x_i)$
+/// ```
+#let subscrito(corpo, compacto: true) = {
+  math.script(corpo, cramped: compacto)
+}
+
+/// Estilo de sub-subscrito (sscript) — equivalente ao \scriptscriptstyle do LaTeX.
+/// Menor tamanho, usado em sub/sobrescritos de segundo nível.
+///
+/// Parâmetros:
+/// - corpo: conteúdo matemático
+/// - compacto: restringe altura de expoentes (padrão: true)
+///
+/// Uso:
+/// ```typst
+/// $subSubscrito(sum_(i=1)^n x_i)$
+/// ```
+#let subSubscrito(corpo, compacto: true) = {
+  math.sscript(corpo, cramped: compacto)
+}
+
+/// Delimitador auto-dimensionável — wrapper sobre `math.lr()`.
+///
+/// Uso:
+/// ```typst
+/// $delimitar((frac(a, b)))$
+/// $delimitar(| x |)$
+/// ```
+#let delimitar(..args) = {
+  math.lr(..args)
+}
+
+/// Vetor com seta — wrapper sobre `math.arrow()`.
+/// Funciona com um ou mais caracteres.
+///
+/// Uso:
+/// ```typst
+/// $vetor(v)$        // v com seta
+/// $vetor(A B)$      // AB com seta (vetor de A a B)
+/// ```
+#let vetor(..args) = {
+  math.arrow(..args)
+}
+
+/// Vetor em negrito — wrapper sobre `math.bold()`.
+///
+/// Uso:
+/// ```typst
+/// $vetorNegrito(v)$, $vetorNegrito(F)$
+/// ```
+#let vetorNegrito(..args) = {
+  math.bold(..args)
+}
+
+/// Conjugado — barra superior sobre um caractere.
+/// Wrapper sobre `math.overline()`.
+///
+/// Uso:
+/// ```typst
+/// $conjugado(z)$
+/// ```
+#let conjugado(..args) = {
+  math.overline(..args)
+}
+
+/// Segmento — barra superior sobre dois pontos.
+/// Wrapper sobre `math.overline()`.
+///
+/// Uso:
+/// ```typst
+/// $segmento(A B)$
+/// ```
+#let segmento(..args) = {
+  math.overline(..args)
+}
+
+// ============================================================================
+// Derivadas em português
+// ============================================================================
+
+/// Derivada na notação de Leibniz.
+///
+/// Parâmetros:
+/// - num: variável do numerador
+/// - denom: variável do denominador
+/// - ordem (opcional): ordem da derivada
+///
+/// Uso:
+/// ```typst
+/// $leibniz(y, x)$      // dy/dx
+/// $leibniz(y, x, 2)$   // d²y/dx²
+/// $leibniz(y, x, n)$   // dⁿy/dxⁿ
+/// ```
+#let leibniz(..args) = {
+  let pos = args.pos()
+  assert(pos.len() >= 2, message: "leibniz() requer ao menos 2 argumentos: leibniz(y, x)")
+  let num = pos.at(0)
+  let denom = pos.at(1)
+  if pos.len() <= 2 {
+    $frac(dif num, dif denom)$
+  } else {
+    let ordem = pos.at(2)
+    $frac(dif^ordem num, dif denom^ordem)$
+  }
+}
+
+/// Derivada parcial.
+///
+/// Com uma variável no denominador: derivada parcial simples.
+/// Com múltiplas variáveis: derivada parcial mista.
+///
+/// Parâmetros:
+/// - num: função no numerador
+/// - ..denoms: variável(is) do denominador
+/// - ordem: ordem da derivada (padrão: inferida do número de variáveis)
+///
+/// Uso:
+/// ```typst
+/// $parcial(f, x)$              // ∂f/∂x
+/// $parcial(f, x, ordem: 2)$    // ∂²f/∂x²
+/// $parcial(f, x, y)$           // ∂²f/∂x∂y
+/// ```
+#let parcial(num, ..denoms, ordem: none) = {
+  let vars = denoms.pos()
+  assert(vars.len() >= 1, message: "parcial() requer ao menos uma variável: parcial(f, x)")
+  if vars.len() == 1 {
+    let v = vars.at(0)
+    if ordem == none {
+      $frac(partial num, partial #v)$
+    } else {
+      $frac(partial^ordem num, partial #v^ordem)$
+    }
+  } else {
+    let n = if ordem != none { ordem } else { vars.len() }
+    let denom = vars.map(v => $partial #v$).join()
+    $frac(partial^#n num, #denom)$
+  }
+}
+
+// ============================================================================
+// Símbolos matemáticos em português
+// ============================================================================
+
+/// Infinito — símbolo ∞.
+///
+/// Uso:
+/// ```typst
+/// $lim_(n -> infinito) a_n$
+/// ```
+#let infinito = symbol("∞")
+
+/// Integral — símbolo ∫ com variantes em português.
+///
+/// Variantes:
+/// - `integral` → ∫
+/// - `integral.dupla` → ∬
+/// - `integral.tripla` → ∭
+/// - `integral.quadrupla` → ⨌
+/// - `integral.contorno` → ∮
+/// - `integral.traco` → ⨍
+/// - `integral.traco.dupla` → ⨎
+/// - `integral.inter` → ⨙
+/// - `integral.seta.gancho` → ⨗
+///
+/// Uso:
+/// ```typst
+/// $integral_a^b f(x) dif x$
+/// $integral.dupla_D f(x,y) dif x dif y$
+/// ```
+#let integral = symbol(
+  "∫",
+  ("dupla", "∬"),
+  ("tripla", "∭"),
+  ("quadrupla", "⨌"),
+  ("contorno", "∮"),
+  ("traco", "⨍"),
+  ("traco.dupla", "⨎"),
+  ("inter", "⨙"),
+  ("seta.gancho", "⨗"),
+)
+
+/// Somatório — símbolo ∑ com variantes.
+///
+/// Variantes:
+/// - `somatorio` → ∑
+/// - `somatorio.integral` → ⨋
+///
+/// Uso:
+/// ```typst
+/// $somatorio_(i=1)^n a_i$
+/// ```
+#let somatorio = symbol(
+  "∑",
+  ("integral", "⨋"),
+)
+
+/// Produtório — símbolo ∏ com variantes.
+///
+/// Variantes:
+/// - `produtorio` → ∏
+/// - `produtorio.co` → ∐
+///
+/// Uso:
+/// ```typst
+/// $produtorio_(i=1)^n a_i$
+/// ```
+#let produtorio = symbol(
+  "∏",
+  ("co", "∐"),
+)
+
+/// União — símbolo ∪ com variantes.
+///
+/// Variantes:
+/// - `uniao` → ∪
+/// - `uniao.maior` → ⋃
+/// - `uniao.seta` → ⊌
+/// - `uniao.ponto` → ⊍
+/// - `uniao.ponto.maior` → ⨃
+/// - `uniao.dupla` → ⋓
+/// - `uniao.menos` → ⩁
+/// - `uniao.ou` → ⩅
+/// - `uniao.mais` → ⊎
+/// - `uniao.mais.maior` → ⨄
+/// - `uniao.quad` → ⊔
+/// - `uniao.quad.maior` → ⨆
+/// - `uniao.quad.dupla` → ⩏
+///
+/// Uso:
+/// ```typst
+/// $uniao.maior_(i=1)^n A_i$
+/// ```
+#let uniao = symbol(
+  "∪",
+  ("maior", "⋃"),
+  ("seta", "⊌"),
+  ("ponto", "⊍"),
+  ("ponto.maior", "⨃"),
+  ("dupla", "⋓"),
+  ("menos", "⩁"),
+  ("ou", "⩅"),
+  ("mais", "⊎"),
+  ("mais.maior", "⨄"),
+  ("quad", "⊔"),
+  ("quad.maior", "⨆"),
+  ("quad.dupla", "⩏"),
+)
+
+/// Interseção — símbolo ∩ com variantes.
+///
+/// Variantes:
+/// - `inter` → ∩
+/// - `inter.maior` → ⋂
+/// - `inter.e` → ⩄
+/// - `inter.ponto` → ⩀
+/// - `inter.dupla` → ⋒
+/// - `inter.quad` → ⊓
+/// - `inter.quad.maior` → ⨅
+/// - `inter.quad.dupla` → ⩎
+///
+/// Uso:
+/// ```typst
+/// $inter.maior_(i=1)^n A_i$
+/// ```
+#let inter = symbol(
+  "∩",
+  ("maior", "⋂"),
+  ("e", "⩄"),
+  ("ponto", "⩀"),
+  ("dupla", "⋒"),
+  ("quad", "⊓"),
+  ("quad.maior", "⨅"),
+  ("quad.dupla", "⩎"),
+)
+
+// ============================================================================
+// Letras gregas em português
+// ============================================================================
+//
+// As seguintes letras já possuem o mesmo nome em português e inglês,
+// e podem ser usadas diretamente no modo matemático sem wrapper:
+// beta (β), delta (δ), epsilon (ε), zeta (ζ), eta (η), iota (ι),
+// lambda (λ), omicron (ο), pi (π), sigma (σ), tau (τ), psi (ψ), omega (ω).
+
+// --- Minúsculas ---
+
+/// Alfa (α).
+///
+/// Uso: `$alfa$`
+#let alfa = sym.alpha
+
+/// Gama (γ).
+///
+/// Uso: `$gama$`
+#let gama = sym.gamma
+
+/// Teta (θ) com variante cursiva.
+///
+/// - `teta` → θ
+/// - `teta.alt` → ϑ
+///
+/// Uso: `$teta$`, `$teta.alt$`
+#let teta = symbol("θ", ("alt", "ϑ"))
+
+/// Kapa (κ) com variante cursiva.
+///
+/// - `kapa` → κ
+/// - `kapa.alt` → ϰ
+///
+/// Uso: `$kapa$`
+#let kapa = symbol("κ", ("alt", "ϰ"))
+
+/// Mi (μ).
+///
+/// Uso: `$mi$`
+#let mi = sym.mu
+
+/// Ni (ν).
+///
+/// Uso: `$ni$`
+#let ni = sym.nu
+
+/// Csi (ξ).
+///
+/// Uso: `$csi$`
+#let csi = sym.xi
+
+/// Rô (ρ) com variante cursiva.
+///
+/// - `ro` → ρ
+/// - `ro.alt` → ϱ
+///
+/// Uso: `$ro$`, `$ro.alt$`
+#let ro = symbol("ρ", ("alt", "ϱ"))
+
+/// Ípsilon (υ).
+///
+/// Uso: `$ipsilon$`
+#let ipsilon = sym.upsilon
+
+/// Fi (φ) com variante.
+///
+/// - `fi` → φ
+/// - `fi.alt` → ϕ
+///
+/// Uso: `$fi$`, `$fi.alt$`
+#let fi = symbol("φ", ("alt", "ϕ"))
+
+/// Qui (χ).
+///
+/// Uso: `$qui$`
+#let qui = sym.chi
+
+// --- Maiúsculas (apenas as visualmente distintas das letras latinas) ---
+
+/// Gama maiúsculo (Γ).
+///
+/// Uso: `$Gama$`
+#let Gama = sym.Gamma
+
+/// Teta maiúsculo (Θ).
+///
+/// Uso: `$Teta$`
+#let Teta = sym.Theta
+
+/// Csi maiúsculo (Ξ).
+///
+/// Uso: `$Csi$`
+#let Csi = sym.Xi
+
+/// Ípsilon maiúsculo (Υ).
+///
+/// Uso: `$Ipsilon$`
+#let Ipsilon = sym.Upsilon
+
+/// Fi maiúsculo (Φ).
+///
+/// Uso: `$Fi$`
+#let Fi = sym.Phi
+
+// ============================================================================
+// Símbolos matemáticos em português
+// ============================================================================
+//
+// Nomes usam camelCase (não hífens) para funcionar em modo matemático:
+// $paraTodo$ funciona, $para-todo$ seria interpretado como "para" - "todo".
+
+// --- Operadores binários ---
+
+/// Vezes (×) — multiplicação.
+///
+/// Uso: `$a vezes b$`
+#let vezes = sym.times
+
+/// Mais ou menos (±).
+///
+/// Uso: `$a maisMenos b$`
+#let maisMenos = sym.plus.minus
+
+/// Menos ou mais (∓).
+///
+/// Uso: `$a menosMais b$`
+#let menosMais = sym.minus.plus
+
+/// Ponto central (⋅) — produto escalar ou multiplicação.
+///
+/// Uso: `$a pontoMedio b$`
+#let pontoMedio = sym.dot
+
+/// Estrela (⋆).
+///
+/// Uso: `$a estrela b$`
+#let estrela = sym.star
+
+/// Marcador (•).
+///
+/// Uso: `$marcador$`
+#let marcador = sym.bullet
+
+/// Losango (⋄).
+///
+/// Uso: `$a losango b$`
+#let losango = sym.diamond
+
+/// Círculo (∘) — composição.
+///
+/// Uso: `$f circulo g$`
+#let circulo = sym.circle.small
+
+/// Sem — diferença de conjuntos (∖).
+///
+/// Uso: `$A sem B$`
+#let sem = sym.without
+
+/// Ou lógico (∨).
+///
+/// Uso: `$p ou q$`
+#let ou = sym.or
+
+/// E lógico (∧).
+///
+/// Uso: `$p eLogico q$`
+#let eLogico = sym.and
+
+/// Ou exclusivo (⊻).
+///
+/// Uso: `$p ouExclusivo q$`
+#let ouExclusivo = sym.xor
+
+// --- Relações ---
+
+/// Aproximadamente (≈).
+///
+/// Uso: `$x aprox y$`
+#let aprox = sym.approx
+
+/// Equivalente (≡).
+///
+/// Uso: `$a equiv b$`
+#let equiv = sym.equiv
+
+/// Precede (≺).
+///
+/// Uso: `$a precede b$`
+#let precede = sym.prec
+
+/// Sucede (≻).
+///
+/// Uso: `$a sucede b$`
+#let sucede = sym.succ
+
+/// Está contido (⊂) com variantes.
+///
+/// - `estaContido` → ⊂
+/// - `estaContido.eq` → ⊆
+///
+/// Uso: `$A estaContido B$`, `$A estaContido.eq B$`
+#let estaContido = symbol("⊂", ("eq", "⊆"))
+
+/// Contém (⊃) com variantes.
+///
+/// - `contem` → ⊃
+/// - `contem.eq` → ⊇
+///
+/// Uso: `$A contem B$`, `$A contem.eq B$`
+#let contem = symbol("⊃", ("eq", "⊇"))
+
+/// Pertence (∈) com variante negada.
+///
+/// - `pertence` → ∈
+/// - `pertence.nao` → ∉
+///
+/// Uso: `$x pertence A$`, `$x pertence.nao A$`
+#let pertence = symbol("∈", ("nao", "∉"))
+
+/// Proporcional (∝).
+///
+/// Uso: `$y proporcional x$`
+#let proporcional = sym.prop
+
+/// Paralelo (∥).
+///
+/// Uso: `$a paralelo b$`
+#let paralelo = sym.parallel
+
+/// Perpendicular (⊥).
+///
+/// Uso: `$a perpendicular b$`
+#let perpendicular = sym.perp
+
+// --- Setas ---
+//
+// Direções usam WASD: w=cima, s=baixo, a=esquerda, d=direita.
+
+/// Seta com variantes direcionais.
+///
+/// - `seta` → → (direita, padrão)
+/// - `seta.d` → →, `seta.a` → ←, `seta.w` → ↑, `seta.s` → ↓
+/// - `seta.w.s` → ↕, `seta.a.d` → ↔
+/// - `seta.d.longa` → ⟶, `seta.a.longa` → ⟵, `seta.a.d.longa` → ⟷
+/// - `seta.gancho` → ↪, `seta.d.cauda` → ↣, `seta.mapa` → ↦
+///
+/// Uso: `$A seta.d B$`, `$seta.w$`
+#let seta = symbol(
+  "→",
+  ("d", "→"),
+  ("a", "←"),
+  ("w", "↑"),
+  ("s", "↓"),
+  ("w.s", "↕"),
+  ("a.d", "↔"),
+  ("d.longa", "⟶"),
+  ("a.longa", "⟵"),
+  ("a.d.longa", "⟷"),
+  ("gancho", "↪"),
+  ("d.cauda", "↣"),
+  ("mapa", "↦"),
+)
+
+/// Implica (⇒).
+///
+/// Uso: `$p implica q$`
+#let implica = sym.arrow.r.double
+
+/// Se e somente se (⇔).
+///
+/// Uso: `$p sse q$`
+#let sse = sym.arrow.l.r.double
+
+// --- Símbolos diversos ---
+
+/// Conjunto vazio (∅).
+///
+/// Uso: `$vazio$`
+#let vazio = sym.emptyset
+
+/// Portanto (∴).
+///
+/// Uso: `$portanto x = 1$`
+#let portanto = sym.therefore
+
+/// Pois / porque (∵).
+///
+/// Uso: `$pois x > 0$`
+#let pois = sym.because
+
+/// Para todo (∀).
+///
+/// Uso: `$paraTodo x in RR$`
+#let paraTodo = sym.forall
+
+/// Existe (∃).
+///
+/// Uso: `$existe x$`
+#let existe = sym.exists
+
+/// Negação (¬).
+///
+/// Uso: `$nao p$`
+#let nao = sym.not
+
+// Parcial (∂) — símbolo de derivada parcial.
+//
+// Nota: a função `parcial(f, x)` gera a fração ∂f/∂x completa.
+// Este alias é para o símbolo isolado ∂.
+//
+// Uso: `$parcial f / parcial x$`
+// Não definido como wrapper porque conflita com a função parcial().
+// Use `partial` (built-in do Typst) para o símbolo isolado,
+// ou `parcial(f, x)` para a notação completa.
+
+/// Alef (ℵ).
+///
+/// Uso: `$alef_0$`
+#let alef = sym.aleph
+
+/// Reticências com variantes.
+///
+/// - `reticencias` → … (genérica)
+/// - `reticencias.h` → ⋯ (horizontal)
+/// - `reticencias.v` → ⋮ (vertical)
+/// - `reticencias.c` → ⋯ (centralizada)
+/// - `reticencias.diagonal` → ⋱ (diagonal descendente)
+/// - `reticencias.diagonal.w` → ⋰ (diagonal ascendente)
+///
+/// Uso: `$a_1, reticencias, a_n$`
+#let reticencias = symbol(
+  "…",
+  ("h", "⋯"),
+  ("v", "⋮"),
+  ("c", "⋯"),
+  ("diagonal", "⋱"),
+  ("diagonal.w", "⋰"),
+)
+
+/// Sobre-chave — wrapper sobre `math.overbrace()`.
+///
+/// Uso: `$sobreChave(a + b + c, "n termos")$`
+#let sobreChave(corpo, ..args) = math.overbrace(corpo, ..args)
+
+/// Sub-chave — wrapper sobre `math.underbrace()`.
+///
+/// Uso: `$subChave(x_1 + x_2 + dots + x_n, "soma")$`
+#let subChave(corpo, ..args) = math.underbrace(corpo, ..args)
+
+/// Sobre-linha — wrapper sobre `math.overline()`.
+///
+/// Uso: `$sobreLinha(A B)$`
+#let sobreLinha(..args) = math.overline(..args)
+
+/// Sub-linha — wrapper sobre `math.underline()`.
+///
+/// Uso: `$subLinha(x + y)$`
+#let subLinha(..args) = math.underline(..args)
+
+/// Acento chapéu — wrapper para `math.hat()`.
+///
+/// Uso: `$chapeu(x)$`
+#let chapeu(corpo) = math.hat(corpo)
+
+/// Acento ponto — wrapper para `math.dot()`.
+///
+/// Uso: `$ponto(x)$`
+#let ponto(corpo) = math.dot(corpo)
+
+/// Acento ponto duplo — wrapper para `math.dot.double()`.
+///
+/// Uso: `$pontoDuplo(x)$`
+#let pontoDuplo(corpo) = math.dot.double(corpo)
+
+/// Acento traço (mácron) — wrapper para `math.macron()`.
+///
+/// Uso: `$traco(x)$`
+#let traco(corpo) = math.macron(corpo)
+
+/// Chapéu largo — wrapper sobre `math.accent()` com hat.
+/// Diferente de `hat()` que cobre apenas um caractere,
+/// `chapeuLargo()` se estende sobre todo o conteúdo.
+///
+/// Uso: `$chapeuLargo(A B C)$`
+#let chapeuLargo(corpo) = math.accent(corpo, math.hat)
+
+/// Til largo — wrapper sobre `math.accent()` com tilde.
+///
+/// Uso: `$tilLargo(A B C)$`
+#let tilLargo(corpo) = math.accent(corpo, math.tilde)
+
+/// Espaço invisível — equivalente ao `\phantom` do LaTeX.
+/// Renderiza o conteúdo de forma invisível, reservando o espaço que ele ocuparia.
+/// Funciona tanto em modo matemático quanto em modo texto.
+///
+/// Uso: `$fantasma(x) + y$`  ou  `#fantasma[texto]`
+#let fantasma(corpo) = hide(corpo)
+
+/// Função por partes com alinhamento à direita.
+/// Usa `lr` + `mat` internamente para alinhar a primeira coluna à direita.
+/// Linhas separadas por `;`, colunas por `,`.
+///
+/// - delim: delimitador esquerdo (`"{"` ou `"["`)
+/// - gap: espaço entre colunas (padrão `0.5em`)
+///
+/// Uso: `$f(x) = porPartes(x, se x > 0; 0, se x = 0; -x, se x < 0)$`
+#let porPartes(delim: "{", gap: 0.5em, ..args) = {
+  let m = math.mat(delim: none, align: right, column-gap: gap, ..args)
+  if delim == "[" {
+    math.lr($bracket.l #m$)
+  } else {
+    math.lr($brace.l #m$)
+  }
+}
+
+/// Operador textual "se" para uso em funções por partes.
+/// Inclui espaço extra após a palavra para equilibrar o espaçamento visual.
+///
+/// Uso: `$porPartes(x, se x > 0; -x, se x < 0)$`
+#let se = { math.op("se"); h(0.3em) }
+

--- a/packages/preview/ferrmat/0.1.0/src/pagina.typ
+++ b/packages/preview/ferrmat/0.1.0/src/pagina.typ
@@ -1,0 +1,316 @@
+// Wrappers em português para configuração de página do Typst
+// Traduz nomes de parâmetros de page(), pagebreak() e margin
+
+// ---------------------------------------------------------------------------
+// Utilitário interno: traduz chaves de margem PT → EN
+// ---------------------------------------------------------------------------
+
+#let _traduzir-margem(m) = {
+  if type(m) == dictionary {
+    let resultado = (:)
+    for (chave, valor) in m {
+      let en = if chave == "superior" { "top" }
+        else if chave == "inferior" { "bottom" }
+        else if chave == "esquerda" { "left" }
+        else if chave == "direita" { "right" }
+        else if chave == "interna" { "inside" }
+        else if chave == "externa" { "outside" }
+        else if chave == "resto" { "rest" }
+        else if chave in ("x", "y", "top", "bottom", "left", "right", "inside", "outside", "rest") { chave }
+        else { panic("margem: chave desconhecida '" + chave + "'. Use: superior, inferior, esquerda, direita, interna, externa, resto, x, y") }
+      resultado.insert(en, valor)
+    }
+    resultado
+  } else {
+    m // valor único (length, auto, etc.)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// configurar-pagina — show-rule para configurar a página
+// ---------------------------------------------------------------------------
+
+/// Configura a página do documento com parâmetros em português.
+/// Uso: `#show: configurar-pagina.with(papel: "a4", margem: (superior: 3cm, inferior: 2cm))`
+#let configurar-pagina(
+  papel: auto,
+  largura: auto,
+  altura: auto,
+  margem: auto,
+  paisagem: auto,
+  colunas: auto,
+  preenchimento: auto,
+  numeracao: auto,
+  alinhamento-numero: auto,
+  cabecalho: auto,
+  rodape: auto,
+  pre-cabecalho: auto,
+  pre-rodape: auto,
+  encadernacao: auto,
+  plano-de-fundo: auto,
+  primeiro-plano: auto,
+  corpo,
+) = {
+  let args = (:)
+  if papel != auto { args.insert("paper", papel) }
+  if largura != auto { args.insert("width", largura) }
+  if altura != auto { args.insert("height", altura) }
+  if margem != auto { args.insert("margin", _traduzir-margem(margem)) }
+  if paisagem != auto { args.insert("flipped", paisagem) }
+  if colunas != auto { args.insert("columns", colunas) }
+  if preenchimento != auto { args.insert("fill", preenchimento) }
+  if numeracao != auto { args.insert("numbering", numeracao) }
+  if alinhamento-numero != auto { args.insert("number-align", alinhamento-numero) }
+  if cabecalho != auto { args.insert("header", cabecalho) }
+  if rodape != auto { args.insert("footer", rodape) }
+  if pre-cabecalho != auto { args.insert("header-ascent", pre-cabecalho) }
+  if pre-rodape != auto { args.insert("footer-descent", pre-rodape) }
+  if encadernacao != auto { args.insert("binding", encadernacao) }
+  if plano-de-fundo != auto { args.insert("background", plano-de-fundo) }
+  if primeiro-plano != auto { args.insert("foreground", primeiro-plano) }
+  set page(..args)
+  corpo
+}
+
+// ---------------------------------------------------------------------------
+// margem — helper para construir dicionário de margens em português
+// ---------------------------------------------------------------------------
+
+/// Constrói um dicionário de margens com chaves em português.
+/// Uso: `margem(superior: 3cm, inferior: 2cm, esquerda: 3cm, direita: 2cm)`
+#let margem(
+  superior: auto,
+  inferior: auto,
+  esquerda: auto,
+  direita: auto,
+  interna: auto,
+  externa: auto,
+  resto: auto,
+  x: auto,
+  y: auto,
+) = {
+  let resultado = (:)
+  if superior != auto { resultado.insert("top", superior) }
+  if inferior != auto { resultado.insert("bottom", inferior) }
+  if esquerda != auto { resultado.insert("left", esquerda) }
+  if direita != auto { resultado.insert("right", direita) }
+  if interna != auto { resultado.insert("inside", interna) }
+  if externa != auto { resultado.insert("outside", externa) }
+  if resto != auto { resultado.insert("rest", resto) }
+  if x != auto { resultado.insert("x", x) }
+  if y != auto { resultado.insert("y", y) }
+  resultado
+}
+
+// ---------------------------------------------------------------------------
+// quebra-pagina — wrapper para pagebreak()
+// ---------------------------------------------------------------------------
+
+/// Insere uma quebra de página.
+/// - `fraco`: se `true`, só quebra se não estiver já no topo da página
+/// - `para`: `"impar"` ou `"par"` para pular até página ímpar/par
+#let quebra-pagina(fraco: false, para: none) = {
+  if para != none {
+    assert(para in ("impar", "par"),
+      message: "quebra-pagina: 'para' deve ser \"impar\" ou \"par\", recebeu " + repr(para))
+    let val = if para == "impar" { "odd" } else { "even" }
+    pagebreak(weak: fraco, to: val)
+  } else {
+    pagebreak(weak: fraco)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// numeracao-pagina — exibe o número da página atual
+// ---------------------------------------------------------------------------
+
+/// Exibe o número da página atual.
+/// - `formato`: formato de numeração (`"1"` arábico, `"i"` romano minúsculo, `"I"` romano maiúsculo)
+/// - `peso`: peso da fonte (ex: `"bold"`)
+#let numeracao-pagina(formato: "1", peso: auto) = {
+  context {
+    let num = counter(page).display(formato)
+    if peso != auto {
+      text(weight: peso, num)
+    } else {
+      num
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// marca-secao — marca corrente de seção (running header/titleps)
+// ---------------------------------------------------------------------------
+
+/// Retorna o título da seção mais recente no nível dado.
+/// Para uso dentro de `cabecalho()` ou `rodape()`.
+/// - `nivel`: nível do heading a buscar
+/// - `caixa`: `"alta"` (upper), `"baixa"` (lower), `none`
+/// - `peso`: peso da fonte
+/// - `estilo`: `"italic"`, `"normal"`
+/// - `com-numero`: incluir número da seção
+/// - `separador`: espaço entre número e título
+#let marca-secao(
+  nivel: 1,
+  caixa: none,
+  peso: auto,
+  estilo: auto,
+  com-numero: false,
+  separador: h(0.5em),
+) = {
+  context {
+    let found = query(heading.where(level: nivel).before(here()))
+    if found.len() == 0 { return }
+    let hdg = found.last()
+
+    let corpo = hdg.body
+    if caixa == "alta" { corpo = upper(corpo) }
+    else if caixa == "baixa" { corpo = lower(corpo) }
+
+    let resultado = if com-numero and hdg.numbering != none {
+      let nums = counter(heading).at(hdg.location())
+      let num-str = numbering(hdg.numbering, ..nums)
+      [#num-str#separador#corpo]
+    } else {
+      corpo
+    }
+
+    if peso != auto { resultado = text(weight: peso, resultado) }
+    if estilo == "italic" { resultado = emph(resultado) }
+
+    resultado
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilitário interno: renderiza grid de 3 colunas para header/footer
+// ---------------------------------------------------------------------------
+
+#let _render-hf(esquerda, centro, direita, tamanho, fonte) = {
+  set text(size: tamanho)
+  if fonte != auto { set text(font: fonte) }
+  grid(
+    columns: (1fr, 1fr, 1fr),
+    align: (left, center, right),
+    if esquerda != none { esquerda } else { [] },
+    if centro != none { centro } else { [] },
+    if direita != none { direita } else { [] },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Utilitário interno: despacho par/ímpar para header/footer
+// ---------------------------------------------------------------------------
+
+#let _dispatch-hf(esquerda, centro, direita, impar, par, render) = {
+  let simple-mode = impar == auto and par == auto
+  if simple-mode {
+    render(esquerda, centro, direita)
+  } else {
+    context {
+      let pg = counter(page).get().first()
+      let is-odd = calc.odd(pg)
+      if is-odd and impar != auto {
+        let cfg = impar
+        render(
+          cfg.at("esquerda", default: none),
+          cfg.at("centro", default: none),
+          cfg.at("direita", default: none),
+        )
+      } else if not is-odd and par != auto {
+        let cfg = par
+        render(
+          cfg.at("esquerda", default: none),
+          cfg.at("centro", default: none),
+          cfg.at("direita", default: none),
+        )
+      } else {
+        render(esquerda, centro, direita)
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// cabecalho — gera conteúdo de header (fancyhdr)
+// ---------------------------------------------------------------------------
+
+/// Gera conteúdo para o cabeçalho da página.
+/// Modo simples: `cabecalho(esquerda: [...], direita: numeracao-pagina())`
+/// Modo par/ímpar: `cabecalho(impar: (direita: marca-secao()), par: (esquerda: [Título]))`
+/// - `linha`: espessura da linha separadora abaixo do cabeçalho
+#let cabecalho(
+  esquerda: none,
+  centro: none,
+  direita: none,
+  impar: auto,
+  par: auto,
+  linha: 0pt,
+  cor-linha: black,
+  distancia-linha: 0.3em,
+  tamanho: 10pt,
+  fonte: auto,
+) = {
+  let render(esq, cen, dir) = {
+    let content = _render-hf(esq, cen, dir, tamanho, fonte)
+    if linha > 0pt {
+      content
+      v(distancia-linha)
+      line(length: 100%, stroke: linha + cor-linha)
+    } else {
+      content
+    }
+  }
+  _dispatch-hf(esquerda, centro, direita, impar, par, render)
+}
+
+// ---------------------------------------------------------------------------
+// rodape — gera conteúdo de footer (fancyhdr)
+// ---------------------------------------------------------------------------
+
+/// Gera conteúdo para o rodapé da página.
+/// Mesma API que `cabecalho()`, mas a linha separadora fica *acima* do conteúdo.
+#let rodape(
+  esquerda: none,
+  centro: none,
+  direita: none,
+  impar: auto,
+  par: auto,
+  linha: 0pt,
+  cor-linha: black,
+  distancia-linha: 0.3em,
+  tamanho: 10pt,
+  fonte: auto,
+) = {
+  let render(esq, cen, dir) = {
+    if linha > 0pt {
+      line(length: 100%, stroke: linha + cor-linha)
+      v(distancia-linha)
+    }
+    _render-hf(esq, cen, dir, tamanho, fonte)
+  }
+  _dispatch-hf(esquerda, centro, direita, impar, par, render)
+}
+
+// ---------------------------------------------------------------------------
+// estilo-pagina — show-rule que aplica cabeçalho + rodapé + numeração
+// ---------------------------------------------------------------------------
+
+/// Atalho que aplica cabeçalho, rodapé e numeração de página de uma vez.
+/// Uso: `#show: estilo-pagina.with(cabecalho: cabecalho(...), rodape: rodape(...))`
+/// Campos `auto` são omitidos (não sobrescrevem configurações existentes).
+#let estilo-pagina(
+  cabecalho: auto,
+  rodape: auto,
+  numeracao: auto,
+  posicao-numero: auto,
+  corpo,
+) = {
+  let args = (:)
+  if cabecalho != auto { args.insert("header", cabecalho) }
+  if rodape != auto { args.insert("footer", rodape) }
+  if numeracao != auto { args.insert("numbering", numeracao) }
+  if posicao-numero != auto { args.insert("number-align", posicao-numero) }
+  set page(..args)
+  corpo
+}

--- a/packages/preview/ferrmat/0.1.0/src/prova.typ
+++ b/packages/preview/ferrmat/0.1.0/src/prova.typ
@@ -1,0 +1,432 @@
+// Módulo de provas e exames acadêmicos (estilo exam.cls)
+
+#import "caixas.typ": caixa
+
+// ── Estado global ─────────────────────────────────────────────────
+
+/// Acumulador de pontos por questão (para tabela-pontos).
+#let _pontos-questao = state("ferrmat-pontos-questao", ())
+/// Acumulador de todos os pontos (questão + sub-questão, para total-pontos).
+#let _pontos-total = state("ferrmat-pontos-total", ())
+
+/// Reseta contadores e acumuladores de pontos para uma nova prova no mesmo documento.
+#let resetar-prova() = {
+  counter("ferrmat-prova-questao").update(0)
+  counter("ferrmat-prova-subquestao").update(0)
+  _pontos-questao.update(())
+  _pontos-total.update(())
+}
+
+// ── Helpers internos ──────────────────────────────────────────────
+
+/// Formata número com vírgula brasileira (sem unidade).
+#let _fmt-valor(pontos) = {
+  let valor = float(pontos)
+  if calc.fract(valor) == 0 {
+    str(int(valor))
+  } else {
+    str(valor).replace(".", ",")
+  }
+}
+
+/// Formata pontos com vírgula brasileira e plural correto.
+/// Em PT-BR, singular para 0 < valor < 2: 0,5 ponto, 1 ponto, 1,5 ponto.
+/// Plural para 0 ou valor >= 2: 0 pontos, 2 pontos, 2,5 pontos.
+#let _formatar-pontos(pontos) = {
+  let valor = float(pontos)
+  let txt = _fmt-valor(pontos)
+  let unidade = if valor > 0 and valor < 2 { "ponto" } else { "pontos" }
+  txt + " " + unidade
+}
+
+/// Checkbox vazio reutilizável.
+#let _checkbox() = box(
+  rect(width: 0.8em, height: 0.8em, stroke: 0.5pt + black),
+  baseline: 0.1em,
+)
+
+// ── Funções públicas ──────────────────────────────────────────────
+
+/// Cabeçalho de prova com identificação, campos e caixa de nota.
+#let cabecalho-prova(
+  instituicao: none,
+  departamento: none,
+  disciplina: none,
+  professor: none,
+  data: none,
+  titulo: "Prova",
+  instrucoes: none,
+  logo: none,
+  logo-largura: 2cm,
+  campos: ("Nome", "Turma"),
+  campo-nota: true,
+  nota-largura: 2.5cm,
+  cor: black,
+  espessura: 1pt,
+) = {
+  // Informações da prova
+  let info-items = ()
+  if instituicao != none { info-items.push(text(weight: "bold", size: 1.1em, instituicao)) }
+  if departamento != none { info-items.push(departamento) }
+  if disciplina != none { info-items.push([*Disciplina:* #disciplina]) }
+  if professor != none { info-items.push([*Professor:* #professor]) }
+  if data != none { info-items.push([*Data:* #data]) }
+
+  let info-block = {
+    if logo != none {
+      grid(
+        columns: (logo-largura + 0.5cm, 1fr),
+        align: (center + horizon, left),
+        box(width: logo-largura, logo),
+        stack(dir: ttb, spacing: 0.4em, ..info-items),
+      )
+    } else {
+      stack(dir: ttb, spacing: 0.4em, ..info-items)
+    }
+  }
+
+  // Bloco principal
+  caixa(
+    borda: "completa",
+    cor: cor,
+    espessura: espessura,
+    raio: 0pt,
+    preenchimento: white,
+    titulo-fundo: white,
+    {
+      // Título centralizado
+      align(center, text(weight: "bold", size: 1.3em, titulo))
+      v(0.5em)
+
+      // Info + nota
+      if campo-nota {
+        grid(
+          columns: (1fr, nota-largura + 1em),
+          column-gutter: 0.5em,
+          align: (left, center),
+          info-block,
+          {
+            rect(
+              width: nota-largura,
+              height: nota-largura,
+              stroke: espessura + cor,
+              align(center + horizon, {
+                place(top + center, dy: 0.3em, text(size: 0.85em, weight: "bold", [Nota]))
+              }),
+            )
+          },
+        )
+      } else {
+        info-block
+      }
+
+      // Campos de preenchimento
+      if campos != none and campos.len() > 0 {
+        v(0.6em)
+        for campo in campos {
+          grid(
+            columns: (auto, 1fr),
+            column-gutter: 0.3em,
+            align: (left, bottom),
+            text(weight: "bold", campo + ":"),
+            line(length: 100%, stroke: 0.5pt + cor),
+          )
+          v(0.3em)
+        }
+      }
+    },
+  )
+
+  // Instruções
+  if instrucoes != none {
+    v(0.3em)
+    caixa(
+      borda: "completa",
+      cor: cor,
+      espessura: 0.5pt,
+      raio: 0pt,
+      preenchimento: white,
+      titulo: text(weight: "bold", [Instruções]),
+      titulo-fundo: luma(235),
+      instrucoes,
+    )
+  }
+
+  v(0.8em)
+}
+
+/// Questão numerada com pontos opcionais e espaço de resposta.
+#let questao(
+  body,
+  pontos: none,
+  separador: true,
+  espaco: none,
+  formato-pontos: auto,
+  recuo: 0pt,
+  negrito: true,
+) = {
+  counter("ferrmat-prova-questao").step()
+  counter("ferrmat-prova-subquestao").update(0)
+
+  if pontos != none {
+    let p = float(pontos)
+    _pontos-questao.update(old => { old.push(p); old })
+    _pontos-total.update(old => { old.push(p); old })
+  }
+
+  context {
+    let num = counter("ferrmat-prova-questao").get().first()
+
+    // Separador (exceto questão 1)
+    if separador and num > 1 {
+      line(length: 100%, stroke: 0.3pt + luma(180))
+      v(0.5em)
+    }
+
+    // Cabeçalho da questão
+    let label = if negrito { [*Questão #num*] } else { [Questão #num] }
+
+    if pontos != none {
+      let fmt = if formato-pontos == auto { _formatar-pontos } else { formato-pontos }
+      let pts-text = if negrito { [*(#fmt(pontos))*] } else { [(#fmt(pontos))] }
+      grid(
+        columns: (auto, 1fr, auto),
+        align: (left + bottom, center + bottom, right + bottom),
+        column-gutter: 0.3em,
+        label,
+        box(width: 100%, repeat[#h(0.15em)─]),
+        pts-text,
+      )
+    } else {
+      label
+    }
+
+    pad(left: recuo, body)
+  }
+
+  // Espaço de resposta
+  if espaco != none {
+    espaco-resposta(altura: espaco)
+  }
+}
+
+/// Sub-questão com letras (a, b, c...).
+#let subquestao(
+  body,
+  pontos: none,
+  recuo: 1.5em,
+  negrito: false,
+) = {
+  counter("ferrmat-prova-subquestao").step()
+
+  if pontos != none {
+    _pontos-total.update(old => { old.push(float(pontos)); old })
+  }
+
+  context {
+    let num = counter("ferrmat-prova-subquestao").get().first()
+    let letra = numbering("a)", num)
+
+    let pts-text = if pontos != none {
+      [ \[#_formatar-pontos(pontos)\]]
+    }
+
+    pad(left: recuo, {
+      if negrito {
+        [*#letra#pts-text* ]
+      } else {
+        [#letra#pts-text ]
+      }
+      body
+    })
+  }
+}
+
+/// Alternativas de múltipla escolha.
+#let alternativas(
+  ..opcoes,
+  marcador: "letra",
+  horizontal: false,
+  colunas: auto,
+  recuo: 1.5em,
+  espacamento: 0.6em,
+) = {
+  let items = opcoes.pos()
+  let n = items.len()
+
+  let entries = items.enumerate().map(((i, item)) => {
+    let prefixo = if marcador == "caixa" {
+      [#_checkbox() #h(0.2em)]
+    } else {
+      numbering("(A)", i + 1) + [ ]
+    }
+    [#prefixo#item]
+  })
+
+  let cols = if colunas != auto {
+    colunas
+  } else if horizontal {
+    n
+  } else {
+    1
+  }
+
+  pad(left: recuo, {
+    if cols == 1 {
+      stack(dir: ttb, spacing: espacamento, ..entries)
+    } else {
+      grid(
+        columns: (1fr,) * calc.min(cols, n),
+        column-gutter: espacamento,
+        row-gutter: espacamento,
+        ..entries,
+      )
+    }
+  })
+}
+
+/// Questões de verdadeiro ou falso.
+#let verdadeiro-falso(
+  ..afirmacoes,
+  marcador: "parenteses",
+  recuo: 1.5em,
+  espacamento: 0.6em,
+) = {
+  let items = afirmacoes.pos()
+
+  let entries = items.map(item => {
+    let prefixo = if marcador == "caixa" {
+      [#_checkbox() V #h(0.3em) #_checkbox() F #h(0.5em)]
+    } else {
+      [(#h(1.2em)) #h(0.3em)]
+    }
+    [#prefixo#item]
+  })
+
+  pad(left: recuo, {
+    stack(dir: ttb, spacing: espacamento, ..entries)
+  })
+}
+
+/// Linhas horizontais para resposta.
+#let preencher-linhas(
+  altura: 3cm,
+  espacamento: 0.8cm,
+  cor: luma(180),
+  espessura: 0.5pt,
+) = {
+  let n = calc.floor(altura / espacamento)
+  block(width: 100%, height: altura, clip: true, {
+    for i in range(n) {
+      v(espacamento)
+      line(length: 100%, stroke: espessura + cor)
+    }
+  })
+}
+
+/// Linhas pontilhadas para resposta.
+#let preencher-pontilhado(
+  altura: 3cm,
+  espacamento: 0.8cm,
+  cor: luma(180),
+  espessura: 0.5pt,
+  traco: 1pt,
+  intervalo: 2pt,
+) = {
+  let n = calc.floor(altura / espacamento)
+  block(width: 100%, height: altura, clip: true, {
+    for i in range(n) {
+      v(espacamento)
+      line(
+        length: 100%,
+        stroke: stroke(paint: cor, thickness: espessura, dash: ("dot", traco, intervalo)),
+      )
+    }
+  })
+}
+
+/// Grade quadriculada para resposta.
+#let preencher-grade(
+  altura: 3cm,
+  celula: 0.5cm,
+  cor: luma(200),
+  espessura: 0.3pt,
+) = {
+  rect(
+    width: 100%,
+    height: altura,
+    stroke: espessura + cor,
+    fill: tiling(size: (celula, celula), {
+      place(line(start: (0%, 100%), end: (100%, 100%), stroke: espessura + cor))
+      place(line(start: (100%, 0%), end: (100%, 100%), stroke: espessura + cor))
+    }),
+  )
+}
+
+/// Espaço em branco para resposta.
+#let espaco-resposta(
+  altura: 3cm,
+  borda: none,
+  cor-borda: luma(200),
+) = {
+  let s = if borda == "completa" {
+    0.5pt + cor-borda
+  } else if borda == "pontilhada" {
+    stroke(paint: cor-borda, thickness: 0.5pt, dash: "dashed")
+  } else {
+    none
+  }
+  block(width: 100%, height: altura, stroke: s)
+}
+
+/// Exibe o total de pontos acumulados (soma de questões + sub-questões).
+#let total-pontos(
+  formato: auto,
+  peso: "bold",
+) = context {
+  let pts = _pontos-total.get()
+  let soma = if pts.len() == 0 { 0 } else { pts.fold(0, (a, b) => a + b) }
+  if formato == auto {
+    text(weight: peso, [Total: #_formatar-pontos(soma)])
+  } else {
+    text(weight: peso, (formato)(soma))
+  }
+}
+
+/// Tabela de pontuação com uma coluna por questão (somente pontos de `questao()`).
+#let tabela-pontos(
+  titulo-questao: "Questão",
+  titulo-total: "Total",
+  cor-cabecalho: luma(230),
+) = context {
+  let pts = _pontos-questao.get()
+  if pts.len() == 0 { return }
+
+  let n = pts.len()
+  let soma = pts.fold(0, (a, b) => a + b)
+
+  // Abreviar cabeçalho quando muitas questões
+  let label = if n > 6 { "Q" } else { titulo-questao }
+
+  // Linha 1: cabeçalhos
+  let header = range(n).map(i => [#label #(i + 1)])
+  header.push(titulo-total)
+
+  // Linha 2: pontos (valor numérico apenas, sem "pontos")
+  let pontos-row = pts.map(p => _fmt-valor(p))
+  pontos-row.push(_fmt-valor(soma))
+
+  // Linha 3: nota (vazia, com altura para escrita manual)
+  let nota-row = range(n + 1).map(_ => block(height: 1.5em))
+
+  table(
+    columns: (auto,) * (n + 1),
+    stroke: 0.5pt,
+    align: center + horizon,
+    inset: 0.5em,
+    fill: (_, row) => if row == 0 { cor-cabecalho },
+    table.header(..header),
+    ..pontos-row,
+    ..nota-row,
+  )
+}

--- a/packages/preview/ferrmat/0.1.0/src/secoes.typ
+++ b/packages/preview/ferrmat/0.1.0/src/secoes.typ
@@ -1,0 +1,195 @@
+// Wrappers em português para formatação de seções/headings do Typst
+// Equivalente ao titlesec do LaTeX
+
+// ---------------------------------------------------------------------------
+// Utilitário interno: merge de dicts (defaults + user overrides)
+// ---------------------------------------------------------------------------
+
+#let _merge(defaults, user) = {
+  if user == auto { return defaults }
+  let result = defaults
+  for (key, value) in user { result.insert(key, value) }
+  result
+}
+
+// ---------------------------------------------------------------------------
+// formatar-secao — formata um nível de heading
+// ---------------------------------------------------------------------------
+
+/// Formata um heading individual. Para uso com show rules:
+/// `#show heading.where(level: 1): formatar-secao.with(peso: "bold", tamanho: 16pt)`
+///
+/// Formas disponíveis:
+/// - `"bloco"`: número + título na mesma linha, bloco separado (padrão)
+/// - `"corrido"`: título corre inline com o parágrafo seguinte
+/// - `"suspenso"`: número pendurado à esquerda, texto indentado
+/// - `"exibicao"`: número em linha separada acima do título
+#let formatar-secao(
+  it,
+  peso: auto,
+  estilo: auto,
+  tamanho: 12pt,
+  fonte: auto,
+  cor: auto,
+  caixa: none,
+  alinhamento: left,
+  recuo: 0pt,
+  espacamento-antes: 1.5em,
+  espacamento-depois: 1.5em,
+  quebra-pagina: false,
+  mostrar-numero: auto,
+  formato-numero: auto,
+  separador-numero: h(0.5em),
+  largura-numero: 2em,
+  forma: "bloco",
+  decoracao: none,
+) = {
+  // Quebra de página antes, se solicitado
+  if quebra-pagina { pagebreak(weak: true) }
+
+  // Processar corpo
+  let corpo = it.body
+  if caixa == "alta" { corpo = upper(corpo) }
+  else if caixa == "baixa" { corpo = lower(corpo) }
+
+  // Processar número
+  let show-num = if mostrar-numero == auto { it.numbering != none } else { mostrar-numero }
+  let num-fmt = if formato-numero == auto { it.numbering } else { formato-numero }
+
+  let numero = if show-num and num-fmt != none {
+    let nums = counter(heading).at(it.location())
+    numbering(num-fmt, ..nums)
+  }
+
+  // Aplicar estilos de texto
+  let apply-style(content) = {
+    set text(size: tamanho)
+    if fonte != auto { set text(font: fonte) }
+    if cor != auto { set text(fill: cor) }
+    if peso != auto { set text(weight: peso) }
+    if estilo == "italic" {
+      emph(content)
+    } else {
+      content
+    }
+  }
+
+  // Renderizar conforme a forma
+  if forma == "bloco" {
+    // Número + título na mesma linha, bloco separado
+    let titulo = if numero != none {
+      [#numero#separador-numero#corpo]
+    } else {
+      corpo
+    }
+
+    v(espacamento-antes, weak: true)
+    block(width: 100%, inset: (left: recuo), {
+      set align(alinhamento)
+      apply-style(titulo)
+      if decoracao != none { decoracao }
+    })
+    v(espacamento-depois, weak: true)
+
+  } else if forma == "corrido" {
+    // Título inline com o parágrafo seguinte (espacamento-depois vira espaço horizontal)
+    let titulo = if numero != none {
+      [#numero#separador-numero#corpo]
+    } else {
+      corpo
+    }
+
+    v(espacamento-antes, weak: true)
+    box(inset: (left: recuo), {
+      apply-style(titulo)
+      if decoracao != none { decoracao }
+    })
+    h(espacamento-depois)
+
+  } else if forma == "suspenso" {
+    // Número pendurado à esquerda, texto indentado
+    v(espacamento-antes, weak: true)
+    block(width: 100%, inset: (left: recuo), {
+      set align(alinhamento)
+      apply-style({
+        if numero != none {
+          grid(
+            columns: (largura-numero, 1fr),
+            column-gutter: 0.3em,
+            [#numero], corpo,
+          )
+        } else {
+          corpo
+        }
+      })
+      if decoracao != none { decoracao }
+    })
+    v(espacamento-depois, weak: true)
+
+  } else if forma == "exibicao" {
+    // Número em linha separada acima do título
+    v(espacamento-antes, weak: true)
+    block(width: 100%, inset: (left: recuo), {
+      set align(alinhamento)
+      apply-style({
+        if numero != none {
+          numero
+          linebreak()
+        }
+        corpo
+      })
+      if decoracao != none {
+        v(0.3em)
+        decoracao
+      }
+    })
+    v(espacamento-depois, weak: true)
+
+  } else {
+    panic("formatar-secao: forma desconhecida '" + forma + "'. Use: bloco, corrido, suspenso, exibicao")
+  }
+}
+
+// ---------------------------------------------------------------------------
+// formatar-secoes — configura todos os níveis de heading de uma vez
+// ---------------------------------------------------------------------------
+
+/// Configura formatação de múltiplos níveis de heading de uma vez.
+/// Cada `secao-N` é um dicionário com as mesmas chaves de `formatar-secao()`.
+/// Uso: `#show: formatar-secoes.with(secao-1: (peso: "bold", tamanho: 18pt))`
+#let formatar-secoes(
+  secao-1: auto,
+  secao-2: auto,
+  secao-3: auto,
+  secao-4: auto,
+  secao-5: auto,
+  numeracao: "1.1",
+  corpo,
+) = {
+  // Defaults sensatos para cada nível
+  let defaults-1 = (peso: "bold", tamanho: 16pt, quebra-pagina: true)
+  let defaults-2 = (peso: "bold", tamanho: 14pt)
+  let defaults-3 = (peso: "bold", tamanho: 12pt)
+  let defaults-4 = (tamanho: 12pt)
+  let defaults-5 = (estilo: "italic", tamanho: 12pt)
+
+  let cfg-1 = _merge(defaults-1, secao-1)
+  let cfg-2 = _merge(defaults-2, secao-2)
+  let cfg-3 = _merge(defaults-3, secao-3)
+  let cfg-4 = _merge(defaults-4, secao-4)
+  let cfg-5 = _merge(defaults-5, secao-5)
+
+  show heading.where(level: 1): it => formatar-secao(it, ..cfg-1)
+  show heading.where(level: 2): it => formatar-secao(it, ..cfg-2)
+  show heading.where(level: 3): it => formatar-secao(it, ..cfg-3)
+  show heading.where(level: 4): it => formatar-secao(it, ..cfg-4)
+  show heading.where(level: 5): it => formatar-secao(it, ..cfg-5)
+
+  // set heading(numbering) precisa envolver corpo para não ficar escopado num if
+  if numeracao != auto {
+    set heading(numbering: numeracao)
+    corpo
+  } else {
+    corpo
+  }
+}

--- a/packages/preview/ferrmat/0.1.0/src/unidades.typ
+++ b/packages/preview/ferrmat/0.1.0/src/unidades.typ
@@ -1,0 +1,859 @@
+// ============================================================================
+// ferrmat – Módulo de Unidades e Números (equivalente ao siunitx do LaTeX)
+// Formatação de números, unidades SI e quantidades com padrões brasileiros.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// Constantes Unicode
+// ---------------------------------------------------------------------------
+
+#let _efino = "\u{2009}" // thin space (separador de milhar SI)
+#let _emenos = "\u{2212}" // minus sign correto
+#let _evezes = "\u{00D7}" // multiplication sign ×
+
+// ---------------------------------------------------------------------------
+// Estado global de configuração
+// ---------------------------------------------------------------------------
+
+#let _config-numeros = state("ferrmat-config-numeros", (
+  decimal: ",",
+  milhar: _efino,
+  grupo: 3,
+  minimo-agrupamento: 5, // ≤4 dígitos não agrupam (regra SI)
+  notacao: auto, // auto, "cientifica", "fixa"
+  limiar-superior: 1000000000, // 10⁹
+  limiar-inferior: 0.001,
+  unidade-modo: "simbolo", // "simbolo", "produto"
+  separador-unidade: _efino,
+  unidade-produto: sym.dot.op,
+))
+
+// Banco de unidades customizadas do usuário
+#let _unidades-custom = state("ferrmat-unidades-custom", (:))
+
+// ---------------------------------------------------------------------------
+// Banco de unidades SI
+// ---------------------------------------------------------------------------
+
+#let _banco-unidades = (
+  // --- 7 unidades de base ---
+  "m":   (nome: "metro",      plural: "metros"),
+  "kg":  (nome: "quilograma", plural: "quilogramas"),
+  "s":   (nome: "segundo",    plural: "segundos"),
+  "A":   (nome: "ampère",     plural: "ampères"),
+  "K":   (nome: "kelvin",     plural: "kelvins"),
+  "mol": (nome: "mol",        plural: "mols"),
+  "cd":  (nome: "candela",    plural: "candelas"),
+
+  // --- Unidades derivadas com nome ---
+  "Hz":  (nome: "hertz",      plural: "hertz"),
+  "N":   (nome: "newton",     plural: "newtons"),
+  "Pa":  (nome: "pascal",     plural: "pascals"),
+  "J":   (nome: "joule",      plural: "joules"),
+  "W":   (nome: "watt",       plural: "watts"),
+  "C":   (nome: "coulomb",    plural: "coulombs"),
+  "V":   (nome: "volt",       plural: "volts"),
+  "F":   (nome: "farad",      plural: "farads"),
+  "Ω":   (nome: "ohm",        plural: "ohms"),
+  "ohm": (nome: "ohm",        plural: "ohms"),
+  "S":   (nome: "siemens",    plural: "siemens"),
+  "Wb":  (nome: "weber",      plural: "webers"),
+  "T":   (nome: "tesla",      plural: "teslas"),
+  "H":   (nome: "henry",      plural: "henrys"),
+  "lm":  (nome: "lúmen",      plural: "lúmens"),
+  "lx":  (nome: "lux",        plural: "lux"),
+  "Bq":  (nome: "becquerel",  plural: "becquerels"),
+  "Gy":  (nome: "gray",       plural: "grays"),
+  "Sv":  (nome: "sievert",    plural: "sieverts"),
+  "kat": (nome: "katal",      plural: "katals"),
+  "rad": (nome: "radiano",    plural: "radianos"),
+  "sr":  (nome: "esferorradiano", plural: "esferorradianos"),
+
+  // --- Unidades aceitas pelo SI ---
+  "L":   (nome: "litro",      plural: "litros"),
+  "l":   (nome: "litro",      plural: "litros"),
+  "min": (nome: "minuto",     plural: "minutos"),
+  "h":   (nome: "hora",       plural: "horas"),
+  "d":   (nome: "dia",        plural: "dias"),
+  "ha":  (nome: "hectare",    plural: "hectares"),
+  "t":   (nome: "tonelada",   plural: "toneladas"),
+  "eV":  (nome: "elétron-volt", plural: "elétrons-volt"),
+  "u":   (nome: "unidade de massa atômica", plural: "unidades de massa atômica"),
+  "Da":  (nome: "dalton",     plural: "daltons"),
+  "au":  (nome: "unidade astronômica", plural: "unidades astronômicas"),
+
+  // --- Unidades brasileiras / uso comum ---
+  "bar":  (nome: "bar",       plural: "bars"),
+  "atm":  (nome: "atmosfera", plural: "atmosferas"),
+  "mmHg": (nome: "milímetro de mercúrio", plural: "milímetros de mercúrio"),
+  "rpm":  (nome: "rotação por minuto", plural: "rotações por minuto"),
+  "cal":  (nome: "caloria",   plural: "calorias"),
+  "Wh":   (nome: "watt-hora", plural: "watts-hora"),
+  "Ah":   (nome: "ampère-hora", plural: "ampères-hora"),
+  "dB":   (nome: "decibel",   plural: "decibéis"),
+
+  // --- Ângulo (grau, minuto, segundo de arco) ---
+  "deg":  (nome: "grau",      plural: "graus"),
+  "°":    (nome: "grau",      plural: "graus"),
+  "arcmin": (nome: "minuto de arco", plural: "minutos de arco"),
+  "arcsec": (nome: "segundo de arco", plural: "segundos de arco"),
+
+  // --- Percentagem ---
+  "%":   (nome: "por cento",  plural: "por cento"),
+)
+
+// ---------------------------------------------------------------------------
+// Prefixos SI (incluindo 2022: quetta, ronna, ronto, quecto)
+// Ordenados por comprimento do símbolo (desc) para matching correto.
+// ---------------------------------------------------------------------------
+
+#let _prefixos-si = (
+  // dois caracteres primeiro
+  (simbolo: "da", nome: "deca",   fator: 1),
+  // um caractere — maiores primeiro
+  (simbolo: "Q",  nome: "quetta", fator: 30),
+  (simbolo: "R",  nome: "ronna",  fator: 27),
+  (simbolo: "Y",  nome: "yotta",  fator: 24),
+  (simbolo: "Z",  nome: "zetta",  fator: 21),
+  (simbolo: "E",  nome: "exa",    fator: 18),
+  (simbolo: "P",  nome: "peta",   fator: 15),
+  // "T" conflita com tesla — resolvido por exact-match primeiro
+  (simbolo: "G",  nome: "giga",   fator: 9),
+  (simbolo: "M",  nome: "mega",   fator: 6),
+  (simbolo: "k",  nome: "quilo",  fator: 3),
+  // "h" conflita com hora — resolvido por exact-match primeiro
+  // "d" conflita com dia  — resolvido por exact-match primeiro
+  (simbolo: "c",  nome: "centi",  fator: -2),
+  // "m" conflita com metro — resolvido por exact-match primeiro
+  (simbolo: "µ",  nome: "micro",  fator: -6),
+  (simbolo: "u",  nome: "micro",  fator: -6), // alias ASCII
+  (simbolo: "n",  nome: "nano",   fator: -9),
+  (simbolo: "p",  nome: "pico",   fator: -12),
+  (simbolo: "f",  nome: "femto",  fator: -15),
+  (simbolo: "a",  nome: "atto",   fator: -18),
+  (simbolo: "z",  nome: "zepto",  fator: -21),
+  (simbolo: "y",  nome: "yocto",  fator: -24),
+  (simbolo: "r",  nome: "ronto",  fator: -27),
+  (simbolo: "q",  nome: "quecto", fator: -30),
+)
+
+// Lookup rápido: símbolo do prefixo → dados do prefixo (O(1) em vez de iteração)
+#let _prefixo-lookup = {
+  let d = (:)
+  for pref in _prefixos-si {
+    if pref.simbolo not in d {
+      d.insert(pref.simbolo, pref)
+    }
+  }
+  d
+}
+
+// ---------------------------------------------------------------------------
+// Helpers internos — manipulação de strings
+// ---------------------------------------------------------------------------
+
+/// Repete uma string `n` vezes.
+#let _repetir(s, n) = {
+  if n <= 0 { return "" }
+  range(n).map(_ => s).join()
+}
+
+/// Agrupa dígitos da direita para a esquerda (parte inteira).
+#let _agrupar-inteiro(digitos, grupo) = {
+  let n = digitos.len()
+  if n <= grupo { return (digitos,) }
+  let resultado = ()
+  let i = n
+  while i > 0 {
+    let inicio = calc.max(0, i - grupo)
+    resultado.insert(0, digitos.slice(inicio, i))
+    i = inicio
+  }
+  resultado
+}
+
+/// Agrupa dígitos da esquerda para a direita (parte decimal).
+#let _agrupar-decimal(digitos, grupo) = {
+  let n = digitos.len()
+  if n <= grupo { return (digitos,) }
+  let resultado = ()
+  let i = 0
+  while i < n {
+    let fim = calc.min(n, i + grupo)
+    resultado.push(digitos.slice(i, fim))
+    i = fim
+  }
+  resultado
+}
+
+/// Garante exatamente `casas` dígitos decimais na string de um número.
+/// Ex: _garantir-casas("3", 2) → "3.00"; _garantir-casas("3.1", 2) → "3.10"
+#let _garantir-casas(s, casas) = {
+  if casas == 0 {
+    if "." in s { s.split(".").at(0) } else { s }
+  } else {
+    let partes = if "." in s { s.split(".") } else { (s, "") }
+    let inteiro = partes.at(0)
+    let decimal = partes.at(1)
+    if decimal.len() < casas {
+      inteiro + "." + decimal + _repetir("0", casas - decimal.len())
+    } else if decimal.len() > casas {
+      inteiro + "." + decimal.slice(0, casas)
+    } else {
+      inteiro + "." + decimal
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Arredondamento
+// ---------------------------------------------------------------------------
+
+/// Arredonda para `n` algarismos significativos.
+#let _arredondar-sig(valor, n) = {
+  if valor == 0 { return 0 }
+  let mag = calc.floor(calc.log(calc.abs(valor), base: 10))
+  let casas = n - 1 - mag
+  if casas >= 0 {
+    calc.round(valor, digits: casas)
+  } else {
+    // calc.round não suporta digits negativo; usar fator
+    let fator = calc.pow(10.0, -casas)
+    calc.round(valor / fator) * fator
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatação interna de número → conteúdo
+// ---------------------------------------------------------------------------
+
+/// Formata um número e retorna conteúdo Typst.
+/// `config` é o dicionário de configuração (já mesclado com overrides).
+#let _formatar-numero(valor, config) = {
+  // --- Converter para float para operações ---
+  let v = if type(valor) == str { float(valor) } else { float(valor) }
+
+  // --- Valores especiais (NaN, Inf) ---
+  // NaN: a única valor onde v != v é verdadeiro
+  if v != v { return [NaN] }
+  if v == float.inf { return [#sym.infinity] }
+  if v == -float.inf { return [#_emenos#sym.infinity] }
+
+  let negativo = v < 0
+  let v = calc.abs(v)
+
+  // --- Limpar ruído de ponto flutuante IEEE 754 ---
+  // Arredonda para 12 algarismos significativos quando nenhum arredondamento explícito
+  if v != 0 and config.at("casas", default: none) == none {
+    v = _arredondar-sig(v, 12)
+  }
+
+  // --- Arredondamento ---
+  let casas-exibir = none // casas decimais para exibição (zeros à direita)
+  if config.at("casas", default: none) != none {
+    casas-exibir = config.casas
+    v = calc.round(v, digits: config.casas)
+  }
+
+  // --- Notação científica ---
+  let expoente = none
+  let usar-cientifica = config.at("notacao") == "cientifica"
+  if config.at("notacao") == auto and v != 0 {
+    if v >= config.at("limiar-superior") or v < config.at("limiar-inferior") {
+      usar-cientifica = true
+    }
+  }
+
+  if usar-cientifica and v != 0 {
+    let mag = calc.floor(calc.log(v, base: 10))
+    expoente = mag
+    v = v / calc.pow(10.0, mag)
+    // Re-limpar ruído de float após divisão
+    v = _arredondar-sig(v, 12)
+    // Re-arredondar a mantissa
+    if config.at("casas", default: none) != none {
+      v = calc.round(v, digits: config.casas)
+    }
+  }
+
+  // --- Suprimir mantissa = 1 em notação científica ---
+  let suprimir-mantissa = false
+  if usar-cientifica and v == 1.0 and config.at("casas", default: none) == none {
+    suprimir-mantissa = true
+  }
+
+  // --- Suprimir expoente = 0 ---
+  if expoente != none and expoente == 0 {
+    expoente = none
+  }
+
+  // --- Converter para string com zeros preservados ---
+  let s = str(v)
+  if casas-exibir != none and config.at("preservar-zeros", default: true) {
+    s = _garantir-casas(s, casas-exibir)
+  }
+
+  // --- Separar parte inteira e decimal ---
+  let partes = if "." in s { s.split(".") } else { (s,) }
+  let digitos-int = partes.at(0)
+  let digitos-dec = if partes.len() > 1 { partes.at(1) } else { none }
+
+  // --- Agrupamento ---
+  let separador = config.at("milhar")
+  let agrupamento = config.at("minimo-agrupamento")
+  let grupo = config.at("grupo")
+
+  let int-formatado = if digitos-int.len() >= agrupamento {
+    _agrupar-inteiro(digitos-int, grupo).join(separador)
+  } else {
+    digitos-int
+  }
+
+  let dec-formatado = if digitos-dec != none and digitos-dec.len() > grupo {
+    _agrupar-decimal(digitos-dec, grupo).join(separador)
+  } else {
+    digitos-dec
+  }
+
+  // --- Montar conteúdo ---
+  let resultado = []
+  if negativo {
+    resultado = resultado + [#_emenos]
+  }
+
+  if not suprimir-mantissa {
+    resultado = resultado + [#int-formatado]
+    if dec-formatado != none {
+      resultado = resultado + [#config.at("decimal")#dec-formatado]
+    }
+  }
+
+  // --- Expoente (notação científica) ---
+  if expoente != none {
+    if not suprimir-mantissa {
+      resultado = resultado + [ #_evezes ]
+    }
+    let exp-str = if expoente < 0 { _emenos + str(calc.abs(expoente)) } else { str(expoente) }
+    resultado = resultado + [10#super[#exp-str]]
+  }
+
+  resultado
+}
+
+// ---------------------------------------------------------------------------
+// Parsing de unidades
+// ---------------------------------------------------------------------------
+
+/// Resolve um token de unidade (ex: "km", "MHz") → (simbolo, nome, plural, prefixo)
+#let _resolver-unidade(token, banco, custom) = {
+  // 1. Exato no custom
+  if token in custom {
+    let dados = custom.at(token)
+    return (
+      simbolo: dados.at("simbolo", default: token),
+      nome: dados.at("nome", default: token),
+      plural: dados.at("plural", default: token),
+      prefixo: "",
+    )
+  }
+
+  // 2. Exato no banco padrão
+  if token in banco {
+    let dados = banco.at(token)
+    return (
+      simbolo: token,
+      nome: dados.nome,
+      plural: dados.plural,
+      prefixo: "",
+    )
+  }
+
+  // 3. Tentar prefixo + unidade base via lookup O(1)
+  //    Tenta prefixo de 2 caracteres primeiro, depois 1 caractere.
+  //    Usa clusters() para lidar com caracteres multibyte (ex: µ).
+  let chars = token.clusters()
+  for plen in (2, 1) {
+    if chars.len() > plen {
+      let ps = chars.slice(0, plen).join()
+      if ps in _prefixo-lookup {
+        let pref = _prefixo-lookup.at(ps)
+        let resto = chars.slice(plen).join()
+        if resto in banco {
+          let dados = banco.at(resto)
+          let ps-display = if ps == "u" { "µ" } else { ps }
+          return (
+            simbolo: ps-display + resto,
+            nome: pref.nome + dados.nome,
+            plural: pref.nome + dados.plural,
+            prefixo: ps-display,
+          )
+        }
+      }
+    }
+  }
+
+  // 4. Desconhecido — usar como está
+  (simbolo: token, nome: token, plural: token, prefixo: "")
+}
+
+/// Analisa um token de unidade com potência: "m^2" → (token: "m", potencia: 2)
+#let _parse-token-potencia(s) = {
+  if "^" in s {
+    let partes = s.split("^")
+    assert(partes.len() == 2,
+      message: "unidade: potência inválida em \"" + s + "\" (use formato \"unidade^n\")")
+    assert(partes.at(0).len() > 0,
+      message: "unidade: token vazio antes de ^ em \"" + s + "\"")
+    (token: partes.at(0), potencia: int(partes.at(1)))
+  } else {
+    (token: s, potencia: 1)
+  }
+}
+
+/// Analisa string de unidade completa: "kg.m/s^2" → (num: [...], den: [...])
+#let _parse-unidade-str(s) = {
+  let num-str = s
+  let den-str = none
+
+  // Separar numerador / denominador
+  if "/" in s {
+    let idx = s.position("/")
+    num-str = s.slice(0, idx)
+    den-str = s.slice(idx + 1)
+    // Remover parênteses do denominador: "(kg.K)" → "kg.K"
+    if den-str.starts-with("(") and den-str.ends-with(")") {
+      den-str = den-str.slice(1, den-str.len() - 1)
+    }
+  }
+
+  let numerador = num-str.split(".").map(_parse-token-potencia)
+  let denominador = if den-str != none {
+    den-str.split(".").map(_parse-token-potencia)
+  } else {
+    ()
+  }
+
+  (numerador: numerador, denominador: denominador)
+}
+
+// ---------------------------------------------------------------------------
+// Renderização de unidades
+// ---------------------------------------------------------------------------
+
+/// Renderiza um único token de unidade resolvido com sua potência.
+#let _renderizar-token(token-info, potencia) = {
+  let simb = token-info.simbolo
+  if potencia == 1 {
+    math.upright(simb)
+  } else {
+    math.attach(math.upright(simb), t: [#potencia])
+  }
+}
+
+/// Renderiza uma lista de tokens como produto (com separador).
+#let _renderizar-produto(tokens, separador) = {
+  tokens.join(separador)
+}
+
+/// Formata unidade completa em modo símbolo.
+/// `parsed` é resultado de _parse-unidade-str, `banco` e `custom` são os bancos de dados.
+#let _formatar-unidade-simbolo(parsed, banco, custom, config) = {
+  let sep = [#h(0.16667em)]
+  let prod = config.at("unidade-produto")
+
+  let num-tokens = parsed.numerador.map(item => {
+    let info = _resolver-unidade(item.token, banco, custom)
+    _renderizar-token(info, item.potencia)
+  })
+
+  let den-tokens = parsed.denominador.map(item => {
+    let info = _resolver-unidade(item.token, banco, custom)
+    _renderizar-token(info, item.potencia)
+  })
+
+  if den-tokens.len() == 0 {
+    // Só numerador
+    math.equation(block: false, _renderizar-produto(num-tokens, [#prod]))
+  } else {
+    // Modo fração: num / den
+    let num-content = _renderizar-produto(num-tokens, [#prod])
+    let den-content = _renderizar-produto(den-tokens, [#prod])
+    math.equation(block: false, [#num-content \/ #den-content])
+  }
+}
+
+/// Formata unidade em modo produto (tudo com expoentes, sem fração).
+#let _formatar-unidade-produto(parsed, banco, custom, config) = {
+  let prod = config.at("unidade-produto")
+
+  let todos = parsed.numerador.map(item => {
+    let info = _resolver-unidade(item.token, banco, custom)
+    _renderizar-token(info, item.potencia)
+  })
+
+  // Denominador entra com expoentes negativos
+  for item in parsed.denominador {
+    let info = _resolver-unidade(item.token, banco, custom)
+    todos.push(_renderizar-token(info, -item.potencia))
+  }
+
+  math.equation(block: false, _renderizar-produto(todos, [#prod]))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers para mesclar config com overrides locais
+// ---------------------------------------------------------------------------
+
+#let _mesclar-config(config, notacao, limiar-superior, limiar-inferior) = {
+  let c = config
+  if notacao != auto { c.insert("notacao", notacao) }
+  if limiar-superior != auto { c.insert("limiar-superior", limiar-superior) }
+  if limiar-inferior != auto { c.insert("limiar-inferior", limiar-inferior) }
+  c
+}
+
+// ===================================================================
+// ATALHOS PARA MODO MATEMÁTICO
+// ===================================================================
+
+// ---------------------------------------------------------------------------
+// ee — notação científica (×10^n) para uso dentro de $...$
+// ---------------------------------------------------------------------------
+
+/// Notação científica para modo matemático: `$6,022 ee(23)$` → 6,022 × 10²³
+#let ee(n) = $times 10^#n$
+
+// ---------------------------------------------------------------------------
+// Atalhos de unidades — variáveis para uso direto dentro de $...$
+// Cada uma inclui espaço fino embutido para separar número da unidade.
+// ---------------------------------------------------------------------------
+
+/// m/s² — aceleração: `$9,8 mss$`
+#let mss = $thin "m/s"^2$
+/// m/s — velocidade: `$25 ms$`
+#let ms = $thin "m/s"$
+/// m² — área: `$25 msq$`
+#let msq = $thin "m"^2$
+/// m³ — volume: `$10 mcb$`
+#let mcb = $thin "m"^3$
+/// km/h — velocidade: `$120 kmh$`
+#let kmh = $thin "km/h"$
+/// kg/m³ — densidade: `$1000 kgm$`
+#let kgm = $thin "kg/m"^3$
+/// mol⁻¹ — inverso de mol: `$6,022 ee(23) molinv$`
+#let molinv = $thin "mol"^(-1)$
+/// J/mol — energia molar: `$8,314 jmol$`
+#let jmol = $thin "J/mol"$
+
+// ===================================================================
+// API PÚBLICA
+// ===================================================================
+
+// ---------------------------------------------------------------------------
+// num — formatar número
+// ---------------------------------------------------------------------------
+
+/// Formata um número com separadores brasileiros e notação científica.
+///
+/// - `valor`: Número (int, float ou string).
+/// - `notacao`: `auto`, `"cientifica"` ou `"fixa"`.
+///
+/// ```example
+/// #num(3.14159)            // → 3,14159
+/// #num(1234567.89)         // → 1 234 567,89
+/// #num("2.998e8")          // → 2,998 × 10⁸
+/// ```
+#let num(
+  valor,
+  casas: auto,          // uso interno (tablenum, ang)
+  preservar-zeros: auto, // uso interno (tablenum)
+  notacao: auto,
+  limiar-superior: auto,
+  limiar-inferior: auto,
+  expoente: none,
+) = context {
+  let config = _config-numeros.get()
+  let config = _mesclar-config(config, notacao, limiar-superior, limiar-inferior)
+  if casas != auto { config.insert("casas", casas) }
+  if preservar-zeros != auto { config.insert("preservar-zeros", preservar-zeros) }
+
+  // Forçar expoente específico
+  if expoente != none {
+    config.insert("notacao", "cientifica")
+  }
+
+  // Lidar com expoente embutido na string: "2.998e8"
+  // Passa a mantissa diretamente + força notação científica com expoente fixo
+  // para evitar perda de precisão ao multiplicar floats grandes.
+  let valor-real = valor
+  let exp-embutido = none
+  if type(valor) == str and ("e" in valor or "E" in valor) {
+    let partes = valor.split(regex("[eE]"))
+    valor-real = float(partes.at(0)) // manter só a mantissa como float
+    exp-embutido = int(partes.at(1))
+    if config.at("notacao") == auto {
+      config.insert("notacao", "cientifica")
+    }
+  }
+
+  let corpo = _formatar-numero(valor-real, config)
+
+  // Se havia expoente embutido na string, compor com o expoente da formatação
+  if exp-embutido != none {
+    // Normalizar mantissa para [1, 10) e somar expoente
+    let mantissa-config = config
+    mantissa-config.insert("notacao", "fixa")
+    let mantissa = _formatar-numero(valor-real, mantissa-config)
+    let exp-total = exp-embutido
+
+    if valor-real != 0 and (calc.abs(valor-real) >= 10 or calc.abs(valor-real) < 1) {
+      let mag = calc.floor(calc.log(calc.abs(valor-real), base: 10))
+      let v-norm = valor-real / calc.pow(10.0, mag)
+      exp-total = exp-embutido + mag
+      let norm-config = config
+      norm-config.insert("notacao", "fixa")
+      mantissa = _formatar-numero(v-norm, norm-config)
+    }
+    let exp-str = if exp-total < 0 { _emenos + str(calc.abs(exp-total)) } else { str(exp-total) }
+    corpo = [#mantissa #_evezes 10#super[#exp-str]]
+  }
+
+  corpo
+}
+
+// ---------------------------------------------------------------------------
+// unidade — formatar unidade
+// ---------------------------------------------------------------------------
+
+/// Formata uma unidade SI a partir de string.
+///
+/// Sintaxe da string:
+/// - `.` separa unidades multiplicadas: `"kg.m"` → kg⋅m
+/// - `/` separa numerador/denominador: `"m/s"` → m/s
+/// - `^` indica potência: `"m^2"` → m²
+/// - `()` agrupa denominador: `"J/(kg.K)"` → J/(kg⋅K)
+///
+/// - `modo`: `"simbolo"` (padrão), `"produto"` (tudo com expoentes), `"por"` (texto extenso)
+///
+/// ```example
+/// #unidade("m/s^2")        // → m/s²
+/// #unidade("kg.m/s^2")     // → kg⋅m/s²
+/// ```
+#let unidade(
+  u,
+  modo: auto,
+) = context {
+  let config = _config-numeros.get()
+  let custom = _unidades-custom.get()
+  let modo = if modo != auto { modo } else { config.at("unidade-modo") }
+  let parsed = _parse-unidade-str(u)
+
+  if modo == "produto" {
+    _formatar-unidade-produto(parsed, _banco-unidades, custom, config)
+  } else {
+    _formatar-unidade-simbolo(parsed, _banco-unidades, custom, config)
+  }
+}
+
+/// Alias curto para `unidade()`.
+#let un = unidade
+
+// ---------------------------------------------------------------------------
+// qtd — quantidade (número + unidade)
+// ---------------------------------------------------------------------------
+
+/// Formata uma quantidade: número + espaço fino + unidade.
+///
+/// ```example
+/// #qtd(9.8, "m/s^2")        // → 9,8 m/s²
+/// #qtd(3.14, "rad")         // → 3,14 rad
+/// #qtd(1e6, "Hz")           // → 10⁶ Hz
+/// ```
+#let qtd(
+  valor,
+  u,
+  notacao: auto,
+  limiar-superior: auto,
+  limiar-inferior: auto,
+  expoente: none,
+  modo-unidade: auto,
+) = {
+  let n = num(
+    valor,
+    notacao: notacao,
+    limiar-superior: limiar-superior,
+    limiar-inferior: limiar-inferior,
+    expoente: expoente,
+  )
+  let un = unidade(u, modo: modo-unidade)
+  [#n#h(0.16667em)#un]
+}
+
+// ---------------------------------------------------------------------------
+// declarar-unidade — registrar unidade customizada
+// ---------------------------------------------------------------------------
+
+/// Registra uma unidade customizada no banco de dados.
+///
+/// ```example
+/// #declarar-unidade("pH", nome: "pH", plural: "pH")
+/// #qtd(7.4, "pH") // → 7,4 pH
+/// ```
+#let declarar-unidade(
+  simbolo,
+  nome: none,
+  plural: none,
+) = {
+  _unidades-custom.update(d => {
+    d.insert(simbolo, (
+      simbolo: simbolo,
+      nome: if nome != none { nome } else { simbolo },
+      plural: if plural != none { plural } else { if nome != none { nome } else { simbolo } },
+    ))
+    d
+  })
+}
+
+// ---------------------------------------------------------------------------
+// configurar-numeros — alterar configuração global
+// ---------------------------------------------------------------------------
+
+/// Altera a configuração global de formatação de números.
+///
+/// ```example
+/// #configurar-numeros(decimal: ".", milhar: ",")
+/// #num(1234.56) // → 1,234.56
+/// ```
+#let configurar-numeros(
+  decimal: auto,
+  milhar: auto,
+  grupo: auto,
+  minimo-agrupamento: auto,
+  notacao: auto,
+  limiar-superior: auto,
+  limiar-inferior: auto,
+  unidade-modo: auto,
+  separador-unidade: auto,
+  unidade-produto: auto,
+) = _config-numeros.update(config => {
+  if decimal != auto { config.insert("decimal", decimal) }
+  if milhar != auto { config.insert("milhar", milhar) }
+  if grupo != auto { config.insert("grupo", grupo) }
+  if minimo-agrupamento != auto { config.insert("minimo-agrupamento", minimo-agrupamento) }
+  if notacao != auto { config.insert("notacao", notacao) }
+  if limiar-superior != auto { config.insert("limiar-superior", limiar-superior) }
+  if limiar-inferior != auto { config.insert("limiar-inferior", limiar-inferior) }
+  if unidade-modo != auto { config.insert("unidade-modo", unidade-modo) }
+  if separador-unidade != auto { config.insert("separador-unidade", separador-unidade) }
+  if unidade-produto != auto { config.insert("unidade-produto", unidade-produto) }
+  config
+})
+
+// ---------------------------------------------------------------------------
+// faixa-num / faixa-qtd — intervalos
+// ---------------------------------------------------------------------------
+
+/// Formata um intervalo de números: "a a b".
+///
+/// ```example
+/// #faixa-num(1, 5) // → 1 a 5
+/// ```
+#let faixa-num(a, b) = {
+  [#num(a) a #num(b)]
+}
+
+/// Formata um intervalo com unidade: "a u a b u" ou "a a b u".
+///
+/// ```example
+/// #faixa-qtd(20, 25, "°C") // → 20 °C a 25 °C
+/// #faixa-qtd(1, 5, "m", repetir-unidade: false) // → 1 a 5 m
+/// ```
+#let faixa-qtd(a, b, u, repetir-unidade: true) = {
+  if repetir-unidade {
+    [#qtd(a, u) a #qtd(b, u)]
+  } else {
+    [#num(a) a #num(b)#h(0.16667em)#unidade(u)]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// lista-num / lista-qtd — listas
+// ---------------------------------------------------------------------------
+
+/// Formata uma lista de números: "a, b e c".
+///
+/// ```example
+/// #lista-num(1, 2, 3) // → 1, 2 e 3
+/// ```
+#let lista-num(..valores) = {
+  let vals = valores.pos()
+  if vals.len() == 0 { return [] }
+  if vals.len() == 1 { return num(vals.first()) }
+  let formatados = vals.map(v => num(v))
+  let init = formatados.slice(0, -1).join([, ])
+  [#init e #formatados.last()]
+}
+
+/// Formata uma lista de quantidades: "a u, b u e c u".
+///
+/// ```example
+/// #lista-qtd(1, 2, 3, u: "m") // → 1 m, 2 m e 3 m
+/// #lista-qtd(1, 2, 3, u: "kg", repetir-unidade: false) // → 1, 2 e 3 kg
+/// ```
+#let lista-qtd(..args) = {
+  let u = args.named().at("u")
+  let repetir = args.named().at("repetir-unidade", default: true)
+  let valores = args.pos()
+  if valores.len() == 0 { return [] }
+  if repetir {
+    let items = valores.map(v => [#num(v)#h(0.16667em)#unidade(u)])
+    if items.len() == 1 { return items.first() }
+    let init = items.slice(0, -1).join([, ])
+    [#init e #items.last()]
+  } else {
+    let items = valores.map(v => num(v))
+    if items.len() == 1 { return [#items.first()#h(0.16667em)#unidade(u)] }
+    let init = items.slice(0, -1).join([, ])
+    [#init e #items.last()#h(0.16667em)#unidade(u)]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ang — ângulos
+// ---------------------------------------------------------------------------
+
+/// Formata um ângulo em graus, minutos e segundos.
+///
+/// ```example
+/// #ang(45.5)                              // → 45,5°
+/// #ang(45, minutos: 30)                   // → 45°30′
+/// #ang(45, minutos: 30, segundos: 15)     // → 45°30′15″
+/// ```
+#let ang(graus, minutos: none, segundos: none) = context {
+  let config = _config-numeros.get()
+  if minutos == none and segundos == none {
+    let g = _formatar-numero(float(graus), config)
+    [#g°]
+  } else {
+    [#int(graus)°#if minutos != none [#int(minutos)′]#if segundos != none [#int(segundos)″]]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tablenum — número alinhado para tabelas
+// ---------------------------------------------------------------------------
+
+/// Formata um número para uso em tabelas, com alinhamento à direita.
+///
+/// ```example
+/// #tablenum(3.14, casas: 2, largura: 100%)
+/// ```
+#let tablenum(valor, casas: auto, largura: auto) = {
+  let n = num(valor, casas: casas, preservar-zeros: true)
+  if largura != auto {
+    box(width: largura, align(right, n))
+  } else {
+    n
+  }
+}
+

--- a/packages/preview/ferrmat/0.1.0/typst.toml
+++ b/packages/preview/ferrmat/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ferrmat"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Esdras"]
+license = "MIT"
+description = "Decorative boxes, math environments, and styled code in Portuguese."
+repository = "https://github.com/3sdras/ferrmat"
+keywords = ["tcolorbox", "theorem", "teorema", "box", "caixa", "math", "matemática", "code", "gantt"]
+categories = ["components", "visualization"]
+compiler = "0.14.0"
+exclude = ["docs/*", "tests/*", "test*.typ", "test*.pdf", "CREDITS.md", ".DS_Store", ".gitignore", ".claude/*"]


### PR DESCRIPTION
## ferrmat:0.1.0

Decorative boxes, math environments, and styled code in Portuguese for Typst.

**Features:**
- Colored/decorative boxes (tcolorbox-like)
- Mathematical theorem environments (theorem, lemma, proof, etc.) with Portuguese labels
- Styled code blocks with syntax highlighting
- Gantt charts via cetz
- SI units module, index, exam/test formatting, annotations, and column layouts

**Repository:** https://github.com/3sdras/ferrmat
**License:** MIT