### PR TITLE
cap-able:0.0.1

### DIFF
--- a/packages/preview/cap-able/0.0.1/LICENSE
+++ b/packages/preview/cap-able/0.0.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SchrodingerBlume (Andrew Junhao Wu)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/cap-able/0.0.1/README.md
+++ b/packages/preview/cap-able/0.0.1/README.md
@@ -1,0 +1,188 @@
+<p align="center">
+  <strong>cap-able</strong><br>
+  <em>Make it more able to caption — now that is cap-able</em>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-0.0.1-blue" alt="version: 0.0.1">
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="license: MIT">
+  <img src="https://img.shields.io/badge/typst-0.13.0+-orange" alt="minimum typst version: 0.13.0">
+</p>
+
+<p align="center">
+  <a href="#english">English</a> | <a href="#中文">中文</a>
+</p>
+
+<p align="center">
+  📖 <a href="https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.0.1/doc-en.pdf">English Documentation</a> · 📖 <a href="https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.0.1/doc-zh.pdf">中文文档</a>
+</p>
+
+---
+
+## English
+
+A comprehensive Typst package for creating professional three-line tables and figures with bilingual caption support, continued tables/figures, subfigures, and flexible customization options for academic documents.
+
+### Features
+
+- **Three-line tables** — Academic-standard tables (top, middle, bottom rules) with Markdown syntax
+- **Bilingual captions** — Auto-formatted bilingual captions (Chinese/English, German/English, Spanish/English, etc.)
+- **Continued tables/figures** — Multi-page tables and figures with automatic numbering
+- **Subfigures** — Flexible multi-image grid layouts with overlay labels and subcaptions
+- **Notes** — Auto-width-matched notes for tables and figures
+- **Multilingual support** — 25+ languages including RTL languages and Traditional/Simplified Chinese
+- **Unified configuration** — Configure both via `cap-style`, or override per-type with `captab-style` / `capfig-style`
+
+### Quick Start
+
+```typst
+#import "@preview/cap-able:0.0.1": *
+
+// Three-line table
+#captab(
+  caption: [Experimental Results],
+)[
+  | Parameter   | Value | Unit |
+  | ----------- | ----- | ---- |
+  | Temperature |  25   |  °C  |
+  | Pressure    |   1   |  atm |
+]
+
+// Figure
+#capfig(
+  image("example.png", width: 50%),
+  caption: [System Architecture],
+)
+
+// Bilingual caption
+#set text(lang: "es")
+
+#captab(
+  caption: [Resultados experimentales],
+  caption-en: [Experimental Results],
+)[
+  | A | B |
+  | 1 | 2 |
+]
+```
+
+### Configuration
+
+```typst
+// Unified configuration for both tables and figures
+#show: cap-style.with(
+  numbering-format: "1.1",
+  use-chapter: true,
+  caption-size: 10.5pt,
+)
+
+// Table-specific configuration
+#show: captab-style.with(
+  caption-above: 1.5em,
+  body-size: 10.5pt,
+)
+
+// Figure-specific configuration
+#show: capfig-style.with(
+  label-mode: "overlay",
+  label-style: "(a)",
+)
+```
+
+### Documentation
+
+Full documentation is available in this repository:
+
+- [English Documentation (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.0.1/doc-en.pdf)
+- [Chinese Documentation (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.0.1/doc-zh.pdf)
+
+### License
+
+MIT License — see [LICENSE](LICENSE) for details.
+
+---
+
+## 中文
+
+一个功能全面的 Typst 包，用于创建专业的三线表和图片，支持双语标题、续表/续图、子图及灵活的自定义选项，适用于学术文档。
+
+### 功能特性
+
+- **三线表** — 符合学术规范的表格（顶线、中线、底线），支持 Markdown 语法
+- **双语标题** — 自动格式化的双语标题（中英、德英、西英等）
+- **续表/续图** — 跨页表格和图片，自动编号
+- **子图** — 灵活的多图并排布局，支持覆盖标签和子标题
+- **注释** — 自动匹配宽度的表注和图注
+- **多语言支持** — 25+ 种语言，包括 RTL 语言及简繁中文区分
+- **统一配置** — 通过 `cap-style` 统一配置，或使用 `captab-style` / `capfig-style` 分别覆盖
+
+### 快速开始
+
+```typst
+#import "@preview/cap-able:0.0.1": *
+
+// 三线表
+#set text(lang: "zh")
+
+#captab(
+  caption: [实验结果],
+  caption-en: [Experimental Results],
+)[
+  | 参数 | 数值 | 单位 |
+  | ---- | ---- | ---- |
+  | 温度 |  25  |  °C  |
+  | 气压 |   1  |  atm |
+]
+
+// 图片
+#capfig(
+  image("example.png", width: 50%),
+  caption: [系统架构],
+  caption-en: [System Architecture],
+)
+
+// 子图
+#capsubfig(
+  (
+    (content: image("a.png"), subcaption: [方案一]),
+    (content: image("b.png"), subcaption: [方案二]),
+  ),
+  columns: 2,
+  caption: [方案对比],
+  caption-en: [Scheme Comparison],
+)
+```
+
+### 配置
+
+```typst
+// 统一配置表格和图片
+#show: cap-style.with(
+  numbering-format: "1.1",
+  use-chapter: true,
+  caption-size: 10.5pt,
+)
+
+// 表格专用配置
+#show: captab-style.with(
+  caption-above: 1.5em,
+  body-size: 10.5pt,
+)
+
+// 图片专用配置
+#show: capfig-style.with(
+  label-mode: "overlay",
+  label-style: "(a)",
+)
+```
+
+### 文档
+
+完整文档见本仓库：
+
+- [中文文档 (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.0.1/doc-zh.pdf)
+- [英文文档 (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.0.1/doc-en.pdf)
+
+### 许可
+
+MIT 许可证 — 详见 [LICENSE](LICENSE)。

--- a/packages/preview/cap-able/0.0.1/lib.typ
+++ b/packages/preview/cap-able/0.0.1/lib.typ
@@ -1,0 +1,10 @@
+// ============================================================
+// cap-able 包主入口文件
+// cap-able Package Main Entry
+// ============================================================
+
+#import "src/config.typ": captab-style, capfig-style, cap-style, set-table-width
+#import "src/bicap.typ": bicap
+#import "src/table.typ": captab
+#import "src/note.typ": captnote, capfnote
+#import "src/figure.typ": capfig, capsubfig

--- a/packages/preview/cap-able/0.0.1/src/bicap.typ
+++ b/packages/preview/cap-able/0.0.1/src/bicap.typ
@@ -1,0 +1,502 @@
+// ============================================================
+// 独立标题模块 (Standalone Caption Module)
+// ============================================================
+//
+// 本模块提供独立的双语标题生成功能，是 cap-able 包的核心标题引擎。
+// This module provides standalone bilingual caption generation,
+// serving as the core caption engine of cap-able.
+//
+// 设计目标 / Design Goals:
+// 1. 将"标题生成逻辑"与"表格/图片布局"解耦，使 cap-table、cap-figure 等
+//    函数可以统一调用同一套标题逻辑。
+//    Decouple "caption generation" from "table/figure layout", allowing
+//    cap-table, cap-figure, etc. to share the same caption engine.
+//
+// 2. 支持主标题和续表/续图两种模式：
+//    Support both main and continued (multi-page) caption modes:
+//    - 主标题：自动分配新编号，写入计数器，可在目录中显示
+//              Main caption: allocates a new number, writes to counter, appears in outline
+//    - 续表/续图：引用原始标签的编号，不新增计数，不出现在目录
+//                 Continued: references original label's number, no new counter, no outline entry
+//
+// 3. 支持 25+ 种语言的本地化文本，自动适配间距规则
+//    Support 25+ language localizations with automatic spacing rules
+//
+// 4. 支持 RTL 语言（阿拉伯文、希伯来文、波斯文、乌尔都文）
+//    Support RTL languages (Arabic, Hebrew, Persian, Urdu)
+//
+// 关键技术 / Key Technical Details:
+// - 主标题通过插入一个 place(hide[#figure(...)]) 来注册编号，
+//   然后立即将计数器减 1，最后在显示时再加 1，从而实现"占位但不渲染"。
+//   Main caption registers a number by inserting a hidden figure via
+//   place(hide[#figure(...)]), then decrements the counter by 1, and
+//   increments when rendering — achieving "register without rendering".
+//
+// - 续表通过 query(refer-to) 查询原始标签所在位置的计数器值，
+//   从而获得原始编号进行显示。
+//   Continued captions use query(refer-to) to get the counter value
+//   at the original label's location, retrieving its number.
+//
+// ============================================================
+
+#import "config.typ": *
+
+/// 内部函数：生成标题核心内容（不含外层 block 和间距），由 `bicap()` 和 `cap-table()` 共用。
+/// Internal: generate core caption content (no outer block/spacing), shared by `bicap()` and `cap-table()`.
+///
+/// -> content
+#let _make_caption_content(
+  /// 主语言标题文本（续表时可为 none，仅显示编号）
+  /// Main language caption text (can be none in continuation, showing only number)
+  /// -> none | content
+  caption: none,
+  /// 英文标题文本（双语模式时使用）
+  /// English caption text (used in bilingual mode)
+  /// -> none | content
+  caption-en: none,
+  /// 续表/续图引用的原始标签（提供此参数则进入续表模式）
+  /// Original label for continued table/figure (entering continuation mode when provided)
+  /// -> none | label
+  refer-to: none,
+  /// 此标题的标签（用于交叉引用，如 <tab:results>）
+  /// Label for this caption (for cross-referencing, e.g. <tab:results>)
+  /// -> none | label
+  label: none,
+  /// 样式配置字典（来自 table-style-config 或 figure-style-config）
+  /// Style configuration dictionary (from table-style-config or figure-style-config)
+  /// -> dictionary
+  config: none,
+  /// 类型标识："table" 使用表格计数器；"figure" 使用图片计数器
+  /// Type identifier: "table" uses table counter; "figure" uses image counter
+  /// -> str
+  kind: "table",
+  /// 续表模式下是否显示标题文本。
+  /// auto：若全局 continued-show-caption 也是 auto，则根据是否提供 caption 决定
+  /// Whether to show caption text in continuation mode.
+  /// auto: if global continued-show-caption is also auto, decided by whether caption is provided
+  /// -> auto | bool
+  show-caption: auto,
+) = {
+  context {
+    // 确定实际使用的文档语言（可被 config.lang 覆盖，支持 region 区分如 zh-TW）
+    // Determine actual document language (can be overridden by config.lang, supports region e.g. zh-TW)
+    let doc-lang = resolve-lang-code(config.lang)
+
+    // 根据 kind 确定使用哪组本地化键名
+    // Determine which set of localization keys to use based on kind
+    // "table" -> table/continued-prefix/continued-suffix 键
+    // "figure" -> figure/fig-continued-prefix/fig-continued-suffix 键
+    let supplement-key = if kind == "table" { "table" } else { "figure" }
+    let continued-prefix-key = if kind == "table" { "continued-prefix" } else { "fig-continued-prefix" }
+    let continued-suffix-key = if kind == "table" { "continued-suffix" } else { "fig-continued-suffix" }
+
+    // ── 文本/间距解析辅助 / Text & spacing resolution helpers ──
+    //
+    // _resolve-main: 解析主语言文本。优先级：英文文档且有 *-en 配置 → *-en；
+    //                否则主键配置（非 auto）→ 主键；否则按语言表自动取。
+    // _resolve-main: main-lang text. English doc + *-en set → *-en;
+    //                otherwise main key (non-auto) → main; else lang-table auto.
+    //
+    // _resolve-en: 解析英文行文本。优先级：*-en → main → 英文语言表。
+    // _resolve-en: English-line text. Priority: *-en → main → English lang-table.
+    //
+    // _resolve-spacing: 解析间距字段。auto → 语言表取值；否则用配置值。
+    // _resolve-spacing: spacing field. auto → lookup by lang; else config value.
+    let _resolve-main(main-key, en-key, lang-key) = {
+      let en-val = config.at(en-key, default: auto)
+      let main-val = config.at(main-key, default: auto)
+      if doc-lang == "en" and en-val != auto { en-val }
+      else if main-val == auto { get-table-text(doc-lang, lang-key) }
+      else { main-val }
+    }
+    let _resolve-en(main-key, en-key, lang-key) = {
+      let en-val = config.at(en-key, default: auto)
+      let main-val = config.at(main-key, default: auto)
+      if en-val != auto { en-val }
+      else if main-val != auto { main-val }
+      else { get-table-text("en", lang-key) }
+    }
+    let _resolve-spacing(key) = {
+      let v = config.at(key)
+      if v == auto { get-table-text(doc-lang, key) } else { v }
+    }
+
+    // ── 解析主语言文本 / Resolve main language text ──
+    let final-supplement         = _resolve-main("supplement", "supplement-en", supplement-key)
+    let final-continued-prefix   = _resolve-main("continued-prefix", "continued-prefix-en", continued-prefix-key)
+    let final-continued-suffix   = _resolve-main("continued-suffix", "continued-suffix-en", continued-suffix-key)
+
+    // ── 解析英文行文本 / Resolve English-line text ──
+    let final-supplement-en         = _resolve-en("supplement", "supplement-en", supplement-key)
+    let final-continued-prefix-en   = _resolve-en("continued-prefix", "continued-prefix-en", continued-prefix-key)
+    let final-continued-suffix-en   = _resolve-en("continued-suffix", "continued-suffix-en", continued-suffix-key)
+
+    // ── 解析各种间距值 / Resolve spacing values ──
+    let pre-spacing      = _resolve-spacing("pre-supplement-number-spacing")
+    let post-spacing     = _resolve-spacing("post-supplement-number-spacing")
+    let title-spacing    = _resolve-spacing("number-title-spacing")
+    let title-spacing-en = _resolve-spacing("number-title-spacing-en")
+
+    // 续表显示模式和全局"是否显示标题"配置
+    // Continuation mode and global "show caption" setting
+    let continued-mode = config.at("continued-mode", default: "prefix")
+    let global-show-caption = config.at("continued-show-caption", default: auto)
+
+    // 是否启用英文副标题
+    // Whether bilingual English sub-caption is enabled
+    let enable-en = config.enable-english-caption
+
+    // ── 统一标题行构造器 / Unified caption-line builder ──
+    //
+    // 按模板 `prefix [+pre-sp+num] [+post-sp+suffix] [+title-sp+title]` 拼接一行标题。
+    // 任一部件为 none 则连同其间距一起跳过；rtl 为 true 时把各部件用 box 包裹以防方向混乱。
+    // Builds one caption line from template above. `none` parts are skipped along
+    // with their spacing; when rtl, each part is wrapped in box to prevent direction issues.
+    let _line(prefix, num, suffix, title, pre-sp, post-sp, title-sp, rtl: false) = {
+      let b(p) = if rtl and p != none { box[#p] } else { p }
+      b(prefix)
+      if num != none {
+        if pre-sp != none { handle-spacing(pre-sp) }
+        b(num)
+      }
+      if suffix != none {
+        if post-sp != none { handle-spacing(post-sp) }
+        b(suffix)
+      }
+      if title != none {
+        if title-sp != none { handle-spacing(title-sp) }
+        b(title)
+      }
+    }
+
+    // 统一生成续表标题（包括主语言与可选的英文副标题）。
+    // Unified builder for continuation captions (main line + optional English subline).
+    //
+    // - num: 原始表/图编号；若为 none 表示 query 未找到，采用降级格式
+    //   Original table/figure number; none means query missed → fallback format
+    // - is-suffix-mode: 续表模式（true=后缀"表X（续）"，false=前缀"续表X"）
+    //   Continuation mode (true = suffix "Table X (cont)", false = prefix "Cont. Table X")
+    // - show-title: 是否显示 caption 文本
+    //   Whether to render caption text
+    let _build-continuation-line(num: none, is-suffix-mode: true, show-title: false) = {
+      let main-prefix  = if is-suffix-mode { final-supplement }        else { final-continued-prefix }
+      let main-suffix  = if is-suffix-mode { final-continued-suffix }  else { none }
+      let en-prefix    = if is-suffix-mode { final-supplement-en }     else { final-continued-prefix-en }
+      let en-suffix    = if is-suffix-mode { final-continued-suffix-en } else { none }
+      // 历史行为：降级（无编号）时跳过 pre-spacing，但仍保留 post-spacing。
+      // Historical behavior: fallback (no num) drops pre-spacing but keeps post-spacing.
+      let main-pre = if num != none { pre-spacing } else { none }
+      let en-pre   = if num != none { [ ] } else { none }
+      let title    = if show-title { caption } else { none }
+      let title-en = if show-title { caption-en } else { none }
+
+      if doc-lang == "en" and enable-en and caption-en != none {
+        _line(main-prefix, num, main-suffix, title-en, main-pre, post-spacing, title-spacing)
+      } else if enable-en and caption-en != none {
+        let m = _line(main-prefix, num, main-suffix, title,    main-pre, post-spacing, title-spacing)
+        let e = _line(en-prefix,   num, en-suffix,   title-en, en-pre,   [ ],          title-spacing-en)
+        [#m \ #e]
+      } else {
+        _line(main-prefix, num, main-suffix, title, main-pre, post-spacing, title-spacing)
+      }
+    }
+
+    if caption != none or refer-to != none {
+      if refer-to != none {
+        // ════════════════════════════════════════════════════════
+        // 续表/续图分支 (Continuation mode branch)
+        // ════════════════════════════════════════════════════════
+        //
+        // 续表不分配新编号，而是查询原始标签的编号进行显示。
+        // Continuation does not allocate a new number but queries
+        // the original label's number for display.
+
+        // 决定是否显示标题文本（还是只显示"续表X"之类的编号信息）
+        // Decide whether to show caption text or just the continuation identifier
+        //
+        // 优先级 / Priority:
+        // 1. 参数 show-caption 明确指定 → 直接用
+        //    show-caption param explicitly set → use directly
+        // 2. 全局 continued-show-caption 有值（非 auto）→ 用全局值
+        //    Global continued-show-caption is set → use global value
+        // 3. 两者都是 auto → 如果提供了 caption/caption-en 则显示，否则不显示
+        //    Both auto → show if caption/caption-en is provided
+        let should-show-caption = if show-caption == auto {
+          if global-show-caption == auto {
+            caption != none or caption-en != none
+          } else {
+            global-show-caption
+          }
+        } else {
+          show-caption
+        }
+
+        // 查询原始标签获取其编号
+        // Query original label to get its number
+        let continuation-caption = {
+          let original = query(refer-to)
+          if original.len() > 0 {
+            // 找到了原始标签，获取其在文档中的编号
+            // Found original label, get its number in the document
+            let use-ch = config.use-chapter
+            // 根据 kind 选择正确的 figure 计数器类型
+            // Choose the correct figure counter type based on kind
+            let figure-kind = if kind == "table" { table } else { image }
+            // 获取原始标签位置处的计数器值（注意：这是历史值，不是当前值）
+            // Get counter value AT the original label's location (historical, not current)
+            let num = counter(figure.where(kind: figure-kind)).at(original.first().location()).first()
+
+            // 根据编号格式生成编号字符串（带或不带章节前缀）
+            // Generate number string with or without chapter prefix
+            let table-num = if use-ch {
+              let levels = config.chapter-level
+              // 在原始标签所在位置处读取标题计数器（非当前位置）
+              // Read heading counter AT the original label's location (not current)
+              let h = counter(heading).at(original.first().location())
+              let chapter-nums = h.slice(0, calc.min(levels, h.len()))
+              numbering(config.numbering-format, ..chapter-nums, num)
+            } else {
+              str(num)
+            }
+
+            _build-continuation-line(
+              num: table-num,
+              is-suffix-mode: continued-mode == "suffix",
+              show-title: should-show-caption,
+            )
+          } else {
+            // ─ 没有找到原始标签（query 返回空）─
+            // ─ Original label not found (query returned empty) ─
+            //
+            // 可能原因：标签拼写错误，或原始表格在当前位置之后（Typst 暂不支持向后查询）
+            // Possible causes: label typo, or original figure appears after current location
+            // (Typst doesn't support forward queries yet)
+            //
+            // 降级处理：不显示编号，只显示续表标识符
+            // Fallback: show continuation identifier without number
+            _build-continuation-line(
+              num: none,
+              is-suffix-mode: continued-mode == "suffix",
+              show-title: should-show-caption,
+            )
+          }
+        }
+
+        // 渲染续表标题内容（应用标题字号和行距）
+        // Render continuation caption content (apply caption size and leading)
+        set par(leading: config.caption-leading)
+        text(size: config.caption-size, weight: config.caption-weight)[
+          #continuation-caption
+        ]
+
+      } else {
+        // ════════════════════════════════════════════════════════
+        // 主表/主图分支 (Main table/figure branch)
+        // ════════════════════════════════════════════════════════
+        //
+        // 技术关键：编号注册技巧
+        // Technical Key: Number Registration Trick
+        //
+        // 问题：cap-table 用自定义布局渲染表格，不使用 Typst 的 figure() 包装，
+        // 因此无法利用 Typst 内置的 figure 计数器自动编号机制。
+        // Problem: cap-table uses custom layout, not Typst's figure() wrapper,
+        // so it can't use Typst's built-in figure counter auto-numbering.
+        //
+        // 解决方案：
+        // Solution:
+        // 1. 用 place(hide[...]) 在文档流中插入一个不可见的 figure，
+        //    其 outlined: true 使其出现在目录中，label 用于交叉引用
+        //    Insert an invisible figure using place(hide[...]),
+        //    with outlined: true for outline, label for cross-referencing
+        // 2. 此操作会使 figure 计数器 +1
+        //    This increments the figure counter by 1
+        // 3. 立即将计数器 -1（还原到插入前的值）
+        //    Immediately decrement counter by 1 (restore to pre-insertion value)
+        // 4. 在显示标题时手动读取计数器 +1 来获得正确的当前编号
+        //    When rendering, manually read counter + 1 to get the correct current number
+        //
+        // 这样做的好处：目录和交叉引用都能正确工作，
+        // 同时标题可以完全自定义格式（不受 Typst 默认标题格式约束）。
+        // Benefits: outline and cross-references work correctly,
+        // while the caption format is fully customizable.
+
+        let figure-kind = if kind == "table" { table } else { image }
+
+        // 步骤1：插入隐藏的 figure，注册编号并设置目录条目
+        // Step 1: Insert hidden figure, register number and set outline entry
+        place(hide[
+          #figure(
+            kind: figure-kind,
+            supplement: final-supplement,
+            outlined: true,             // 出现在目录中 / Appears in outline
+            caption: {
+              // 目录中显示的标题文本（与主标题可能不同）
+              // Caption text shown in outline (may differ from main caption)
+              if doc-lang == "en" and enable-en and caption-en != none {
+                caption-en
+              } else if enable-en and caption-en != none {
+                if config.outline-bilingual {
+                  // 目录双语模式
+                  // Bilingual outline mode
+                  if config.outline-newline {
+                    if is-rtl-lang(doc-lang) {
+                      // RTL 语言：英文在前，主语言在后
+                      // RTL: English first, main language second
+                      [#caption-en \ #caption]
+                    } else {
+                      [#caption \ #caption-en]
+                    }
+                  } else {
+                    let sep = config.outline-separator
+                    if is-rtl-lang(doc-lang) {
+                      [#caption-en#sep#caption]
+                    } else {
+                      [#caption#sep#caption-en]
+                    }
+                  }
+                } else {
+                  // 目录只显示主语言
+                  // Outline shows main language only
+                  caption
+                }
+              } else {
+                caption
+              }
+            },
+            // 同样需要设置编号格式，以便目录中的编号格式正确
+            // Also set numbering format so outline shows correct numbers
+            numbering: num => {
+              if config.use-chapter {
+                let levels = config.chapter-level
+                let h = counter(heading).get()
+                let chapter-nums = h.slice(0, calc.min(levels, h.len()))
+                numbering(config.numbering-format, ..chapter-nums, num)
+              } else {
+                numbering("1", num)
+              }
+            },
+            [],
+          )#if label != none { label }   // 绑定交叉引用标签 / Bind cross-reference label
+        ])
+
+        // 步骤2：将计数器减 1，抵消上面隐藏 figure 造成的计数增加
+        // Step 2: Decrement counter by 1 to cancel the increment from the hidden figure
+        counter(figure.where(kind: figure-kind)).update(n => if n > 0 { n - 1 } else { 0 })
+
+        // 步骤3：读取当前计数器值 +1，得到本表格的正确编号
+        // Step 3: Read current counter + 1 to get the correct number for this table
+        let use-ch = config.use-chapter
+        let num = counter(figure.where(kind: figure-kind)).get().first() + 1
+
+        let table-num = if use-ch {
+          let levels = config.chapter-level
+          let h = counter(heading).get()
+          let chapter-nums = h.slice(0, calc.min(levels, h.len()))
+          numbering(config.numbering-format, ..chapter-nums, num)
+        } else {
+          str(num)
+        }
+
+        // 步骤4：生成主标题内容（考虑 RTL 和双语布局）
+        // Step 4: Generate main caption content (considering RTL and bilingual layout)
+        // 使用统一的 _line 构造器；RTL 语言需对各部件 box 包裹并对英文行强制 ltr。
+        // Uses the unified _line builder; RTL wraps parts in box and forces ltr on English line.
+        let rtl = is-rtl-lang(doc-lang)
+        let main-caption = if doc-lang == "en" and enable-en and caption-en != none {
+          _line(final-supplement, table-num, none, caption-en, pre-spacing, none, title-spacing)
+        } else if enable-en and caption-en != none {
+          let m = _line(final-supplement, table-num, none, caption, pre-spacing, none, title-spacing, rtl: rtl)
+          let e = _line(final-supplement-en, table-num, none, caption-en, [ ], none, title-spacing-en)
+          if rtl { [#m \ #text(dir: ltr)[#e]] } else { [#m \ #e] }
+        } else {
+          _line(final-supplement, table-num, none, caption, pre-spacing, none, title-spacing, rtl: rtl)
+        }
+
+        // 步骤5：将计数器推进 +1（完成本表格的编号分配）
+        // Step 5: Advance counter by 1 (completing number allocation for this table)
+        counter(figure.where(kind: figure-kind)).step()
+
+        // 步骤6：渲染主标题内容
+        // Step 6: Render main caption content
+        set par(leading: config.caption-leading)
+        text(size: config.caption-size, weight: config.caption-weight)[
+          #main-caption
+        ]
+      }
+    }
+  }
+}
+
+
+/// 独立双语标题函数，可用于表格（`kind: "table"`）或图片（`kind: "figure"`）。
+/// Standalone bilingual caption for tables (`kind: "table"`) or figures (`kind: "figure"`).
+///
+/// -> content
+#let bicap(
+  /// 主语言标题文本
+  /// Main language caption text
+  /// -> none | content
+  caption: none,
+  /// 英文标题文本（双语模式）
+  /// English caption text (bilingual mode)
+  /// -> none | content
+  caption-en: none,
+  /// 引用原始表/图的标签（提供此参数则进入续表模式）
+  /// Reference to the original table/figure label (enables continuation mode)
+  /// -> none | label
+  refer-to: none,
+  /// 此标题的标签（用于交叉引用）
+  /// Label for this caption (for cross-references)
+  /// -> none | label
+  label: none,
+  /// 内容类型："table" 或 "figure"
+  /// Content type: "table" or "figure"
+  /// -> str
+  kind: "table",
+  /// 续表/图是否显示标题文本（auto=自动根据 caption 是否提供决定）
+  /// Whether to show caption text in continuation (auto = based on whether caption is provided)
+  /// -> auto | bool
+  show-caption: auto,
+  /// 样式配置，auto 则从全局 table-style-config 获取
+  /// Style config, auto = use global table-style-config
+  /// -> auto | dictionary
+  config: auto,
+) = {
+  context {
+    // 解析配置：auto 则读取全局表格配置，否则使用传入值
+    // Resolve config: auto = read global table config, otherwise use provided value
+    let final-config = if config == auto {
+      if kind == "figure" { figure-style-config.get() } else { table-style-config.get() }
+    } else {
+      config
+    }
+
+    // 生成标题核心内容
+    // Generate the core caption content
+    let content = _make_caption_content(
+      caption: caption,
+      caption-en: caption-en,
+      refer-to: refer-to,
+      label: label,
+      config: final-config,
+      kind: kind,
+      show-caption: show-caption,
+    )
+
+    // 解析语言和首行缩进修复标志 / Resolve language and indent-fix flag
+    let (_, should-indent) = resolve-lang-indent(final-config)
+
+    if caption != none or refer-to != none {
+      // 用 block 包装：设置不换页、上下间距
+      // Wrap in block: non-breakable, above/below spacing
+      block(
+        breakable: false,
+        above: final-config.at("caption-above", default: 0pt),
+        below: final-config.at("caption-below", default: 0pt),
+      )[
+        #content
+      ]
+      if should-indent { _fakepar }
+    }
+  }
+}

--- a/packages/preview/cap-able/0.0.1/src/config.typ
+++ b/packages/preview/cap-able/0.0.1/src/config.typ
@@ -1,0 +1,1199 @@
+// ============================================================
+// 配置和辅助函数模块 (Configuration and Helper Functions Module)
+// ============================================================
+//
+// 本模块是 cap-able 包的核心配置层，负责：
+// This module is the core configuration layer of cap-able:
+//
+// 1. 多语言文本支持（25+ 种语言）
+//    Multilingual text support (25+ languages)
+// 2. 全局状态管理（表格/图片样式、间距、子图）
+//    Global state management (table/figure style, spacing, subfigures)
+// 3. 辅助工具函数（间距处理、语言检测、章节计算）
+//    Utility functions (spacing, language detection, chapter calculation)
+// 4. 用户配置入口函数（table-style、figure-style、set-table-width）
+//    User-facing configuration functions
+//
+// ============================================================
+
+#import "@preview/tablem:0.3.0": tablem
+
+// ============================================================
+// 辅助内容块 (Helper Content Block)
+// ============================================================
+
+// 假段落，用于修复中文等语言在表格/图片/表注后首行缩进丢失的问题。
+// Fake paragraph to restore first-line indentation after tables/figures in CJK languages.
+//
+// 原理：Typst 的 first-line-indent 只在"真实段落"开头生效。通过插入一个不可见
+// 的零高度块，欺骗 Typst 将后续内容识别为新段落，从而恢复正确的缩进。
+// Principle: Typst's first-line-indent only activates at paragraph starts.
+// This invisible zero-height block tricks Typst into treating what follows as a new paragraph.
+#let _fakepar = context{box();v(-measure(block()+block()).height)}
+
+// ============================================================
+// 语言分类列表 (Language Classification Lists)
+// ============================================================
+
+// 需要段落首行缩进的语言：中文、日文、韩文、法文、越南文、泰文
+// Languages requiring paragraph first-line indentation: CJK + French, Vietnamese, Thai
+#let indent-languages = ("zh", "ja", "ko", "fr", "vi", "th")
+
+// 检测是否为需要段落首行缩进的语言。
+// Check if the language requires paragraph first-line indentation.
+// 用于决定在表格/图片/表注后是否插入 _fakepar 修复缩进。
+// Used to decide whether to insert _fakepar after tables/figures/notes.
+// lang-code (str): 语言代码，如 "zh"、"en" / Language code
+#let needs-after-indent(
+  lang-code
+) = {
+  lang-code in indent-languages
+}
+
+// 从右到左书写的语言：阿拉伯文、希伯来文、波斯文、乌尔都文
+// Right-to-left languages: Arabic, Hebrew, Persian, Urdu
+// RTL 语言在双语标题中需要调换主语言和英文行的顺序，
+// 并为英文行显式设置 dir: ltr。
+// RTL languages swap main/English line order in bilingual captions,
+// and need explicit dir: ltr on the English line.
+#let rtl-languages = ("ar", "he", "fa", "ur")
+
+// 检测是否为从右到左书写的语言。
+// Check if the language is written right-to-left (RTL).
+// lang-code (str): 语言代码 / Language code
+#let is-rtl-lang(
+  lang-code
+) = {
+  lang-code in rtl-languages
+}
+
+// ============================================================
+// 多语言文本配置 (Multilingual Text Configuration)
+// ============================================================
+//
+// table-lang-config 字典键说明 / Key descriptions for table-lang-config:
+//
+// - table:                    表格前缀词，如 "表"、"Table"、"Tabelle"
+//                             Table prefix word
+// - continued-prefix:         续表前缀，如 "续表"、"Continuation of Table"
+//                             Continued table prefix
+// - continued-suffix:         续表后缀，如 "（续）"、"(continued)"
+//                             Continued table suffix
+// - figure:                   图片前缀词，如 "图"、"Figure"、"Abbildung"
+//                             Figure prefix word
+// - fig-continued-prefix:     续图前缀
+//                             Continued figure prefix
+// - fig-continued-suffix:     续图后缀
+//                             Continued figure suffix
+// - pre-supplement-number-spacing:
+//     前缀词与编号之间的间距。中文/日文为 0em（紧排如"表1"），西文为空格（如"Table 1"）
+//     Space between prefix and number. CJK: 0em (tight: "表1"); Western: space ("Table 1")
+// - post-supplement-number-spacing:
+//     编号与续表后缀之间的间距
+//     Space between number and continuation suffix
+// - number-title-spacing:
+//     编号与主语言标题之间的分隔。中文用全角空格（\u{3000}），西文用 ": " 或 ". "
+//     Separator between number and title. CJK: em-space (\u{3000}); Western: ": " or ". "
+// - number-title-spacing-en:
+//     编号与英文标题之间的分隔（双语标题英文行使用）
+//     Separator between number and English title (for bilingual English line)
+//
+#let table-lang-config = (
+  // 英文 / English
+  en: (
+    table: "Table",
+    continued-prefix: "Continuation of Table",
+    continued-suffix: "(continued)",
+    figure: "Figure",
+    fig-continued-prefix: "Continuation of Figure",
+    fig-continued-suffix: "(continued)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 简体中文 / Simplified Chinese
+  // 特点：前缀与编号紧排（0em），编号与标题用全角空格（U+3000）
+  // Feature: prefix-number tight (0em), number-title uses em-space (U+3000)
+  zh: (
+    table: "表",
+    continued-prefix: "续表",
+    continued-suffix: "（续）",
+    figure: "图",
+    fig-continued-prefix: "续图",
+    fig-continued-suffix: "（续）",
+    pre-supplement-number-spacing: 0em,
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [\u{3000}],
+    number-title-spacing-en: [#h(0.5em)],
+  ),
+  // 繁體中文 / Traditional Chinese
+  // 使用 #set text(lang: "zh", region: "TW") 啟用
+  // Enable with #set text(lang: "zh", region: "TW")
+  zh-TW: (
+    table: "表",
+    continued-prefix: "續表",
+    continued-suffix: "（續）",
+    figure: "圖",
+    fig-continued-prefix: "續圖",
+    fig-continued-suffix: "（續）",
+    pre-supplement-number-spacing: 0em,
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [\u{3000}],
+    number-title-spacing-en: [#h(0.5em)],
+  ),
+  // 德文 / German
+  de: (
+    table: "Tabelle",
+    continued-prefix: "Fortsetzung von Tabelle",
+    continued-suffix: "(Fortsetzung)",
+    figure: "Abbildung",
+    fig-continued-prefix: "Fortsetzung von Abbildung",
+    fig-continued-suffix: "(Fortsetzung)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 法文 / French
+  // 注：法文排版规范要求冒号前有空格，如 "Tableau 1 : Titre"
+  // Note: French typography requires a space before the colon: "Tableau 1 : Titre"
+  fr: (
+    table: "Tableau",
+    continued-prefix: "Suite du Tableau",
+    continued-suffix: "(suite)",
+    figure: "Figure",
+    fig-continued-prefix: "Suite de la Figure",
+    fig-continued-suffix: "(suite)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [ : ],
+    number-title-spacing-en: [: ],
+  ),
+  // 西班牙文 / Spanish
+  es: (
+    table: "Tabla",
+    continued-prefix: "Continuación de la Tabla",
+    continued-suffix: "(continuación)",
+    figure: "Figura",
+    fig-continued-prefix: "Continuación de la Figura",
+    fig-continued-suffix: "(continuación)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 意大利文 / Italian
+  it: (
+    table: "Tabella",
+    continued-prefix: "Continuazione della Tabella",
+    continued-suffix: "(continua)",
+    figure: "Figura",
+    fig-continued-prefix: "Continuazione della Figura",
+    fig-continued-suffix: "(continua)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 葡萄牙文 / Portuguese
+  pt: (
+    table: "Tabela",
+    continued-prefix: "Continuação da Tabela",
+    continued-suffix: "(continuação)",
+    figure: "Figura",
+    fig-continued-prefix: "Continuação da Figura",
+    fig-continued-suffix: "(continuação)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 俄文 / Russian
+  ru: (
+    table: "Таблица",
+    continued-prefix: "Продолжение таблицы",
+    continued-suffix: "(продолжение)",
+    figure: "Рисунок",
+    fig-continued-prefix: "Продолжение рисунка",
+    fig-continued-suffix: "(продолжение)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 日文 / Japanese（与中文相同规则 / Same rules as Chinese）
+  ja: (
+    table: "表",
+    continued-prefix: "表の続き",
+    continued-suffix: "（続き）",
+    figure: "図",
+    fig-continued-prefix: "図の続き",
+    fig-continued-suffix: "（続き）",
+    pre-supplement-number-spacing: 0em,
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [\u{3000}],
+    number-title-spacing-en: [#h(0.5em)],
+  ),
+  // 韩文 / Korean
+  ko: (
+    table: "표",
+    continued-prefix: "표 계속",
+    continued-suffix: "(계속)",
+    figure: "그림",
+    fig-continued-prefix: "그림 계속",
+    fig-continued-suffix: "(계속)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 阿拉伯文（RTL）/ Arabic (RTL)
+  ar: (
+    table: "جدول",
+    continued-prefix: "تابع الجدول",
+    continued-suffix: "(تابع)",
+    figure: "شكل",
+    fig-continued-prefix: "تابع الشكل",
+    fig-continued-suffix: "(تابع)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 荷兰文 / Dutch
+  nl: (
+    table: "Tabel",
+    continued-prefix: "Vervolg van Tabel",
+    continued-suffix: "(vervolg)",
+    figure: "Figuur",
+    fig-continued-prefix: "Vervolg van Figuur",
+    fig-continued-suffix: "(vervolg)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 波兰文 / Polish
+  pl: (
+    table: "Tabela",
+    continued-prefix: "Kontynuacja Tabeli",
+    continued-suffix: "(cd.)",
+    figure: "Rysunek",
+    fig-continued-prefix: "Kontynuacja Rysunku",
+    fig-continued-suffix: "(cd.)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 捷克文 / Czech
+  cs: (
+    table: "Tabulka",
+    continued-prefix: "Pokračování Tabulky",
+    continued-suffix: "(pokračování)",
+    figure: "Obrázek",
+    fig-continued-prefix: "Pokračování Obrázku",
+    fig-continued-suffix: "(pokračování)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 瑞典文 / Swedish
+  sv: (
+    table: "Tabell",
+    continued-prefix: "Fortsättning av Tabell",
+    continued-suffix: "(forts.)",
+    figure: "Figur",
+    fig-continued-prefix: "Fortsättning av Figur",
+    fig-continued-suffix: "(forts.)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 丹麦文 / Danish
+  da: (
+    table: "Tabel",
+    continued-prefix: "Fortsættelse af Tabel",
+    continued-suffix: "(fortsat)",
+    figure: "Figur",
+    fig-continued-prefix: "Fortsættelse af Figur",
+    fig-continued-suffix: "(fortsat)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 挪威文 / Norwegian
+  no: (
+    table: "Tabell",
+    continued-prefix: "Fortsettelse av Tabell",
+    continued-suffix: "(forts.)",
+    figure: "Figur",
+    fig-continued-prefix: "Fortsettelse av Figur",
+    fig-continued-suffix: "(forts.)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 芬兰文 / Finnish
+  fi: (
+    table: "Taulukko",
+    continued-prefix: "Taulukon jatko",
+    continued-suffix: "(jatkoa)",
+    figure: "Kuva",
+    fig-continued-prefix: "Kuvan jatko",
+    fig-continued-suffix: "(jatkoa)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 土耳其文 / Turkish
+  tr: (
+    table: "Tablo",
+    continued-prefix: "Tablonun Devamı",
+    continued-suffix: "(devam)",
+    figure: "Şekil",
+    fig-continued-prefix: "Şeklin Devamı",
+    fig-continued-suffix: "(devam)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 希腊文 / Greek
+  el: (
+    table: "Πίνακας",
+    continued-prefix: "Συνέχεια Πίνακα",
+    continued-suffix: "(συνέχεια)",
+    figure: "Σχήμα",
+    fig-continued-prefix: "Συνέχεια Σχήματος",
+    fig-continued-suffix: "(συνέχεια)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 希伯来文（RTL）/ Hebrew (RTL)
+  he: (
+    table: "טבלה",
+    continued-prefix: "המשך טבלה",
+    continued-suffix: "(המשך)",
+    figure: "תמונה",
+    fig-continued-prefix: "המשך תמונה",
+    fig-continued-suffix: "(המשך)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 印地文 / Hindi
+  hi: (
+    table: "तालिका",
+    continued-prefix: "तालिका जारी",
+    continued-suffix: "(जारी)",
+    figure: "चित्र",
+    fig-continued-prefix: "चित्र जारी",
+    fig-continued-suffix: "(जारी)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 泰文 / Thai（用普通空格，无冒号 / Regular space, no colon）
+  th: (
+    table: "ตาราง",
+    continued-prefix: "ตารางต่อ",
+    continued-suffix: "(ต่อ)",
+    figure: "รูป",
+    fig-continued-prefix: "รูปต่อ",
+    fig-continued-suffix: "(ต่อ)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [ ],
+    number-title-spacing-en: [ ],
+  ),
+  // 越南文 / Vietnamese
+  vi: (
+    table: "Bảng",
+    continued-prefix: "Tiếp theo Bảng",
+    continued-suffix: "(tiếp theo)",
+    figure: "Hình",
+    fig-continued-prefix: "Tiếp theo Hình",
+    fig-continued-suffix: "(tiếp theo)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 波斯文（RTL）/ Persian (RTL)
+  fa: (
+    table: "جدول",
+    continued-prefix: "ادامه جدول",
+    continued-suffix: "(ادامه)",
+    figure: "شکل",
+    fig-continued-prefix: "ادامه شکل",
+    fig-continued-suffix: "(ادامه)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 乌尔都文（RTL）/ Urdu (RTL)
+  ur: (
+    table: "جدول",
+    continued-prefix: "جدول کا تسلسل",
+    continued-suffix: "(جاری)",
+    figure: "شکل",
+    fig-continued-prefix: "شکل کا تسلسل",
+    fig-continued-suffix: "(جاری)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+)
+
+// ============================================================
+// 全局配置状态 (Global Configuration States)
+// ============================================================
+//
+// 所有全局配置通过 Typst 的 state() 机制传递，保证上下文正确性。
+// All global config is passed via Typst's state() for context correctness.
+// 使用方式：state.get() 必须在 context {...} 块内调用。
+// Usage: state.get() must be called inside context {...} blocks.
+//
+// table-style-config 字段说明 / Field descriptions:
+//   caption-above:        标题块上方间距 / Space above caption block
+//   caption-below:        标题与表体之间间距 / Space between caption and table body
+//   table-below:          整个表格下方间距 / Space below the whole table
+//   caption-leading:      标题行距（影响双语标题两行间距）/ Caption line spacing
+//   numbering-format:     编号格式，如 "1"、"1.1"、"A.1" / Numbering format
+//   use-chapter:          是否包含章节号 / Include chapter number
+//   chapter-level:        由 numbering-format 自动计算的章节层级数
+//                         Chapter level count, auto-calculated from numbering-format
+//   supplement:           主语言前缀词（auto=从语言配置自动获取）
+//                         Main language prefix (auto = from lang config)
+//   supplement-en:        英文前缀词 / English prefix
+//   continued-prefix:     续表前缀（主语言）/ Continued table prefix
+//   continued-prefix-en:  续表前缀（英文）/ English continued prefix
+//   continued-suffix:     续表后缀（主语言）/ Continued table suffix
+//   continued-suffix-en:  续表后缀（英文）/ English continued suffix
+//   continued-mode:       续表模式："prefix"（续表X）或"suffix"（表X（续））
+//                         Continuation mode: "prefix" or "suffix"
+//   continued-show-caption: 续表是否显示标题文本 / Show caption text in continuation
+//   caption-size:         标题字号 / Caption font size
+//   caption-weight:       标题字重 / Caption font weight
+//   pre-supplement-number-spacing:  前缀与编号间距 / Prefix-number spacing
+//   post-supplement-number-spacing: 编号与后缀间距 / Number-suffix spacing
+//   number-title-spacing:    编号与主语言标题间距 / Number-title separator
+//   number-title-spacing-en: 编号与英文标题间距 / Number-English-title separator
+//   lang:                 语言覆盖（auto=跟随 text.lang）/ Language override
+//   enable-english-caption: 是否生成英文副标题 / Enable English sub-caption
+//   body-size:            表格内容字号 / Table body font size
+//   body-leading:         表格内容行距 / Table body line spacing
+//   cell-inset:           单元格内边距（字典或标量）/ Cell padding
+//   note-above:           表注上方间距 / Space above note
+//   note-below:           表注下方间距 / Space below note
+//   note-size:            表注字号 / Note font size
+//   note-leading:         表注行距 / Note line spacing
+//   note-justify:         表注是否两端对齐 / Justify note text
+//   outline-bilingual:    目录中是否双语显示 / Bilingual captions in outline
+//   outline-separator:    目录双语分隔符 / Bilingual separator in outline
+//   outline-newline:      目录双语是否换行 / Newline for bilingual in outline
+//   after-indent:         首行缩进修复（auto=按语言自动）/ Indentation fix
+
+// 表格全局样式配置状态，由 table-style() 更新，被 cap-table()、bicap()、table-note() 读取。
+// Global table style state, updated by table-style(), read by cap-table(), bicap(), table-note().
+#let table-style-config = state("table-style-config", (
+  caption-above: 1.5em,
+  caption-below: 0.5em,
+  table-below: 0.5em,
+  caption-leading: 0.5em,
+  numbering-format: "1",
+  use-chapter: true,
+  chapter-level: 0,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: "prefix",
+  continued-show-caption: auto,
+  caption-size: 10.5pt,
+  caption-weight: "regular",
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: true,
+  body-size: 10.5pt,
+  body-leading: 0.45em,
+  cell-inset: (x: 3pt, y: 6.5pt),
+  note-above: 0.7em,
+  note-below: 1em + 1.5pt,
+  note-size: 10.5pt,
+  note-leading: 6.5pt,
+  note-justify: true,
+  outline-bilingual: false,
+  outline-separator: " / ",
+  outline-newline: false,
+  after-indent: auto,
+))
+
+// 图片全局样式配置状态（合并了样式、间距、子图三部分字段）。
+// 由 figure-style() 更新，被 capfig()、capsubfig()、capfnote()、bicap()（图片模式）读取。
+// Global figure config (merged: style + spacing + subfigure fields).
+// Updated by figure-style(), read by capfig(), capsubfig(), capfnote(), bicap() (figure mode).
+#let figure-style-config = state("figure-style", (
+  // ─ 编号与标题 / Numbering & caption ─
+  numbering-format: "1",
+  use-chapter: false,
+  chapter-level: 0,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: "prefix",
+  continued-show-caption: auto,
+  caption-size: 10.5pt,
+  caption-weight: "regular",
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: true,
+  outline-bilingual: false,
+  outline-separator: " / ",
+  outline-newline: false,
+  after-indent: auto,
+  // ─ 图注 / Figure note ─
+  note-above: 0.7em,
+  note-below: 1em + 1.5pt,
+  note-size: 10.5pt,
+  note-leading: 6.5pt,
+  note-justify: true,
+  // ─ 间距 / Spacing ─
+  figure-above: 1em,
+  figure-below: 1em,
+  caption-above: 0.5em,
+  caption-leading: 0.5em,
+  subcaption-above: 0.3em,
+  subcaption-below: 0.5em,
+  // ─ 子图布局与标签 / Subfigure layout & labels ─
+  gutter: 1em,
+  subcaption-pos: "bottom",
+  show-subcaption: false,
+  show-subcaption-label: true,
+  align: "horizon",
+  label-mode: none,
+  label-style: "(a)",
+  label-font: ("Arial",),
+  label-size: 12pt,
+  label-offset: (4pt, 4pt),
+  label-text-color: black,
+  label-stroke: none,
+  label-bg: none,
+  label-bg-shape: "rect",
+  label-bg-radius: 2pt,
+  label-bg-inset: 3pt,
+  label-sep: auto,
+))
+
+// 表格宽度全局配置（百分比，1-100）。
+// Global table width config (percentage, 1-100).
+#let table-width-config = state("table-width", 100)
+
+// 图片宽度全局配置（百分比，1-100），用于 capfnote 默认宽度匹配。
+// Global figure width config (percentage, 1-100), used by capfnote auto-width.
+#let figure-width-config = state("figure-width", 100)
+
+// ============================================================
+// 辅助工具函数 (Utility Functions)
+// ============================================================
+
+/// Set table width percentage (1-100) for all subsequent captab calls.
+/// -> content
+#let set-table-width(
+  // 宽度百分比，有效范围 1-100 / Width percentage, valid range 1-100
+  percentage: 100
+) = {
+  // 参数校验：百分比必须在合法范围内 / Validate percentage is in range
+  assert(percentage > 0 and percentage <= 100, message: "percentage必须在1-100之间")
+  table-width-config.update(percentage)
+}
+
+/// Set figure width percentage (1-100) for capfnote auto-width matching.
+/// -> content
+#let set-figure-width(
+  percentage: 100
+) = {
+  assert(percentage > 0 and percentage <= 100, message: "percentage必须在1-100之间")
+  figure-width-config.update(percentage)
+}
+
+// 解析语言代码：结合 text.lang 和 text.region 生成完整语言代码。
+// 例如 lang="zh", region="TW" → 先查 "zh-TW"，再回退到 "zh"。
+// Resolve language code: combine text.lang and text.region.
+// e.g. lang="zh", region="TW" → try "zh-TW" first, fall back to "zh".
+// 必须在 context 块内调用 / Must be called inside a context block.
+#let resolve-lang-code(lang) = {
+  let base = if lang == auto { text.lang } else { lang }
+  let region = text.region
+  if region != none {
+    let combined = base + "-" + region
+    if combined in table-lang-config { combined } else { base }
+  } else {
+    base
+  }
+}
+
+/// 共享语言与缩进修复解析函数。给定含 lang/after-indent 字段的配置，
+/// 返回 (lang, should-indent)。供 captab/capfig/captnote/capfnote 复用。
+/// Shared language/indent resolution. Given a config dict with lang/after-indent
+/// fields, returns (lang, should-indent). Used by captab/capfig/captnote/capfnote.
+#let resolve-lang-indent(config) = {
+  let lang = resolve-lang-code(config.at("lang", default: auto))
+  let should-indent = if config.at("after-indent", default: auto) == auto {
+    needs-after-indent(lang)
+  } else {
+    config.at("after-indent")
+  }
+  (lang, should-indent)
+}
+
+// 从编号格式字符串计算章节层级数。
+// Calculate the number of chapter levels from a numbering format string.
+// format-str (str): 编号格式字符串，如 "1"、"1.1"、"A.1" / Numbering format string
+#let calculate-chapter-levels(
+  format-str
+) = {
+  let count = 0
+  let i = 0
+  // 逐字符遍历，统计格式占位符数量
+  // Iterate char by char, count format placeholder characters
+  while i < format-str.len() {
+    let char = format-str.at(i)
+    // 支持的格式字符：1（阿拉伯数字）、a（小写字母）、A（大写字母）、
+    // i（小写罗马数字）、I（大写罗马数字）
+    // Supported: 1 (arabic), a (lowercase), A (uppercase), i (roman lc), I (roman uc)
+    if char == "1" or char == "a" or char == "A" or char == "i" or char == "I" {
+      count += 1
+    }
+    i += 1
+  }
+  // 最后一个格式字符代表图/表本身的序号，不计入章节层级
+  // The last format char is the figure/table number itself, not a chapter level
+  if count > 0 { count - 1 } else { 1 }
+}
+
+// 获取文档语言对应的本地化文本，不支持的语言回退到英文。
+// Get localized text for the document language, falling back to English if unsupported.
+// lang-code (str): 语言代码 / Language code; key (str): 配置字典键名 / Config dict key
+#let get-table-text(
+  lang-code,
+  key
+) = {
+  if lang-code in table-lang-config {
+    table-lang-config.at(lang-code).at(key)
+  } else {
+    // 语言不在支持列表中，回退到英文 / Language not supported, fall back to English
+    table-lang-config.en.at(key)
+  }
+}
+
+// 处理间距值：length/relative 类型转为 h() 水平间距，内容类型直接输出。
+// Handle spacing: convert length/relative to h(); pass content through as-is.
+// spacing-value: 间距值（长度或内容块）/ Spacing value (length or content)
+#let handle-spacing(
+  spacing-value
+) = {
+  if type(spacing-value) == length or type(spacing-value) == relative {
+    h(spacing-value)  // 长度转水平间距 / Convert length to horizontal space
+  } else {
+    spacing-value     // 内容直接输出 / Output content as-is
+  }
+}
+
+// ============================================================
+// 表格样式配置函数 (Table Style Configuration Function)
+// ============================================================
+
+/// Configure global table style for all cap-table, bicap and table-note calls within the body.
+/// -> content
+#let captab-style(
+  // 标题块上方垂直间距 / Space above caption block
+  caption-above: 1.5em,
+  // 标题与表体之间垂直间距 / Space between caption and table body
+  caption-below: 0.5em,
+  // 整个表格下方垂直间距 / Space below the whole table
+  table-below: 0.5em,
+  // 标题行距 / Caption line spacing
+  caption-leading: 0.5em,
+  // 编号格式字符串，如 "1" 或 "1.1" / Numbering format string
+  numbering-format: "1",
+  // 是否在编号中包含章节号 / Whether to include chapter number
+  use-chapter: true,
+  // 主语言表格前缀词（auto=自动）/ Main language table prefix (auto=automatic)
+  supplement: auto,
+  // 英文表格前缀词 / English table prefix
+  supplement-en: auto,
+  // 续表前缀（主语言，auto=自动）/ Continued table prefix (main language, auto=automatic)
+  continued-prefix: auto,
+  // 续表前缀（英文，auto=自动）/ Continued table prefix (English, auto=automatic)
+  continued-prefix-en: auto,
+  // 续表后缀（主语言，auto=自动）/ Continued table suffix (main language, auto=automatic)
+  continued-suffix: auto,
+  // 续表后缀（英文，auto=自动）/ Continued table suffix (English, auto=automatic)
+  continued-suffix-en: auto,
+  // 续表模式："prefix" 或 "suffix" / Continuation mode: "prefix" or "suffix"
+  continued-mode: "prefix",
+  // 续表是否显示原标题文本（auto=有标题则显示）/ Show caption in continuation
+  continued-show-caption: auto,
+  // 标题字号 / Caption font size
+  caption-size: 10.5pt,
+  // 标题字重 / Caption font weight
+  caption-weight: "regular",
+  // 前缀词与编号间距（auto=按语言自动）/ Prefix-number spacing
+  pre-supplement-number-spacing: auto,
+  // 编号与续表后缀间距（auto=按语言自动）/ Number-suffix spacing
+  post-supplement-number-spacing: auto,
+  // 编号与主语言标题间距（auto=按语言自动）/ Number-to-title separator
+  number-title-spacing: auto,
+  // 编号与英文标题间距（auto=按语言自动）/ Number-to-English-title separator
+  number-title-spacing-en: auto,
+  // 语言代码覆盖（auto=跟随 text.lang）/ Language code override
+  lang: auto,
+  // 是否生成英文副标题 / Generate English sub-caption
+  enable-english-caption: true,
+  // 表格内容字号 / Table body font size
+  body-size: 10.5pt,
+  // 表格内容行距 / Table body line spacing
+  body-leading: 0.45em,
+  // 单元格内边距 / Cell padding
+  cell-inset: (x: 5pt, y: 5pt),
+  // 表注上方间距 / Space above table note
+  note-above: 0.5em,
+  // 表注下方间距 / Space below table note
+  note-below: 1em,
+  // 表注字号 / Table note font size
+  note-size: 10.5pt,
+  // 表注行距 / Table note line spacing
+  note-leading: 6.5pt,
+  // 表注是否两端对齐 / Justify table note text
+  note-justify: true,
+  // 目录中是否双语显示标题 / Show bilingual captions in outline
+  outline-bilingual: false,
+  // 目录双语分隔符 / Bilingual separator in outline
+  outline-separator: " / ",
+  // 目录双语是否换行显示 / Newline for bilingual captions in outline
+  outline-newline: false,
+  // 是否修复表格后首行缩进（auto=按语言自动）/ Fix indentation after table
+  after-indent: auto,
+  // 文档内容 / Document body content
+  it
+) = {
+  // 从 numbering-format 自动计算章节层级数
+  // Auto-calculate chapter level count from numbering-format
+  let final-chapter-level = calculate-chapter-levels(numbering-format)
+
+  // 更新全局表格配置状态 / Update global table configuration state
+  table-style-config.update((
+    caption-above: caption-above,
+    caption-below: caption-below,
+    table-below: table-below,
+    caption-leading: caption-leading,
+    numbering-format: numbering-format,
+    use-chapter: use-chapter,
+    chapter-level: final-chapter-level,
+    supplement: supplement,
+    supplement-en: supplement-en,
+    continued-prefix: continued-prefix,
+    continued-prefix-en: continued-prefix-en,
+    continued-suffix: continued-suffix,
+    continued-suffix-en: continued-suffix-en,
+    continued-mode: continued-mode,
+    continued-show-caption: continued-show-caption,
+    caption-size: caption-size,
+    caption-weight: caption-weight,
+    pre-supplement-number-spacing: pre-supplement-number-spacing,
+    post-supplement-number-spacing: post-supplement-number-spacing,
+    number-title-spacing: number-title-spacing,
+    number-title-spacing-en: number-title-spacing-en,
+    lang: lang,
+    enable-english-caption: enable-english-caption,
+    body-size: body-size,
+    body-leading: body-leading,
+    cell-inset: cell-inset,
+    note-above: note-above,
+    note-below: note-below,
+    note-size: note-size,
+    note-leading: note-leading,
+    note-justify: note-justify,
+    outline-bilingual: outline-bilingual,
+    outline-separator: outline-separator,
+    outline-newline: outline-newline,
+    after-indent: after-indent,
+  ))
+
+  // 仅对 kind: table 的 figure 设置标题位置与间距
+  // Scoped to kind: table — caption on top, gap between caption and body
+  show figure.where(kind: table): set figure.caption(position: top)
+  show figure.where(kind: table): set figure(gap: caption-below)
+
+  // 章节前缀编号（全局生效；capfig-style 会以相同策略再次设置）
+  // Chapter-prefixed numbering (applies globally; capfig-style sets the same strategy)
+  set figure(
+    numbering: num => {
+      if use-chapter {
+        let levels = final-chapter-level
+        let h = counter(heading).get()
+        let chapter-nums = h.slice(0, calc.min(levels, h.len()))
+        numbering(numbering-format, ..chapter-nums, num)
+      } else {
+        numbering("1", num)
+      }
+    }
+  )
+
+  // 覆盖 figure.caption 渲染（仅针对 kind: table 类型）
+  // Override figure.caption rendering (only for kind: table)
+  // 注意：cap-table() 使用 _make_caption_content() 直接生成标题，不经过此规则
+  // Note: cap-table() bypasses this rule via _make_caption_content()
+  show figure.caption.where(kind: table): cap => {
+    set par(leading: caption-leading)
+    text(size: caption-size, weight: caption-weight)[
+      #cap.supplement
+      #context {
+        let current-lang = resolve-lang-code(lang)
+        let pre-space = if pre-supplement-number-spacing == auto {
+          get-table-text(current-lang, "pre-supplement-number-spacing")
+        } else {
+          pre-supplement-number-spacing
+        }
+        handle-spacing(pre-space)
+        if use-chapter {
+          let levels = final-chapter-level
+          let h-counter = counter(heading).get()
+          let chapter-nums = h-counter.slice(0, calc.min(levels, h-counter.len()))
+          let num = cap.counter.at(cap.location()).first()
+          numbering(numbering-format, ..chapter-nums, num)
+        } else {
+          cap.counter.display()
+        }
+        let title-space = if number-title-spacing == auto {
+          get-table-text(current-lang, "number-title-spacing")
+        } else {
+          number-title-spacing
+        }
+        handle-spacing(title-space)
+      }
+      #cap.body
+    ]
+  }
+
+  it
+}
+
+
+// ============================================================
+// 图片样式配置函数 (Figure Style Configuration Function)
+// ============================================================
+
+/// Configure global figure and subfigure style within the body.
+/// -> content
+#let capfig-style(
+  // 编号格式字符串 / Numbering format string
+  numbering-format: "1",
+  // 是否使用章节号 / Whether to use chapter numbering
+  use-chapter: false,
+  // 主语言图片前缀词（auto=自动）/ Main language figure prefix
+  supplement: auto,
+  // 英文图片前缀词 / English figure prefix
+  supplement-en: auto,
+  // 续图前缀（主语言，auto=自动）/ Continued figure prefix (main language)
+  continued-prefix: auto,
+  // 续图前缀（英文，auto=自动）/ Continued figure prefix (English)
+  continued-prefix-en: auto,
+  // 续图后缀（主语言，auto=自动）/ Continued figure suffix (main language)
+  continued-suffix: auto,
+  // 续图后缀（英文，auto=自动）/ Continued figure suffix (English)
+  continued-suffix-en: auto,
+  // 续图模式："prefix" 或 "suffix" / Continuation mode
+  continued-mode: "prefix",
+  // 续图是否显示原标题文本 / Show caption in continued figure
+  continued-show-caption: auto,
+  // 标题字号 / Caption font size
+  caption-size: 10.5pt,
+  // 标题字重 / Caption font weight
+  caption-weight: "regular",
+  // 前缀与编号间距（auto=按语言）/ Prefix-number spacing
+  pre-supplement-number-spacing: auto,
+  // 编号与后缀间距（auto=按语言）/ Number-suffix spacing
+  post-supplement-number-spacing: auto,
+  // 编号与主语言标题间距（auto=按语言）/ Number-to-title separator
+  number-title-spacing: auto,
+  // 编号与英文标题间距（auto=按语言）/ Number-to-English-title separator
+  number-title-spacing-en: auto,
+  // 语言代码覆盖（auto=跟随 text.lang）/ Language code override
+  lang: auto,
+  // 是否启用英文副标题 / Enable English sub-caption
+  enable-english-caption: true,
+  // 目录中是否双语显示 / Show bilingual captions in outline
+  outline-bilingual: false,
+  // 目录双语分隔符 / Bilingual separator in outline
+  outline-separator: " / ",
+  // 目录双语是否换行 / Newline for bilingual captions in outline
+  outline-newline: false,
+  // 首行缩进修复（auto=按语言）/ Indentation fix
+  after-indent: auto,
+  // 图片上方间距 / Space above figure
+  figure-above: 1em,
+  // 图片下方间距 / Space below figure
+  figure-below: 1em,
+  // 标题上方间距（标题与图片之间）/ Space above caption
+  caption-above: 0.5em,
+  // 标题行距 / Caption line spacing
+  caption-leading: 0.5em,
+  // 子标题上方间距 / Space above subcaption
+  subcaption-above: 0.3em,
+  // 子标题下方间距 / Space below subcaption
+  subcaption-below: 0.5em,
+  // 子图水平间距 / Horizontal gap between subfigures
+  gutter: 1em,
+  // 子标题位置："top" 或 "bottom" / Subcaption position
+  subcaption-pos: "bottom",
+  // 是否显示子标题文字 / Show subcaption text
+  show-subcaption: false,
+  // 子标题是否含标签 / Whether subcaption includes the label
+  show-subcaption-label: true,
+  // 多子图垂直对齐 / Vertical alignment of subfigures
+  align: "horizon",
+  // 标签模式：none 或 "overlay" / Label mode: none or "overlay"
+  label-mode: none,
+  // 标签样式字符串 / Label style string
+  label-style: "(a)",
+  // 标签字体列表 / Label font list
+  label-font: ("Arial",),
+  // 标签字号 / Label font size
+  label-size: 12pt,
+  // 标签偏移量 (dx, dy) / Label offset from top-left
+  label-offset: (4pt, 4pt),
+  // 标签文字颜色 / Label text color
+  label-text-color: black,
+  // 标签描边（none=无描边）/ Label stroke
+  label-stroke: none,
+  // 标签背景色（none=无背景）/ Label background color
+  label-bg: none,
+  // 背景形状："rect" 或 "circle" / Background shape
+  label-bg-shape: "rect",
+  // 矩形背景圆角 / Border radius for rect background
+  label-bg-radius: 2pt,
+  // 背景内边距 / Background padding
+  label-bg-inset: 3pt,
+  // 子图引用分隔符（auto=自动）/ Subfigure reference separator
+  label-sep: auto,
+  // 图注上方间距 / Space above figure note
+  note-above: 0.7em,
+  // 图注下方间距 / Space below figure note
+  note-below: 1em + 1.5pt,
+  // 图注字号 / Figure note font size
+  note-size: 10.5pt,
+  // 图注行距 / Figure note line spacing
+  note-leading: 6.5pt,
+  // 图注是否两端对齐 / Justify figure note text
+  note-justify: true,
+  // 文档内容 / Document body content
+  it,
+) = {
+  // 从编号格式自动计算章节层级 / Auto-calculate chapter level from numbering format
+  let final-chapter-level = calculate-chapter-levels(numbering-format)
+
+  // 合并后的单一状态更新（样式 + 间距 + 子图）
+  // Single merged state update (style + spacing + subfigure)
+  figure-style-config.update((
+    numbering-format: numbering-format,
+    use-chapter: use-chapter,
+    chapter-level: final-chapter-level,
+    supplement: supplement,
+    supplement-en: supplement-en,
+    continued-prefix: continued-prefix,
+    continued-prefix-en: continued-prefix-en,
+    continued-suffix: continued-suffix,
+    continued-suffix-en: continued-suffix-en,
+    continued-mode: continued-mode,
+    continued-show-caption: continued-show-caption,
+    caption-size: caption-size,
+    caption-weight: caption-weight,
+    pre-supplement-number-spacing: pre-supplement-number-spacing,
+    post-supplement-number-spacing: post-supplement-number-spacing,
+    number-title-spacing: number-title-spacing,
+    number-title-spacing-en: number-title-spacing-en,
+    lang: lang,
+    enable-english-caption: enable-english-caption,
+    outline-bilingual: outline-bilingual,
+    outline-separator: outline-separator,
+    outline-newline: outline-newline,
+    after-indent: after-indent,
+    note-above: note-above,
+    note-below: note-below,
+    note-size: note-size,
+    note-leading: note-leading,
+    note-justify: note-justify,
+    figure-above: figure-above,
+    figure-below: figure-below,
+    caption-above: caption-above,
+    caption-leading: caption-leading,
+    subcaption-above: subcaption-above,
+    subcaption-below: subcaption-below,
+    gutter: gutter,
+    subcaption-pos: subcaption-pos,
+    show-subcaption: show-subcaption,
+    show-subcaption-label: show-subcaption-label,
+    align: align,
+    label-mode: label-mode,
+    label-style: label-style,
+    label-font: label-font,
+    label-size: label-size,
+    label-offset: label-offset,
+    label-text-color: label-text-color,
+    label-stroke: label-stroke,
+    label-bg: label-bg,
+    label-bg-shape: label-bg-shape,
+    label-bg-radius: label-bg-radius,
+    label-bg-inset: label-bg-inset,
+    label-sep: label-sep,
+  ))
+
+  // 章节前缀编号（全局生效；captab-style 会以相同策略再次设置）
+  // Chapter-prefixed numbering (applies globally; captab-style sets the same strategy)
+  set figure(
+    numbering: num => {
+      if use-chapter {
+        let levels = final-chapter-level
+        let h = counter(heading).get()
+        let chapter-nums = h.slice(0, calc.min(levels, h.len()))
+        numbering(numbering-format, ..chapter-nums, num)
+      } else {
+        numbering("1", num)
+      }
+    }
+  )
+
+  it
+}
+
+// ============================================================
+// 统一样式配置函数 (Unified Style Configuration Function)
+// ============================================================
+
+/// 同时为表格和图片设置全局样式。共享参数会同时作用于两者；
+/// 之后再调用 captab-style 或 capfig-style 可对某一类进行覆盖。
+/// Configure both table and figure global styles at once. Shared params are applied to
+/// both; a subsequent captab-style / capfig-style call can override for one type only.
+/// -> content
+#let cap-style(
+  numbering-format: "1",
+  use-chapter: false,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: "prefix",
+  continued-show-caption: auto,
+  caption-size: 10.5pt,
+  caption-weight: "regular",
+  caption-leading: 0.5em,
+  caption-above: 1.5em,
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: true,
+  outline-bilingual: false,
+  outline-separator: " / ",
+  outline-newline: false,
+  after-indent: auto,
+  note-above: 0.7em,
+  note-below: 1em,
+  note-size: 10.5pt,
+  note-leading: 6.5pt,
+  note-justify: true,
+  it,
+) = {
+  show: captab-style.with(
+    numbering-format: numbering-format,
+    use-chapter: use-chapter,
+    supplement: supplement,
+    supplement-en: supplement-en,
+    continued-prefix: continued-prefix,
+    continued-prefix-en: continued-prefix-en,
+    continued-suffix: continued-suffix,
+    continued-suffix-en: continued-suffix-en,
+    continued-mode: continued-mode,
+    continued-show-caption: continued-show-caption,
+    caption-size: caption-size,
+    caption-weight: caption-weight,
+    caption-leading: caption-leading,
+    caption-above: caption-above,
+    pre-supplement-number-spacing: pre-supplement-number-spacing,
+    post-supplement-number-spacing: post-supplement-number-spacing,
+    number-title-spacing: number-title-spacing,
+    number-title-spacing-en: number-title-spacing-en,
+    lang: lang,
+    enable-english-caption: enable-english-caption,
+    outline-bilingual: outline-bilingual,
+    outline-separator: outline-separator,
+    outline-newline: outline-newline,
+    after-indent: after-indent,
+    note-above: note-above,
+    note-below: note-below,
+    note-size: note-size,
+    note-leading: note-leading,
+    note-justify: note-justify,
+  )
+  show: capfig-style.with(
+    numbering-format: numbering-format,
+    use-chapter: use-chapter,
+    supplement: supplement,
+    supplement-en: supplement-en,
+    continued-prefix: continued-prefix,
+    continued-prefix-en: continued-prefix-en,
+    continued-suffix: continued-suffix,
+    continued-suffix-en: continued-suffix-en,
+    continued-mode: continued-mode,
+    continued-show-caption: continued-show-caption,
+    caption-size: caption-size,
+    caption-weight: caption-weight,
+    caption-leading: caption-leading,
+    caption-above: caption-above,
+    pre-supplement-number-spacing: pre-supplement-number-spacing,
+    post-supplement-number-spacing: post-supplement-number-spacing,
+    number-title-spacing: number-title-spacing,
+    number-title-spacing-en: number-title-spacing-en,
+    lang: lang,
+    enable-english-caption: enable-english-caption,
+    outline-bilingual: outline-bilingual,
+    outline-separator: outline-separator,
+    outline-newline: outline-newline,
+    after-indent: after-indent,
+    note-above: note-above,
+    note-below: note-below,
+    note-size: note-size,
+    note-leading: note-leading,
+    note-justify: note-justify,
+  )
+  it
+}

--- a/packages/preview/cap-able/0.0.1/src/figure.typ
+++ b/packages/preview/cap-able/0.0.1/src/figure.typ
@@ -1,0 +1,767 @@
+// ============================================================
+// 图片和子图模块 (Figure and Subfigure Module)
+// ============================================================
+//
+// 本模块提供完整的图片处理功能，包括单图片和多子图布局。
+// This module provides complete figure functionality, including
+// single figures and multi-subfigure layouts.
+//
+// 模块结构 / Module Structure:
+//
+// ┌─────────────────────────────────────────────────────────┐
+// │ cap-figure()                                            │
+// │   单图片：content + 双语标题 + 间距控制                │
+// │   Single figure: content + bilingual caption + spacing  │
+// └─────────────────────────────────────────────────────────┘
+//
+// ┌─────────────────────────────────────────────────────────┐
+// │ capsubfig()                                              │
+// │   子图网格：多个图片排列 + 子标题/覆盖标签 + 主标题    │
+// │   Subfigure grid: multiple images + sub/overlay labels  │
+// │                                                         │
+// │   内部辅助：                                           │
+// │   Internal helpers:                                     │
+// │   - _parse-label-style()   解析标签样式字符串          │
+// │   - _make-label-text()     生成标签文字（含编号）      │
+// │   - _add-overlay-label()   在图片上叠加标签            │
+// └─────────────────────────────────────────────────────────┘
+//
+// 子图标签样式 / Subfigure label styles:
+// 支持多种格式，可通过 label-style 参数配置：
+// Multiple formats via the label-style parameter:
+//
+//  "(a)" → (a), (b), (c), ...     括号小写字母 / Parenthesized lowercase
+//  "(A)" → (A), (B), (C), ...     括号大写字母 / Parenthesized uppercase
+//  "(1)" → (1), (2), (3), ...     括号数字 / Parenthesized numbers
+//  "(i)" → (i), (ii), (iii), ...  括号小写罗马数字 / Parenthesized roman lowercase
+//  "(I)" → (I), (II), (III), ...  括号大写罗马数字 / Parenthesized roman uppercase
+//  "图a" → 图a, 图b, 图c, ...    中文前缀 / Chinese prefix
+//  "a)"  → a), b), c), ...        仅后缀括号 / Trailing parenthesis only
+//  "Fig. A" → Fig. A, Fig. B, ... 英文前缀 / English prefix
+//
+// 依赖 / Dependencies:
+// - src/config.typ: 全局配置、辅助函数
+// - src/bicap.typ:  标题生成引擎
+//
+// ============================================================
+
+#import "config.typ": *
+#import "bicap.typ": _make_caption_content
+
+// ============================================================
+// 单图片函数 (Single Figure Function)
+// ============================================================
+
+/// 创建带双语标题的单个图片，标题始终在图片下方。
+/// Create a single figure with bilingual caption; caption always below image.
+///
+/// - content (content): 图片内容（通常为 `image()` 调用）/ Figure content (usually `image()`)
+/// - caption (none | content): 主语言标题 / Main language caption
+/// - caption-en (none | content): 英文标题 / English caption
+/// - label (none | label): 图片标签，用于交叉引用 / Figure label for cross-references
+/// - refer-to (none | label): 续图引用的原图标签 / Original label for continued figure
+/// - show-caption (auto | bool): 续图是否显示标题文本 / Show caption in continued figure
+/// - figure-above (auto | length): 图片上方间距 / Space above figure
+/// - figure-below (auto | length): 图片下方间距 / Space below figure
+/// - caption-above (auto | length): 标题与图片间距 / Space between image and caption
+/// - caption-leading (auto | length): 标题行距 / Caption line spacing
+#let capfig(
+  content,
+  caption: none,
+  caption-en: none,
+  label: none,
+  refer-to: none,
+  show-caption: auto,
+  figure-above: auto,
+  figure-below: auto,
+  caption-above: auto,
+  caption-leading: auto,
+) = {
+  context {
+    // 读取合并后的图片配置 / Read merged figure config
+    let fig-config = figure-style-config.get()
+    let table-config = table-style-config.get()
+
+    // 解析间距参数（参数优先于全局配置）
+    // Resolve spacing params (params take priority over global config)
+    let final-figure-above = if figure-above != auto { figure-above } else { fig-config.figure-above }
+    let final-figure-below = if figure-below != auto { figure-below } else { fig-config.figure-below }
+    let final-caption-above = if caption-above != auto { caption-above } else { fig-config.caption-above }
+    let final-caption-leading = if caption-leading != auto { caption-leading } else { fig-config.caption-leading }
+
+    // 构建传递给 bicap 的配置字典（基于 figure-style-config）
+    // Build config dict for bicap (based on figure-style-config)
+    let merged-config = fig-config
+
+    // 注入本次调用的 caption-leading（可能被参数覆盖）
+    // Inject caption-leading for this call (may be overridden by param)
+    merged-config.insert("caption-leading", final-caption-leading)
+
+    // 如果图片配置中语言是 auto，但表格配置中有具体语言设置，则继承之
+    // If figure config lang is auto but table config has a specific lang, inherit it
+    if fig-config.lang == auto and table-config.at("lang", default: auto) != auto {
+      merged-config.insert("lang", table-config.lang)
+    }
+
+    // 图片上方间距（通过 v() 实现）
+    // Space above figure (via v())
+    v(final-figure-above)
+
+    // 将图片内容和标题放在居中的不换页 block 中
+    // Place image content and caption in a centered non-breakable block
+    align(center)[
+      #block(
+        breakable: false,   // 禁止图片和标题跨页分离 / Prevent page break between image and caption
+        above: 0pt,         // 间距由外部 v() 控制，这里设为 0
+                            // Spacing controlled by external v(), set to 0 here
+        below: 0pt,
+      )[
+        // 图片内容
+        // Image content
+        #content
+        // 标题上方间距
+        // Space above caption
+        #v(final-caption-above)
+        // 直接调用内部标题生成函数（外层已有 block，不需要 bicap 的 block 包装）
+        // Call the internal caption generator directly (outer block exists, so we don't need bicap's wrapper)
+        #_make_caption_content(
+          caption: caption,
+          caption-en: caption-en,
+          refer-to: refer-to,
+          label: label,
+          config: merged-config,
+          kind: "figure",
+          show-caption: show-caption,
+        )
+      ]
+    ]
+
+    // 图片下方间距
+    // Space below figure
+    v(final-figure-below)
+  }
+}
+
+// ============================================================
+// 子图辅助函数 (Subfigure Helper Functions)
+// ============================================================
+//
+// 以下三个内部函数处理子图标签的解析、生成和渲染：
+// The following three internal functions handle subfigure label
+// parsing, generation, and rendering:
+//
+// 标签样式字符串的结构 / Label style string structure:
+//   前缀 + 格式字符 + 后缀
+//   prefix + format_char + suffix
+//
+// 例如 / Examples:
+//   "(a)" → prefix="(", format="a", suffix=")"
+//   "图a" → prefix="图", format="a", suffix=""
+//   "Fig. A" → prefix="Fig. ", format="A", suffix=""
+//   "a)"  → prefix="", format="a", suffix=")"
+//
+// 格式字符对应的编号序列 / Format char to numbering sequence:
+//   "a" → a, b, c, ..., z
+//   "A" → A, B, C, ..., Z
+//   "1" → 1, 2, 3, ...
+//   "i" → i, ii, iii, iv, v, ...
+//   "I" → I, II, III, IV, V, ...
+//
+// ============================================================
+
+/// 解析标签样式字符串，提取格式字符和前后缀
+/// Parse label style string, extracting format character and prefix/suffix
+///
+/// 从标签样式字符串中定位第一个格式字符（a/A/1/i/I），
+/// 将其前面的部分作为前缀，后面的部分作为后缀。
+///
+/// Locates the first format character (a/A/1/i/I) in the style string,
+/// using everything before it as prefix and everything after as suffix.
+///
+/// *解析示例 / Parsing Examples:*
+/// - "(a)" → `(format: "a", prefix: "(", suffix: ")")`
+/// - "图a" → `(format: "a", prefix: "图", suffix: "")`
+/// - "Fig. A" → `(format: "A", prefix: "Fig. ", suffix: "")`  ← 注意前缀里的 "i" 不会被误当作占位符
+/// - "(1)" → `(format: "1", prefix: "(", suffix: ")")`
+/// - "abc"（无格式字符）→ `(format: "a", prefix: "abc", suffix: "")`
+///
+/// - style (str): 标签样式字符串 / Label style string
+/// -> dictionary: 包含 format, prefix, suffix 三个键的字典
+///                Dictionary with keys: format, prefix, suffix
+#let _parse-label-style(style) = {
+  // 支持的格式字符列表
+  // Supported format characters
+  let format-chars = ("a", "A", "1", "i", "I")
+  let format-char = none
+  let format-pos = none
+
+  // 从后向前扫描，找到最后一个格式字符及其位置。
+  // Scan from the end to find the LAST format character.
+  // 原因：前缀可能包含和格式字符重合的字母（例如 "Fig. A" 中的 "i"），
+  // 从前向后扫描会误把 "i" 当作占位符。实际样式占位符总是出现在末尾
+  // （"(a)"、"图a"、"Fig. A"、"(1)"），因此从后向前更稳健。
+  // Reason: prefixes may contain letters that collide with format chars
+  // (e.g. the "i" in "Fig. A"). Scanning forward would wrongly pick that "i"
+  // as the placeholder. In practice the placeholder always sits at the end
+  // ("(a)", "图a", "Fig. A", "(1)"), so scanning backward is more robust.
+  // 注意：用 clusters() 而非 codepoints() 以正确处理多字节字符（如中文）
+  // Note: use clusters() not codepoints() to handle multi-byte chars (e.g. Chinese)
+  let all-clusters = style.clusters()
+  let i = all-clusters.len()
+  while i > 0 {
+    i = i - 1
+    if all-clusters.at(i) in format-chars {
+      format-char = all-clusters.at(i)
+      format-pos = i
+      break
+    }
+  }
+
+  // 如果没有找到任何格式字符，将整个字符串作为前缀，默认格式为 "a"
+  // If no format character found, use entire string as prefix, default format "a"
+  if format-char == none {
+    return (format: "a", prefix: style, suffix: "")
+  }
+
+  // 提取前缀（格式字符前的所有字符）和后缀（格式字符后的所有字符）
+  // Extract prefix (everything before format char) and suffix (everything after)
+  let prefix = all-clusters.slice(0, format-pos).join()
+  let suffix = all-clusters.slice(format-pos + 1).join()
+
+  (format: format-char, prefix: prefix, suffix: suffix)
+}
+
+/// 根据索引和样式生成子图标签文本
+/// Generate subfigure label text based on index and style
+///
+/// 使用 _parse-label-style 解析样式，然后根据格式字符和索引生成编号，
+/// 最后组合前缀+编号+后缀（可选择是否保留修饰）。
+///
+/// Uses _parse-label-style to parse the style, generates the number
+/// based on format char and index, then combines prefix+number+suffix
+/// (optionally stripping decorations).
+///
+/// *生成示例 / Generation Examples（style="(a)"）:*
+/// - idx=0 → "(a)"
+/// - idx=1 → "(b)"
+/// - idx=25 → "(z)"
+///
+/// *生成示例（style="(1)"）:*
+/// - idx=0 → "(1)"
+/// - idx=2 → "(3)"
+///
+/// *移除修饰 remove-decorations=true（style="(a)"）:*
+/// - idx=0 → "a"（用于子图交叉引用的标签部分）
+///           (used as the subfigure part of cross-reference)
+///
+/// - idx (int): 子图索引（从0开始）/ Subfigure index (0-based)
+/// - style (str): 标签样式字符串 / Label style string
+/// - remove-decorations (bool): 是否移除前缀和后缀（用于生成引用标签）
+///                               Remove prefix/suffix (for cross-reference generation)
+/// -> str: 生成的标签文本 / Generated label text
+#let _make-label-text(idx, style, remove-decorations: false) = {
+  let parsed = _parse-label-style(style)
+  let format-char = parsed.format
+
+  // 根据格式字符和索引生成编号文本
+  // Generate number text based on format character and index
+  let number-text = if format-char == "A" {
+    // 大写字母：从 'A'(65) 开始，idx=0→"A", idx=1→"B"...
+    // Uppercase: start from 'A'(65), idx=0→"A", idx=1→"B"...
+    str.from-unicode(65 + idx)
+  } else if format-char == "a" {
+    // 小写字母：从 'a'(97) 开始
+    // Lowercase: start from 'a'(97)
+    str.from-unicode(97 + idx)
+  } else if format-char == "1" {
+    // 阿拉伯数字：从 1 开始
+    // Arabic numerals: start from 1
+    str(idx + 1)
+  } else if format-char == "I" {
+    // 大写罗马数字：使用预定义映射表（支持1-20）
+    // Uppercase Roman numerals: use predefined map (supports 1-20)
+    let roman-map = ("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X",
+                     "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX")
+    if idx < roman-map.len() { roman-map.at(idx) } else { str(idx + 1) }
+  } else if format-char == "i" {
+    // 小写罗马数字
+    // Lowercase Roman numerals
+    let roman-map = ("i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x",
+                     "xi", "xii", "xiii", "xiv", "xv", "xvi", "xvii", "xviii", "xix", "xx")
+    if idx < roman-map.len() { roman-map.at(idx) } else { str(idx + 1) }
+  } else {
+    // 未知格式字符的保底处理：使用小写字母
+    // Fallback for unknown format char: use lowercase letter
+    str.from-unicode(97 + idx)
+  }
+
+  // 根据 remove-decorations 决定是否添加前缀和后缀
+  // Decide whether to add prefix/suffix based on remove-decorations
+  if remove-decorations {
+    // 只返回编号部分（用于生成交叉引用中的标签字符）
+    // Return only the number part (for cross-reference label character)
+    number-text
+  } else {
+    // 返回完整标签：前缀 + 编号 + 后缀
+    // Return full label: prefix + number + suffix
+    parsed.prefix + number-text + parsed.suffix
+  }
+}
+
+/// 在图片内容上叠加标签
+/// Add an overlay label on top of figure content
+///
+/// 将标签放置在子图的左上角（通过 place(top + left, ...) 实现）。
+/// 标签可以有多种背景样式：无背景、矩形背景、圆形背景。
+/// 每个子图可以通过 label-style-override 字典覆盖部分样式。
+///
+/// Places the label at the top-left of the subfigure via place(top + left, ...).
+/// Labels can have: no background, rectangular background, or circular background.
+/// Each subfigure can override partial styles via label-style-override dict.
+///
+/// 可覆盖的样式键 / Overridable style keys:
+/// - text-color: 文字颜色 / Text color
+/// - stroke: 描边 / Stroke
+/// - bg: 背景色 / Background color
+/// - bg-shape: 背景形状 / Background shape
+/// - bg-radius: 背景圆角 / Background radius
+/// - bg-inset: 背景内边距 / Background padding
+///
+/// - content (content): 子图内容 / Subfigure content
+/// - idx (int): 子图索引 / Subfigure index
+/// - label-style (str): 标签样式字符串 / Label style string
+/// - label-font (array): 字体列表 / Font list
+/// - label-size (length): 字号 / Font size
+/// - label-offset (tuple): (dx, dy) 偏移量，从左上角算起 / Offset from top-left
+/// - label-text-color (color): 文字颜色 / Text color
+/// - label-stroke (none | stroke): 描边 / Stroke
+/// - label-bg (none | color): 背景色 / Background color
+/// - label-bg-shape (str): 背景形状 "rect" 或 "circle" / "rect" or "circle"
+/// - label-bg-radius (length): 矩形圆角 / Rect border radius
+/// - label-bg-inset (length): 背景内边距 / Background padding
+/// - override-style (none | dictionary): 针对此子图的样式覆盖 / Per-subfigure overrides
+/// -> content: 含叠加标签的图片内容 / Figure content with overlay label
+#let _add-overlay-label(
+  content,
+  idx,
+  label-style,
+  label-font,
+  label-size,
+  label-offset,
+  label-text-color,
+  label-stroke,
+  label-bg,
+  label-bg-shape,
+  label-bg-radius,
+  label-bg-inset,
+  override-style: none,
+) = {
+  // 解析各样式参数：覆盖样式优先于全局样式
+  // Resolve each style param: override takes priority over global
+  let pick(key, fallback) = if override-style != none and key in override-style {
+    override-style.at(key)
+  } else {
+    fallback
+  }
+  let overlay-text-color = pick("text-color", label-text-color)
+  let overlay-stroke     = pick("stroke", label-stroke)
+  let overlay-bg         = pick("bg", label-bg)
+  let overlay-bg-shape   = pick("bg-shape", label-bg-shape)
+  let overlay-bg-radius  = pick("bg-radius", label-bg-radius)
+  let overlay-bg-inset   = pick("bg-inset", label-bg-inset)
+
+  // 用 box 包装图片内容，使 place() 相对于图片而非页面定位
+  // Wrap figure content in box so place() positions relative to the figure, not the page
+  box({
+    // 图片内容
+    content
+    // 叠加标签（place 不占据文档流空间）
+    // Overlay label (place doesn't take up document flow space)
+    place(
+      top + left,               // 定位到左上角 / Anchor to top-left
+      dx: label-offset.at(0),   // 水平偏移 / Horizontal offset
+      dy: label-offset.at(1),   // 垂直偏移 / Vertical offset
+      {
+        // 生成标签文字内容（含前缀+编号+后缀）
+        // Generate label text (with prefix+number+suffix)
+        let label-content = text(
+          font: label-font,
+          size: label-size,
+          weight: "bold",           // 标签通常加粗 / Labels are usually bold
+          fill: overlay-text-color,
+          stroke: overlay-stroke,
+        )[#_make-label-text(idx, label-style, remove-decorations: false)]
+
+        if overlay-bg != none {
+          if overlay-bg-shape == "circle" {
+            // ─ 圆形背景：使用 circle() 元素 ─
+            // ─ Circular background: use circle() element ─
+            circle(
+              radius: label-size * 0.8,    // 圆的半径基于字号 / Radius based on font size
+              fill: overlay-bg,
+              stroke: overlay-stroke,
+            )[
+              #align(center + horizon)[#label-content]
+            ]
+          } else {
+            // ─ 矩形背景（默认）：使用 box() 元素 ─
+            // ─ Rectangular background (default): use box() element ─
+            box(
+              fill: overlay-bg,
+              inset: overlay-bg-inset,
+              radius: overlay-bg-radius,
+              stroke: overlay-stroke,
+            )[#label-content]
+          }
+        } else {
+          // ─ 无背景：直接显示标签文字 ─
+          // ─ No background: show label text directly ─
+          label-content
+        }
+      }
+    )
+  })
+}
+
+// ============================================================
+// 子图布局函数 (Subfigure Layout Function)
+// ============================================================
+
+/// 创建多子图网格布局，支持子标题、覆盖标签和主双语标题。
+/// Create a multi-subfigure grid layout with subcaptions, overlay labels, and bilingual main caption.
+///
+/// 每个子图为字典：`(content: ..., subcaption: ..., label: ..., label-style-override: (...))` 。
+/// Each subfigure is a dict: `(content: ..., subcaption: ..., label: ..., label-style-override: (...))`.
+///
+/// - subfigs (array): 子图字典数组 / Array of subfigure dicts
+/// - columns (auto | int): 每行列数，auto=所有子图在一行 / Columns per row
+/// - caption (none | content): 主标题（主语言）/ Main caption (main language)
+/// - caption-en (none | content): 主标题（英文）/ Main caption (English)
+/// - label (none | label): 主图标签 / Main figure label
+/// - refer-to (none | label): 续图引用的原图标签 / Original label for continuation
+/// - show-caption (auto | bool): 续图是否显示标题 / Show caption in continuation
+/// - gutter (auto | length): 子图水平间距 / Horizontal gap between subfigures
+/// - subcaption-pos (auto | str): 子标题位置 "top"/"bottom"
+/// - show-subcaption (auto | bool): 是否显示子标题 / Show subcaptions
+/// - show-subcaption-label (auto | bool): 子标题是否含标签 / Subcaption includes label
+/// - align (auto | str): 垂直对齐 "top"/"horizon"/"bottom"
+/// - label-mode (auto | none | str): 标签模式 / Label mode (none or "overlay")
+/// - label-style (auto | str): 标签样式，如 "(a)"/"图a" / Label style
+/// - label-font (auto | array): 标签字体 / Label font
+/// - label-size (auto | length): 标签大小 / Label size
+/// - label-offset (auto | tuple): 标签偏移 (dx, dy) / Label offset
+/// - label-text-color (auto | color): 标签颜色 / Label text color
+/// - label-stroke (auto | none | stroke): 标签描边 / Label stroke
+/// - label-bg (auto | none | color): 标签背景 / Label background
+/// - label-bg-shape (auto | str): 背景形状 / Background shape
+/// - label-bg-radius (auto | length): 背景圆角 / Background radius
+/// - label-bg-inset (auto | length): 背景内边距 / Background padding
+/// - label-sep (auto | str): 子图引用分隔符 / Subfigure reference separator
+/// - figure-above (auto | length): 图片上方间距 / Space above figure
+/// - figure-below (auto | length): 图片下方间距 / Space below figure
+/// - caption-above (auto | length): 主标题上方间距 / Space above main caption
+/// - subcaption-above (auto | length): 子标题上方间距 / Space above subcaption
+/// - subcaption-below (auto | length): 子标题下方间距 / Space below subcaption
+#let capsubfig(
+  subfigs,
+  columns: auto,
+  caption: none,
+  caption-en: none,
+  label: none,
+  refer-to: none,
+  show-caption: auto,
+  gutter: auto,
+  subcaption-pos: auto,
+  show-subcaption: auto,
+  show-subcaption-label: auto,
+  align: auto,
+  label-mode: auto,
+  label-style: auto,
+  label-font: auto,
+  label-size: auto,
+  label-offset: auto,
+  label-text-color: auto,
+  label-stroke: auto,
+  label-bg: auto,
+  label-bg-shape: auto,
+  label-bg-radius: auto,
+  label-bg-inset: auto,
+  label-sep: auto,
+  figure-above: auto,
+  figure-below: auto,
+  caption-above: auto,
+  subcaption-above: auto,
+  subcaption-below: auto,
+) = {
+  // ★ 重要：立即重命名 align 参数，因为 Typst 中 `align` 既是函数又是关键字，
+  // 如果不重命名，在函数体内调用 align(center, ...) 时会发生参数名遮蔽冲突。
+  // ★ Important: Rename `align` parameter immediately because in Typst,
+  // `align` is both a function and a keyword. Without renaming, calling
+  // align(center, ...) inside would shadow/conflict with the parameter name.
+  let vertical-align-param = align
+
+  context {
+    // 读取合并后的图片/子图配置 / Read merged figure/subfigure config
+    let config = figure-style-config.get()
+
+    // ── 解析所有参数（参数优先于全局配置）────────────────────────
+    // ── Resolve all parameters (params take priority over global config) ──
+    let final-gutter = if gutter != auto { gutter } else { config.gutter }
+    let final-subcaption-pos = if subcaption-pos != auto { subcaption-pos } else { config.subcaption-pos }
+    let final-show-subcaption = if show-subcaption != auto { show-subcaption } else { config.show-subcaption }
+    let final-show-subcaption-label = if show-subcaption-label != auto { show-subcaption-label } else { config.show-subcaption-label }
+    let final-align = if vertical-align-param != auto { vertical-align-param } else { config.align }
+    let final-label-mode = if label-mode != auto { label-mode } else { config.label-mode }
+    let final-label-style = if label-style != auto { label-style } else { config.label-style }
+    let final-label-font = if label-font != auto { label-font } else { config.label-font }
+    let final-label-size = if label-size != auto { label-size } else { config.label-size }
+    let final-label-offset = if label-offset != auto { label-offset } else { config.label-offset }
+    let final-label-text-color = if label-text-color != auto { label-text-color } else { config.label-text-color }
+    let final-label-stroke = if label-stroke != auto { label-stroke } else { config.label-stroke }
+    let final-label-bg = if label-bg != auto { label-bg } else { config.label-bg }
+    let final-label-bg-shape = if label-bg-shape != auto { label-bg-shape } else { config.label-bg-shape }
+    let final-label-bg-radius = if label-bg-radius != auto { label-bg-radius } else { config.label-bg-radius }
+    let final-label-bg-inset = if label-bg-inset != auto { label-bg-inset } else { config.label-bg-inset }
+    let final-label-sep = if label-sep != auto { label-sep } else { config.label-sep }
+
+    let final-subcaption-above = if subcaption-above != auto { subcaption-above } else { config.subcaption-above }
+    let final-subcaption-below = if subcaption-below != auto { subcaption-below } else { config.subcaption-below }
+
+    // ── 将字符串对齐参数转换为 Typst 对齐值 ─────────────────────
+    // ── Convert string alignment param to Typst alignment value ──
+    let vertical-align = if final-align == "top" {
+      top
+    } else if final-align == "bottom" {
+      bottom
+    } else {
+      horizon   // 默认居中对齐 / Default: center alignment
+    }
+
+    // ── 确定列数 ─────────────────────────────────────────────────
+    // ── Determine number of columns ───────────────────────────────
+    let cols = if columns == auto {
+      // auto：所有子图放在同一行
+      // auto: all subfigures in one row
+      subfigs.len()
+    } else {
+      columns
+    }
+
+    // ── 确定子图引用分隔符 ────────────────────────────────────────
+    // ── Determine subfigure reference separator ───────────────────
+    // 分隔符用于交叉引用中主编号与子图标签之间（如 "图1.1a" 中的连接）
+    // Separator between main number and subfig label in cross-references (e.g., "Figure 1.1a")
+    let sep = if final-label-sep == auto {
+      let parsed = _parse-label-style(final-label-style)
+      // 数字格式用点分隔（如 "图1.1.2"），字母格式无分隔（如 "图1.1a"）
+      // Numeric format uses dot (e.g., "Fig.1.1.2"), letter format uses none (e.g., "Fig.1.1a")
+      if parsed.format == "1" { "." } else { "" }
+    } else {
+      final-label-sep
+    }
+
+    // ── 将子图数组按行分组 ────────────────────────────────────────
+    // ── Group subfigures into rows ────────────────────────────────
+    let rows = ()
+    let current-row = ()
+    for (idx, subfig) in subfigs.enumerate() {
+      current-row.push(subfig)
+      // 每当当前行满了（达到列数）或者是最后一个子图时，封装当前行
+      // Seal the current row when it's full (reached column count) or at the last subfig
+      if current-row.len() == cols or idx == subfigs.len() - 1 {
+        rows.push(current-row)
+        current-row = ()
+      }
+    }
+
+    // ── 构建子图内容（需要在 context 中进行，因为要读取计数器）──
+    // ── Build subfigure content (needs context to read counters) ──
+    let subfig-content = context {
+      let fig-config = figure-style-config.get()
+      // 计算主图编号字符串（与 _make_caption_content 中的逻辑保持一致）。
+      // 支持 use-chapter=false（默认，仅编号）和 use-chapter=true（带章节前缀）。
+      // Compute the main figure number string (matches _make_caption_content).
+      // Supports both use-chapter=false (default, plain number) and true (with chapter prefix).
+      let fig-num = counter(figure.where(kind: image)).get().first() + 1
+      let main-num = if fig-config.use-chapter {
+        let levels = fig-config.chapter-level
+        let h = counter(heading).get()
+        let chapter-nums = h.slice(0, calc.min(levels, h.len()))
+        numbering(fig-config.numbering-format, ..chapter-nums, fig-num)
+      } else {
+        numbering(fig-config.numbering-format, fig-num)
+      }
+
+      // ════════════════════════════════════════════════════════════
+      // 子图交叉引用注册（Hidden Figure Trick）
+      // Subfigure Cross-Reference Registration (Hidden Figure Trick)
+      // ════════════════════════════════════════════════════════════
+      //
+      // 对于每个有 label 的子图，我们需要：
+      // For each subfig with a label, we need to:
+      //
+      // 1. 创建一个可引用的 figure（注册到计数器，可被 @ 引用）
+      //    Create a referenceable figure (registered to counter, usable via @)
+      // 2. 但该 figure 不应该：出现在目录、占据页面空间、显示内容
+      //    But the figure should NOT: appear in outline, take page space, show content
+      //
+      // 解决方案：用 place(hide[#figure(...)#label]) 在当前位置"注册"一个
+      // 不可见、不占空间的隐藏 figure，并绑定标签。
+      // Solution: Use place(hide[#figure(...)#label]) to "register" an
+      // invisible, zero-space hidden figure at current location with the label.
+      //
+      // 隐藏 figure 的编号格式设置为 "章号.图号+分隔符+子图字母"，
+      // 例如 idx=0, style="(a)" → 编号函数返回 "1.1a"
+      // The hidden figure's numbering is set to "chapter.fig-num+sep+label",
+      // e.g. idx=0, style="(a)" → numbering returns "1.1a"
+      //
+      // 注意：每个隐藏 figure 都会使计数器 +1，所以最后需要批量减回去
+      // Note: each hidden figure increments counter, so we batch-decrement afterwards
+
+      let hidden-figures = ()
+      let subfig-label-count = 0
+
+      for (idx, subfig) in subfigs.enumerate() {
+        if "label" in subfig and subfig.label != none {
+          subfig-label-count = subfig-label-count + 1
+          // 获取此子图的标签字母（不含修饰，如 "(a)" → "a"）
+          // Get the label letter without decorations (e.g., "(a)" → "a")
+          let sublabel = _make-label-text(idx, final-label-style, remove-decorations: true)
+
+          hidden-figures = hidden-figures + (
+            place(
+              hide[
+                #figure(
+                  kind: image,
+                  supplement: if fig-config.supplement != auto {
+                    fig-config.supplement
+                  } else {
+                    // 从语言配置获取图片前缀词（如 "图" 或 "Figure"）
+                    // Get figure prefix from language config (e.g., "图" or "Figure")
+                    get-table-text(resolve-lang-code(fig-config.lang), "figure")
+                  },
+                  // 设置子图的引用显示格式：主图编号 + 分隔符 + 子图字母
+                  // Set subfig reference display: main-num + sep + sublabel
+                  // 例如 main-num="1", sep="", sublabel="a" → "1a"
+                  // 或 main-num="1.2", sep="", sublabel="a" → "1.2a"
+                  // e.g. main-num="1", sep="", sublabel="a" → "1a"
+                  //   or main-num="1.2", sep="", sublabel="a" → "1.2a"
+                  numbering: _ => [#main-num#sep#sublabel],
+                  outlined: false,    // 不出现在目录 / Not in outline
+                  []
+                )#subfig.label    // 绑定子图标签 / Bind subfigure label
+              ]
+            ),
+          )
+        }
+      }
+
+      // ── 逐行构建子图布局内容 ─────────────────────────────────
+      // ── Build subfigure layout content row by row ─────────────
+      let row-contents = ()
+      for (row-idx, row-subfigs) in rows.enumerate() {
+        let start-idx = row-idx * cols         // 此行第一个子图的全局索引
+        let num-in-row = row-subfigs.len()     // 此行实际子图数
+        // 最后一行且不满列（需要特殊处理 columns 参数）
+        // Last row with fewer than full columns (needs special columns handling)
+        let is-last-incomplete = num-in-row < cols and row-idx == rows.len() - 1
+
+        // 提取共享的"处理单张子图内容"闭包：应用 overlay 标签（如有）
+        // Shared "process one subfig content" closure: applies overlay label if needed
+        let process-content(subfig, idx) = {
+          let override = subfig.at("label-style-override", default: none)
+          if final-label-mode == "overlay" {
+            _add-overlay-label(
+              subfig.content, idx,
+              final-label-style, final-label-font, final-label-size,
+              final-label-offset, final-label-text-color, final-label-stroke,
+              final-label-bg, final-label-bg-shape, final-label-bg-radius, final-label-bg-inset,
+              override-style: override,
+            )
+          } else {
+            subfig.content
+          }
+        }
+
+        // 统一处理本行所有子图 / Uniformly process all subfigs in this row
+        let contents = ()
+        let subcaptions = ()
+        for (col-idx, subfig) in row-subfigs.enumerate() {
+          let idx = start-idx + col-idx
+          contents.push(process-content(subfig, idx))
+          if final-show-subcaption {
+            let cap-body = if final-show-subcaption-label {
+              [#_make-label-text(idx, final-label-style, remove-decorations: false) #subfig.subcaption]
+            } else {
+              subfig.subcaption
+            }
+            subcaptions.push(text(size: 10pt, cap-body))
+          }
+        }
+
+        let row-cols = (1fr,) * (if is-last-incomplete { num-in-row } else { cols })
+
+        if final-show-subcaption {
+          // 有子标题：用 table 同时控制列间距和行间距
+          // With subcaption: use table for both column-gutter and row-gutter
+          row-contents.push(table(
+            columns: row-cols,
+            column-gutter: final-gutter,
+            row-gutter: final-subcaption-above,
+            stroke: none,
+            align: center + vertical-align,
+            ..if final-subcaption-pos == "top" {
+              (..subcaptions, ..contents)
+            } else {
+              (..contents, ..subcaptions)
+            }
+          ))
+        } else {
+          // 无子标题：grid 更轻量 / No subcaption: grid is lighter
+          row-contents.push(grid(
+            columns: row-cols,
+            column-gutter: final-gutter,
+            align: center + vertical-align,
+            ..contents
+          ))
+        }
+      }
+
+      // 将所有行内容垂直堆叠（使用 stack 而非 v() 以避免额外的空间）
+      // Stack all row contents vertically (use stack instead of v() for precise spacing)
+      //
+      // ⚠ 计数器回退必须发生在 hidden-figures.join() 之后。
+      // 在代码块里 `counter.update(...)` 作为裸语句会被拼进返回内容里，
+      // 如果写在 hidden-figures 之前，布局时回退会早于 figure 增量执行，
+      // 于是 `max(0, n - k)` 对初始为 0 的计数器无效、最终净多 +k，
+      // 主图编号会变成"章号.(k+1)"（如 "1.3" 而非 "1.1"）。
+      // ⚠ The counter rollback MUST emit AFTER hidden-figures.join().
+      // Inside a code block, a bare `counter.update(...)` is concatenated into
+      // the returned content stream; placing it before hidden-figures would
+      // make the rollback fire before the figure increments. With an initial
+      // counter of 0, `max(0, n - k)` is a no-op, leaving a net +k offset —
+      // so the main caption renders as "chapter.(k+1)" (e.g. "1.3" not "1.1").
+      [
+        #hidden-figures.join()   // 先输出所有隐藏 figure（注册标签）/ Output hidden figures first
+        // 批量减回隐藏 figure 造成的计数器增量；calc.max 保护避免布局迭代中 n<k 时报错
+        // Batch-rollback the hidden-figure increments; calc.max guards against n<k during layout iterations
+        #counter(figure.where(kind: image)).update(n => calc.max(0, n - subfig-label-count))
+        #stack(dir: ttb, spacing: 1em, ..row-contents)   // 再垂直堆叠子图行 / Then stack rows
+      ]
+    }
+
+    // ── 用 cap-figure 包装整个子图组合并添加主标题 ──────────────
+    // ── Wrap the entire subfigure assembly with cap-figure for main caption ──
+    capfig(
+      subfig-content,
+      caption: caption,
+      caption-en: caption-en,
+      label: label,
+      refer-to: refer-to,
+      show-caption: show-caption,
+      figure-above: figure-above,
+      figure-below: figure-below,
+      caption-above: caption-above,
+    )
+  }
+}

--- a/packages/preview/cap-able/0.0.1/src/note.typ
+++ b/packages/preview/cap-able/0.0.1/src/note.typ
@@ -1,0 +1,124 @@
+// ============================================================
+// 表注和图注模块 (Table and Figure Note Module)
+// ============================================================
+//
+// 本模块提供表格和图片的注释（脚注式说明文字）功能。
+// This module provides note/annotation functionality for tables and figures.
+//
+// 什么是表注/图注 / What are table/figure notes:
+// 表注（表格注释）和图注（图片注释）是位于表格或图片下方的补充说明文字，
+// 通常用于以下场景：
+// Table/figure notes are supplementary text placed below tables or figures,
+// commonly used for:
+//
+// - 数据来源说明（如"数据来源：国家统计局"）
+//   Data source attribution (e.g., "Source: National Bureau of Statistics")
+// - 统计显著性标记说明（如"* p < 0.05, ** p < 0.01"）
+//   Statistical significance markers (e.g., "* p < 0.05, ** p < 0.01")
+// - 缩写或专业术语解释
+//   Abbreviation or technical term explanations
+// - 补充说明信息
+//   Supplementary information
+//
+// 设计特性 / Design Features:
+// - 自动宽度匹配：默认宽度与所属表格/图片一致
+//   Auto-width matching: default width matches containing table/figure
+// - 灵活宽度控制：支持 auto、百分比（ratio）、绝对长度三种宽度模式
+//   Flexible width: supports auto, percentage (ratio), and absolute length
+// - 语言感知：检测是否需要首行缩进修复
+//   Language-aware: detects if indentation fix is needed
+// - 样式继承：从全局配置读取样式
+//   Style inheritance: reads style from global config
+//
+// 导出函数 / Exported Functions:
+// - captnote(): 表注 / Table note
+// - capfnote(): 图注 / Figure note
+//
+// 依赖 / Dependencies:
+// - src/config.typ: 全局配置和辅助函数 / Global config and utilities
+//
+// ============================================================
+
+#import "config.typ": *
+
+// 内部：统一的 note 渲染函数，处理三种宽度模式（auto/ratio/length）。
+// Internal: unified note renderer handling three width modes (auto/ratio/length).
+//
+// - config:       note 样式字段来源（含 note-size、note-leading、note-above、note-below、note-justify、lang、after-indent）
+// - width:        用户传入的 width 参数（auto/ratio/length）
+// - auto-percent: width 为 auto 时使用的百分比来源（int 1..100），非 auto 时可传 none
+// - justify:      用户传入的 justify 参数（auto 或 bool）
+// - content:      注释内容
+#let _render-note(config, width, auto-percent, justify, content) = {
+  let (_, should-indent) = resolve-lang-indent(config)
+  let final-justify = if justify == auto { config.note-justify } else { justify }
+
+  // 内层块构造：按需追加首行缩进修复用的前导空间
+  // Inner block: optionally prepend leading space for indent-fix languages
+  let inner(add-leading-space) = {
+    set text(size: config.note-size)
+    if add-leading-space and should-indent { v(0.8em) }
+    set par(first-line-indent: 0pt, leading: config.note-leading, justify: final-justify)
+    content
+  }
+
+  block(
+    above: config.note-above,
+    below: config.note-below,
+  )[
+    #if width == auto or type(width) == ratio {
+      // ─ 百分比模式（auto 或 ratio）：以指定百分比缩窄并居中 ─
+      // ─ Percentage mode (auto or ratio): narrow and center ─
+      let percentage = if width == auto { auto-percent } else { width / 1% }
+      let margin-percent = (100 - percentage) / 2
+      pad(
+        left: margin-percent * 1%,
+        right: margin-percent * 1%,
+        block(width: 100%, inner(true)),
+      )
+    } else {
+      // ─ 绝对长度模式：固定宽度，居中显示，无额外前导空间 ─
+      // ─ Absolute length mode: fixed width, centered, no leading space ─
+      align(center, block(width: width, inner(false)))
+    }
+  ]
+
+  // 首行缩进敏感语言需要假段落修复 / Indent-sensitive langs need fake-para fix
+  if should-indent { _fakepar }
+}
+
+/// 创建表格注释（表注），默认宽度自动匹配 `captab` 表格宽度。
+/// Create a table note; default width auto-matches `captab` width.
+///
+/// - width (auto | ratio | length): 表注宽度 / Note width
+/// - justify (auto | bool): 是否两端对齐（auto=使用全局配置）/ Text justification
+/// - content (content): 表注内容 / Note content
+#let captnote(
+  width: auto,
+  justify: auto,
+  content
+) = {
+  context {
+    let config = table-style-config.get()
+    let percent = table-width-config.get()
+    _render-note(config, width, percent, justify, content)
+  }
+}
+
+/// 创建图片注释（图注），从 `figure-style-config` 读取样式，默认宽度自动匹配。
+/// Create a figure note; reads style from `figure-style-config`, auto-matches figure width.
+///
+/// - width (auto | ratio | length): 图注宽度 / Note width
+/// - justify (auto | bool): 是否两端对齐 / Text justification
+/// - content (content): 图注内容 / Note content
+#let capfnote(
+  width: auto,
+  justify: auto,
+  content
+) = {
+  context {
+    let config = figure-style-config.get()
+    let percent = figure-width-config.get()
+    _render-note(config, width, percent, justify, content)
+  }
+}

--- a/packages/preview/cap-able/0.0.1/src/table.typ
+++ b/packages/preview/cap-able/0.0.1/src/table.typ
@@ -1,0 +1,278 @@
+// ============================================================
+// 三线表模块 (Three-line Table Module)
+// ============================================================
+//
+// 本模块提供符合学术规范的三线表功能。
+// This module provides academic-standard three-line table functionality.
+//
+// 什么是三线表 / What is a three-line table:
+// 三线表是学术出版物中最常用的表格样式，以三条水平线为特征，
+// 无竖线，视觉简洁、信息层次清晰：
+// The three-line table is the most common table style in academic publications,
+// characterized by three horizontal rules and no vertical rules:
+//
+//  ═══════════════════════  ← 顶线 1.5pt（粗）/ Top rule 1.5pt (heavy)
+//  Header | Header | Header
+//  ───────────────────────  ← 中线 0.5pt（细）/ Middle rule 0.5pt (light)
+//  Data   | Data   | Data
+//  Data   | Data   | Data
+//  ═══════════════════════  ← 底线 1.5pt（粗）/ Bottom rule 1.5pt (heavy)
+//
+// 表格语法（基于 tablem）/ Table syntax (powered by tablem):
+// 使用 Markdown 风格的管道符语法：
+// Uses Markdown-style pipe syntax:
+//
+//  | Header 1 | Header 2 | Header 3 |
+//  | -------- | -------- | -------- |   ← 分隔行，必须存在 / Required separator row
+//  | Cell 1   | Cell 2   | Cell 3   |
+//
+// 对齐控制 / Alignment control:
+//  | :Left | :Center: | Right: |
+//
+// 单元格合并 / Cell merging:
+//  | Span | <    |    ← < 向左合并 / < merges left
+//  | A    | Span |
+//  | ^    | B    |    ← ^ 向上合并 / ^ merges up
+//
+// 导出函数 / Exported Functions:
+// - cap-table(): 三线表主函数（Three-line table main function）
+// - tlt: cap-table 的国际化别名（International alias）
+// - biaoge: cap-table 的中文拼音别名（Chinese alias）
+//
+// 依赖 / Dependencies:
+// - @preview/tablem:0.3.0 — Markdown 表格解析
+// - src/config.typ         — 全局配置和辅助函数
+// - src/bicap.typ          — 标题内容生成引擎
+//
+// ============================================================
+
+#import "@preview/tablem:0.3.0": tablem
+#import "config.typ": *
+#import "bicap.typ": _make_caption_content
+
+/// 创建三线表，支持 Markdown 语法、双语标题、续表和自定义线条。
+/// Create a three-line table with Markdown syntax, bilingual captions, continuation, and custom lines.
+///
+/// - cols (auto | int | array): 列配置（auto=自动检测，int=等宽列数，array=列宽数组）/ Column config
+/// - size (auto | length): 表格内容字号 / Table content font size
+/// - leading (auto | length): 表格内容行距 / Table content line spacing
+/// - inset (auto | length | dictionary): 单元格内边距 / Cell padding
+/// - caption (none | content): 主语言标题 / Main language caption
+/// - caption-en (none | content): 英文标题 / English caption
+/// - refer-to (none | label): 续表引用的原表标签 / Original label for continuation
+/// - show-caption (auto | bool): 续表是否显示标题文本 / Show caption in continuation
+/// - hlines (array): 额外横线，每项为 `(row: int, start: int, end: none|int, stroke: stroke)` / Extra h-rules
+/// - vlines (array): 额外竖线，每项为 `(col: int, start: int, end: none|int, stroke: stroke)` / Extra v-rules
+/// - label (none | label): 表格标签，用于交叉引用 / Label for cross-reference
+/// - content (content): Markdown 风格的表格内容 / Markdown-style table content
+#let captab(
+  cols: auto,
+  size: auto,
+  leading: auto,
+  inset: auto,
+  caption: none,
+  caption-en: none,
+  refer-to: none,
+  show-caption: auto,
+  hlines: (),
+  vlines: (),
+  label: none,
+  content
+) = {
+  context {
+    // 读取全局配置状态（在 context 中才能读取）
+    // Read global config state (only readable inside context)
+    let percentage = table-width-config.get()
+    let config = table-style-config.get()
+
+    // 解析样式参数：优先使用传入值，否则使用全局配置
+    // Resolve style params: prefer passed value, fall back to global config
+    let final-size = if size == auto { config.body-size } else { size }
+    let final-leading = if leading == auto { config.body-leading } else { leading }
+    let final-inset = if inset == auto { config.cell-inset } else { inset }
+
+    // 解析文档语言和首行缩进修复标志 / Resolve language and indent-fix flag
+    let (doc-lang, should-indent) = resolve-lang-indent(config)
+
+    // ── 构建表格主体 ─────────────────────────────────────────────
+    // ── Build table body ─────────────────────────────────────────
+    let table-body = {
+      let raw-table = {
+        // 设置文本和段落样式（在 tablem 解析前设置，会应用到所有单元格）
+        // Set text/paragraph style before tablem parsing (applies to all cells)
+        set text(size: final-size)
+        set par(leading: final-leading)
+
+        tablem(
+          columns: cols,
+          // tablem 的 render 回调：接收解析好的列数/对齐/单元格内容，
+          // 由我们来决定如何渲染最终的 table
+          // tablem's render callback: receives parsed columns/alignment/cells,
+          // we decide how to render the final table
+          render: (columns: auto, align: auto, ..args) => {
+            // ── 处理列宽 ──────────────────────────────────────────
+            // ── Handle column widths ──────────────────────────────
+            let final-columns = if cols != auto {
+              // 用户指定了 cols：直接使用（不管 tablem 解析到的列数）
+              // User specified cols: use directly (ignore tablem-parsed column count)
+              cols
+            } else if type(columns) == int {
+              // tablem 检测到 n 列（返回整数）：转换为 n 个等宽 fr 列
+              // tablem detected n columns (returns int): convert to n equal-width fr columns
+              (1fr,) * columns
+            } else {
+              // tablem 返回了列宽数组（来自 Markdown 对齐语法）：直接使用
+              // tablem returned column width array (from Markdown alignment syntax): use directly
+              columns
+            }
+
+            // ── 处理对齐 ──────────────────────────────────────────
+            // ── Handle alignment ──────────────────────────────────
+            let final-align = if align == auto {
+              // 无对齐信息：默认居中+垂直居中
+              // No alignment info: default to center + horizon
+              center + horizon
+            } else if type(align) == array {
+              // 有对齐数组（来自 Markdown `:---:` 语法）：
+              // 保留水平对齐，强制垂直居中
+              // Alignment array (from Markdown `:---:` syntax):
+              // keep horizontal alignment, force vertical center
+              align.map(a => if a == auto { center + horizon } else { a + horizon })
+            } else {
+              align + horizon
+            }
+
+            // ── 构建表格内容列表 ───────────────────────────────────
+            // ── Build table content list ───────────────────────────
+            let table-content = ()
+
+            // 三线表固定线条：顶线（1.5pt粗线，y=0 表示在第0行上方）
+            // Three-line table fixed rules: top rule (1.5pt heavy, y=0 = above row 0)
+            table-content.push(table.hline(y: 0, stroke: 1.5pt))
+
+            // 中线（0.5pt细线，y=1 表示在第1行（数据第一行）上方，即表头下方）
+            // Middle rule (0.5pt light, y=1 = above row 1 = below header)
+            table-content.push(table.hline(y: 1, stroke: 0.5pt))
+
+            // 添加 tablem 解析到的单元格内容
+            // Add tablem-parsed cell content
+            table-content += args.pos()
+
+            // ── 添加用户自定义额外横线 ─────────────────────────────
+            // ── Add user-defined extra horizontal lines ─────────────
+            for line in hlines {
+              let y = line.at("row", default: 2)         // 默认第2行上方 / default: above row 2
+              let start = line.at("start", default: 0)   // 默认从第0列开始 / default: from col 0
+              let end = line.at("end", default: none)     // 默认到最右列 / default: to rightmost
+              let stroke-style = line.at("stroke", default: 0.5pt)
+              table-content.push(
+                table.hline(y: y, start: start, end: end, stroke: stroke-style)
+              )
+            }
+
+            // ── 添加用户自定义额外竖线 ─────────────────────────────
+            // ── Add user-defined extra vertical lines ───────────────
+            for line in vlines {
+              let x = line.at("col", default: 1)         // 默认第1列右侧 / default: right of col 1
+              let start = line.at("start", default: 0)
+              let end = line.at("end", default: none)
+              let stroke-style = line.at("stroke", default: 0.5pt)
+              table-content.push(
+                table.vline(x: x, start: start, end: end, stroke: stroke-style)
+              )
+            }
+
+            // 底线（1.5pt粗线，不指定 y 则自动放在最后一行下方）
+            // Bottom rule (1.5pt heavy, no y = automatically placed below last row)
+            table-content.push(table.hline(stroke: 1.5pt))
+
+            // ── 处理 inset（单元格内边距）─────────────────────────
+            // ── Process inset (cell padding) ───────────────────────
+            // inset 可以是字典（{x: ..., y: ...}）或标量（统一应用）
+            // inset can be a dict ({x: ..., y: ...}) or scalar (uniform)
+            let final-table-inset = if type(final-inset) == dictionary {
+              final-inset
+            } else {
+              // 标量转换为 x/y 字典
+              // Convert scalar to x/y dict
+              (x: final-inset, y: final-inset)
+            }
+
+            // 渲染最终的 Typst table（无描边，由我们手动添加三线）
+            // Render the final Typst table (no stroke, we add rules manually)
+            table(
+              columns: final-columns,
+              stroke: none,             // 禁用默认描边 / Disable default stroke
+              align: final-align,
+              inset: final-table-inset,
+              ..table-content           // 展开所有内容（线条+单元格）/ Spread all content
+            )
+          },
+          content
+        )
+      }
+
+      // ── 应用表格宽度百分比 ────────────────────────────────────
+      // ── Apply table width percentage ─────────────────────────
+      // 通过在左右添加等量 padding 来实现居中缩窄效果
+      // Centering + narrowing achieved by adding equal padding on both sides
+      let margin-percent = (100 - percentage) / 2
+      pad(
+        left: margin-percent * 1%,
+        right: margin-percent * 1%,
+        block(
+          width: 100%,
+          align(center, raw-table)
+        )
+      )
+    }
+
+    // ── 组合标题和表体 ────────────────────────────────────────────
+    // ── Combine caption and table body ───────────────────────────
+    //
+    // 三种情况：
+    // Three cases:
+    // 1. 有标题 + 续表（refer-to 非 none）
+    //    Has caption + continuation
+    // 2. 有标题 + 主表（refer-to 为 none）
+    //    Has caption + main table
+    // 3. 无标题（只有表体）
+    //    No caption (table body only)
+    //
+    // 标题和表体放在同一个不换页 block 中，防止跨页分离
+    // Caption and body are in the same non-breakable block to prevent page splits
+
+    if caption != none {
+      // 续表不设置标签（避免重复引用），主表才设置 label
+      // Continuation gets no label (avoid duplicate refs); main table gets the label
+      let is-continuation = refer-to != none
+      block(
+        breakable: false,
+        above: config.caption-above,
+        below: config.table-below,
+      )[
+        #align(center)[
+          #_make_caption_content(
+            caption: caption,
+            caption-en: caption-en,
+            refer-to: refer-to,
+            label: if is-continuation { none } else { label },
+            config: config,
+            kind: "table",
+            show-caption: show-caption,
+          )
+        ]
+        // 标题与表体之间的间距；减去 1em 是因为 block 的 below 已贡献默认段距
+        // Gap between caption and body; subtract 1em because block below contributes default paragraph spacing
+        #v(config.caption-below - 1em)
+        #table-body
+      ]
+      if should-indent { _fakepar }
+    } else {
+      // ─ 无标题：直接输出表体 ─ (No caption: output table body only)
+      table-body
+      if should-indent { _fakepar }
+    }
+  }
+}
+

--- a/packages/preview/cap-able/0.0.1/typst.toml
+++ b/packages/preview/cap-able/0.0.1/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cap-able"
+version = "0.0.1"
+entrypoint = "lib.typ"
+authors = ["SchrodingerBlume"]
+license = "MIT"
+description = "Professional three-line tables and figures with bilingual captions, continued tables/figures, subfigures, and 25+ language support for academic documents."
+repository = "https://github.com/SchrodingerBlume/typst-cap-able"
+keywords = ["table", "figure", "caption", "bilingual", "academic"]
+categories = ["components", "layout"]
+compiler = "0.13.0"
+exclude = ["*.pdf"]


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description: **cap-able** is a comprehensive Typst package for creating professional three-line tables and figures with bilingual caption support. It is designed for academic documents (theses, papers, technical reports) that require:

- **Three-line tables** with Markdown syntax (via `tablem`)
- **Bilingual captions** — auto-formatted dual-language captions (Chinese/English, German/English, Spanish/English, etc.)
- **Continued tables/figures** — multi-page tables and figures with automatic numbering and continuation markers
- **Subfigures** — flexible multi-image grid layouts with overlay labels and subcaptions
- **Table/figure notes** — auto-width-matched notes
- **25+ language localization** including RTL languages (Arabic, Hebrew, Persian, Urdu) and Simplified/Traditional Chinese distinction
- **Unified configuration** — `cap-style` for shared settings, `captab-style` / `capfig-style` for per-type overrides

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE