### PR TITLE
ab-annotate:0.1.0

### DIFF
--- a/packages/preview/ab-annotate/0.1.0/LICENSE
+++ b/packages/preview/ab-annotate/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cameron Wimpy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/ab-annotate/0.1.0/README.md
+++ b/packages/preview/ab-annotate/0.1.0/README.md
@@ -1,0 +1,79 @@
+# ab-annotate
+
+Annotated bibliographies for Typst. Each entry renders as **citation → abstract → user annotation**, all pulled from standard BibLaTeX fields in a `.bib` file.
+
+- `abstract` — journal abstract (often present in Zotero exports)
+- `annotation` — your own notes on the source (with `annote` accepted as a fallback)
+
+Both fields are optional per entry. Entries without either render as normal citations.
+
+## Usage
+
+```typst
+#import "@preview/ab-annotate:0.1.0": annotated-bib
+
+#set page(paper: "us-letter", margin: 1in)
+
+= Annotated Bibliography
+
+#annotated-bib(
+  read("references.bib", encoding: none),
+  title: none,
+  style: "apa",
+)
+```
+
+> **Why `read(..., encoding: none)`?** Typst resolves file paths relative to the file that syntactically contains the `read()` call. Because this function lives inside the package, it can't open your `.bib` directly — you pass in the bytes yourself, and the package handles the rest.
+
+## BibTeX entry format
+
+```bibtex
+@article{smith2024,
+  author     = {Smith, Jane},
+  title      = {Rural Election Administration Challenges},
+  journal    = {Journal of Elections and Public Opinion},
+  year       = {2024},
+  abstract   = {This paper examines the unique challenges...},
+  annotation = {Key paper for the adaptive informality framework.
+                Smith's typology maps well onto the Delta cases.}
+}
+```
+
+## Parameters
+
+```typst
+#annotated-bib(
+  read("references.bib", encoding: none),
+  title: "Annotated Bibliography",   // or `none` to suppress
+  style: "apa",                       // any CSL style Typst ships with
+  show-abstract: true,
+  show-annotation: true,
+  show-labels: true,
+  abstract-label: "Abstract",
+  annotation-label: "Annotation",
+  indent: 1.5em,
+  block-spacing: 0.5em,
+  entry-spacing: 1.2em,
+)
+```
+
+## How it works
+
+Typst's `bibliography()` function renders as a monolithic block with no per-entry hooks. `ab-annotate` parses the `.bib` file itself, renders the native `bibliography()` with the chosen CSL style, and then appends styled abstract/annotation blocks for each entry that has them — keyed by citation key, with a colored left border for visual grouping.
+
+### Limitation
+
+Because Typst's bibliography API doesn't yet allow per-entry injection, annotations appear as a grouped section *after* the bibliography rather than interleaved with each entry. When [typst/typst#942](https://github.com/typst/typst/issues/942) lands, `ab-annotate` will switch to true interleaved rendering.
+
+## Cross-format companion
+
+This package is part of a cross-format toolchain that also provides:
+
+- a **biblatex `.sty`** package for LaTeX
+- a **Lua filter / Quarto extension** for Quarto (PDF, HTML, Typst, Word)
+
+All three read the same `.bib` fields. See [github.com/cwimpy/ab-annotate](https://github.com/cwimpy/ab-annotate) for the LaTeX and Quarto implementations.
+
+## License
+
+MIT

--- a/packages/preview/ab-annotate/0.1.0/README.md
+++ b/packages/preview/ab-annotate/0.1.0/README.md
@@ -59,11 +59,17 @@ Both fields are optional per entry. Entries without either render as normal cita
 
 ## How it works
 
-Typst's `bibliography()` function renders as a monolithic block with no per-entry hooks. `ab-annotate` parses the `.bib` file itself, renders the native `bibliography()` with the chosen CSL style, and then appends styled abstract/annotation blocks for each entry that has them — keyed by citation key, with a colored left border for visual grouping.
+Typst's `bibliography()` function renders as a monolithic block with no per-entry hooks, so `ab-annotate`:
 
-### Limitation
+1. Parses the `.bib` file itself to collect `abstract` / `annotation` fields per key.
+2. Declares `bibliography()` to register citation keys, but suppresses its grouped output with `show bibliography: _ => none`.
+3. Walks the entries in `.bib` order and renders each one with `cite(key, form: "full")` — pulling the CSL-styled reference — followed immediately by its abstract/annotation block (with a colored left border for visual grouping).
 
-Because Typst's bibliography API doesn't yet allow per-entry injection, annotations appear as a grouped section *after* the bibliography rather than interleaved with each entry. When [typst/typst#942](https://github.com/typst/typst/issues/942) lands, `ab-annotate` will switch to true interleaved rendering.
+The result is a true annotated bibliography: each citation is followed by its own notes, rather than annotations appearing as a separate grouped section.
+
+### Caveat on entry order
+
+Because entries are emitted in the order they appear in the `.bib` file, ordering follows your source file rather than the CSL style's sort order. For author-year styles (APA, APSA, Chicago), sort your `.bib` alphabetically by first-author surname if order matters.
 
 ## Cross-format companion
 

--- a/packages/preview/ab-annotate/0.1.0/ab-annotate.typ
+++ b/packages/preview/ab-annotate/0.1.0/ab-annotate.typ
@@ -114,43 +114,47 @@
     heading(level: 1, numbering: none, title)
   }
 
-  // Render the real bibliography so cite keys resolve and formatting
-  // comes from the chosen CSL style. `bibliography()` accepts bytes
-  // since Typst 0.12.
+  // Declare the bibliography so `cite()` keys resolve and formatting
+  // comes from the chosen CSL style — but suppress its grouped
+  // rendering so we can interleave each entry with its annotation.
+  show bibliography: _ => none
   bibliography(bib-source, title: none, style: style, full: true)
-  
-  // Now append annotation blocks for entries that have them
+
+  // Render each entry manually using `cite(form: "full")`, followed
+  // by any abstract/annotation blocks.
   for entry in entries {
     let has-abs = entry.abstract != none and show-abstract
     let has-ann = entry.annotation != none and show-annotation
-    
-    if has-abs or has-ann {
-      v(block-spacing)
-      block(
-        inset: (left: indent, top: 0.3em, bottom: 0.3em),
-        stroke: (left: 1.5pt + luma(180)),
-        width: 100%,
-      )[
-        #text(weight: "bold", size: 9pt)[#entry.key]
-        
-        #if has-abs [
-          #v(0.2em)
-          #if show-labels [
-            #text(weight: "bold", size: 8.5pt)[#abstract-label:]
-            #h(0.3em)
+
+    block(breakable: false, width: 100%, below: entry-spacing)[
+      #cite(label(entry.key), form: "full")
+
+      #if has-abs or has-ann {
+        v(block-spacing)
+        block(
+          inset: (left: indent, top: 0.3em, bottom: 0.3em),
+          stroke: (left: 1.5pt + luma(180)),
+          width: 100%,
+        )[
+          #if has-abs [
+            #if show-labels [
+              #text(weight: "bold", size: 0.9em)[#abstract-label:]
+              #h(0.3em)
+            ]
+            #text(size: 0.9em, style: "italic")[#entry.abstract]
           ]
-          #text(size: 8.5pt, style: "italic")[#entry.abstract]
-        ]
-        
-        #if has-ann [
-          #v(0.2em)
-          #if show-labels [
-            #text(weight: "bold", size: 8.5pt)[#annotation-label:]
-            #h(0.3em)
+
+          #if has-abs and has-ann { v(0.3em) }
+
+          #if has-ann [
+            #if show-labels [
+              #text(weight: "bold", size: 0.9em)[#annotation-label:]
+              #h(0.3em)
+            ]
+            #text(size: 0.9em)[#entry.annotation]
           ]
-          #text(size: 8.5pt)[#entry.annotation]
         ]
-      ]
-    }
+      }
+    ]
   }
 }

--- a/packages/preview/ab-annotate/0.1.0/ab-annotate.typ
+++ b/packages/preview/ab-annotate/0.1.0/ab-annotate.typ
@@ -1,0 +1,156 @@
+// ab-annotate.typ
+// Annotated bibliography support for Typst.
+//
+// Because Typst's bibliography() function renders as a monolithic block
+// with no per-entry hooks, we take a different approach:
+//   1. Parse the .bib file to extract abstract/annotation fields
+//   2. For each entry, emit a formatted block with the citation key
+//      as a label and the abstract/annotation underneath
+//   3. Use Typst's native bibliography() in a hidden block so that
+//      cite() works correctly for formatting
+//
+// Usage:
+//   #import "ab-annotate.typ": annotated-bib, parse-bib
+//
+//   // At the end of your document:
+//   #annotated-bib("references.bib")
+
+// ── .bib parser ─────────────────────────────────────────────────
+// Extracts key, abstract, annotation/annote from BibLaTeX .bib files.
+
+#let parse-bib(bib-content) = {
+  let entries = ()
+  let text = bib-content
+  
+  // Find each @type{key block
+  let entry-starts = ()
+  let i = 0
+  let chars = text.clusters()
+  while i < chars.len() {
+    if chars.at(i) == "@" {
+      entry-starts.push(i)
+    }
+    i += 1
+  }
+  
+  for (idx, start) in entry-starts.enumerate() {
+    let end = if idx + 1 < entry-starts.len() {
+      entry-starts.at(idx + 1)
+    } else {
+      chars.len()
+    }
+    let chunk = chars.slice(start, end).join()
+    
+    // Get entry type and key
+    let header = chunk.match(regex("@(\w+)\s*\{\s*([^,\s]+)"))
+    if header == none { continue }
+    let entry-type = header.captures.at(0).trim()
+    let key = header.captures.at(1).trim()
+    
+    // Skip @comment, @preamble, @string
+    if entry-type in ("comment", "preamble", "string") { continue }
+    
+    // Helper: extract a brace-delimited field value
+    let extract-field(field-name, chunk) = {
+      let pattern = regex(field-name + "\s*=\s*\{")
+      let m = chunk.match(pattern)
+      if m == none { return none }
+      let s = m.end
+      let depth = 1
+      let pos = s
+      let c = chunk.clusters()
+      while pos < c.len() and depth > 0 {
+        if c.at(pos) == "{" { depth += 1 }
+        if c.at(pos) == "}" { depth -= 1 }
+        if depth > 0 { pos += 1 }
+      }
+      c.slice(s, pos).join().replace(regex("\s+"), " ").trim()
+    }
+    
+    let abst = extract-field("abstract", chunk)
+    let annot = extract-field("annotation", chunk)
+    let annote = extract-field("annote", chunk)
+    
+    // Merge: annotation takes priority over annote
+    let final-annotation = if annot != none { annot } else { annote }
+    
+    entries.push((
+      key: key,
+      abstract: abst,
+      annotation: final-annotation,
+    ))
+  }
+  
+  entries
+}
+
+// ── Render annotated bibliography ───────────────────────────────
+
+#let annotated-bib(
+  bib-source,
+  title: "Annotated Bibliography",
+  style: "apa",
+  show-abstract: true,
+  show-annotation: true,
+  show-labels: true,
+  abstract-label: "Abstract",
+  annotation-label: "Annotation",
+  indent: 1.5em,
+  block-spacing: 0.5em,
+  entry-spacing: 1.2em,
+) = {
+  // `bib-source` must be bytes from `read(path, encoding: none)` called
+  // at the user's document site — Typst resolves `read()` paths relative
+  // to the file that syntactically contains the call, so the user must
+  // do the reading themselves.
+  let bib-content = if type(bib-source) == bytes {
+    str(bib-source)
+  } else {
+    bib-source
+  }
+  let entries = parse-bib(bib-content)
+
+  if title != none {
+    heading(level: 1, numbering: none, title)
+  }
+
+  // Render the real bibliography so cite keys resolve and formatting
+  // comes from the chosen CSL style. `bibliography()` accepts bytes
+  // since Typst 0.12.
+  bibliography(bib-source, title: none, style: style, full: true)
+  
+  // Now append annotation blocks for entries that have them
+  for entry in entries {
+    let has-abs = entry.abstract != none and show-abstract
+    let has-ann = entry.annotation != none and show-annotation
+    
+    if has-abs or has-ann {
+      v(block-spacing)
+      block(
+        inset: (left: indent, top: 0.3em, bottom: 0.3em),
+        stroke: (left: 1.5pt + luma(180)),
+        width: 100%,
+      )[
+        #text(weight: "bold", size: 9pt)[#entry.key]
+        
+        #if has-abs [
+          #v(0.2em)
+          #if show-labels [
+            #text(weight: "bold", size: 8.5pt)[#abstract-label:]
+            #h(0.3em)
+          ]
+          #text(size: 8.5pt, style: "italic")[#entry.abstract]
+        ]
+        
+        #if has-ann [
+          #v(0.2em)
+          #if show-labels [
+            #text(weight: "bold", size: 8.5pt)[#annotation-label:]
+            #h(0.3em)
+          ]
+          #text(size: 8.5pt)[#entry.annotation]
+        ]
+      ]
+    }
+  }
+}

--- a/packages/preview/ab-annotate/0.1.0/typst.toml
+++ b/packages/preview/ab-annotate/0.1.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ab-annotate"
+version = "0.1.0"
+entrypoint = "ab-annotate.typ"
+authors = ["Cameron Wimpy <cwimpy@astate.edu>"]
+license = "MIT"
+description = "Annotated bibliographies that render abstracts and user annotations beneath each citation entry."
+repository = "https://github.com/cwimpy/ab-annotate"
+keywords = ["bibliography", "annotated-bibliography", "citation", "biblatex"]
+categories = ["scripting"]
+compiler = "0.11.0"

--- a/packages/preview/ab-annotate/0.1.0/typst.toml
+++ b/packages/preview/ab-annotate/0.1.0/typst.toml
@@ -8,4 +8,4 @@ description = "Annotated bibliographies that render abstracts and user annotatio
 repository = "https://github.com/cwimpy/ab-annotate"
 keywords = ["bibliography", "annotated-bibliography", "citation", "biblatex"]
 categories = ["scripting"]
-compiler = "0.11.0"
+compiler = "0.13.0"


### PR DESCRIPTION
Adds `ab-annotate:0.1.0` — an annotated bibliography package.

Each entry renders as **citation → abstract → user annotation**, reading the standard `abstract` and `annotation` (or `annote` as fallback) biblatex fields from a `.bib` file. Both fields are optional per entry; entries without either render as a normal citation.

## Usage

```typst
#import "@preview/ab-annotate:0.1.0": annotated-bib

#annotated-bib(
  read("references.bib", encoding: none),
  style: "apa",
)
```

The function takes bytes (from the user's own `read()` call) rather than a path, because Typst resolves `read()` relative to the containing file — a package cannot read a path the user gives it. The bytes are passed straight through to `bibliography()`, which accepts bytes since 0.12.

## Checklist

- [x] `README.md` documents usage with a compilable example using the `@preview` import
- [x] `LICENSE` (MIT) matches the `license` field in `typst.toml`
- [x] No binary blobs (no example PDFs included)
- [x] Name: `ab-annotate` — not the canonical name for this functionality (`annotated-bibliography` / `bibliography` would be), uses kebab-case, no "typst" in name
- [x] Compiles cleanly against Typst 0.14.2 (smoke-tested locally via `@local` namespace)

## Cross-format companion

Part of a cross-format toolchain (also provides a biblatex `.sty` and a Quarto extension reading the same `.bib` fields). Full source: https://github.com/cwimpy/ab-annotate