### PR TITLE
quan:0.1.0

### DIFF
--- a/packages/preview/quan/0.1.0/LICENSE
+++ b/packages/preview/quan/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SchrodingerBlume (Andrew Junhao Wu)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/quan/0.1.0/README.md
+++ b/packages/preview/quan/0.1.0/README.md
@@ -1,0 +1,232 @@
+<p align="center">
+  <strong>quan</strong><br>
+  <em>圈 /quān/ — circled numbers for Typst, Unicode-first</em>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-0.1.0-blue" alt="Package version: 0.1.0">
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT">
+  <img src="https://img.shields.io/badge/typst-0.13.0+-orange" alt="Minimum Typst version: 0.13.0">
+</p>
+
+<p align="center">
+  <a href="#english">English</a> | <a href="#中文">中文</a>
+</p>
+
+---
+
+## English
+
+A Typst package for circled numbers. It uses native Unicode circled glyphs (⓪–㊿) within the declared font coverage range, and automatically draws a circle around the number otherwise — so it works with any font, even those with partial or no circled-digit support.
+
+### Features
+
+- **Unicode glyphs first** — uses ⓪–㊿ (U+24EA–U+32BF) when the current font supports them, avoiding the inconsistency of drawn circles mixed with native glyphs
+- **Automatic drawn-circle fallback** — renders any integer outside font coverage as a drawn circle, including numbers beyond 50
+- **Font coverage declaration** — `quan-init` accepts range strings like `"1-20"` or `"1-5,7,9-11"` to declare exactly which glyphs your font provides
+- **Per-range style rules** — `quan-style` lets you tune stroke, radius, inset, baseline, text size and letter-spacing per numeric range
+- **SimSun-tuned defaults** — built-in rules handle single digits (0–9) and the varying visual width of digit pairs from 10 to 99 out of the box; easily overridden for other fonts
+
+### Quick Start
+
+```typst
+#import "@preview/quan:0.1.0": quan, quan-init, quan-style
+
+// Declare your font's circled-digit coverage (default: 1-10)
+#quan-init(digits: "1-20")
+
+Step #quan(1): install. Step #quan(2): configure. Step #quan(15): done.
+```
+
+If `quan-init` is not called, the default coverage is **1–10** (supported by most Chinese fonts). Numbers outside the declared range, or beyond 50, are drawn automatically.
+
+### API Reference
+
+#### `quan(n)` — core function
+
+Outputs a circled number. Uses the Unicode circled glyph if `n` is within the coverage declared by `quan-init`; otherwise draws a circle.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `n` | `int` | The number to render. Must be an integer; non-integer input panics. Coverage and style rules determine the output. |
+
+```typst
+#quan(1)    // ① (Unicode, if in coverage)
+#quan(25)   // drawn circle with "25"
+#quan(100)  // drawn circle with "100"
+```
+
+---
+
+#### `quan-init(digits: none)` — declare font coverage
+
+Declares which circled-digit glyphs the current font provides. Numbers outside this range will be drawn.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `digits` | `str` or `none` | `none` (clears to empty) | Range string, e.g. `"1-20"` or `"1-5,7,9-11"`. |
+
+```typst
+#quan-init(digits: "1-20")       // font has ①–⑳
+#quan-init(digits: "0-50")       // font has ⓪–㊿
+#quan-init(digits: "1-5,7,9-11") // sparse coverage
+```
+
+> **Note** — if `quan-init` is never called, the default coverage is `1-10`.
+
+---
+
+#### `quan-style(..args)` — configure drawn-circle appearance
+
+Named arguments update the global default style. Positional arguments are `(range-str, style-dict)` tuples for per-range overrides. Rules are matched in order; the first match wins.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `stroke` | `length` | `0.0315em` | Circle stroke width. |
+| `radius` | `ratio` | `50%` | Box corner radius (50% = circle). |
+| `inset` | `dict` | `(x: 0em, y: 0.015em)` | Inner padding. Per-range rules override this. |
+| `outset` | `dict` | `(y: 0.15em)` | Outer expansion. |
+| `baseline` | `length` | `-0.06em` | Vertical alignment shift. |
+| `size` | `length` | `0.825em` | Font size of the digit inside the circle. |
+| `kern` | `length` | `-0.075em` | Letter-spacing (`tracking`) of the digit inside the circle. Negative values tighten multi-digit numbers. |
+
+```typst
+// Change stroke globally
+#quan-style(stroke: 0.05em)
+
+// Adjust size and kern for a specific range
+#quan-style(("11-50", (size: 0.75em, kern: -0.1em)))
+
+// Multiple overrides in one call
+#quan-style(
+  stroke: 0.04em,
+  ("11-99", (size: 0.8em)),
+  ("100-999", (size: 0.65em, kern: -0.2em)),
+)
+```
+
+### SimSun Default Rules
+
+The built-in style rules are tuned for **SimSun** (Windows 宋体) and cover 0–99. They adjust `inset` and `kern` based on the visual width of each digit:
+
+| Group | Numbers | Logic |
+|---|---|---|
+| Single digit | 0–9 | one character; wider horizontal inset keeps the circle round |
+| Both narrow | 11 | digits 1+1 |
+| Narrow + medium | 12, 21 | digits 1+2, 2+1 |
+| Narrow + wide | 10, 13–19, 31, 41, 51, 61, 71, 81, 91 | one digit is 1, the other is 0 or ≥ 3 |
+| Wide + wide | 20–99 (units ≠ 1) | neither digit is 1 |
+
+For other fonts, override with `quan-style()` as needed.
+
+---
+
+## 中文
+
+用于排版带圈数字的 Typst 包。在声明的字体覆盖范围内使用原生 Unicode 带圈字形（⓪–㊿），超出范围时自动画圈——因此适用于任何字体，包括带圈字形支持不完整的字体。
+
+### 功能特性
+
+- **优先使用 Unicode 字形** — 在字体支持的范围内使用 ⓪–㊿，避免原生字形与画圈混排不一致
+- **自动画圈兜底** — 对超出字体覆盖范围的整数（含大于 50 的数字）自动绘制带圈字形
+- **声明字体覆盖范围** — `quan-init` 接受 `"1-20"` 或 `"1-5,7,9-11"` 等范围字符串，精确声明字体支持哪些带圈字形
+- **按范围配置样式** — `quan-style` 支持按数字范围分别设置描边、圆角、内边距、基线偏移、字号、字间距
+- **SimSun 开箱即用** — 内置规则针对宋体（SimSun）的字宽特点，覆盖 0–9 单位数及 10–99 数字对，其他字体可通过 `quan-style()` 覆盖
+
+### 快速上手
+
+```typst
+#import "@preview/quan:0.1.0": quan, quan-init, quan-style
+
+// 声明当前字体支持的带圈数字范围（默认：1-10）
+#quan-init(digits: "1-20")
+
+第 #quan(1) 步：安装。第 #quan(2) 步：配置。第 #quan(15) 步：完成。
+```
+
+若不调用 `quan-init`，默认覆盖范围为 **1–10**（大多数中文字体均支持）。超出声明范围或大于 50 的数字将自动画圈。
+
+### API 参考
+
+#### `quan(n)` — 核心函数
+
+输出带圈数字。若 `n` 在 `quan-init` 声明的覆盖范围内，使用 Unicode 字形；否则自动画圈。
+
+| 参数 | 类型 | 说明 |
+|---|---|---|
+| `n` | `int` | 要渲染的数字，必须为整数，非整数输入会 panic。 |
+
+```typst
+#quan(1)    // ①（Unicode 字形，若在覆盖范围内）
+#quan(25)   // 画圈，内含 "25"
+#quan(100)  // 画圈，内含 "100"
+```
+
+---
+
+#### `quan-init(digits: none)` — 声明字体覆盖范围
+
+声明当前字体支持哪些带圈数字字形。超出范围的数字将自动画圈。
+
+| 参数 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `digits` | `str` 或 `none` | `none`（清空为空） | 范围字符串，如 `"1-20"` 或 `"1-5,7,9-11"`。 |
+
+```typst
+#quan-init(digits: "1-20")       // 字体支持 ①–⑳
+#quan-init(digits: "0-50")       // 字体支持 ⓪–㊿
+#quan-init(digits: "1-5,7,9-11") // 稀疏覆盖
+```
+
+> **注意** — 若从未调用 `quan-init`，默认覆盖范围为 `1-10`。
+
+---
+
+#### `quan-style(..args)` — 配置画圈样式
+
+具名参数修改全局默认样式；位置参数为 `(范围字符串, 样式字典)` 元组，按范围覆盖。规则按顺序匹配，取第一个命中。
+
+| 字段 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `stroke` | `length` | `0.0315em` | 圆圈描边粗细。 |
+| `radius` | `ratio` | `50%` | 圆角半径（50% 即圆形）。 |
+| `inset` | `dict` | `(x: 0em, y: 0.015em)` | 内边距，按范围规则可覆盖。 |
+| `outset` | `dict` | `(y: 0.15em)` | 外扩距离。 |
+| `baseline` | `length` | `-0.06em` | 垂直对齐偏移。 |
+| `size` | `length` | `0.825em` | 圈内数字字号。 |
+| `kern` | `length` | `-0.075em` | 圈内数字字间距（`tracking`），负值收紧多位数字。 |
+
+```typst
+// 全局修改描边
+#quan-style(stroke: 0.05em)
+
+// 按范围调整字号和字间距
+#quan-style(("11-50", (size: 0.75em, kern: -0.1em)))
+
+// 多条规则一次设置
+#quan-style(
+  stroke: 0.04em,
+  ("11-99",  (size: 0.8em)),
+  ("100-999", (size: 0.65em, kern: -0.2em)),
+)
+```
+
+### SimSun 默认规则
+
+内置样式规则针对 **SimSun（宋体）** 调校，覆盖 0–99，根据数字的视觉宽度分五组：
+
+| 分组 | 数字范围 | 依据 |
+|---|---|---|
+| 单位数 | 0–9 | 单字符，较大水平内边距保持圆形视觉 |
+| 双窄 | 11 | 两位均为 1 |
+| 窄+中 | 12、21 | 1 与 2 的组合 |
+| 窄+宽 | 10、13–19、31、41、51、61、71、81、91 | 一位为 1，另一位为 0 或 ≥ 3 |
+| 宽+宽 | 20–99（个位非 1） | 两位均非 1 |
+
+如需适配其他字体，通过 `quan-style()` 按需覆盖即可。
+
+---
+
+## License / 许可
+
+MIT License — see [LICENSE](LICENSE) for details.

--- a/packages/preview/quan/0.1.0/lib.typ
+++ b/packages/preview/quan/0.1.0/lib.typ
@@ -1,0 +1,188 @@
+// quan — 带圈数字 / Circled Numbers
+//
+// Public API:
+//   `quan-init(digits: "1-20")`              声明字体支持范围，默认 1-10
+//                                            declare font glyph coverage, default 1-10
+//   `quan-style(stroke:.., ("11-50", (..)))` 配置画圈样式，范围外自动画圈
+//                                            configure drawn-circle style
+//   `quan(n)`                                输出带圈数字，范围外自动画圈
+//                                            output circled number; draws circle if out of coverage
+
+// ── 辅助函数 / Helpers ────────────────────────────────────────────────────
+
+// 解析 "`1-5,7,9-11`" → `array<int>`  /  parse range string to int array
+#let _parse-int-ranges(s) = {
+  let result = ()
+  for part in s.split(",") {
+    let p = part.trim()
+    if p == "" { continue }
+    let dash = p.position("-")
+    if dash != none and dash > 0 {
+      let a = int(p.slice(0, dash).trim())
+      let b = int(p.slice(dash + 1).trim())
+      for i in range(a, b + 1) { result.push(i) }
+    } else {
+      result.push(int(p))
+    }
+  }
+  result
+}
+
+#let _u(n) = calc.rem(n, 10)    // 个位 / units digit
+#let _t(n) = calc.floor(n / 10) // 十位 / tens digit
+
+// ── 状态 / State ─────────────────────────────────────────────────────────
+
+// 字体字形覆盖范围  /  font glyph coverage
+#let _quan-state = state("quan", (
+  digits: range(1, 11),  // 默认 1-10 / default 1-10
+))
+
+// 画圈样式  /  drawn-circle style\
+// `rules` 按顺序匹配，取第一个命中  /  `rules` are matched in order, first match wins
+#let _quan-draw-state = state("quan-draw", (
+  // `default` 作用于未命中任何 rule 的数字（含个位数及 100+）
+  // `default` applies to numbers not matched by any rule (single-digit and 100+)
+  default: (
+    stroke:   0.0315em,
+    radius:   50%,
+    inset:    (x: 0em,    y: 0.015em),
+    outset:   (y: 0.15em),
+    baseline: -0.06em,
+    size:     0.825em,
+    kern:     -0.075em,
+  ),
+  // `rules` 覆盖 0-99，按字形宽度分五组
+  // `rules` cover 0-99, grouped by digit visual width
+  rules: (
+    // 0-9：单位数，需较大水平内边距保持圆形视觉 / single digit, wider horizontal inset for circular look
+    (values: range(0, 10),
+     style:  (inset: (x: 0.25em, y: 0.015em))),
+    // 11：双窄 / both narrow (1+1)
+    (values: (11,),
+     style:  (inset: (x: 0.09em, y: 0.015em), kern: -0.15em)),
+    // 12、21：窄+中 / narrow + medium (1+2, 2+1)
+    (values: (12, 21),
+     style:  (inset: (x: 0.09em, y: 0.015em), kern: -0.125em)),
+    // 窄+宽 / narrow + wide: 10、1X(X≥3) 或 X1(X≥3)
+    // (units digit 0 is wide; tens digit 1 is narrow)
+    (values: range(10, 20).filter(n => _u(n) != 1 and _u(n) != 2) + range(20, 100).filter(n => _u(n) == 1 and _t(n) >= 3),
+     style:  (inset: (x: 0.08em, y: 0.015em), kern: -0.125em)),
+    // 宽+宽 / wide + wide: 20-99，个位非 1
+    (values: range(20, 100).filter(n => _u(n) != 1),
+     style:  (inset: (x: 0.07em, y: 0.015em), kern: -0.1em)),
+  ),
+  // 针对 SimSun 调校 / tuned for SimSun\
+  // 其他字体可能需要通过 `quan-style()` 调整\
+  // adjust via `quan-style()` for other fonts
+))
+
+// ── 公开 API / Public API ────────────────────────────────────────────────
+
+/// 声明字体支持的带圈数字范围。\
+/// Declare which circled digits the current font supports.
+/// 
+/// 示例 / Example:\
+/// "`1-20`", "`1-5,7,9-11`"
+#let quan-init(digits: none) = {
+  _quan-state.update(_ => (
+    digits: if digits != none { _parse-int-ranges(digits) } else { () },
+  ))
+}
+
+/// 配置画圈样式。具名参数修改全局默认；位置参数按范围覆盖。\
+/// Configure drawn-circle style. Named args update global defaults;
+/// positional args are (range-str, style-dict) tuples for per-range overrides.
+///
+/// 示例 / Example:\
+///   `#quan-style(stroke: 0.05em, ("11-50", (size: 0.75em, kern: -0.1em)))`
+///
+/// 可配置字段 / Configurable fields:
+///   `stroke`, `radius`, `inset`, `outset`, `baseline`, `size`, `kern`
+#let quan-style(
+  stroke:   none,
+  radius:   none,
+  inset:    none,
+  outset:   none,
+  baseline: none,
+  size:     none,
+  kern:     none,
+  ..rules,
+) = {
+  _quan-draw-state.update(prev => {
+    let d = prev.default
+    if stroke   != none { d.insert("stroke",   stroke)   }
+    if radius   != none { d.insert("radius",   radius)   }
+    if inset    != none { d.insert("inset",    inset)    }
+    if outset   != none { d.insert("outset",   outset)   }
+    if baseline != none { d.insert("baseline", baseline) }
+    if size     != none { d.insert("size",     size)     }
+    if kern     != none { d.insert("kern",     kern)     }
+    let parsed-rules = prev.rules
+    for rule in rules.pos() {
+      parsed-rules.push((
+        values: _parse-int-ranges(rule.at(0)),
+        style:  rule.at(1),
+      ))
+    }
+    (default: d, rules: parsed-rules)
+  })
+}
+
+// ── 内部渲染 / Internal Rendering ────────────────────────────────────────
+
+// Unicode 带圈字符（0–50）/ Unicode circled digit characters (0–50)
+#let _circled-digit(n) = {
+  if      n == 0               { str.from-unicode(0x24EA) }
+  else if n >= 1  and n <= 20  { str.from-unicode(0x245F + n) }
+  else if n >= 21 and n <= 35  { str.from-unicode(0x3251 + (n - 21)) }
+  else if n >= 36 and n <= 50  { str.from-unicode(0x32B1 + (n - 36)) }
+  else { none }
+}
+
+// 根据 `value` 查找匹配的样式（`default` + 首条命中 `rule`）
+// Resolve style for `value`: merge `default` with first matching `rule`.
+#let _resolve-style(value, draw-cfg) = {
+  let s = draw-cfg.default
+  if type(value) == int {
+    for rule in draw-cfg.rules {
+      if value in rule.values {
+        for (k, v) in rule.style.pairs() { s.insert(k, v) }
+        break
+      }
+    }
+  }
+  s
+}
+
+// 画圈渲染  /  draw a circle around body
+#let _drawn(body, value: none) = context {
+  let s = _resolve-style(value, _quan-draw-state.get())
+  box(
+    stroke:   s.stroke,
+    radius:   s.radius,
+    inset:    s.inset,
+    outset:   s.outset,
+    baseline: s.baseline,
+    text(size: s.size, tracking: s.kern, body),
+  )
+}
+
+/// 输出带圈数字（`int`）。在 `quan-init` 声明的覆盖范围内使用 Unicode 字形；
+/// 超出范围或字体不支持时自动画圈。仅接受整数，非整数输入会触发 panic。
+///
+/// Output a circled number (`int`). Uses Unicode glyphs within the coverage
+/// declared by `quan-init`; falls back to a drawn circle otherwise.
+/// Only integers are accepted; non-integer input panics.
+#let quan(value) = {
+  assert(type(value) == int, message: "quan: expected int, got " + str(type(value)))
+  context {
+    let cfg = _quan-state.get()
+    let g = _circled-digit(value)
+    if g == none or value not in cfg.digits {
+      _drawn(str(value), value: value)
+    } else {
+      g
+    }
+  }
+}

--- a/packages/preview/quan/0.1.0/typst.toml
+++ b/packages/preview/quan/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "quan"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["SchrodingerBlume <https://github.com/SchrodingerBlume>"]
+license = "MIT"
+description = "Circled numbers / 带圈数字"
+repository = "https://github.com/SchrodingerBlume/typst-quan"
+keywords = ["circled", "number"]
+categories = ["text", "utility"]
+compiler = "0.13.0"
+exclude = ["*.pdf"]


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description: `quan` (圈, meaning "circled" in Chinese) is a lightweight package for typesetting circled numbers in Typst. It uses native Unicode circled glyphs (⓪–㊿) when the current font supports them, and automatically draws a circle around the number otherwise — so it works with any font, even those with partial or no circled-digit support. Users declare their font's coverage range via `quan-init`, and can fine-tune the drawn-circle appearance (stroke, radius, inset, size, letter-spacing) globally or per numeric range via `quan-style`. Built-in style rules are tuned for SimSun and cover 0–99 out of the box.

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] `exclude`d PDFs or README images, if any, but not the LICENSE
