### PR TITLE
Document `typst info` and snap quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Once used, they are cached in `{cache-dir}/typst/packages/preview` where
 - `~/Library/Caches` on macOS
 - `%LOCALAPPDATA%` on Windows
 
+You may also run `typst info` and check _Package cache path_ for the actual path.
+This would be helpful if you have installed the Typst compiler from Snap or are
+using special environment variables.
+
 Importing a cached package does not result in network access.
 
 ## Local packages
@@ -47,6 +51,10 @@ locally on your system. Here, `{data-dir}` is
 - `$XDG_DATA_HOME` or `~/.local/share` on Linux
 - `~/Library/Application Support` on macOS
 - `%APPDATA%` on Windows
+
+You may also run `typst info` and check _Package path_ for the actual path. This
+would be helpful if you have installed the Typst compiler from Snap or are using
+special environment variables.
 
 You can create an arbitrary `{namespace}`. A good namespace for system-local
 packages is `local`. Using this namespace:


### PR DESCRIPTION
Resolves #3838
Relates-to: [Why does Typst not find packages in ./local/share/typst? - Questions - Typst Forum](https://forum.typst.app/t/why-does-typst-not-find-packages-in-local-share-typst/5777/14?u=y.d.x)

I didn't mention `~/snap/typst/current/.cache/` in the README, because on my machine, snap's typst just uses `~/.local/share/`.

---


[Discord](https://discord.com/channels/1054443721975922748/1399326777540608041/1493988049426714754):

> The packages repo's README uses `{cache-dir}` and `{data-dir}`, but `typst info` outputs  *Package path* and *Package cache path*.
> Perhaps they can be unified?

> yes we should unify them