### PR TITLE
codegds:0.1.0

### DIFF
--- a/packages/preview/codegds/0.1.0/LICENSE
+++ b/packages/preview/codegds/0.1.0/LICENSE
@@ -1,0 +1,14 @@
+MIT No Attribution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/codegds/0.1.0/README.md
+++ b/packages/preview/codegds/0.1.0/README.md
@@ -1,0 +1,26 @@
+# codegds
+
+GDscript syntax highlighting for [Typst](https://typst.app/).
+
+## Installation
+
+````typst
+#import "@preview/codegds:0.1.0": gdscript-syntax
+#set raw(syntaxes: gdscript-syntax)
+
+```gdscript
+func process_items(items: Array) -> void:
+	# Check if the array is empty
+	if items.is_empty():
+		print("No items to process")
+		return
+	
+	# Process each item
+	for item in items:
+		print("Processing: ", item)
+```
+````
+
+## Credits
+
+- Syntax patterns informed by [dementive/SublimeGodot](https://github.com/dementive/SublimeGodot)

--- a/packages/preview/codegds/0.1.0/codegds.typ
+++ b/packages/preview/codegds/0.1.0/codegds.typ
@@ -1,0 +1,1 @@
+#let gdscript-syntax = read("gdscript.sublime-syntax", encoding: none)

--- a/packages/preview/codegds/0.1.0/gdscript.sublime-syntax
+++ b/packages/preview/codegds/0.1.0/gdscript.sublime-syntax
@@ -1,0 +1,502 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# Generated from the official godot VSCode tmlanguage.json file and then tweaked manually to make the scopes work just like the sublime text python syntax.
+name: GDScript
+file_extensions:
+  - gd
+scope: source.gdscript
+
+variables:
+  red_comments: \b(ALERT|ATTENTION|CAUTION|CRITICAL|DANGER|SECURITY)\b
+  yellow_comments: \b(BUG|DEPRECATED|FIXME|HACK|TASK|TBD|TODO|WARNING)\b
+  green_comments: \b(INFO|NOTE|NOTICE|TEST|TESTING)\b
+
+contexts:
+  main:
+    - include: statement
+    - include: expression
+
+  comment:
+    - match: \#
+      push: comments
+
+  comments:
+    - meta_scope: comment.line
+    - include: special-comments
+    - match: \n
+      pop: 1
+
+  special-comments:
+    - match: ({{red_comments}})
+      scope: keyword.special.comment
+    - match: ({{yellow_comments}})
+      scope: string.special.comment
+    - match: ({{green_comments}})
+      scope: entity.name.special.comment
+  annotated_parameter:
+    - match: '(?x)\s* ([a-zA-Z_]\w*) \s* (:)\s* ([a-zA-Z_]\w*)?'
+      captures:
+        1: variable.parameter.function.language.gdscript
+        2: punctuation.separator.annotation.gdscript
+        3: storage.type.class.gdscript
+      push:
+        - match: (,)|(?=\))
+          captures:
+            1: punctuation.separator.parameters.gdscript
+          pop: true
+        - include: base_expression
+        - match: '=(?!=)'
+          scope: keyword.operator.assignment.gdscript
+  annotations:
+    - match: (@)(export|export_group|export_color_no_alpha|export_custom|export_dir|export_enum|export_exp_easing|export_file|export_flags|export_flags_2d_navigation|export_flags_2d_physics|export_flags_2d_render|export_flags_3d_navigation|export_flags_3d_physics|export_flags_3d_render|export_global_dir|export_global_file|export_multiline|export_node_path|export_placeholder|export_range|export_storage|icon|onready|rpc|tool|warning_ignore|static_unload)\b
+      captures:
+        1: keyword.function.decorator.gdscript
+        2: keyword.function.decorator.gdscript
+  any_method:
+    - match: '\b([A-Za-z_]\w*)\b(?=\s*(?:[(]))'
+      scope: variable.function.other.gdscript
+  any_property:
+    - match: '\b(\.)\s*(?<![@\$#%])(?:([A-Z_][A-Z_0-9]*)|([A-Za-z_]\w*))\b(?![(])'
+      captures:
+        1: punctuation.accessor.gdscript
+        2: constant.language.gdscript
+        3: variable.other.property.gdscript
+  any_variable:
+    - match: '\b(?<![@\$#%])([A-Za-z_]\w*)\b(?![(])'
+      scope: variable.other.gdscript
+  arithmetic_operator:
+    - match: '->|\+=|-=|\*=|\^=|/=|%=|&=|~=|\|=|\*\*|\*|/|%|\+|-'
+      scope: keyword.operator.arithmetic.gdscript
+  assignment_operator:
+    - match: '='
+      scope: keyword.operator.assignment.gdscript
+  base_expression:
+    - include: builtin_get_node_shorthand
+    - include: nodepath_object
+    - include: nodepath_function
+    - include: strings
+    - include: builtin_classes
+    - include: const_vars
+    - include: keywords
+    - include: operators
+    - include: lambda_declaration
+    - include: class_declaration
+    - include: variable_declaration
+    - include: signal_declaration_bare
+    - include: signal_declaration
+    - include: function_declaration
+    - include: statement_keyword
+    - include: assignment_operator
+    - include: control_flow
+    - include: match_keyword
+    - include: curly_braces
+    - include: square_braces
+    - include: round_braces
+    - include: function_call
+    - include: comment
+    - include: self
+    - include: func
+    - include: letter
+    - include: numbers
+    - include: line_continuation
+  bitwise_operator:
+    - match: '&|\||<<=|>>=|<<|>>|\^|~'
+      scope: keyword.operator.bitwise.gdscript
+  boolean_operator:
+    - match: (&&|\|\|)
+      scope: keyword.operator.boolean.gdscript
+  builtin_classes:
+    - match: '(?<![^.]\.|:)\b(Vector2|Vector2i|Vector3|Vector3i|Vector4|Vector4i|Color|Rect2|Rect2i|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|Transform3D|AABB|String|Color|NodePath|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray|bool|int|float|Signal|Callable|StringName|Quaternion|Projection|PackedByteArray|PackedInt32Array|PackedInt64Array|PackedFloat32Array|PackedFloat64Array|PackedStringArray|PackedVector2Array|PackedVector2iArray|PackedVector3Array|PackedVector3iArray|PackedVector4Array|PackedColorArray|super|void)\b'
+      scope: support.type.builtin.gdscript
+  builtin_get_node_shorthand:
+    - include: builtin_get_node_shorthand_quoted
+    - include: builtin_get_node_shorthand_bare_multi
+  builtin_get_node_shorthand_bare_multi:
+    - match: '(\$\s*|%|\$%\s*)(/\s*)?([a-zA-Z_]\w*)'
+      captures:
+        1: keyword.control.flow.gdscript
+        2: constant.character.escape.gdscript
+        3: constant.character.escape.gdscript
+      push:
+        - meta_scope: meta.literal.nodepath.bare.gdscript
+        - match: '(?!\s*/\s*%?\s*[a-zA-Z_]\w*)'
+          pop: true
+        - match: '(/)\s*(%)?\s*([a-zA-Z_]\w*)\s*'
+          captures:
+            1: constant.character.escape.gdscript
+            2: keyword.control.flow.gdscript
+            3: constant.character.escape.gdscript
+  builtin_get_node_shorthand_quoted:
+    - match: (?:(\$|%)|(&|\^|@))("|')
+      captures:
+        1: keyword.control.flow.gdscript
+        2: variable.other.enummember.gdscript
+      push:
+        - meta_scope: string.quoted.gdscript meta.literal.nodepath.gdscript constant.character.escape.gdscript
+        - match: (\3)
+          pop: true
+        - match: '%'
+          scope: keyword.control.flow
+  class_declaration:
+    - match: '(?<=^class)\s+([a-zA-Z_]\w*)\s*(?=:)'
+      captures:
+        1: entity.name.type.class.gdscript
+        2: class.other.gdscript
+  class_enum:
+    - match: '\b([A-Z][a-zA-Z_0-9]*)\.([A-Z_0-9]+)'
+      captures:
+        1: entity.name.type.class.gdscript
+        2: variable.other.enummember.gdscript
+  class_is:
+    - match: '\s+(is)\s+([a-zA-Z_]\w*)'
+      captures:
+        1: storage.type.is.gdscript
+        2: entity.name.type.class.gdscript
+  class_name:
+    - match: '(?<=class_name|class|enum)\s+([a-zA-Z_]\w*(\.([a-zA-Z_]\w*))?)'
+      captures:
+        1: entity.name.type.class.gdscript
+        2: class.other.gdscript
+  compare_operator:
+    - match: <=|>=|==|<|>|!=|!
+      scope: keyword.operator.comparison.gdscript
+  const_vars:
+    - match: '\b([A-Z_][A-Z_0-9]*)\b'
+      scope: variable.other.constant.gdscript
+  control_flow:
+    - match: \b(?:if|elif|else|for|in|while|break|continue|pass|return|when|yield|await)\b
+      scope: keyword.control.gdscript
+  curly_braces:
+    - match: '\{'
+      captures:
+        0: punctuation.definition.dict.begin.gdscript
+      push:
+        - match: '\}'
+          captures:
+            0: punctuation.definition.dict.end.gdscript
+          pop: true
+        - include: base_expression
+        - include: any_variable
+  expression:
+    - include: base_expression
+    - include: getter_setter_godot4
+    - include: assignment_operator
+    - include: annotations
+    - include: class_name
+    - include: builtin_classes
+    - include: class_is
+    - include: class_enum
+    - include: any_method
+    - include: any_variable
+    - include: any_property
+  extends_statement:
+    - match: '(extends)\s+([a-zA-Z_]\w*\.[a-zA-Z_]\w*)?'
+      captures:
+        1: keyword.language.gdscript
+        2: entity.other.inherited-class.gdscript
+  func:
+    - match: \bfunc\b
+      scope: keyword.language.gdscript
+  function_arguments:
+    - match: (\()
+      captures:
+        1: punctuation.definition.arguments.begin.gdscript
+      push:
+        - meta_content_scope: meta.function.parameters.gdscript
+        - match: (?=\))(?!\)\s*\()
+          pop: true
+        - match: (,)
+          scope: punctuation.separator.arguments.gdscript
+        - match: '\b([a-zA-Z_]\w*)\s*(=)(?!=)'
+          captures:
+            1: variable.parameter.function-call.gdscript
+            2: keyword.operator.assignment.gdscript
+        - match: '=(?!=)'
+          scope: keyword.operator.assignment.gdscript
+        - include: base_expression
+        - match: \s*(\))\s*(\()
+          captures:
+            1: punctuation.definition.arguments.end.gdscript
+            2: punctuation.definition.arguments.begin.gdscript
+        - include: letter
+        - include: any_variable
+        - include: any_property
+        - include: keywords
+  function_call:
+    - match: '(?=\b[a-zA-Z_]\w*\b\()'
+      comment: Regular function call of the type "name(args)"
+      push:
+        - meta_scope: meta.function-call.gdscript
+        - match: (\))
+          captures:
+            1: punctuation.definition.arguments.end.gdscript
+          pop: true
+        - include: function_name
+        - include: function_arguments
+  function_declaration:
+    - match: '(?x) \s*(func) \s+([a-zA-Z_]\w*) \s*(?=\()'
+      captures:
+        1: keyword.language.gdscript storage.type.function.gdscript
+        2: entity.name.function.gdscript
+      push:
+        - meta_scope: meta.function.gdscript
+        - match: (:)
+          captures:
+            1: punctuation.section.function.begin.gdscript
+          pop: true
+        - include: parameters
+        - include: line_continuation
+        - include: base_expression
+  function_name:
+    - include: builtin_classes
+    - match: \b(preload)\b
+      scope: keyword.language.gdscript
+    - match: '\b([a-zA-Z_]\w*)\b'
+      comment: Some color schemas support meta.function-call.generic scope
+      scope: variable.function.gdscript
+  getter_setter_godot4:
+    - match: '\b(get):'
+      captures:
+        1: variable.function.gdscript
+    - match: (?x) \s+(set) \s*(?=\()
+      captures:
+        1: variable.function.gdscript
+      push:
+        - meta_scope: meta.function.gdscript
+        - match: '(:|(?=[#''"\n]))'
+          pop: true
+        - include: parameters
+        - include: line_continuation
+  keywords:
+    - match: \b(?:class_name|abstract|is|onready|tool|static|export|as|void|assert|breakpoint|sync|remote|master|puppet|slave|remotesync|mastersync|puppetsync|trait|namespace)\b
+      scope: keyword.language.gdscript
+  lambda_declaration:
+    - match: (func)\s?(?=\()
+      captures:
+        1: keyword.language.gdscript storage.type.function.gdscript
+        2: variable.function.gdscript
+      push:
+        - meta_scope: meta.function.gdscript
+        - match: '(:|(?=[#''"\n]))'
+          pop: true
+        - include: parameters
+        - include: line_continuation
+        - include: base_expression
+        - include: any_variable
+        - include: any_property
+  letter:
+    - match: \b(?:true|false|null)\b
+      scope: constant.language.gdscript
+  line_continuation:
+    - match: (\\)\s*(\S.*$\n?)
+      captures:
+        1: punctuation.separator.continuation.line.gdscript
+        2: invalid.illegal.line.continuation.gdscript
+    - match: (\\)\s*$\n?
+      captures:
+        1: punctuation.separator.continuation.line.gdscript
+      push:
+        - match: '(?x)(?=^\s*$)|(?! (\s* [rR]? (\''\''\''|\"\"\"|\''|\"))|(\G $)  (?# ''\G'' is necessary for ST))'
+          pop: true
+        - include: base_expression
+  loose_default:
+    - match: (=)
+      captures:
+        1: keyword.operator.gdscript
+      push:
+        - match: (,)|(?=\))
+          captures:
+            1: punctuation.separator.parameters.gdscript
+          pop: true
+        - include: base_expression
+  match_keyword:
+    - match: ^\s*(match)
+      captures:
+        1: keyword.control.gdscript
+  nodepath_function:
+    - match: (get_node_or_null|has_node|has_node_and_resource|find_node|get_node)\s*(\()
+      captures:
+        1: variable.function.gdscript
+        2: punctuation.definition.parameters.begin.gdscript
+      push:
+        - meta_scope: meta.function.gdscript
+        - meta_content_scope: meta.function.parameters.gdscript
+        - match: (\))
+          captures:
+            1: punctuation.definition.parameters.end.gdscript
+          pop: true
+        - match: ("|')
+          push:
+            - meta_scope: string.quoted.gdscript meta.literal.nodepath.gdscript constant.character.escape
+            - match: \1
+              pop: true
+            - match: '%'
+              scope: keyword.control.flow
+        - include: base_expression
+  nodepath_object:
+    - match: (NodePath)\s*(?:\()
+      captures:
+        1: support.class.library.gdscript
+      push:
+        - meta_scope: meta.literal.nodepath.gdscript
+        - match: (?:\))
+          pop: true
+        - match: ("|')
+          push:
+            - meta_scope: string.quoted.gdscript constant.character.escape.gdscript
+            - match: \1
+              pop: true
+            - match: '%'
+              scope: keyword.control.flow.gdscript
+  numbers:
+    - match: '0b[01_]+'
+      scope: constant.numeric.integer.binary.gdscript
+    - match: '0x[0-9A-Fa-f_]+'
+      scope: constant.numeric.integer.hexadecimal.gdscript
+    - match: '\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?'
+      scope: constant.numeric.float.gdscript
+    - match: '([0-9][0-9_]*)?\.[0-9_]*([eE][+-]?[0-9_]+)?'
+      scope: constant.numeric.float.gdscript
+    - match: '[0-9][0-9_]*[eE][+-]?[0-9_]+'
+      scope: constant.numeric.float.gdscript
+    - match: '[-]?[0-9][0-9_]*'
+      scope: constant.numeric.integer.gdscript
+  operators:
+    - include: wordlike_operator
+    - include: boolean_operator
+    - include: arithmetic_operator
+    - include: bitwise_operator
+    - include: compare_operator
+  parameters:
+    - match: (\()
+      captures:
+        1: punctuation.definition.parameters.begin.gdscript
+      push:
+        - meta_scope: meta.function.parameters.gdscript
+        - match: (\))
+          captures:
+            1: punctuation.definition.parameters.end.gdscript
+          pop: true
+        - include: annotated_parameter
+        - match: '(?x)([a-zA-Z_]\w*)\s* (?: (,) | (?=[)#\n=]))'
+          captures:
+            1: variable.parameter.function.language.gdscript
+            2: punctuation.separator.parameters.gdscript
+        - include: comment
+        - include: loose_default
+  round_braces:
+    - match: \(
+      captures:
+        0: punctuation.parenthesis.begin.gdscript
+      push:
+        - match: \)
+          captures:
+            0: punctuation.parenthesis.end.gdscript
+          pop: true
+        - include: base_expression
+        - include: any_variable
+  self:
+    - match: \bself\b
+      scope: variable.language.gdscript
+  signal_declaration:
+    - match: '(?x) \s*(signal) \s+([a-zA-Z_]\w*) \s*(?=\()'
+      captures:
+        1: keyword.language.gdscript storage.type.function.gdscript
+        2: variable.function.gdscript
+      push:
+        - meta_scope: meta.signal.gdscript
+        - match: '((?=[#''"\n]))'
+          pop: true
+        - include: parameters
+        - include: line_continuation
+  signal_declaration_bare:
+    - match: '(?x) \s*(signal) \s+([a-zA-Z_]\w*)(?=[\n\s])'
+      scope: meta.signal.gdscript
+      captures:
+        1: keyword.language.gdscript storage.type.function.gdscript
+        2: variable.function.gdscript
+  square_braces:
+    - match: '\['
+      captures:
+        0: punctuation.definition.list.begin.gdscript
+      push:
+        - match: '\]'
+          captures:
+            0: punctuation.definition.list.end.gdscript
+          pop: true
+        - include: base_expression
+        - include: any_variable
+  statement:
+    - include: extends_statement
+  statement_keyword:
+    - match: (?x) \b(?<!\.)(continue | assert | break | elif | else | if | pass | return | while )\b
+      scope: keyword.control.flow.gdscript
+    - match: \b(?<!\.)(class|enum)\b
+      scope: storage.type.class.gdscript
+    - match: '(?x)^\s*(case | match)(?=\s*([-+\w\d(\[{''":#]|$))\b'
+      captures:
+        1: keyword.control.flow.gdscript
+  string_bracket_placeholders:
+    - match: '(?x)({{ | }}| (?:{\w* (\.[[:alpha:]_]\w* | \[[^\]''"]+\])*(![rsa])?( : \w? [<>=^]? [-+ ]? \#?\d* ,? (\.\d+)? [bcdeEfFgGnosxX%]? )?}))'
+      scope: meta.format.brace.gdscript
+      captures:
+        1: constant.character.format.placeholder.other.gdscript
+        3: storage.type.format.gdscript
+        4: storage.type.format.gdscript
+    - match: '(?x)({\w* (\.[[:alpha:]_]\w* | \[[^\]''"]+\])*(![rsa])?(:)[^''"{}\n]* (?:\{ [^''"}\n]*? \} [^''"{}\n]*)*})'
+      scope: meta.format.brace.gdscript
+      captures:
+        1: constant.character.format.placeholder.other.gdscript
+        3: storage.type.format.gdscript
+        4: storage.type.format.gdscript
+  string_percent_placeholders:
+    - match: '(?x)(% (\([\w\s]*\))?[-+#0 ]*(\d+|\*)? (\.(\d+|\*))?([hlL])?[diouxXeEfFgGcrsab%])'
+      scope: meta.format.percent.gdscript
+      captures:
+        1: constant.character.format.placeholder.other.gdscript
+  strings:
+    - match: (r)?("""|'''|"|')
+      captures:
+        1: constant.character.escape.gdscript
+      push:
+        - meta_scope: string.quoted.gdscript
+        - match: \2
+          pop: true
+        - match: \\.
+          scope: constant.character.escape.gdscript
+        - include: string_percent_placeholders
+        - include: string_bracket_placeholders
+  variable_declaration:
+    - match: \b(?:(var)|(const))\b
+      captures:
+        1: keyword.language.gdscript storage.type.var.gdscript
+        2: keyword.language.gdscript storage.type.const.gdscript
+      push:
+        - meta_scope: meta.variable.declaration.gdscript
+        - match: $|;
+          pop: true
+        - match: '(:)?\s*(set|get)\s+=\s+([a-zA-Z_]\w*)'
+          captures:
+            1: punctuation.separator.annotation.gdscript
+            2: keyword.language.gdscript storage.type.const.gdscript
+            3: variable.function.gdscript
+        - match: ':=|=(?!=)'
+          scope: keyword.operator.assignment.gdscript
+        - match: '(:)\s*([a-zA-Z_]\w*)?'
+          captures:
+            1: punctuation.separator.annotation.gdscript
+            2: support.type.class.gdscript
+        - match: '(setget)\s+([a-zA-Z_]\w*)(?:[,]\s*([a-zA-Z_]\w*))?'
+          captures:
+            1: keyword.language.gdscript storage.type.const.gdscript
+            2: variable.function.gdscript
+            3: variable.function.gdscript
+        - include: expression
+        - include: letter
+        - include: any_variable
+        - include: any_property
+        - include: keywords
+  wordlike_operator:
+    - match: \b(and|or|not)\b
+      scope: keyword.operator.wordlike.gdscript

--- a/packages/preview/codegds/0.1.0/typst.toml
+++ b/packages/preview/codegds/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "codegds"
+version = "0.1.0"
+entrypoint = "codegds.typ"
+authors = ["Daniel Cancelas"]
+license = "MIT"
+description = "Syntax highlighting support for the GDScript programming language."
+repository = "https://github.com/Kioraga/typst-gdscript"
+keywords = ["syntax-highlighting", "gdscript"]
+categories = ["text"]
+compiler = "0.13.0"
+exclude = ["example.*"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Syntax highlighting support for the GDScript programming language.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [x] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
