### PR TITLE
cap-able:0.1.0

### DIFF
--- a/packages/preview/cap-able/0.1.0/LICENSE
+++ b/packages/preview/cap-able/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SchrodingerBlume (Andrew Junhao Wu)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/cap-able/0.1.0/README.md
+++ b/packages/preview/cap-able/0.1.0/README.md
@@ -1,0 +1,188 @@
+<p align="center">
+  <strong>cap-able</strong><br>
+  <em>Make it more able to caption — now that is cap-able</em>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-0.1.0-blue" alt="version: 0.1.0">
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="license: MIT">
+  <img src="https://img.shields.io/badge/typst-0.13.0+-orange" alt="minimum typst version: 0.13.0">
+</p>
+
+<p align="center">
+  <a href="#english">English</a> | <a href="#中文">中文</a>
+</p>
+
+<p align="center">
+  📖 <a href="https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.1.0/doc-en.pdf">English Documentation</a> · 📖 <a href="https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.1.0/doc-zh.pdf">中文文档</a>
+</p>
+
+---
+
+## English
+
+A comprehensive Typst package for creating professional three-line tables and figures with bilingual caption support, continued tables/figures, subfigures, and flexible customization options for academic documents.
+
+### Features
+
+- **Three-line tables** — Academic-standard tables (top, middle, bottom rules) with Markdown syntax
+- **Bilingual captions** — Auto-formatted bilingual captions (Chinese/English, German/English, Spanish/English, etc.)
+- **Continued tables/figures** — Multi-page tables and figures with automatic numbering
+- **Subfigures** — Flexible multi-image grid layouts with overlay labels and subcaptions
+- **Notes** — Auto-width-matched notes for tables and figures
+- **Multilingual support** — 25+ languages including RTL languages and Traditional/Simplified Chinese
+- **Unified configuration** — Configure both via `cap-style`, or override per-type with `captab-style` / `capfig-style`
+
+### Quick Start
+
+```typst
+#import "@preview/cap-able:0.1.0": *
+
+// Three-line table
+#captab(
+  caption: [Experimental Results],
+)[
+  | Parameter   | Value | Unit |
+  | ----------- | ----- | ---- |
+  | Temperature |  25   |  °C  |
+  | Pressure    |   1   |  atm |
+]
+
+// Figure
+#capfig(
+  image("example.png", width: 50%),
+  caption: [System Architecture],
+)
+
+// Bilingual caption
+#set text(lang: "es")
+
+#captab(
+  caption: [Resultados experimentales],
+  caption-en: [Experimental Results],
+)[
+  | A | B |
+  | 1 | 2 |
+]
+```
+
+### Configuration
+
+```typst
+// Unified configuration for both tables and figures
+#show: cap-style.with(
+  numbering-format: "1.1",
+  use-chapter: true,
+  caption-size: 10.5pt,
+)
+
+// Table-specific configuration
+#show: captab-style.with(
+  caption-above: 1.5em,
+  body-size: 10.5pt,
+)
+
+// Figure-specific configuration
+#show: capfig-style.with(
+  label-mode: "overlay",
+  label-style: "(a)",
+)
+```
+
+### Documentation
+
+Full documentation is available in this repository:
+
+- [English Documentation (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.1.0/doc-en.pdf)
+- [Chinese Documentation (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.1.0/doc-zh.pdf)
+
+### License
+
+MIT License — see [LICENSE](LICENSE) for details.
+
+---
+
+## 中文
+
+一个功能全面的 Typst 包，用于创建专业的三线表和图片，支持双语标题、续表/续图、子图及灵活的自定义选项，适用于学术文档。
+
+### 功能特性
+
+- **三线表** — 符合学术规范的表格（顶线、中线、底线），支持 Markdown 语法
+- **双语标题** — 自动格式化的双语标题（中英、德英、西英等）
+- **续表/续图** — 跨页表格和图片，自动编号
+- **子图** — 灵活的多图并排布局，支持覆盖标签和子标题
+- **注释** — 自动匹配宽度的表注和图注
+- **多语言支持** — 25+ 种语言，包括 RTL 语言及简繁中文区分
+- **统一配置** — 通过 `cap-style` 统一配置，或使用 `captab-style` / `capfig-style` 分别覆盖
+
+### 快速开始
+
+```typst
+#import "@preview/cap-able:0.1.0": *
+
+// 三线表
+#set text(lang: "zh")
+
+#captab(
+  caption: [实验结果],
+  caption-en: [Experimental Results],
+)[
+  | 参数 | 数值 | 单位 |
+  | ---- | ---- | ---- |
+  | 温度 |  25  |  °C  |
+  | 气压 |   1  |  atm |
+]
+
+// 图片
+#capfig(
+  image("example.png", width: 50%),
+  caption: [系统架构],
+  caption-en: [System Architecture],
+)
+
+// 子图
+#capsubfig(
+  (
+    (content: image("a.png"), subcaption: [方案一]),
+    (content: image("b.png"), subcaption: [方案二]),
+  ),
+  columns: 2,
+  caption: [方案对比],
+  caption-en: [Scheme Comparison],
+)
+```
+
+### 配置
+
+```typst
+// 统一配置表格和图片
+#show: cap-style.with(
+  numbering-format: "1.1",
+  use-chapter: true,
+  caption-size: 10.5pt,
+)
+
+// 表格专用配置
+#show: captab-style.with(
+  caption-above: 1.5em,
+  body-size: 10.5pt,
+)
+
+// 图片专用配置
+#show: capfig-style.with(
+  label-mode: "overlay",
+  label-style: "(a)",
+)
+```
+
+### 文档
+
+完整文档见本仓库：
+
+- [中文文档 (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.1.0/doc-zh.pdf)
+- [英文文档 (PDF)](https://github.com/SchrodingerBlume/typst-cap-able/releases/download/v0.1.0/doc-en.pdf)
+
+### 许可
+
+MIT 许可证 — 详见 [LICENSE](LICENSE)。

--- a/packages/preview/cap-able/0.1.0/lib.typ
+++ b/packages/preview/cap-able/0.1.0/lib.typ
@@ -1,0 +1,10 @@
+// ============================================================
+// cap-able 包主入口文件
+// cap-able Package Main Entry
+// ============================================================
+
+#import "src/config.typ": captab-style, capfig-style, cap-style, set-table-width
+#import "src/bicap.typ": bicap
+#import "src/table.typ": captab
+#import "src/note.typ": captnote, capfnote
+#import "src/figure.typ": capfig, capsubfig

--- a/packages/preview/cap-able/0.1.0/src/bicap.typ
+++ b/packages/preview/cap-able/0.1.0/src/bicap.typ
@@ -1,0 +1,941 @@
+// ============================================================
+// 独立标题模块 (Standalone Caption Module)
+// ============================================================
+//
+// 本模块提供独立的双语标题生成功能，是 cap-able 包的核心标题引擎。
+// This module provides standalone bilingual caption generation,
+// serving as the core caption engine of cap-able.
+//
+// 设计目标 / Design Goals:
+// 1. 将"标题生成逻辑"与"表格/图片布局"解耦，使 cap-table、cap-figure 等
+//    函数可以统一调用同一套标题逻辑。
+//    Decouple "caption generation" from "table/figure layout", allowing
+//    cap-table, cap-figure, etc. to share the same caption engine.
+//
+// 2. 支持主标题和续表/续图两种模式：
+//    Support both main and continued (multi-page) caption modes:
+//    - 主标题：自动分配新编号，写入计数器，可在目录中显示
+//              Main caption: allocates a new number, writes to counter, appears in outline
+//    - 续表/续图：引用原始标签的编号，不新增计数，不出现在目录
+//                 Continued: references original label's number, no new counter, no outline entry
+//
+// 3. 支持 25+ 种语言的本地化文本，自动适配间距规则
+//    Support 25+ language localizations with automatic spacing rules
+//
+// 4. 支持 RTL 语言（阿拉伯文、希伯来文、波斯文、乌尔都文）
+//    Support RTL languages (Arabic, Hebrew, Persian, Urdu)
+//
+// 关键技术 / Key Technical Details:
+// - 主标题通过插入一个 place(hide[#figure(...)]) 来注册编号，
+//   然后立即将计数器减 1，最后在显示时再加 1，从而实现"占位但不渲染"。
+//   Main caption registers a number by inserting a hidden figure via
+//   place(hide[#figure(...)]), then decrements the counter by 1, and
+//   increments when rendering — achieving "register without rendering".
+//
+// - 续表通过 query(refer-to) 查询原始标签所在位置的计数器值，
+//   从而获得原始编号进行显示。
+//   Continued captions use query(refer-to) to get the counter value
+//   at the original label's location, retrieving its number.
+//
+// ============================================================
+
+#import "config.typ": *
+
+/// 内部函数：生成标题核心内容（不含外层 block 和间距），由 `bicap()` 和 `cap-table()` 共用。
+/// Internal: generate core caption content (no outer block/spacing), shared by `bicap()` and `cap-table()`.
+///
+/// -> content
+#let _make_caption_content(
+  /// 主语言标题文本（续表时可为 none，仅显示编号）
+  /// Main language caption text (can be none in continuation, showing only number)
+  /// -> none | content
+  caption: none,
+  /// 英文标题文本（双语模式时使用）
+  /// English caption text (used in bilingual mode)
+  /// -> none | content
+  caption-en: none,
+  /// 续表/续图引用的原始标签（提供此参数则进入续表模式）
+  /// Original label for continued table/figure (entering continuation mode when provided)
+  /// -> none | label
+  refer-to: none,
+  /// 此标题的标签（用于交叉引用，如 <tab:results>）
+  /// Label for this caption (for cross-referencing, e.g. <tab:results>)
+  /// -> none | label
+  label: none,
+  /// 样式配置字典（来自 table-style-config 或 figure-style-config）
+  /// Style configuration dictionary (from table-style-config or figure-style-config)
+  /// -> dictionary
+  config: none,
+  /// 类型标识："table" 使用表格计数器；"figure" 使用图片计数器
+  /// Type identifier: "table" uses table counter; "figure" uses image counter
+  /// -> str
+  kind: "table",
+  /// 续表模式下是否显示标题文本。
+  /// auto：若全局 continued-show-caption 也是 auto，则根据是否提供 caption 决定
+  /// Whether to show caption text in continuation mode.
+  /// auto: if global continued-show-caption is also auto, decided by whether caption is provided
+  /// -> auto | bool
+  show-caption: auto,
+) = {
+  context {
+    // 确定实际使用的文档语言（可被 config.lang 覆盖，支持 region 区分如 zh-TW）
+    // Determine actual document language (can be overridden by config.lang, supports region e.g. zh-TW)
+    let doc-lang = resolve-lang-code(config.lang)
+
+    // 根据 kind 确定使用哪组本地化键名
+    // Determine which set of localization keys to use based on kind
+    // "table" -> table/continued-prefix/continued-suffix 键
+    // "figure" -> figure/fig-continued-prefix/fig-continued-suffix 键
+    let supplement-key = if kind == "table" { "table" } else { "figure" }
+    let continued-prefix-key = if kind == "table" { "continued-prefix" } else { "fig-continued-prefix" }
+    let continued-suffix-key = if kind == "table" { "continued-suffix" } else { "fig-continued-suffix" }
+
+    // ── 文本/间距解析辅助 / Text & spacing resolution helpers ──
+    //
+    // _resolve-main: 解析主语言文本。优先级：英文文档且有 *-en 配置 → *-en；
+    //                否则主键配置（非 auto）→ 主键；否则按语言表自动取。
+    // _resolve-main: main-lang text. English doc + *-en set → *-en;
+    //                otherwise main key (non-auto) → main; else lang-table auto.
+    //
+    // _resolve-en: 解析英文行文本。优先级：*-en → main → 英文语言表。
+    // _resolve-en: English-line text. Priority: *-en → main → English lang-table.
+    //
+    // _resolve-spacing: 解析间距字段。auto → 语言表取值；否则用配置值。
+    // _resolve-spacing: spacing field. auto → lookup by lang; else config value.
+    let _resolve-main(main-key, en-key, lang-key) = {
+      let en-val = config.at(en-key, default: auto)
+      let main-val = config.at(main-key, default: auto)
+      if doc-lang == "en" and en-val != auto { en-val }
+      else if main-val == auto { get-table-text(doc-lang, lang-key) }
+      else { main-val }
+    }
+    let _resolve-en(main-key, en-key, lang-key) = {
+      let en-val = config.at(en-key, default: auto)
+      let main-val = config.at(main-key, default: auto)
+      if en-val != auto { en-val }
+      else if main-val != auto { main-val }
+      else { get-table-text("en", lang-key) }
+    }
+    let _resolve-spacing(key) = {
+      let v = config.at(key)
+      if v == auto { get-table-text(doc-lang, key) } else { v }
+    }
+
+    // ── 解析主语言文本 / Resolve main language text ──
+    let final-supplement         = _resolve-main("supplement", "supplement-en", supplement-key)
+    let final-continued-prefix   = _resolve-main("continued-prefix", "continued-prefix-en", continued-prefix-key)
+    let final-continued-suffix   = _resolve-main("continued-suffix", "continued-suffix-en", continued-suffix-key)
+
+    // ── 解析英文行文本 / Resolve English-line text ──
+    let final-supplement-en         = _resolve-en("supplement", "supplement-en", supplement-key)
+    let final-continued-prefix-en   = _resolve-en("continued-prefix", "continued-prefix-en", continued-prefix-key)
+    let final-continued-suffix-en   = _resolve-en("continued-suffix", "continued-suffix-en", continued-suffix-key)
+
+    // ── 解析各种间距值 / Resolve spacing values ──
+    let pre-spacing      = _resolve-spacing("pre-supplement-number-spacing")
+    let post-spacing     = _resolve-spacing("post-supplement-number-spacing")
+    let title-spacing    = _resolve-spacing("number-title-spacing")
+    let title-spacing-en = _resolve-spacing("number-title-spacing-en")
+
+    // 续表显示模式和全局"是否显示标题"配置
+    // Continuation mode and global "show caption" setting
+    let continued-mode = config.at("continued-mode", default: "prefix")
+    let global-show-caption = config.at("continued-show-caption", default: auto)
+
+    // 是否启用英文副标题
+    // Whether bilingual English sub-caption is enabled
+    let enable-en = config.enable-english-caption
+
+    // 解析 caption-text 分层 dict（whole / prefix / supplement / number / body）。
+    // 闭包内的 _line 会读取这里的 layers，无需逐处传参。
+    // Resolve caption-text into layered sub-dicts; _line closes over `layers` below.
+    let layers = _resolve-caption-text-layers(config.at("caption-text", default: (:)))
+
+    // ── 统一标题行构造器 / Unified caption-line builder ──
+    //
+    // 按模板 `prefix [+pre-sp+num] [+post-sp+suffix] [+title-sp+title]` 拼接一行标题。
+    // 任一部件为 none 则连同其间距一起跳过；rtl 为 true 时把各部件用 box 包裹以防方向混乱。
+    // 各部件按 caption-text 分层包装：prefix-block (supplement + num + suffix) 外层包
+    // layers.prefix；supplement/suffix 内再包 layers.supplement；num 包 layers.number；
+    // title 包 layers.body。各层默认 `(:)` 为透明 wrap。
+    // Builds one caption line. Each part is wrapped per the caption-text layers:
+    // prefix-block (supplement + num + suffix) wrapped by layers.prefix; supplement and
+    // suffix by layers.supplement; num by layers.number; title by layers.body.
+    let _line(prefix, num, suffix, title, pre-sp, post-sp, title-sp, rtl: false) = {
+      let b(p) = if rtl and p != none { box[#p] } else { p }
+      // 先构建 prefix-block：supplement + (pre-sp + num) + (post-sp + suffix)
+      let prefix-block = {
+        if prefix != none { text(..layers.supplement)[#b(prefix)] }
+        if num != none {
+          if pre-sp != none { handle-spacing(pre-sp) }
+          text(..layers.number)[#b(num)]
+        }
+        if suffix != none {
+          if post-sp != none { handle-spacing(post-sp) }
+          text(..layers.supplement)[#b(suffix)]
+        }
+      }
+      text(..layers.prefix)[#prefix-block]
+      if title != none {
+        if title-sp != none { handle-spacing(title-sp) }
+        text(..layers.body)[#b(title)]
+      }
+    }
+
+    // 统一生成续表标题（包括主语言与可选的英文副标题）。
+    // Unified builder for continuation captions (main line + optional English subline).
+    //
+    // - num: 原始表/图编号；若为 none 表示 query 未找到，采用降级格式
+    //   Original table/figure number; none means query missed → fallback format
+    // - is-suffix-mode: 续表模式（true=后缀"表X（续）"，false=前缀"续表X"）
+    //   Continuation mode (true = suffix "Table X (cont)", false = prefix "Cont. Table X")
+    // - show-title: 是否显示 caption 文本
+    //   Whether to render caption text
+    let _build-continuation-line(num: none, is-suffix-mode: true, show-title: false) = {
+      let main-prefix  = if is-suffix-mode { final-supplement }        else { final-continued-prefix }
+      let main-suffix  = if is-suffix-mode { final-continued-suffix }  else { none }
+      let en-prefix    = if is-suffix-mode { final-supplement-en }     else { final-continued-prefix-en }
+      let en-suffix    = if is-suffix-mode { final-continued-suffix-en } else { none }
+      // 历史行为：降级（无编号）时跳过 pre-spacing，但仍保留 post-spacing。
+      // Historical behavior: fallback (no num) drops pre-spacing but keeps post-spacing.
+      let main-pre = if num != none { pre-spacing } else { none }
+      let en-pre   = if num != none { [ ] } else { none }
+      let title    = if show-title { caption } else { none }
+      let title-en = if show-title { caption-en } else { none }
+
+      if doc-lang == "en" and enable-en and caption-en != none {
+        _line(main-prefix, num, main-suffix, title-en, main-pre, post-spacing, title-spacing)
+      } else if enable-en and caption-en != none {
+        let m = _line(main-prefix, num, main-suffix, title,    main-pre, post-spacing, title-spacing)
+        let e = _line(en-prefix,   num, en-suffix,   title-en, en-pre,   [ ],          title-spacing-en)
+        [#m \ #e]
+      } else {
+        _line(main-prefix, num, main-suffix, title, main-pre, post-spacing, title-spacing)
+      }
+    }
+
+    if caption != none or refer-to != none {
+      if refer-to != none {
+        // ════════════════════════════════════════════════════════
+        // 续表/续图分支 (Continuation mode branch)
+        // ════════════════════════════════════════════════════════
+        //
+        // 续表不分配新编号，而是查询原始标签的编号进行显示。
+        // Continuation does not allocate a new number but queries
+        // the original label's number for display.
+
+        // 决定是否显示标题文本（还是只显示"续表X"之类的编号信息）
+        // Decide whether to show caption text or just the continuation identifier
+        //
+        // 优先级 / Priority:
+        // 1. 参数 show-caption 明确指定 → 直接用
+        //    show-caption param explicitly set → use directly
+        // 2. 全局 continued-show-caption 有值（非 auto）→ 用全局值
+        //    Global continued-show-caption is set → use global value
+        // 3. 两者都是 auto → 如果提供了 caption/caption-en 则显示，否则不显示
+        //    Both auto → show if caption/caption-en is provided
+        let should-show-caption = if show-caption == auto {
+          if global-show-caption == auto {
+            caption != none or caption-en != none
+          } else {
+            global-show-caption
+          }
+        } else {
+          show-caption
+        }
+
+        // 查询原始标签获取其编号
+        // Query original label to get its number
+        let continuation-caption = {
+          let original = query(refer-to)
+          if original.len() > 0 {
+            // 找到了原始标签，获取其在文档中的编号
+            // Found original label, get its number in the document
+            let use-ch = config.use-chapter
+            // 根据 kind 选择正确的 figure 计数器类型
+            // Choose the correct figure counter type based on kind
+            let figure-kind = if kind == "table" { table } else { image }
+            // 获取原始标签位置处的计数器值（注意：这是历史值，不是当前值）
+            // Get counter value AT the original label's location (historical, not current)
+            let num = counter(figure.where(kind: figure-kind)).at(original.first().location()).first()
+
+            // 根据编号格式生成编号字符串（带或不带章节前缀）
+            // Generate number string with or without chapter prefix
+            let table-num = if use-ch {
+              // 在原始标签所在位置处读取标题计数器（非当前位置）
+              // Read heading counter AT the original label's location (not current)
+              let h = counter(heading).at(original.first().location())
+              let chapter-nums = if type(config.numbering-format) == str {
+                h.slice(0, calc.min(config.chapter-level, h.len()))
+              } else {
+                h
+              }
+              numbering(config.numbering-format, ..chapter-nums, num)
+            } else {
+              // use-chapter: false 也走 numbering-format（保留单数字格式）
+              // Honour numbering-format even without chapter prefix.
+              numbering(config.numbering-format, num)
+            }
+
+            _build-continuation-line(
+              num: table-num,
+              is-suffix-mode: continued-mode == "suffix",
+              show-title: should-show-caption,
+            )
+          } else {
+            // ─ 没有找到原始标签（query 返回空）─
+            // ─ Original label not found (query returned empty) ─
+            //
+            // 可能原因：标签拼写错误，或原始表格在当前位置之后（Typst 暂不支持向后查询）
+            // Possible causes: label typo, or original figure appears after current location
+            // (Typst doesn't support forward queries yet)
+            //
+            // 降级处理：不显示编号，只显示续表标识符
+            // Fallback: show continuation identifier without number
+            _build-continuation-line(
+              num: none,
+              is-suffix-mode: continued-mode == "suffix",
+              show-title: should-show-caption,
+            )
+          }
+        }
+
+        // 渲染续表标题内容（应用标题字号和行距）
+        // Render continuation caption content (apply caption size and leading)
+        set par(leading: config.caption-leading)
+        text(size: config.caption-size, weight: config.caption-weight, ..layers.whole)[
+          #continuation-caption
+        ]
+
+      } else {
+        // ════════════════════════════════════════════════════════
+        // 主表/主图分支 (Main table/figure branch)
+        // ════════════════════════════════════════════════════════
+        //
+        // 技术关键：编号注册技巧
+        // Technical Key: Number Registration Trick
+        //
+        // 问题：cap-table 用自定义布局渲染表格，不使用 Typst 的 figure() 包装，
+        // 因此无法利用 Typst 内置的 figure 计数器自动编号机制。
+        // Problem: cap-table uses custom layout, not Typst's figure() wrapper,
+        // so it can't use Typst's built-in figure counter auto-numbering.
+        //
+        // 解决方案：
+        // Solution:
+        // 1. 用 place(hide[...]) 在文档流中插入一个不可见的 figure，
+        //    其 outlined: true 使其出现在目录中，label 用于交叉引用
+        //    Insert an invisible figure using place(hide[...]),
+        //    with outlined: true for outline, label for cross-referencing
+        // 2. 此操作会使 figure 计数器 +1
+        //    This increments the figure counter by 1
+        // 3. 立即将计数器 -1（还原到插入前的值）
+        //    Immediately decrement counter by 1 (restore to pre-insertion value)
+        // 4. 在显示标题时手动读取计数器 +1 来获得正确的当前编号
+        //    When rendering, manually read counter + 1 to get the correct current number
+        //
+        // 这样做的好处：目录和交叉引用都能正确工作，
+        // 同时标题可以完全自定义格式（不受 Typst 默认标题格式约束）。
+        // Benefits: outline and cross-references work correctly,
+        // while the caption format is fully customizable.
+
+        let figure-kind = if kind == "table" { table } else { image }
+
+        // 步骤1：插入隐藏的 figure，注册编号并设置目录条目
+        // Step 1: Insert hidden figure, register number and set outline entry
+        place(hide[
+          #figure(
+            kind: figure-kind,
+            supplement: final-supplement,
+            outlined: true,             // 出现在目录中 / Appears in outline
+            caption: {
+              // 目录中显示的标题文本（与主标题可能不同）
+              // Caption text shown in outline (may differ from main caption)
+              if doc-lang == "en" and enable-en and caption-en != none {
+                caption-en
+              } else if enable-en and caption-en != none {
+                if config.outline-bilingual {
+                  // 目录双语模式
+                  // Bilingual outline mode
+                  if config.outline-newline {
+                    if is-rtl-lang(doc-lang) {
+                      // RTL 语言：英文在前，主语言在后
+                      // RTL: English first, main language second
+                      [#caption-en \ #caption]
+                    } else {
+                      [#caption \ #caption-en]
+                    }
+                  } else {
+                    let sep = config.outline-separator
+                    if is-rtl-lang(doc-lang) {
+                      [#caption-en#sep#caption]
+                    } else {
+                      [#caption#sep#caption-en]
+                    }
+                  }
+                } else {
+                  // 目录只显示主语言
+                  // Outline shows main language only
+                  caption
+                }
+              } else {
+                caption
+              }
+            },
+            // 同样需要设置编号格式，以便目录中的编号格式正确
+            // Also set numbering format so outline shows correct numbers
+            numbering: num => {
+              if config.use-chapter {
+                let h = counter(heading).get()
+                let chapter-nums = if type(config.numbering-format) == str {
+                  h.slice(0, calc.min(config.chapter-level, h.len()))
+                } else {
+                  h
+                }
+                numbering(config.numbering-format, ..chapter-nums, num)
+              } else {
+                numbering(config.numbering-format, num)
+              }
+            },
+            [],
+          )#if label != none { label }   // 绑定交叉引用标签 / Bind cross-reference label
+        ])
+
+        // 步骤2：将计数器减 1，抵消上面隐藏 figure 造成的计数增加
+        // Step 2: Decrement counter by 1 to cancel the increment from the hidden figure
+        counter(figure.where(kind: figure-kind)).update(n => if n > 0 { n - 1 } else { 0 })
+
+        // 步骤3：读取当前计数器值 +1，得到本表格的正确编号
+        // Step 3: Read current counter + 1 to get the correct number for this table
+        let use-ch = config.use-chapter
+        let num = counter(figure.where(kind: figure-kind)).get().first() + 1
+
+        let table-num = if use-ch {
+          let h = counter(heading).get()
+          let chapter-nums = if type(config.numbering-format) == str {
+            h.slice(0, calc.min(config.chapter-level, h.len()))
+          } else {
+            h
+          }
+          numbering(config.numbering-format, ..chapter-nums, num)
+        } else {
+          // use-chapter: false 也走 numbering-format
+          numbering(config.numbering-format, num)
+        }
+
+        // 步骤4：生成主标题内容（考虑 RTL 和双语布局）
+        // Step 4: Generate main caption content (considering RTL and bilingual layout)
+        // 使用统一的 _line 构造器；RTL 语言需对各部件 box 包裹并对英文行强制 ltr。
+        // Uses the unified _line builder; RTL wraps parts in box and forces ltr on English line.
+        let rtl = is-rtl-lang(doc-lang)
+        let main-caption = if doc-lang == "en" and enable-en and caption-en != none {
+          _line(final-supplement, table-num, none, caption-en, pre-spacing, none, title-spacing)
+        } else if enable-en and caption-en != none {
+          let m = _line(final-supplement, table-num, none, caption, pre-spacing, none, title-spacing, rtl: rtl)
+          let e = _line(final-supplement-en, table-num, none, caption-en, [ ], none, title-spacing-en)
+          if rtl { [#m \ #text(dir: ltr)[#e]] } else { [#m \ #e] }
+        } else {
+          _line(final-supplement, table-num, none, caption, pre-spacing, none, title-spacing, rtl: rtl)
+        }
+
+        // 步骤5：将计数器推进 +1（完成本表格的编号分配）
+        // Step 5: Advance counter by 1 (completing number allocation for this table)
+        counter(figure.where(kind: figure-kind)).step()
+
+        // 步骤6：渲染主标题内容
+        // Step 6: Render main caption content
+        set par(leading: config.caption-leading)
+        text(size: config.caption-size, weight: config.caption-weight, ..layers.whole)[
+          #main-caption
+        ]
+      }
+    }
+  }
+}
+
+
+/// 独立双语标题函数，可用于表格（`kind: "table"`）或图片（`kind: "figure"`）。
+///
+/// 调用方式 / Usage:
+/// - `#bicap(caption: [...], kind: "...")` —— 仅渲染题注，按 `caption-above` /
+///   `caption-below` 间距独立成块。
+/// - `#bicap(caption: [...], kind: "...")[body]` —— 把 body 与题注一起包进一个
+///   不换页 block，相当于一个 `figure(kind: ...)` 的 cap-able 版本。题注与
+///   body 的相对位置由 `caption-position` 决定（state 默认：table=top、figure=bottom；
+///   可通过 `captab-style` / `capfig-style` 全局覆盖，或直接传 `config`）。
+///
+/// Standalone bilingual caption for tables (`kind: "table"`) or figures (`kind: "figure"`).
+///
+/// Calling forms:
+/// - `#bicap(caption: [...], kind: "...")` — caption only, in its own non-breakable block.
+/// - `#bicap(caption: [...], kind: "...")[body]` — wraps body and caption together,
+///   conceptually a cap-able-flavoured `figure(kind: ...)`. Caption position is taken
+///   from `caption-position` (default top for tables, bottom for figures; configurable
+///   via `captab-style` / `capfig-style` or by passing `config`).
+///
+/// -> content
+#let bicap(
+  /// 主语言标题文本
+  /// Main language caption text
+  /// -> none | content
+  caption: none,
+  /// 英文标题文本（双语模式）
+  /// English caption text (bilingual mode)
+  /// -> none | content
+  caption-en: none,
+  /// 引用原始表/图的标签（提供此参数则进入续表模式）
+  /// Reference to the original table/figure label (enables continuation mode)
+  /// -> none | label
+  refer-to: none,
+  /// 此标题的标签（用于交叉引用）
+  /// Label for this caption (for cross-references)
+  /// -> none | label
+  label: none,
+  /// 内容类型："table" 或 "figure"
+  /// Content type: "table" or "figure"
+  /// -> str
+  kind: "table",
+  /// 续表/图是否显示标题文本（auto=自动根据 caption 是否提供决定）
+  /// Whether to show caption text in continuation (auto = based on whether caption is provided)
+  /// -> auto | bool
+  show-caption: auto,
+  /// 样式配置，auto 则从全局 table-style-config 获取
+  /// Style config, auto = use global table-style-config
+  /// -> auto | dictionary
+  config: auto,
+  /// 题注位置（auto = 跟随全局 caption-position；top 或 bottom 直接覆盖）
+  /// Caption position (auto = follow global caption-position; top / bottom to override)
+  /// -> auto | alignment
+  position: auto,
+  /// 题注水平对齐：字符串 "center" / "left" / "right" / "text-left" / "text-right"
+  /// 也接受 dict (main: ..., continued: ...) 拆分主与续。auto = 跟随全局 caption-align。
+  /// Caption horizontal alignment: string "center" / "left" / "right" / "text-left" /
+  /// "text-right". Also accepts dict (main, continued) for split. auto = follow global.
+  /// -> auto | str | dictionary
+  caption-align: auto,
+  /// 浮动定位：none（默认，原地）/ top / bottom（浮到当前页或下一页的顶/底）。auto =
+  /// 跟随全局 placement。启用时强制 breakable: false（Typst float 不允许跨页）。
+  /// Floating placement; auto follows global. Forces breakable: false when active.
+  /// -> auto | none | alignment
+  placement: (),
+  /// 外层 block 是否允许跨页。默认 `true`，让 body 里本身可跨页的内容（如长 captab、
+  /// 长段落）顺延到下一页；设为 `false` 则强制把题注 + body 锁在同一页。
+  /// Whether the outer block may break across pages. Defaults to `true` so a body
+  /// that is itself breakable (e.g. a long captab or paragraph) flows naturally;
+  /// set `false` to keep caption + body atomic on one page.
+  /// -> bool
+  breakable: true,
+  /// 跨页时是否在 body 里 *每张原生 #table()* 的顶部重复题注。
+  /// 仅在 `kind == "table"` 时生效；通过 `show table:` 注入一个 level-1
+  /// `table.header(repeat: true)` 实现，复用与 `captab(continued-caption: true)` 同款的
+  /// `query(label) + here().page()` 检测，续页才显示。
+  ///
+  /// *约定*：一个 bicap 里只放一张 `#table()`。如果 body 里同时有多张表，所有表都会被
+  /// 注入相同的题注（因为 bicap 把它们视作"同一题注下的多个表"），通常不是你想要的；
+  /// 此时请改写成多个 bicap 调用，或用 `captab` 直接管理每张表的题注。
+  ///
+  /// `kind == "figure"` 下此参数为 no-op（图片本身不跨页；如有跨页图请用 `refer-to`）。
+  ///
+  /// Whether to repeat the caption above each native `#table()` inside body when it
+  /// breaks across pages. Only active when `kind == "table"`. Implemented by injecting
+  /// a level-1 `table.header(repeat: true)` via `show table:`, reusing the
+  /// `query(label) + here().page()` mechanism from `captab(continued-caption: true)` so the
+  /// repeated caption only renders on continuation pages.
+  ///
+  /// *Convention*: keep at most one `#table()` per bicap. If body contains multiple
+  /// tables, the same caption is injected into ALL of them — usually not what you want;
+  /// in that case use multiple bicap calls or manage each table's caption with `captab`.
+  ///
+  /// No-op when `kind == "figure"`; for cross-page figures use `refer-to`.
+  /// -> bool
+  continued-caption: false,
+  /// 跨页时是否重复 body 内 `#table()` 的 markdown 表头行。
+  /// `auto`（默认）= 不干涉用户写在 `table.header(...)` 里的 `repeat` 设定；
+  /// `true | false | <int>` = 强制覆盖，跟 Typst 原生 `table.header(repeat: ...)` 一致。
+  /// 仅 `kind == "table"` 生效，与 `continued-caption` 互相独立。
+  ///
+  /// Whether to repeat the markdown header row of `#table()` inside body across pages.
+  /// `auto` (default) leaves the user's existing `table.header(repeat: ...)` untouched;
+  /// `true | false | <int>` overrides it (matching Typst's native semantics).
+  /// Only active when `kind == "table"`; independent of `continued-caption`.
+  /// -> auto | bool | int
+  repeat-header: auto,
+  /// 可选的 body：可以用名参 `body: [...]` 或在调用尾部用内容块 `#bicap()[...]`，
+  /// 后者会通过 `..body-args` 收集进来。两种形式等价。
+  /// Optional body — pass via the named arg `body: [...]` or as a trailing content
+  /// block `#bicap()[...]` (collected through `..body-args`); the two forms are equivalent.
+  /// -> none | content
+  body: none,
+  ..body-args,
+) = {
+  context {
+    // 如果用户用 #bicap()[...] 形式，body 通过 ..body-args 进来
+    // If the user wrote #bicap()[...], the body comes in via ..body-args
+    let body = if body != none {
+      body
+    } else if body-args.pos().len() > 0 {
+      body-args.pos().first()
+    } else {
+      none
+    }
+    // 拒绝 ..body-args 里出现命名参数（bicap 不接受未声明的命名参数）
+    // Reject named args in ..body-args (bicap does not accept unknown named args)
+    assert(
+      body-args.named().len() == 0,
+      message: "bicap: unexpected named arguments " + repr(body-args.named().keys()),
+    )
+    assert(
+      body-args.pos().len() <= 1,
+      message: "bicap: at most one positional argument (body) is allowed",
+    )
+    // 解析配置：auto 则读取全局表格配置，否则使用传入值
+    // Resolve config: auto = read global table config, otherwise use provided value
+    let final-config = if config == auto {
+      if kind == "figure" { figure-style-config.get() } else { table-style-config.get() }
+    } else {
+      config
+    }
+
+    // ── continued-caption 启用条件 / continued-caption activation ──
+    // 仅在 kind == "table"、有 body、有 caption、且不是 refer-to 模式时启用。
+    // 续页 query 需要一个 label，没传就合成隐藏 label（仿照 captab）。
+    // Only active when kind == "table" with body + caption (not refer-to mode).
+    // Continuation needs a label for query(); auto-synthesise a hidden one if absent.
+    let cap-in-body = (continued-caption
+                       and kind == "table"
+                       and caption != none
+                       and refer-to == none
+                       and body != none)
+    let synth-id = if cap-in-body and label == none {
+      counter("__bicap-synth-id").get().first()
+    } else { 0 }
+    let effective-label = if label != none {
+      label
+    } else if cap-in-body {
+      std.label("__bicap_repeat_" + str(synth-id))
+    } else {
+      none
+    }
+
+    // 生成标题核心内容（用 effective-label 注册，方便续页 query）
+    // Generate caption content (registered with effective-label so continuation pages can query it)
+    let caption-content = _make_caption_content(
+      caption: caption,
+      caption-en: caption-en,
+      refer-to: refer-to,
+      label: effective-label,
+      config: final-config,
+      kind: kind,
+      show-caption: show-caption,
+    )
+
+    // 解析语言和首行缩进修复标志 / Resolve language and indent-fix flag
+    let (_, should-indent) = resolve-lang-indent(final-config)
+
+    // 解析题注位置：参数 > 全局 state > 按 kind 兜底
+    // Resolve caption position: param > global state > kind-based fallback
+    let final-position = if position != auto {
+      position
+    } else {
+      final-config.at(
+        "caption-position",
+        default: if kind == "figure" { bottom } else { top },
+      )
+    }
+
+    // 题注水平对齐：参数 > 全局 state > "center"；dict 形式 (main, continued) 拆分。
+    // 续表那侧 text-left/text-right 静默降级为 left/right（cap-cell 锁在表内）。
+    // 必要时改用 *手动 refer-to* 拆段，把续题放到表外。
+    // Caption horizontal alignment: param > global state > "center"; dict (main, continued)
+    // splits sides. Continuation side text-left/text-right silently degrade to left/right
+    // (cap-cell is locked within the table). Use manual refer-to for true text-anchored
+    // continuation captions.
+    let raw-cap-align = if caption-align != auto {
+      caption-align
+    } else {
+      final-config.at("caption-align", default: "center")
+    }
+    let final-cap-align-main = if type(raw-cap-align) == dictionary {
+      raw-cap-align.at("main", default: "center")
+    } else {
+      raw-cap-align
+    }
+    let _cap-align-continued-raw = if type(raw-cap-align) == dictionary {
+      raw-cap-align.at("continued", default: "center")
+    } else {
+      raw-cap-align
+    }
+    let final-cap-align-continued = if _cap-align-continued-raw == "text-left" { "left" }
+      else if _cap-align-continued-raw == "text-right" { "right" }
+      else { _cap-align-continued-raw }
+
+    let _resolve-cap-align(s) = {
+      if s == "left"        { (kind: "local", value: left) }
+      else if s == "right"  { (kind: "local", value: right) }
+      else if s == "text-left"  { (kind: "text", value: left) }
+      else if s == "text-right" { (kind: "text", value: right) }
+      else                  { (kind: "local", value: center) }
+    }
+    let main-align-resolved      = _resolve-cap-align(final-cap-align-main)
+    let continued-align-resolved = _resolve-cap-align(final-cap-align-continued)
+
+    // 浮动定位：per-call > state > none
+    // Floating placement: per-call > state > none
+    let final-placement = if placement != () {
+      placement
+    } else {
+      final-config.at("placement", default: none)
+    }
+    // 浮动启用时强制 breakable: false（Typst float 不允许跨页）
+    // Float forces breakable: false (Typst floats can't break across pages)
+    let breakable = if final-placement != none { false } else { breakable }
+
+    // 如果用了 cap-in-body 且我们合成了 label，把 synth-id 计数器推进 1
+    // If cap-in-body used a synthesised label, step the synth counter
+    if cap-in-body and label == none {
+      counter("__bicap-synth-id").step()
+    }
+
+    // 续页 cell 的内容：仅在续页（页码 != 主表登记页）调 _make_caption_content
+    // 走 refer-to 分支输出"续表 X.Y caption"，不会重复登记 figure 编号。
+    // Continuation cell content: only on continuation pages (page != main location's
+    // page) call _make_caption_content's refer-to branch to render "Cont. Table X.Y".
+    let cap-cell-content = if cap-in-body {
+      context {
+        let originals = query(effective-label)
+        if originals.len() > 0 {
+          let start-page = originals.first().location().page()
+          if here().page() != start-page {
+            v(final-config.at("caption-above", default: 0pt))
+            _make_caption_content(
+              caption: caption,
+              caption-en: caption-en,
+              refer-to: effective-label,
+              label: none,
+              config: final-config,
+              kind: "table",
+              show-caption: true,
+            )
+            v(final-config.at("caption-below", default: 0pt))
+          }
+        }
+      }
+    } else { none }
+
+    // body 的展示形式：cap-in-body 时用 show table: rule 给 body 内每张原生
+    // #table() 注入一个 level-1 table.header(repeat: true) caption 行；
+    // 已经带有 level-1 header 的（例如 captab 自己生成的 table）跳过，避免双层。
+    // Body presentation: when cap-in-body, use show table: rule to inject a
+    // level-1 table.header(repeat: true) caption row into every native #table()
+    // in body. Tables that already have a level-1 table.header (e.g. those generated
+    // by captab itself) are skipped to avoid double-stacking.
+    // show table 注入条件：要么需要插 caption header（cap-in-body），要么需要
+    // 覆盖 markdown 表头的 repeat 设定（repeat-header != auto）。
+    // Show-table activation: when caption injection is needed (cap-in-body) OR
+    // when we have to override the markdown header's repeat setting.
+    let needs-show-table = (
+      kind == "table"
+      and body != none
+      and (cap-in-body or repeat-header != auto)
+    )
+    let presented-body = if needs-show-table {
+      {
+        show table: it => {
+          let f = it.fields()
+          let cols = f.at("columns", default: 1)
+          let ncols = if type(cols) == array { cols.len() } else if type(cols) == int { cols } else { 1 }
+          let original-children = f.at("children", default: ())
+          // 任何 children 里有 level >= 2 的 table.header 说明：要么是 captab 嵌套结构
+          // （level 1 caption + level 2 markdown header），要么是我们这条 show rule
+          // 上一轮已经处理过的 output（用户原 L1 已被 promote 到 L2）。无论哪种都
+          // 直接返回 it，避免重复注入和无限 show-rule 递归。
+          // Any child being a level >= 2 table.header means either (a) captab's nested
+          // structure, or (b) our own previous-pass output where the user's L1 header
+          // was promoted to L2. Either way, skip — both prevents stacking captions and
+          // breaks the show-rule recursion.
+          let is-captab-shaped = original-children.any(c => (
+            c.func() == table.header
+            and c.fields().at("level", default: 1) >= 2
+          ))
+          // 用户原始 L1 header 是否存在
+          // Whether the user wrote a level-1 table.header
+          let has-user-l1-header = original-children.any(c => (
+            c.func() == table.header
+            and c.fields().at("level", default: 1) == 1
+          ))
+          if is-captab-shaped {
+            it
+          } else if not cap-in-body and not has-user-l1-header {
+            // 没有 caption 注入，又没有 L1 header 可以覆盖 repeat —— 没事可做，原样返回
+            // Nothing to inject and no user L1 header to override → leave as-is
+            it
+          } else {
+            // 改写用户原有的 level-1 table.header：
+            // - cap-in-body 时把 level 提升到 2（让我们的 caption header 占据 level 1）；
+            // - repeat-header != auto 时覆盖其 repeat 字段。
+            // Rewrite the user's level-1 table.header:
+            // - when cap-in-body, promote level to 2 (we take level 1 for the caption);
+            // - when repeat-header != auto, override its repeat field.
+            // 用户原有 level-1 header 一律 promote 到 level 2：
+            // 1) cap-in-body 时让我们的 caption header 占据 level 1；
+            // 2) 没有 cap-in-body 但需要覆盖 repeat 时，把 level 推到 2 也能让
+            //    `is-captab-shaped` 检查在下一次 show 触发时识别"已处理"，
+            //    避免 show rule 无限递归（max show rule depth）。
+            // Always promote the user's level-1 header to level 2:
+            // 1) when cap-in-body, our cap-header takes level 1;
+            // 2) when only overriding repeat, promoting to level 2 makes
+            //    `is-captab-shaped` on the next pass detect "already processed",
+            //    avoiding the "maximum show rule depth exceeded" panic.
+            let promoted-children = original-children.map(c => {
+              let is-l1-header = c.func() == table.header and c.fields().at("level", default: 1) == 1
+              if is-l1-header {
+                let cf = c.fields()
+                let kids = cf.at("children", default: ())
+                let user-repeat = cf.at("repeat", default: true)
+                let final-repeat = if repeat-header != auto { repeat-header } else { user-repeat }
+                let other = (:)
+                for (k, v) in cf.pairs() {
+                  if k != "children" and k != "level" and k != "repeat" {
+                    other.insert(k, v)
+                  }
+                }
+                table.header(level: 2, repeat: final-repeat, ..other, ..kids)
+              } else {
+                c
+              }
+            })
+            // 重建 table，保留所有非 children 字段
+            // Rebuild the table preserving all non-children fields
+            let other-fields = (:)
+            for (k, v) in f.pairs() {
+              if k != "children" {
+                other-fields.insert(k, v)
+              }
+            }
+            if cap-in-body {
+              let cap-header = table.header(
+                level: 1,
+                repeat: true,
+                table.cell(
+                  colspan: ncols,
+                  stroke: none,
+                  align: continued-align-resolved.value,
+                  inset: (x: 0pt, y: 0pt),
+                  cap-cell-content,
+                ),
+              )
+              // 兜底：如果用户原本没有 L1 header（也就没有可 promote 到 L2 的东西），
+              // promoted-children 里就缺乏 level >= 2 的 marker，本轮 output 进入下一次
+              // show 触发时 is-captab-shaped 会判 false → 无限递归。塞一个空的
+              // level-2 table.header 当 marker，不渲染任何可见内容，仅用于打断递归。
+              // Fallback: if the user had no L1 header to promote, promoted-children
+              // lacks the level >= 2 marker that the next show-pass uses to short-circuit,
+              // causing infinite show-rule recursion. Insert an empty level-2 header as
+              // a marker — it renders nothing visible but stops the recursion.
+              let has-l2-or-higher = promoted-children.any(c => (
+                c.func() == table.header
+                and c.fields().at("level", default: 1) >= 2
+              ))
+              let final-promoted = if has-l2-or-higher {
+                promoted-children
+              } else {
+                (table.header(level: 2, repeat: true),) + promoted-children
+              }
+              table(..other-fields, cap-header, ..final-promoted)
+            } else {
+              // 只是覆盖 repeat-header，没有题注重复 / Header-repeat override only
+              table(..other-fields, ..promoted-children)
+            }
+          }
+        }
+        body
+      }
+    } else { body }
+
+    // 浮动包装 helper：placement: top/bottom 时把 outer block 包进 place(float: true)。
+    // place() 仅给 vertical alignment 时水平默认贴左——补 + center 保留居中行为。
+    // 隐藏 figure 一同 ride 进 float wrapper，counter 在 float 落地时 step，`@ref` 解析
+    // 到 float 落地页。长 body float 装不下时 Typst 会溢出/裁切——用户应保持 placement: none。
+    // Float-wrapping helper. place() with vertical-only alignment defaults to left-align
+    // horizontally — we add `+ center` to keep things centered. Hidden figure rides along.
+    let _normalize-placement(p) = if p == top { top + center }
+      else if p == bottom { bottom + center }
+      else { p }
+    let _maybe-float(content) = if final-placement != none {
+      place(_normalize-placement(final-placement), float: true, content)
+    } else {
+      content
+    }
+
+    if caption != none or refer-to != none {
+      if body == none {
+        // 旧形式：只渲染题注；走主标题对齐（kind="text" 时占满文本宽对齐到正文边缘，
+        // kind="local" 时由调用上下文负责居中——这里直接 align 即可）
+        // Caption-only form. Apply main caption-align: text-anchored aligns to text-area
+        // edges (full block), local alignment is applied in-place (caller handles centering).
+        let cap-line = if main-align-resolved.kind == "text" {
+          block(width: 100%, std.align(main-align-resolved.value, caption-content))
+        } else {
+          std.align(main-align-resolved.value, caption-content)
+        }
+        _maybe-float(block(
+          breakable: breakable,
+          above: final-config.at("caption-above", default: 0pt),
+          below: final-config.at("caption-below", default: 0pt),
+        )[#cap-line])
+      } else {
+        // 新形式：题注 + body 一起包进一个不换页 block，模拟 figure(body, caption: ...)
+        // Body form: wrap caption + body in a single non-breakable block (figure-like)
+        let above-key = if kind == "figure" { "figure-above" } else { "caption-above" }
+        let below-key = if kind == "figure" { "figure-below" } else { "table-below" }
+        // caption 与 body 之间的间距：caption 在上时用 caption-below，caption 在下时用 caption-above
+        // Gap between caption and body: caption-below if caption on top; caption-above if caption on bottom
+        let gap-key = if final-position == top { "caption-below" } else { "caption-above" }
+        let gap = final-config.at(gap-key, default: 0.5em)
+        // 根据 main-align-resolved 组合 caption + body：
+        //   kind == "text"  → caption 单独占一行 block(width: 100%)，body 居中独立排版；
+        //   kind == "local" → caption 与 body 共享一个 align(center) 容器，
+        //                     在该容器内对 caption 应用 left/right/center。
+        // 由于 bicap 的 body 宽度不可靠测量，"local left/right" 会作用于 *居中容器内*：
+        // 当 body < text-width 时，效果与 text-left/text-right 接近但未完全等同
+        // （详见手册"已知限制"段落）。
+        // For bicap, body width is generally unknown. local left/right aligns within the
+        // centered container (≈ text-anchored when body < text width); see the manual.
+        let composed = if main-align-resolved.kind == "text" {
+          let cap-line = block(width: 100%, std.align(main-align-resolved.value, caption-content))
+          let body-line = align(center, presented-body)
+          if final-position == top {
+            cap-line
+            v(gap)
+            body-line
+          } else {
+            body-line
+            v(gap)
+            cap-line
+          }
+        } else {
+          align(center)[
+            #if final-position == top {
+              std.align(main-align-resolved.value, caption-content)
+              v(gap)
+              presented-body
+            } else {
+              presented-body
+              v(gap)
+              std.align(main-align-resolved.value, caption-content)
+            }
+          ]
+        }
+        _maybe-float(block(
+          breakable: breakable,
+          above: final-config.at(above-key, default: 0pt),
+          below: final-config.at(below-key, default: 0pt),
+        )[#composed])
+      }
+      if should-indent { _fakepar }
+    } else if body != none {
+      // 没有题注但有 body：直接输出 body（也支持 placement）
+      // No caption, only body: emit body (also supports placement)
+      _maybe-float(presented-body)
+    }
+  }
+}

--- a/packages/preview/cap-able/0.1.0/src/config.typ
+++ b/packages/preview/cap-able/0.1.0/src/config.typ
@@ -1,0 +1,1347 @@
+// ============================================================
+// 配置和辅助函数模块 (Configuration and Helper Functions Module)
+// ============================================================
+//
+// 本模块是 cap-able 包的核心配置层，负责：
+// This module is the core configuration layer of cap-able:
+//
+// 1. 多语言文本支持（25+ 种语言）
+//    Multilingual text support (25+ languages)
+// 2. 全局状态管理（表格/图片样式、间距、子图）
+//    Global state management (table/figure style, spacing, subfigures)
+// 3. 辅助工具函数（间距处理、语言检测、章节计算）
+//    Utility functions (spacing, language detection, chapter calculation)
+// 4. 用户配置入口函数（table-style、figure-style、set-table-width）
+//    User-facing configuration functions
+//
+// ============================================================
+
+#import "@preview/tablem:0.3.0": tablem
+
+// ============================================================
+// 辅助内容块 (Helper Content Block)
+// ============================================================
+
+// 假段落，用于修复中文等语言在表格/图片/表注后首行缩进丢失的问题。
+// Fake paragraph to restore first-line indentation after tables/figures in CJK languages.
+//
+// 原理：Typst 的 first-line-indent 只在"真实段落"开头生效。通过插入一个不可见
+// 的零高度块，欺骗 Typst 将后续内容识别为新段落，从而恢复正确的缩进。
+// Principle: Typst's first-line-indent only activates at paragraph starts.
+// This invisible zero-height block tricks Typst into treating what follows as a new paragraph.
+#let _fakepar = context{box();v(-measure(block()+block()).height)}
+
+// ============================================================
+// 语言分类列表 (Language Classification Lists)
+// ============================================================
+
+// 需要段落首行缩进的语言：中文、日文、韩文、法文、越南文、泰文
+// Languages requiring paragraph first-line indentation: CJK + French, Vietnamese, Thai
+#let indent-languages = ("zh", "ja", "ko", "fr", "vi", "th")
+
+// 检测是否为需要段落首行缩进的语言。
+// Check if the language requires paragraph first-line indentation.
+// 用于决定在表格/图片/表注后是否插入 _fakepar 修复缩进。
+// Used to decide whether to insert _fakepar after tables/figures/notes.
+// lang-code (str): 语言代码，如 "zh"、"en" / Language code
+#let needs-after-indent(
+  lang-code
+) = {
+  lang-code in indent-languages
+}
+
+// 从右到左书写的语言：阿拉伯文、希伯来文、波斯文、乌尔都文
+// Right-to-left languages: Arabic, Hebrew, Persian, Urdu
+// RTL 语言在双语标题中需要调换主语言和英文行的顺序，
+// 并为英文行显式设置 dir: ltr。
+// RTL languages swap main/English line order in bilingual captions,
+// and need explicit dir: ltr on the English line.
+#let rtl-languages = ("ar", "he", "fa", "ur")
+
+// 检测是否为从右到左书写的语言。
+// Check if the language is written right-to-left (RTL).
+// lang-code (str): 语言代码 / Language code
+#let is-rtl-lang(
+  lang-code
+) = {
+  lang-code in rtl-languages
+}
+
+// ============================================================
+// 多语言文本配置 (Multilingual Text Configuration)
+// ============================================================
+//
+// table-lang-config 字典键说明 / Key descriptions for table-lang-config:
+//
+// - table:                    表格前缀词，如 "表"、"Table"、"Tabelle"
+//                             Table prefix word
+// - continued-prefix:         续表前缀，如 "续表"、"Continuation of Table"
+//                             Continued table prefix
+// - continued-suffix:         续表后缀，如 "（续）"、"(continued)"
+//                             Continued table suffix
+// - figure:                   图片前缀词，如 "图"、"Figure"、"Abbildung"
+//                             Figure prefix word
+// - fig-continued-prefix:     续图前缀
+//                             Continued figure prefix
+// - fig-continued-suffix:     续图后缀
+//                             Continued figure suffix
+// - pre-supplement-number-spacing:
+//     前缀词与编号之间的间距。中文/日文为 0em（紧排如"表1"），西文为空格（如"Table 1"）
+//     Space between prefix and number. CJK: 0em (tight: "表1"); Western: space ("Table 1")
+// - post-supplement-number-spacing:
+//     编号与续表后缀之间的间距
+//     Space between number and continuation suffix
+// - number-title-spacing:
+//     编号与主语言标题之间的分隔。中文用全角空格（\u{3000}），西文用 ": " 或 ". "
+//     Separator between number and title. CJK: em-space (\u{3000}); Western: ": " or ". "
+// - number-title-spacing-en:
+//     编号与英文标题之间的分隔（双语标题英文行使用）
+//     Separator between number and English title (for bilingual English line)
+//
+#let table-lang-config = (
+  // 英文 / English
+  en: (
+    table: "Table",
+    continued-prefix: "Continuation of Table",
+    continued-suffix: "(continued)",
+    figure: "Figure",
+    fig-continued-prefix: "Continuation of Figure",
+    fig-continued-suffix: "(continued)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 简体中文 / Simplified Chinese
+  // 特点：前缀与编号紧排（0em），编号与标题用全角空格（U+3000）
+  // Feature: prefix-number tight (0em), number-title uses em-space (U+3000)
+  zh: (
+    table: "表",
+    continued-prefix: "续表",
+    continued-suffix: "（续）",
+    figure: "图",
+    fig-continued-prefix: "续图",
+    fig-continued-suffix: "（续）",
+    pre-supplement-number-spacing: 0em,
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [\u{3000}],
+    number-title-spacing-en: [#h(0.5em)],
+  ),
+  // 繁體中文 / Traditional Chinese
+  // 使用 #set text(lang: "zh", region: "TW") 啟用
+  // Enable with #set text(lang: "zh", region: "TW")
+  zh-TW: (
+    table: "表",
+    continued-prefix: "續表",
+    continued-suffix: "（續）",
+    figure: "圖",
+    fig-continued-prefix: "續圖",
+    fig-continued-suffix: "（續）",
+    pre-supplement-number-spacing: 0em,
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [\u{3000}],
+    number-title-spacing-en: [#h(0.5em)],
+  ),
+  // 德文 / German
+  de: (
+    table: "Tabelle",
+    continued-prefix: "Fortsetzung von Tabelle",
+    continued-suffix: "(Fortsetzung)",
+    figure: "Abbildung",
+    fig-continued-prefix: "Fortsetzung von Abbildung",
+    fig-continued-suffix: "(Fortsetzung)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 法文 / French
+  // 注：法文排版规范要求冒号前有空格，如 "Tableau 1 : Titre"
+  // Note: French typography requires a space before the colon: "Tableau 1 : Titre"
+  fr: (
+    table: "Tableau",
+    continued-prefix: "Suite du Tableau",
+    continued-suffix: "(suite)",
+    figure: "Figure",
+    fig-continued-prefix: "Suite de la Figure",
+    fig-continued-suffix: "(suite)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [ : ],
+    number-title-spacing-en: [: ],
+  ),
+  // 西班牙文 / Spanish
+  es: (
+    table: "Tabla",
+    continued-prefix: "Continuación de la Tabla",
+    continued-suffix: "(continuación)",
+    figure: "Figura",
+    fig-continued-prefix: "Continuación de la Figura",
+    fig-continued-suffix: "(continuación)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 意大利文 / Italian
+  it: (
+    table: "Tabella",
+    continued-prefix: "Continuazione della Tabella",
+    continued-suffix: "(continua)",
+    figure: "Figura",
+    fig-continued-prefix: "Continuazione della Figura",
+    fig-continued-suffix: "(continua)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 葡萄牙文 / Portuguese
+  pt: (
+    table: "Tabela",
+    continued-prefix: "Continuação da Tabela",
+    continued-suffix: "(continuação)",
+    figure: "Figura",
+    fig-continued-prefix: "Continuação da Figura",
+    fig-continued-suffix: "(continuação)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 俄文 / Russian
+  ru: (
+    table: "Таблица",
+    continued-prefix: "Продолжение таблицы",
+    continued-suffix: "(продолжение)",
+    figure: "Рисунок",
+    fig-continued-prefix: "Продолжение рисунка",
+    fig-continued-suffix: "(продолжение)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 日文 / Japanese（与中文相同规则 / Same rules as Chinese）
+  ja: (
+    table: "表",
+    continued-prefix: "表の続き",
+    continued-suffix: "（続き）",
+    figure: "図",
+    fig-continued-prefix: "図の続き",
+    fig-continued-suffix: "（続き）",
+    pre-supplement-number-spacing: 0em,
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [\u{3000}],
+    number-title-spacing-en: [#h(0.5em)],
+  ),
+  // 韩文 / Korean
+  ko: (
+    table: "표",
+    continued-prefix: "표 계속",
+    continued-suffix: "(계속)",
+    figure: "그림",
+    fig-continued-prefix: "그림 계속",
+    fig-continued-suffix: "(계속)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 阿拉伯文（RTL）/ Arabic (RTL)
+  ar: (
+    table: "جدول",
+    continued-prefix: "تابع الجدول",
+    continued-suffix: "(تابع)",
+    figure: "شكل",
+    fig-continued-prefix: "تابع الشكل",
+    fig-continued-suffix: "(تابع)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 荷兰文 / Dutch
+  nl: (
+    table: "Tabel",
+    continued-prefix: "Vervolg van Tabel",
+    continued-suffix: "(vervolg)",
+    figure: "Figuur",
+    fig-continued-prefix: "Vervolg van Figuur",
+    fig-continued-suffix: "(vervolg)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 波兰文 / Polish
+  pl: (
+    table: "Tabela",
+    continued-prefix: "Kontynuacja Tabeli",
+    continued-suffix: "(cd.)",
+    figure: "Rysunek",
+    fig-continued-prefix: "Kontynuacja Rysunku",
+    fig-continued-suffix: "(cd.)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 捷克文 / Czech
+  cs: (
+    table: "Tabulka",
+    continued-prefix: "Pokračování Tabulky",
+    continued-suffix: "(pokračování)",
+    figure: "Obrázek",
+    fig-continued-prefix: "Pokračování Obrázku",
+    fig-continued-suffix: "(pokračování)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 瑞典文 / Swedish
+  sv: (
+    table: "Tabell",
+    continued-prefix: "Fortsättning av Tabell",
+    continued-suffix: "(forts.)",
+    figure: "Figur",
+    fig-continued-prefix: "Fortsättning av Figur",
+    fig-continued-suffix: "(forts.)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 丹麦文 / Danish
+  da: (
+    table: "Tabel",
+    continued-prefix: "Fortsættelse af Tabel",
+    continued-suffix: "(fortsat)",
+    figure: "Figur",
+    fig-continued-prefix: "Fortsættelse af Figur",
+    fig-continued-suffix: "(fortsat)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 挪威文 / Norwegian
+  no: (
+    table: "Tabell",
+    continued-prefix: "Fortsettelse av Tabell",
+    continued-suffix: "(forts.)",
+    figure: "Figur",
+    fig-continued-prefix: "Fortsettelse av Figur",
+    fig-continued-suffix: "(forts.)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 芬兰文 / Finnish
+  fi: (
+    table: "Taulukko",
+    continued-prefix: "Taulukon jatko",
+    continued-suffix: "(jatkoa)",
+    figure: "Kuva",
+    fig-continued-prefix: "Kuvan jatko",
+    fig-continued-suffix: "(jatkoa)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 土耳其文 / Turkish
+  tr: (
+    table: "Tablo",
+    continued-prefix: "Tablonun Devamı",
+    continued-suffix: "(devam)",
+    figure: "Şekil",
+    fig-continued-prefix: "Şeklin Devamı",
+    fig-continued-suffix: "(devam)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 希腊文 / Greek
+  el: (
+    table: "Πίνακας",
+    continued-prefix: "Συνέχεια Πίνακα",
+    continued-suffix: "(συνέχεια)",
+    figure: "Σχήμα",
+    fig-continued-prefix: "Συνέχεια Σχήματος",
+    fig-continued-suffix: "(συνέχεια)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 希伯来文（RTL）/ Hebrew (RTL)
+  he: (
+    table: "טבלה",
+    continued-prefix: "המשך טבלה",
+    continued-suffix: "(המשך)",
+    figure: "תמונה",
+    fig-continued-prefix: "המשך תמונה",
+    fig-continued-suffix: "(המשך)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 印地文 / Hindi
+  hi: (
+    table: "तालिका",
+    continued-prefix: "तालिका जारी",
+    continued-suffix: "(जारी)",
+    figure: "चित्र",
+    fig-continued-prefix: "चित्र जारी",
+    fig-continued-suffix: "(जारी)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 泰文 / Thai（用普通空格，无冒号 / Regular space, no colon）
+  th: (
+    table: "ตาราง",
+    continued-prefix: "ตารางต่อ",
+    continued-suffix: "(ต่อ)",
+    figure: "รูป",
+    fig-continued-prefix: "รูปต่อ",
+    fig-continued-suffix: "(ต่อ)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [ ],
+    number-title-spacing-en: [ ],
+  ),
+  // 越南文 / Vietnamese
+  vi: (
+    table: "Bảng",
+    continued-prefix: "Tiếp theo Bảng",
+    continued-suffix: "(tiếp theo)",
+    figure: "Hình",
+    fig-continued-prefix: "Tiếp theo Hình",
+    fig-continued-suffix: "(tiếp theo)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [. ],
+    number-title-spacing-en: [. ],
+  ),
+  // 波斯文（RTL）/ Persian (RTL)
+  fa: (
+    table: "جدول",
+    continued-prefix: "ادامه جدول",
+    continued-suffix: "(ادامه)",
+    figure: "شکل",
+    fig-continued-prefix: "ادامه شکل",
+    fig-continued-suffix: "(ادامه)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+  // 乌尔都文（RTL）/ Urdu (RTL)
+  ur: (
+    table: "جدول",
+    continued-prefix: "جدول کا تسلسل",
+    continued-suffix: "(جاری)",
+    figure: "شکل",
+    fig-continued-prefix: "شکل کا تسلسل",
+    fig-continued-suffix: "(جاری)",
+    pre-supplement-number-spacing: [ ],
+    post-supplement-number-spacing: 0em,
+    number-title-spacing: [: ],
+    number-title-spacing-en: [: ],
+  ),
+)
+
+// ============================================================
+// 全局配置状态 (Global Configuration States)
+// ============================================================
+//
+// 所有全局配置通过 Typst 的 state() 机制传递，保证上下文正确性。
+// All global config is passed via Typst's state() for context correctness.
+// 使用方式：state.get() 必须在 context {...} 块内调用。
+// Usage: state.get() must be called inside context {...} blocks.
+//
+// table-style-config 字段说明 / Field descriptions:
+//   caption-above:        标题块上方间距 / Space above caption block
+//   caption-below:        标题与表体之间间距 / Space between caption and table body
+//   table-below:          整个表格下方间距 / Space below the whole table
+//   caption-leading:      标题行距（影响双语标题两行间距）/ Caption line spacing
+//   numbering-format:     编号格式，如 "1"、"1.1"、"A.1" / Numbering format
+//   use-chapter:          是否包含章节号 / Include chapter number
+//   chapter-level:        由 numbering-format 自动计算的章节层级数
+//                         Chapter level count, auto-calculated from numbering-format
+//   supplement:           主语言前缀词（auto=从语言配置自动获取）
+//                         Main language prefix (auto = from lang config)
+//   supplement-en:        英文前缀词 / English prefix
+//   continued-prefix:     续表前缀（主语言）/ Continued table prefix
+//   continued-prefix-en:  续表前缀（英文）/ English continued prefix
+//   continued-suffix:     续表后缀（主语言）/ Continued table suffix
+//   continued-suffix-en:  续表后缀（英文）/ English continued suffix
+//   continued-mode:       续表模式："prefix"（续表X）或"suffix"（表X（续））
+//                         Continuation mode: "prefix" or "suffix"
+//   continued-show-caption: 续表是否显示标题文本 / Show caption text in continuation
+//   caption-size:         标题字号 / Caption font size
+//   caption-weight:       标题字重 / Caption font weight
+//   pre-supplement-number-spacing:  前缀与编号间距 / Prefix-number spacing
+//   post-supplement-number-spacing: 编号与后缀间距 / Number-suffix spacing
+//   number-title-spacing:    编号与主语言标题间距 / Number-title separator
+//   number-title-spacing-en: 编号与英文标题间距 / Number-English-title separator
+//   lang:                 语言覆盖（auto=跟随 text.lang）/ Language override
+//   enable-english-caption: 是否生成英文副标题 / Enable English sub-caption
+//   body-size:            表格内容字号 / Table body font size
+//   body-leading:         表格内容行距 / Table body line spacing
+//   cell-inset:           单元格内边距（字典或标量）/ Cell padding
+//   note-above:           表注上方间距 / Space above note
+//   note-below:           表注下方间距 / Space below note
+//   note-size:            表注字号 / Note font size
+//   note-leading:         表注行距 / Note line spacing
+//   note-justify:         表注是否两端对齐 / Justify note text
+//   outline-bilingual:    目录中是否双语显示 / Bilingual captions in outline
+//   outline-separator:    目录双语分隔符 / Bilingual separator in outline
+//   outline-newline:      目录双语是否换行 / Newline for bilingual in outline
+//   after-indent:         首行缩进修复（auto=按语言自动）/ Indentation fix
+
+// 表格全局样式配置状态，由 table-style() 更新，被 cap-table()、bicap()、table-note() 读取。
+// Global table style state, updated by table-style(), read by cap-table(), bicap(), table-note().
+#let table-style-config = state("table-style-config", (
+  caption-above: 1.5em,
+  caption-below: 0.5em,
+  table-below: 0.5em,
+  caption-leading: 0.5em,
+  numbering-format: "1",
+  use-chapter: true,
+  chapter-level: 0,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: "prefix",
+  continued-show-caption: auto,
+  caption-size: 10.5pt,
+  caption-weight: "regular",
+  // 题注的额外 text(...) 参数（dict），原样透传给底层 text() 调用。
+  // 可指定 font / fill / tracking / spacing / stretch 等任何 Typst text() 接受的字段。
+  // 与 caption-size / caption-weight 同名键冲突时本字段 *优先*（覆盖层）。
+  // Extra text(...) args for caption rendering (dict). Spread verbatim into the
+  // underlying text() call — any key Typst's text() takes (font / fill / tracking / ...).
+  // Wins over caption-size / caption-weight when keys collide (override layer).
+  caption-text: (:),
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: true,
+  body-size: 10.5pt,
+  body-leading: 0.45em,
+  cell-inset: (x: 3pt, y: 6.5pt),
+  note-above: 0.7em,
+  note-below: 1em + 1.5pt,
+  note-size: 10.5pt,
+  note-leading: 6.5pt,
+  note-justify: true,
+  outline-bilingual: false,
+  outline-separator: " / ",
+  outline-newline: false,
+  after-indent: auto,
+  // 是否生成三线表（true：手动三线 + stroke:none；false：跳过三线、使用
+  // Typst 默认 table 边框样式）
+  // Whether to render as a three-line table (true: manual top/mid/bottom rules with
+  // stroke:none; false: skip the rules and use Typst's default table stroke)
+  three-line-table: true,
+  // 三线表线条粗细（仅 three-line-table: true 时生效）
+  // Three-line table rule strokes (only used when three-line-table: true)
+  top-rule: 1.5pt,
+  middle-rule: 0.5pt,
+  bottom-rule: 1.5pt,
+  // 跨页控制 / Page-break control
+  breakable: true,            // 表格是否允许跨页 / Whether table may break across pages
+  repeat-header: true,        // 跨页时是否重复表头行 / Repeat header row on each page
+  continued-caption: false,      // 跨页时是否重复题注（true 时题注会在每页表头上方再渲染一次）/ Repeat caption on each page
+  // bicap 包内容时的题注位置（top=题注在内容上方；bottom=题注在内容下方；表格默认 top）
+  // Caption position when bicap wraps body (default top for tables)
+  caption-position: top,
+  // 题注水平对齐：字符串 "center"（默认）/ "left" / "right"（与表/图对齐）/
+  // "text-left" / "text-right"（与正文区对齐）。也接受 dict (main: ..., continued: ...)
+  // 拆分主标题与续表标题。
+  // Caption horizontal alignment: string values "center" (default) / "left" / "right"
+  // (table-local) / "text-left" / "text-right" (text-area-local). Also accepts dict
+  // (main, continued) for splitting main vs continuation captions.
+  caption-align: "center",
+  // 浮动定位：none（默认，原地）/ top / bottom（浮到当前页或下一页的顶/底）。
+  // 类似 Typst figure(placement: ...)，但通过 place(float: true) 包外层 block 实现。
+  // 浮动启用时强制 breakable: false（Typst float 不允许跨页）；长表请保持 placement: none。
+  // Floating placement: none (default, in-flow) / top / bottom (float to top/bottom of
+  // current or next page). Mirrors Typst's figure(placement: ...) but via place(float: true)
+  // wrapping. Forces breakable: false when active (Typst floats can't break across pages);
+  // long tables should keep placement: none.
+  placement: none,
+))
+
+// 图片全局样式配置状态（合并了样式、间距、子图三部分字段）。
+// 由 figure-style() 更新，被 capfig()、capsubfig()、capfnote()、bicap()（图片模式）读取。
+// Global figure config (merged: style + spacing + subfigure fields).
+// Updated by figure-style(), read by capfig(), capsubfig(), capfnote(), bicap() (figure mode).
+#let figure-style-config = state("figure-style", (
+  // ─ 编号与标题 / Numbering & caption ─
+  numbering-format: "1",
+  use-chapter: false,
+  chapter-level: 0,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: "prefix",
+  continued-show-caption: auto,
+  caption-size: 10.5pt,
+  caption-weight: "regular",
+  // 题注的额外 text(...) 参数（dict），原样透传给底层 text() 调用。
+  // Extra text(...) args for caption rendering (dict).
+  caption-text: (:),
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: true,
+  outline-bilingual: false,
+  outline-separator: " / ",
+  outline-newline: false,
+  after-indent: auto,
+  // ─ 图注 / Figure note ─
+  note-above: 0.7em,
+  note-below: 1em + 1.5pt,
+  note-size: 10.5pt,
+  note-leading: 6.5pt,
+  note-justify: true,
+  // ─ 间距 / Spacing ─
+  figure-above: 1em,
+  figure-below: 1em,
+  caption-above: 0.5em,
+  caption-leading: 0.5em,
+  subcaption-above: 0.3em,
+  subcaption-below: 0.5em,
+  // auto = 继承大题注的 number-title-spacing；也可显式传 content / length
+  // auto = inherit number-title-spacing from the main caption;
+  // accepts content / length as override
+  subcaption-number-title-spacing: auto,
+  // ─ 子图布局与标签 / Subfigure layout & labels ─
+  gutter: 1em,
+  subcaption-pos: "bottom",
+  show-subcaption: false,
+  show-subcaption-label: true,
+  align: "horizon",
+  label-mode: none,
+  label-style: "(a)",
+  label-font: ("Arial",),
+  label-size: 12pt,
+  label-offset: (4pt, 4pt),
+  label-text-color: black,
+  label-stroke: none,
+  label-bg: none,
+  label-bg-shape: "rect",
+  label-bg-radius: 2pt,
+  label-bg-inset: 3pt,
+  label-sep: auto,
+  // bicap 包内容时的题注位置（图片默认 bottom）/ Caption position for figures
+  caption-position: bottom,
+  // 题注水平对齐（含义同 captab）/ Caption horizontal alignment (same semantics as captab)
+  caption-align: "center",
+  // 浮动定位（含义同 captab）/ Floating placement (same semantics as captab)
+  placement: none,
+))
+
+// 表格宽度全局配置 / Global table width config.
+// 接受 auto（默认，不固定宽度）/ length（如 8cm）/ ratio（如 80%、80.5%）。
+// Accepts auto (default, unconstrained) / length (e.g. 8cm) / ratio (e.g. 80%, 80.5%).
+#let table-width-config = state("table-width", auto)
+
+// 图片宽度全局配置（百分比，1-100），用于 capfnote 默认宽度匹配。
+// Global figure width config (percentage, 1-100), used by capfnote auto-width.
+#let figure-width-config = state("figure-width", 100)
+
+// ============================================================
+// 辅助工具函数 (Utility Functions)
+// ============================================================
+
+/// Set table width globally. Accepts `auto` (no fixed width), a `length`
+/// (e.g. `8cm`) or a `ratio` (e.g. `80%`, `80.5%`).
+///
+/// 兼容旧 API：`set-table-width(percentage: 80)` 仍然可用，会被转成 `80%`。
+/// Backward-compat: legacy `set-table-width(percentage: <int>)` is still
+/// accepted and converted to `<int>%` internally.
+/// -> content
+#let set-table-width(
+  // 新 API：auto / length / ratio。优先级高于 percentage。
+  // New API: auto / length / ratio. Wins over `percentage` when both supplied.
+  width: none,
+  // 旧 API：1-100 之间的整数，会被转成 ratio。/ Legacy 1-100 int, converted to ratio.
+  percentage: none,
+) = {
+  let resolved = if width != none {
+    width
+  } else if percentage != none {
+    assert(
+      type(percentage) == int and percentage > 0 and percentage <= 100,
+      message: "percentage 必须是 1-100 之间的整数",
+    )
+    percentage * 1%
+  } else {
+    auto
+  }
+  table-width-config.update(resolved)
+}
+
+/// Set figure width percentage (1-100) for capfnote auto-width matching.
+/// -> content
+#let set-figure-width(
+  percentage: 100
+) = {
+  assert(percentage > 0 and percentage <= 100, message: "percentage必须在1-100之间")
+  figure-width-config.update(percentage)
+}
+
+// 解析语言代码：结合 text.lang 和 text.region 生成完整语言代码。
+// 例如 lang="zh", region="TW" → 先查 "zh-TW"，再回退到 "zh"。
+// Resolve language code: combine text.lang and text.region.
+// e.g. lang="zh", region="TW" → try "zh-TW" first, fall back to "zh".
+// 必须在 context 块内调用 / Must be called inside a context block.
+#let resolve-lang-code(lang) = {
+  let base = if lang == auto { text.lang } else { lang }
+  let region = text.region
+  if region != none {
+    let combined = base + "-" + region
+    if combined in table-lang-config { combined } else { base }
+  } else {
+    base
+  }
+}
+
+/// 共享语言与缩进修复解析函数。给定含 lang/after-indent 字段的配置，
+/// 返回 (lang, should-indent)。供 captab/capfig/captnote/capfnote 复用。
+/// Shared language/indent resolution. Given a config dict with lang/after-indent
+/// fields, returns (lang, should-indent). Used by captab/capfig/captnote/capfnote.
+#let resolve-lang-indent(config) = {
+  let lang = resolve-lang-code(config.at("lang", default: auto))
+  let should-indent = if config.at("after-indent", default: auto) == auto {
+    needs-after-indent(lang)
+  } else {
+    config.at("after-indent")
+  }
+  (lang, should-indent)
+}
+
+// 从编号格式字符串计算章节层级数。
+// Calculate the number of chapter levels from a numbering format string.
+// format (str | function): 编号格式 / Numbering format
+//   字符串：扫描格式占位符（1/a/A/i/I），最后一个当作图/表自身编号；
+//   函数：返回 0，意味着 *章节层级数不由我们决定*——见 set-figure 处的处理。
+//   String: scan for format placeholders (1/a/A/i/I); the last one is the figure/table
+//     number, the rest are chapter prefix levels.
+//   Function: return 0; chapter-level is irrelevant for function-form formats — call sites
+//     pass all heading levels and let the user's function decide what to consume.
+#let calculate-chapter-levels(
+  format
+) = {
+  // 函数形式直接返回 0：使用方按需要消费 heading 各级编号，不靠 calculate
+  // Function form: return 0; callers pass all heading levels for function-form formats.
+  if type(format) != str { return 0 }
+
+  let count = 0
+  // 用 clusters() 按字素遍历，避免在多字节字符（如中文 "附"）中间切到非边界
+  // Iterate by graphemes (clusters) so we don't index into the middle of a
+  // multi-byte char like "附". A naïve byte index breaks UTF-8 boundaries.
+  for char in format.clusters() {
+    // 支持的格式字符：1（阿拉伯数字）、a（小写字母）、A（大写字母）、
+    // i（小写罗马数字）、I（大写罗马数字）
+    // Supported: 1 (arabic), a (lowercase), A (uppercase), i (roman lc), I (roman uc)
+    if char == "1" or char == "a" or char == "A" or char == "i" or char == "I" {
+      count += 1
+    }
+  }
+  // 最后一个格式字符代表图/表本身的序号，不计入章节层级
+  // The last format char is the figure/table number itself, not a chapter level
+  if count > 0 { count - 1 } else { 1 }
+}
+
+// 获取文档语言对应的本地化文本，不支持的语言回退到英文。
+// Get localized text for the document language, falling back to English if unsupported.
+// lang-code (str): 语言代码 / Language code; key (str): 配置字典键名 / Config dict key
+#let get-table-text(
+  lang-code,
+  key
+) = {
+  if lang-code in table-lang-config {
+    table-lang-config.at(lang-code).at(key)
+  } else {
+    // 语言不在支持列表中，回退到英文 / Language not supported, fall back to English
+    table-lang-config.en.at(key)
+  }
+}
+
+// 解析 caption-text 字段为分层 dict（whole / prefix / supplement / number / body），
+// 返回 5 个独立的子 dict，调用方分别 spread 到对应的 text(...) 调用。
+//
+// caption-text 接受两种形式：
+//   - 扁平 dict（含 Typst text() 字段如 font/fill/...）→ 视为 whole 层
+//   - 分层 dict（出现 whole/prefix/supplement/number/body 任一键）→ 按层拆分
+//
+// Resolve a `caption-text` value into the 5 layered sub-dicts (whole / prefix /
+// supplement / number / body); each call site spreads them into nested text(...) calls.
+//
+// Two forms accepted:
+//   - flat dict (Typst text() fields like font/fill/...) → treated as the `whole` layer
+//   - nested dict (any of whole/prefix/supplement/number/body present) → split per layer
+#let _resolve-caption-text-layers(value) = {
+  let empty = (
+    whole: (:), prefix: (:), supplement: (:), number: (:), body: (:),
+  )
+  if type(value) != dictionary { return empty }
+  let layer-keys = ("whole", "prefix", "supplement", "number", "body")
+  let is-nested = value.keys().any(k => k in layer-keys)
+  if is-nested {
+    (
+      whole:      value.at("whole",      default: (:)),
+      prefix:     value.at("prefix",     default: (:)),
+      supplement: value.at("supplement", default: (:)),
+      number:     value.at("number",     default: (:)),
+      body:       value.at("body",       default: (:)),
+    )
+  } else {
+    // 扁平 dict 整体作为 whole 层
+    // Flat dict applies to the whole caption.
+    (
+      whole: value, prefix: (:), supplement: (:), number: (:), body: (:),
+    )
+  }
+}
+
+// 处理间距值：length/relative 类型转为 h() 水平间距，内容类型直接输出。
+// Handle spacing: convert length/relative to h(); pass content through as-is.
+// spacing-value: 间距值（长度或内容块）/ Spacing value (length or content)
+#let handle-spacing(
+  spacing-value
+) = {
+  if type(spacing-value) == length or type(spacing-value) == relative {
+    h(spacing-value)  // 长度转水平间距 / Convert length to horizontal space
+  } else {
+    spacing-value     // 内容直接输出 / Output content as-is
+  }
+}
+
+// ============================================================
+// 表格样式配置函数 (Table Style Configuration Function)
+// ============================================================
+
+/// Configure global table style for all cap-table, bicap and table-note calls within the body.
+/// 所有参数默认为 auto = "保持当前 state 不变"，因此可以多次调用 captab-style 仅
+/// 覆盖部分字段（patch 语义），而不会把未提供的字段重置为默认值。
+/// All params default to auto = "keep current state". Multiple captab-style calls
+/// patch only the supplied fields; omitted fields are preserved.
+/// -> content
+#let captab-style(
+  caption-above: auto,
+  caption-below: auto,
+  table-below: auto,
+  caption-leading: auto,
+  numbering-format: auto,
+  use-chapter: auto,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: auto,
+  continued-show-caption: auto,
+  caption-size: auto,
+  caption-weight: auto,
+  // 题注的 text() 参数透传字典；接受任何 Typst text() 形参（font / fill / tracking 等）
+  // Pass-through dict for caption text() — accepts any Typst text() field.
+  caption-text: auto,
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: auto,
+  body-size: auto,
+  body-leading: auto,
+  cell-inset: auto,
+  inset: auto,             // ← cell-inset 的别名（与 captab 的 inset 保持一致）/ alias of cell-inset
+  note-above: auto,
+  note-below: auto,
+  note-size: auto,
+  note-leading: auto,
+  note-justify: auto,
+  outline-bilingual: auto,
+  outline-separator: auto,
+  outline-newline: auto,
+  after-indent: auto,
+  // 表格宽度（auto = 不固定；length 如 8cm；ratio 如 80%、80.5%）
+  // Table width (auto = unconstrained; length e.g. 8cm; ratio e.g. 80%, 80.5%)
+  width: auto,
+  // 是否使用三线表（默认 true；false 时跳过手动三线，使用 Typst 默认 table 边框）
+  // Three-line table mode (default true; false skips manual rules, uses default Typst stroke)
+  three-line-table: auto,
+  // 三线表线条粗细（接受任何 stroke 值，如 1.5pt + red；仅 three-line-table: true 时生效）
+  // Three-line rule strokes (any stroke value; only used when three-line-table: true)
+  top-rule: auto,
+  middle-rule: auto,
+  bottom-rule: auto,
+  // 跨页控制 / Page-break control
+  breakable: auto,            // bool：表格能否跨页 / Whether the table may break across pages
+  repeat-header: auto,        // bool | int：跨页时重复表头行的页数（true=全部，int=前 n 页）/ Repeat header (true / n)
+  continued-caption: auto,       // bool：跨页时是否在每页表头上方重复题注 / Repeat caption on every page
+  // bicap()[body] 模式下题注位置（top=题注在内容上方，bottom=题注在内容下方）/ Caption position for bicap+body
+  caption-position: auto,
+  // 题注水平对齐：center / left / right / text-left / text-right
+  // 也接受 dict (main: ..., continued: ...) 拆分主与续
+  caption-align: auto,
+  // 浮动定位：none / top / bottom（top/bottom 启用 Typst float 包装，禁止跨页）
+  // Floating placement; top/bottom enable Typst float wrapping (no page breaks)
+  placement: (),
+  it
+) = {
+  // ── 1. Patch state（仅覆盖非 auto 字段）/ Patch state (only non-auto) ──
+  context {
+    let cur = table-style-config.get()
+    let new = cur
+    if caption-above != auto { new.insert("caption-above", caption-above) }
+    if caption-below != auto { new.insert("caption-below", caption-below) }
+    if table-below != auto { new.insert("table-below", table-below) }
+    if caption-leading != auto { new.insert("caption-leading", caption-leading) }
+    if numbering-format != auto {
+      new.insert("numbering-format", numbering-format)
+      new.insert("chapter-level", calculate-chapter-levels(numbering-format))
+    }
+    if use-chapter != auto { new.insert("use-chapter", use-chapter) }
+    if supplement != auto { new.insert("supplement", supplement) }
+    if supplement-en != auto { new.insert("supplement-en", supplement-en) }
+    if continued-prefix != auto { new.insert("continued-prefix", continued-prefix) }
+    if continued-prefix-en != auto { new.insert("continued-prefix-en", continued-prefix-en) }
+    if continued-suffix != auto { new.insert("continued-suffix", continued-suffix) }
+    if continued-suffix-en != auto { new.insert("continued-suffix-en", continued-suffix-en) }
+    if continued-mode != auto { new.insert("continued-mode", continued-mode) }
+    if continued-show-caption != auto { new.insert("continued-show-caption", continued-show-caption) }
+    if caption-size != auto { new.insert("caption-size", caption-size) }
+    if caption-weight != auto { new.insert("caption-weight", caption-weight) }
+    if caption-text != auto { new.insert("caption-text", caption-text) }
+    if pre-supplement-number-spacing != auto { new.insert("pre-supplement-number-spacing", pre-supplement-number-spacing) }
+    if post-supplement-number-spacing != auto { new.insert("post-supplement-number-spacing", post-supplement-number-spacing) }
+    if number-title-spacing != auto { new.insert("number-title-spacing", number-title-spacing) }
+    if number-title-spacing-en != auto { new.insert("number-title-spacing-en", number-title-spacing-en) }
+    if lang != auto { new.insert("lang", lang) }
+    if enable-english-caption != auto { new.insert("enable-english-caption", enable-english-caption) }
+    if body-size != auto { new.insert("body-size", body-size) }
+    if body-leading != auto { new.insert("body-leading", body-leading) }
+    // 接受 cell-inset 或 inset；同时传入时 cell-inset 优先（与 state 字段名一致）
+    // Accept either cell-inset or inset; cell-inset wins when both are passed (matches state key)
+    let effective-cell-inset = if cell-inset != auto { cell-inset } else { inset }
+    if effective-cell-inset != auto { new.insert("cell-inset", effective-cell-inset) }
+    if note-above != auto { new.insert("note-above", note-above) }
+    if note-below != auto { new.insert("note-below", note-below) }
+    if note-size != auto { new.insert("note-size", note-size) }
+    if note-leading != auto { new.insert("note-leading", note-leading) }
+    if note-justify != auto { new.insert("note-justify", note-justify) }
+    if outline-bilingual != auto { new.insert("outline-bilingual", outline-bilingual) }
+    if outline-separator != auto { new.insert("outline-separator", outline-separator) }
+    if outline-newline != auto { new.insert("outline-newline", outline-newline) }
+    if after-indent != auto { new.insert("after-indent", after-indent) }
+    if three-line-table != auto { new.insert("three-line-table", three-line-table) }
+    if top-rule != auto { new.insert("top-rule", top-rule) }
+    if middle-rule != auto { new.insert("middle-rule", middle-rule) }
+    if bottom-rule != auto { new.insert("bottom-rule", bottom-rule) }
+    if breakable != auto { new.insert("breakable", breakable) }
+    if repeat-header != auto { new.insert("repeat-header", repeat-header) }
+    if continued-caption != auto { new.insert("continued-caption", continued-caption) }
+    if caption-position != auto { new.insert("caption-position", caption-position) }
+    if caption-align != auto { new.insert("caption-align", caption-align) }
+    if placement != () { new.insert("placement", placement) }
+    table-style-config.update(new)
+    // 表格宽度走独立的 table-width-config state；这里按 patch 语义在非 auto 时写入
+    // Width lives in its own table-width-config state; patch only when non-auto
+    if width != auto { table-width-config.update(width) }
+  }
+
+  // ── 2. 静态 figure.caption 位置 ──
+  show figure.where(kind: table): set figure.caption(position: top)
+
+  // ── 3. figure(gap) — 在 show 回调内 context-read state ──
+  show figure.where(kind: table): fig => context {
+    let cfg = table-style-config.get()
+    set figure(gap: cfg.caption-below)
+    fig
+  }
+
+  // ── 4. figure 编号回调（context 读取 state） ──
+  set figure(
+    numbering: num => context {
+      let cfg = table-style-config.get()
+      if cfg.use-chapter {
+        // 字符串格式：按 chapter-level 切片；函数格式：把所有 heading 层级全发过去，
+        // 让用户函数自行决定怎么消费。
+        // String format: slice heading levels by chapter-level. Function format:
+        // pass all heading levels and let the user's function decide.
+        let h = counter(heading).get()
+        let chapter-nums = if type(cfg.numbering-format) == str {
+          h.slice(0, calc.min(cfg.chapter-level, h.len()))
+        } else {
+          h
+        }
+        numbering(cfg.numbering-format, ..chapter-nums, num)
+      } else {
+        // use-chapter: false 时也尊重用户的 numbering-format（字符串或函数）
+        // 只传图/表自身的 num，不附加 heading 前缀。
+        // Honour the user's numbering-format (str | function) even without chapter prefix.
+        numbering(cfg.numbering-format, num)
+      }
+    }
+  )
+
+  // ── 5. 标题渲染（context 读取 state） ──
+  show figure.caption.where(kind: table): cap => context {
+    let cfg = table-style-config.get()
+    set par(leading: cfg.caption-leading)
+
+    // 解析 caption-text 分层 dict（whole / prefix / supplement / number / body）。
+    // 扁平 dict 整体当 whole 层；分层 dict 按层拆分。
+    // Resolve caption-text into 5 layered sub-dicts.
+    let layers = _resolve-caption-text-layers(cfg.at("caption-text", default: (:)))
+
+    // 提前在 context 内解析 spacing 与 numbering 内容，避免内层多嵌一层 context
+    // Resolve spacings + number content inside the existing context block.
+    let current-lang = resolve-lang-code(cfg.lang)
+    let pre-space = if cfg.pre-supplement-number-spacing == auto {
+      get-table-text(current-lang, "pre-supplement-number-spacing")
+    } else {
+      cfg.pre-supplement-number-spacing
+    }
+    let title-space = if cfg.number-title-spacing == auto {
+      get-table-text(current-lang, "number-title-spacing")
+    } else {
+      cfg.number-title-spacing
+    }
+    let num-val = cap.counter.at(cap.location()).first()
+    let num-content = if cfg.use-chapter {
+      let h-counter = counter(heading).get()
+      let chapter-nums = if type(cfg.numbering-format) == str {
+        h-counter.slice(0, calc.min(cfg.chapter-level, h-counter.len()))
+      } else {
+        h-counter
+      }
+      numbering(cfg.numbering-format, ..chapter-nums, num-val)
+    } else {
+      numbering(cfg.numbering-format, num-val)
+    }
+
+    text(size: cfg.caption-size, weight: cfg.caption-weight, ..layers.whole)[
+      #text(..layers.prefix)[
+        #text(..layers.supplement)[#cap.supplement]
+        #handle-spacing(pre-space)
+        #text(..layers.number)[#num-content]
+      ]
+      #handle-spacing(title-space)
+      #text(..layers.body)[#cap.body]
+    ]
+  }
+
+  it
+}
+
+
+// ============================================================
+// 图片样式配置函数 (Figure Style Configuration Function)
+// ============================================================
+
+/// Configure global figure and subfigure style within the body.
+/// 所有参数默认 auto = "保持当前 state 不变"，多次调用做 patch（增量覆盖）。
+/// All params default to auto = "keep current state". Multiple calls patch incrementally.
+/// -> content
+#let capfig-style(
+  numbering-format: auto,
+  use-chapter: auto,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: auto,
+  continued-show-caption: auto,
+  caption-size: auto,
+  caption-weight: auto,
+  // 题注的 text() 参数透传字典 / Pass-through dict for caption text()
+  caption-text: auto,
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: auto,
+  outline-bilingual: auto,
+  outline-separator: auto,
+  outline-newline: auto,
+  after-indent: auto,
+  figure-above: auto,
+  figure-below: auto,
+  caption-above: auto,
+  caption-leading: auto,
+  subcaption-above: auto,
+  subcaption-below: auto,
+  subcaption-number-title-spacing: auto,
+  gutter: auto,
+  subcaption-pos: auto,
+  show-subcaption: auto,
+  show-subcaption-label: auto,
+  align: auto,
+  label-mode: auto,
+  label-style: auto,
+  label-font: auto,
+  label-size: auto,
+  label-offset: auto,
+  label-text-color: auto,
+  label-stroke: auto,
+  label-bg: auto,
+  label-bg-shape: auto,
+  label-bg-radius: auto,
+  label-bg-inset: auto,
+  label-sep: auto,
+  note-above: auto,
+  note-below: auto,
+  note-size: auto,
+  note-leading: auto,
+  note-justify: auto,
+  // bicap()[body] 模式下题注位置（图片默认 bottom）/ Caption position for bicap+body
+  caption-position: auto,
+  // 题注水平对齐：center / left / right / text-left / text-right
+  // 也接受 dict (main: ..., continued: ...) 拆分主与续
+  caption-align: auto,
+  // 浮动定位（含义同 captab-style）/ Floating placement
+  placement: (),
+  it,
+) = {
+  // ── 1. Patch state（仅覆盖非 auto 字段）/ Patch state (only non-auto) ──
+  context {
+    let cur = figure-style-config.get()
+    let new = cur
+    if numbering-format != auto {
+      new.insert("numbering-format", numbering-format)
+      new.insert("chapter-level", calculate-chapter-levels(numbering-format))
+    }
+    if use-chapter != auto { new.insert("use-chapter", use-chapter) }
+    if supplement != auto { new.insert("supplement", supplement) }
+    if supplement-en != auto { new.insert("supplement-en", supplement-en) }
+    if continued-prefix != auto { new.insert("continued-prefix", continued-prefix) }
+    if continued-prefix-en != auto { new.insert("continued-prefix-en", continued-prefix-en) }
+    if continued-suffix != auto { new.insert("continued-suffix", continued-suffix) }
+    if continued-suffix-en != auto { new.insert("continued-suffix-en", continued-suffix-en) }
+    if continued-mode != auto { new.insert("continued-mode", continued-mode) }
+    if continued-show-caption != auto { new.insert("continued-show-caption", continued-show-caption) }
+    if caption-size != auto { new.insert("caption-size", caption-size) }
+    if caption-weight != auto { new.insert("caption-weight", caption-weight) }
+    if caption-text != auto { new.insert("caption-text", caption-text) }
+    if pre-supplement-number-spacing != auto { new.insert("pre-supplement-number-spacing", pre-supplement-number-spacing) }
+    if post-supplement-number-spacing != auto { new.insert("post-supplement-number-spacing", post-supplement-number-spacing) }
+    if number-title-spacing != auto { new.insert("number-title-spacing", number-title-spacing) }
+    if number-title-spacing-en != auto { new.insert("number-title-spacing-en", number-title-spacing-en) }
+    if lang != auto { new.insert("lang", lang) }
+    if enable-english-caption != auto { new.insert("enable-english-caption", enable-english-caption) }
+    if outline-bilingual != auto { new.insert("outline-bilingual", outline-bilingual) }
+    if outline-separator != auto { new.insert("outline-separator", outline-separator) }
+    if outline-newline != auto { new.insert("outline-newline", outline-newline) }
+    if after-indent != auto { new.insert("after-indent", after-indent) }
+    if figure-above != auto { new.insert("figure-above", figure-above) }
+    if figure-below != auto { new.insert("figure-below", figure-below) }
+    if caption-above != auto { new.insert("caption-above", caption-above) }
+    if caption-leading != auto { new.insert("caption-leading", caption-leading) }
+    if subcaption-above != auto { new.insert("subcaption-above", subcaption-above) }
+    if subcaption-below != auto { new.insert("subcaption-below", subcaption-below) }
+    if subcaption-number-title-spacing != auto { new.insert("subcaption-number-title-spacing", subcaption-number-title-spacing) }
+    if gutter != auto { new.insert("gutter", gutter) }
+    if subcaption-pos != auto { new.insert("subcaption-pos", subcaption-pos) }
+    if show-subcaption != auto { new.insert("show-subcaption", show-subcaption) }
+    if show-subcaption-label != auto { new.insert("show-subcaption-label", show-subcaption-label) }
+    if align != auto { new.insert("align", align) }
+    if label-mode != auto { new.insert("label-mode", label-mode) }
+    if label-style != auto { new.insert("label-style", label-style) }
+    if label-font != auto { new.insert("label-font", label-font) }
+    if label-size != auto { new.insert("label-size", label-size) }
+    if label-offset != auto { new.insert("label-offset", label-offset) }
+    if label-text-color != auto { new.insert("label-text-color", label-text-color) }
+    if label-stroke != auto { new.insert("label-stroke", label-stroke) }
+    if label-bg != auto { new.insert("label-bg", label-bg) }
+    if label-bg-shape != auto { new.insert("label-bg-shape", label-bg-shape) }
+    if label-bg-radius != auto { new.insert("label-bg-radius", label-bg-radius) }
+    if label-bg-inset != auto { new.insert("label-bg-inset", label-bg-inset) }
+    if label-sep != auto { new.insert("label-sep", label-sep) }
+    if note-above != auto { new.insert("note-above", note-above) }
+    if note-below != auto { new.insert("note-below", note-below) }
+    if note-size != auto { new.insert("note-size", note-size) }
+    if note-leading != auto { new.insert("note-leading", note-leading) }
+    if note-justify != auto { new.insert("note-justify", note-justify) }
+    if caption-position != auto { new.insert("caption-position", caption-position) }
+    if caption-align != auto { new.insert("caption-align", caption-align) }
+    if placement != () { new.insert("placement", placement) }
+    figure-style-config.update(new)
+  }
+
+  // ── 2. 编号回调（context 读取 state） ──
+  set figure(
+    numbering: num => context {
+      let cfg = figure-style-config.get()
+      if cfg.use-chapter {
+        let h = counter(heading).get()
+        let chapter-nums = if type(cfg.numbering-format) == str {
+          h.slice(0, calc.min(cfg.chapter-level, h.len()))
+        } else {
+          h
+        }
+        numbering(cfg.numbering-format, ..chapter-nums, num)
+      } else {
+        // use-chapter: false 时也尊重 numbering-format（字符串或函数）
+        // Honour the user's numbering-format even without chapter prefix.
+        numbering(cfg.numbering-format, num)
+      }
+    }
+  )
+
+  it
+}
+
+// ============================================================
+// 统一样式配置函数 (Unified Style Configuration Function)
+// ============================================================
+
+/// 同时为表格和图片设置全局样式。共享参数会同时作用于两者；
+/// 之后再调用 captab-style 或 capfig-style 可对某一类进行覆盖。
+/// Configure both table and figure global styles at once. Shared params are applied to
+/// both; a subsequent captab-style / capfig-style call can override for one type only.
+/// -> content
+#let cap-style(
+  numbering-format: auto,
+  use-chapter: auto,
+  supplement: auto,
+  supplement-en: auto,
+  continued-prefix: auto,
+  continued-prefix-en: auto,
+  continued-suffix: auto,
+  continued-suffix-en: auto,
+  continued-mode: auto,
+  continued-show-caption: auto,
+  caption-size: auto,
+  caption-weight: auto,
+  // 题注的 text() 参数透传字典；同时作用于表与图
+  // Pass-through dict for caption text() — applies to both tables and figures
+  caption-text: auto,
+  caption-leading: auto,
+  caption-above: auto,
+  pre-supplement-number-spacing: auto,
+  post-supplement-number-spacing: auto,
+  number-title-spacing: auto,
+  number-title-spacing-en: auto,
+  lang: auto,
+  enable-english-caption: auto,
+  outline-bilingual: auto,
+  outline-separator: auto,
+  outline-newline: auto,
+  after-indent: auto,
+  note-above: auto,
+  note-below: auto,
+  note-size: auto,
+  note-leading: auto,
+  note-justify: auto,
+  // bicap()[body] 模式下题注位置 / Caption position for bicap+body
+  // auto = 让 captab-style 与 capfig-style 各自走 kind 默认（table=top, figure=bottom）
+  // auto = let captab-style/capfig-style fall back to per-kind defaults
+  caption-position: auto,
+  // 题注水平对齐：center / left / right / text-left / text-right；也接受 dict (main, continued)
+  // Caption horizontal alignment; also accepts dict (main, continued)
+  caption-align: auto,
+  // 浮动定位：none / top / bottom；同时作用于表与图
+  // Floating placement; applies to both tables and figures
+  placement: (),
+  it,
+) = {
+  show: captab-style.with(
+    numbering-format: numbering-format,
+    use-chapter: use-chapter,
+    supplement: supplement,
+    supplement-en: supplement-en,
+    continued-prefix: continued-prefix,
+    continued-prefix-en: continued-prefix-en,
+    continued-suffix: continued-suffix,
+    continued-suffix-en: continued-suffix-en,
+    continued-mode: continued-mode,
+    continued-show-caption: continued-show-caption,
+    caption-size: caption-size,
+    caption-weight: caption-weight,
+    caption-text: caption-text,
+    caption-leading: caption-leading,
+    caption-above: caption-above,
+    pre-supplement-number-spacing: pre-supplement-number-spacing,
+    post-supplement-number-spacing: post-supplement-number-spacing,
+    number-title-spacing: number-title-spacing,
+    number-title-spacing-en: number-title-spacing-en,
+    lang: lang,
+    enable-english-caption: enable-english-caption,
+    outline-bilingual: outline-bilingual,
+    outline-separator: outline-separator,
+    outline-newline: outline-newline,
+    after-indent: after-indent,
+    note-above: note-above,
+    note-below: note-below,
+    note-size: note-size,
+    note-leading: note-leading,
+    note-justify: note-justify,
+    caption-position: caption-position,
+    caption-align: caption-align,
+    placement: placement,
+  )
+  show: capfig-style.with(
+    numbering-format: numbering-format,
+    use-chapter: use-chapter,
+    supplement: supplement,
+    supplement-en: supplement-en,
+    continued-prefix: continued-prefix,
+    continued-prefix-en: continued-prefix-en,
+    continued-suffix: continued-suffix,
+    continued-suffix-en: continued-suffix-en,
+    continued-mode: continued-mode,
+    continued-show-caption: continued-show-caption,
+    caption-size: caption-size,
+    caption-weight: caption-weight,
+    caption-text: caption-text,
+    caption-leading: caption-leading,
+    caption-above: caption-above,
+    pre-supplement-number-spacing: pre-supplement-number-spacing,
+    post-supplement-number-spacing: post-supplement-number-spacing,
+    number-title-spacing: number-title-spacing,
+    number-title-spacing-en: number-title-spacing-en,
+    lang: lang,
+    enable-english-caption: enable-english-caption,
+    outline-bilingual: outline-bilingual,
+    outline-separator: outline-separator,
+    outline-newline: outline-newline,
+    after-indent: after-indent,
+    note-above: note-above,
+    note-below: note-below,
+    note-size: note-size,
+    note-leading: note-leading,
+    note-justify: note-justify,
+    caption-position: caption-position,
+    caption-align: caption-align,
+    placement: placement,
+  )
+  it
+}

--- a/packages/preview/cap-able/0.1.0/src/figure.typ
+++ b/packages/preview/cap-able/0.1.0/src/figure.typ
@@ -1,0 +1,924 @@
+// ============================================================
+// 图片和子图模块 (Figure and Subfigure Module)
+// ============================================================
+//
+// 本模块提供完整的图片处理功能，包括单图片和多子图布局。
+// This module provides complete figure functionality, including
+// single figures and multi-subfigure layouts.
+//
+// 模块结构 / Module Structure:
+//
+// ┌─────────────────────────────────────────────────────────┐
+// │ cap-figure()                                            │
+// │   单图片：content + 双语标题 + 间距控制                │
+// │   Single figure: content + bilingual caption + spacing  │
+// └─────────────────────────────────────────────────────────┘
+//
+// ┌─────────────────────────────────────────────────────────┐
+// │ capsubfig()                                              │
+// │   子图网格：多个图片排列 + 子标题/覆盖标签 + 主标题    │
+// │   Subfigure grid: multiple images + sub/overlay labels  │
+// │                                                         │
+// │   内部辅助：                                           │
+// │   Internal helpers:                                     │
+// │   - _parse-label-style()   解析标签样式字符串          │
+// │   - _make-label-text()     生成标签文字（含编号）      │
+// │   - _add-overlay-label()   在图片上叠加标签            │
+// └─────────────────────────────────────────────────────────┘
+//
+// 子图标签样式 / Subfigure label styles:
+// 支持多种格式，可通过 label-style 参数配置：
+// Multiple formats via the label-style parameter:
+//
+//  "(a)" → (a), (b), (c), ...     括号小写字母 / Parenthesized lowercase
+//  "(A)" → (A), (B), (C), ...     括号大写字母 / Parenthesized uppercase
+//  "(1)" → (1), (2), (3), ...     括号数字 / Parenthesized numbers
+//  "(i)" → (i), (ii), (iii), ...  括号小写罗马数字 / Parenthesized roman lowercase
+//  "(I)" → (I), (II), (III), ...  括号大写罗马数字 / Parenthesized roman uppercase
+//  "图a" → 图a, 图b, 图c, ...    中文前缀 / Chinese prefix
+//  "a)"  → a), b), c), ...        仅后缀括号 / Trailing parenthesis only
+//  "Fig. A" → Fig. A, Fig. B, ... 英文前缀 / English prefix
+//
+// 依赖 / Dependencies:
+// - src/config.typ: 全局配置、辅助函数
+// - src/bicap.typ:  标题生成引擎
+//
+// ============================================================
+
+#import "config.typ": *
+#import "bicap.typ": _make_caption_content
+
+// ============================================================
+// 单图片函数 (Single Figure Function)
+// ============================================================
+
+/// 创建带双语标题的单个图片，标题始终在图片下方。
+/// Create a single figure with bilingual caption; caption always below image.
+///
+/// - content (content): 图片内容（通常为 `image()` 调用）/ Figure content (usually `image()`)
+/// - caption (none | content): 主语言标题 / Main language caption
+/// - caption-en (none | content): 英文标题 / English caption
+/// - label (none | label): 图片标签，用于交叉引用 / Figure label for cross-references
+/// - refer-to (none | label): 续图引用的原图标签 / Original label for continued figure
+/// - show-caption (auto | bool): 续图是否显示标题文本 / Show caption in continued figure
+/// - figure-above (auto | length): 图片上方间距 / Space above figure
+/// - figure-below (auto | length): 图片下方间距 / Space below figure
+/// - caption-above (auto | length): 标题与图片间距 / Space between image and caption
+/// - caption-leading (auto | length): 标题行距 / Caption line spacing
+#let capfig(
+  content,
+  caption: none,
+  caption-en: none,
+  label: none,
+  refer-to: none,
+  show-caption: auto,
+  figure-above: auto,
+  figure-below: auto,
+  caption-above: auto,
+  caption-leading: auto,
+  // 浮动定位：none（默认，原地）/ top / bottom；auto 跟随全局
+  // Floating placement; auto follows global. Forces non-breakable when active.
+  placement: (),
+) = {
+  context {
+    // 读取合并后的图片配置 / Read merged figure config
+    let fig-config = figure-style-config.get()
+    let table-config = table-style-config.get()
+
+    // 解析间距参数（参数优先于全局配置）
+    // Resolve spacing params (params take priority over global config)
+    let final-figure-above = if figure-above != auto { figure-above } else { fig-config.figure-above }
+    let final-figure-below = if figure-below != auto { figure-below } else { fig-config.figure-below }
+    let final-caption-above = if caption-above != auto { caption-above } else { fig-config.caption-above }
+    let final-caption-leading = if caption-leading != auto { caption-leading } else { fig-config.caption-leading }
+
+    // 浮动定位：per-call > state > none
+    // Floating placement: per-call > state > none
+    let final-placement = if placement != () {
+      placement
+    } else {
+      fig-config.at("placement", default: none)
+    }
+
+    // 构建传递给 bicap 的配置字典（基于 figure-style-config）
+    // Build config dict for bicap (based on figure-style-config)
+    let merged-config = fig-config
+
+    // 注入本次调用的 caption-leading（可能被参数覆盖）
+    // Inject caption-leading for this call (may be overridden by param)
+    merged-config.insert("caption-leading", final-caption-leading)
+
+    // 如果图片配置中语言是 auto，但表格配置中有具体语言设置，则继承之
+    // If figure config lang is auto but table config has a specific lang, inherit it
+    if fig-config.lang == auto and table-config.at("lang", default: auto) != auto {
+      merged-config.insert("lang", table-config.lang)
+    }
+
+    // 将图片内容和标题放在居中的不换页 block 中
+    // Place image content and caption in a centered non-breakable block
+    let composed = align(center)[
+      #block(
+        breakable: false,   // 禁止图片和标题跨页分离 / Prevent page break between image and caption
+        above: 0pt,         // 间距由外部 v() 控制，这里设为 0
+                            // Spacing controlled by external v(), set to 0 here
+        below: 0pt,
+      )[
+        // 图片内容
+        // Image content
+        #content
+        // 标题上方间距
+        // Space above caption
+        #v(final-caption-above)
+        // 直接调用内部标题生成函数（外层已有 block，不需要 bicap 的 block 包装）
+        // Call the internal caption generator directly (outer block exists, so we don't need bicap's wrapper)
+        #_make_caption_content(
+          caption: caption,
+          caption-en: caption-en,
+          refer-to: refer-to,
+          label: label,
+          config: merged-config,
+          kind: "figure",
+          show-caption: show-caption,
+        )
+      ]
+    ]
+
+    // 浮动包装：placement: top/bottom 时把整体（含上下间距）float。
+    // place() 在仅给 vertical alignment（top/bottom）时水平默认贴左——必须补 + center
+    // 才能保留 cap-able 一贯的居中行为。Typst 原生 figure(placement: top) 内部也是这么做的。
+    // 隐藏 figure 也一同 ride 进来，counter 在 float 落地时 step。
+    // Float wrap. place() with vertical-only alignment (top/bottom) defaults horizontally
+    // to left — we add `+ center` to keep cap-able's centered look (matches Typst's
+    // native figure float behaviour). Hidden figure rides along.
+    if final-placement != none {
+      let aligned-placement = if final-placement == top { top + center }
+        else if final-placement == bottom { bottom + center }
+        else { final-placement }
+      place(aligned-placement, float: true, composed)
+    } else {
+      // 图片上方间距（通过 v() 实现）
+      // Space above figure (via v())
+      v(final-figure-above)
+      composed
+      // 图片下方间距
+      // Space below figure
+      v(final-figure-below)
+    }
+  }
+}
+
+// ============================================================
+// 子图辅助函数 (Subfigure Helper Functions)
+// ============================================================
+//
+// 以下三个内部函数处理子图标签的解析、生成和渲染：
+// The following three internal functions handle subfigure label
+// parsing, generation, and rendering:
+//
+// 标签样式字符串的结构 / Label style string structure:
+//   前缀 + 格式字符 + 后缀
+//   prefix + format_char + suffix
+//
+// 例如 / Examples:
+//   "(a)" → prefix="(", format="a", suffix=")"
+//   "图a" → prefix="图", format="a", suffix=""
+//   "Fig. A" → prefix="Fig. ", format="A", suffix=""
+//   "a)"  → prefix="", format="a", suffix=")"
+//
+// 格式字符对应的编号序列 / Format char to numbering sequence:
+//   "a" → a, b, c, ..., z
+//   "A" → A, B, C, ..., Z
+//   "1" → 1, 2, 3, ...
+//   "i" → i, ii, iii, iv, v, ...
+//   "I" → I, II, III, IV, V, ...
+//
+// ============================================================
+
+/// 解析 label-style 为指定用途（overlay / subcaption）的字符串样式。
+/// Resolve label-style to a string for the requested kind (overlay / subcaption).
+///
+/// label-style 接受两种形式 / label-style accepts two forms:
+/// - `str`（如 `"(a)"`）：overlay 与 subcaption 使用同一样式（默认耦合）
+///   `str` (e.g. `"(a)"`): both overlay and subcaption share the style (coupled by default)
+/// - `dict`（如 `(overlay: "a)", subcaption: "(a)")`）：分别指定。缺失的键
+///    回退到包默认 `"(a)"`，而不是回退到另一边——保持两边各自独立。
+///   `dict` (e.g. `(overlay: "a)", subcaption: "(a)")`): per-side override.
+///   Missing keys fall back to the package default `"(a)"`, *not* to the other side.
+///
+/// - style (str | dictionary): 标签样式 / Label style
+/// - kind (str): "overlay" 或 "subcaption" / "overlay" or "subcaption"
+/// -> str: 已解析为字符串的样式 / Resolved style string
+#let _resolve-label-style(style, kind) = {
+  if type(style) == str {
+    style
+  } else if type(style) == dictionary {
+    style.at(kind, default: "(a)")
+  } else {
+    "(a)"
+  }
+}
+
+/// 解析标签样式字符串，提取格式字符和前后缀
+/// Parse label style string, extracting format character and prefix/suffix
+///
+/// 从标签样式字符串中定位第一个格式字符（a/A/1/i/I），
+/// 将其前面的部分作为前缀，后面的部分作为后缀。
+///
+/// Locates the first format character (a/A/1/i/I) in the style string,
+/// using everything before it as prefix and everything after as suffix.
+///
+/// *解析示例 / Parsing Examples:*
+/// - "(a)" → `(format: "a", prefix: "(", suffix: ")")`
+/// - "图a" → `(format: "a", prefix: "图", suffix: "")`
+/// - "Fig. A" → `(format: "A", prefix: "Fig. ", suffix: "")`  ← 注意前缀里的 "i" 不会被误当作占位符
+/// - "(1)" → `(format: "1", prefix: "(", suffix: ")")`
+/// - "abc"（无格式字符）→ `(format: "a", prefix: "abc", suffix: "")`
+///
+/// - style (str): 标签样式字符串 / Label style string
+/// -> dictionary: 包含 format, prefix, suffix 三个键的字典
+///                Dictionary with keys: format, prefix, suffix
+#let _parse-label-style(style) = {
+  // 支持的格式字符列表
+  // Supported format characters
+  let format-chars = ("a", "A", "1", "i", "I")
+  let format-char = none
+  let format-pos = none
+
+  // 从后向前扫描，找到最后一个格式字符及其位置。
+  // Scan from the end to find the LAST format character.
+  // 原因：前缀可能包含和格式字符重合的字母（例如 "Fig. A" 中的 "i"），
+  // 从前向后扫描会误把 "i" 当作占位符。实际样式占位符总是出现在末尾
+  // （"(a)"、"图a"、"Fig. A"、"(1)"），因此从后向前更稳健。
+  // Reason: prefixes may contain letters that collide with format chars
+  // (e.g. the "i" in "Fig. A"). Scanning forward would wrongly pick that "i"
+  // as the placeholder. In practice the placeholder always sits at the end
+  // ("(a)", "图a", "Fig. A", "(1)"), so scanning backward is more robust.
+  // 注意：用 clusters() 而非 codepoints() 以正确处理多字节字符（如中文）
+  // Note: use clusters() not codepoints() to handle multi-byte chars (e.g. Chinese)
+  let all-clusters = style.clusters()
+  let i = all-clusters.len()
+  while i > 0 {
+    i = i - 1
+    if all-clusters.at(i) in format-chars {
+      format-char = all-clusters.at(i)
+      format-pos = i
+      break
+    }
+  }
+
+  // 如果没有找到任何格式字符，将整个字符串作为前缀，默认格式为 "a"
+  // If no format character found, use entire string as prefix, default format "a"
+  if format-char == none {
+    return (format: "a", prefix: style, suffix: "")
+  }
+
+  // 提取前缀（格式字符前的所有字符）和后缀（格式字符后的所有字符）
+  // Extract prefix (everything before format char) and suffix (everything after)
+  let prefix = all-clusters.slice(0, format-pos).join()
+  let suffix = all-clusters.slice(format-pos + 1).join()
+
+  (format: format-char, prefix: prefix, suffix: suffix)
+}
+
+/// 根据索引和样式生成子图标签文本
+/// Generate subfigure label text based on index and style
+///
+/// 使用 _parse-label-style 解析样式，然后根据格式字符和索引生成编号，
+/// 最后组合前缀+编号+后缀（可选择是否保留修饰）。
+///
+/// Uses _parse-label-style to parse the style, generates the number
+/// based on format char and index, then combines prefix+number+suffix
+/// (optionally stripping decorations).
+///
+/// *生成示例 / Generation Examples（style="(a)"）:*
+/// - idx=0 → "(a)"
+/// - idx=1 → "(b)"
+/// - idx=25 → "(z)"
+///
+/// *生成示例（style="(1)"）:*
+/// - idx=0 → "(1)"
+/// - idx=2 → "(3)"
+///
+/// *移除修饰 remove-decorations=true（style="(a)"）:*
+/// - idx=0 → "a"（用于子图交叉引用的标签部分）
+///           (used as the subfigure part of cross-reference)
+///
+/// - idx (int): 子图索引（从0开始）/ Subfigure index (0-based)
+/// - style (str): 标签样式字符串 / Label style string
+/// - remove-decorations (bool): 是否移除前缀和后缀（用于生成引用标签）
+///                               Remove prefix/suffix (for cross-reference generation)
+/// -> str: 生成的标签文本 / Generated label text
+#let _make-label-text(idx, style, remove-decorations: false) = {
+  let parsed = _parse-label-style(style)
+  let format-char = parsed.format
+
+  // 根据格式字符和索引生成编号文本
+  // Generate number text based on format character and index
+  let number-text = if format-char == "A" {
+    // 大写字母：从 'A'(65) 开始，idx=0→"A", idx=1→"B"...
+    // Uppercase: start from 'A'(65), idx=0→"A", idx=1→"B"...
+    str.from-unicode(65 + idx)
+  } else if format-char == "a" {
+    // 小写字母：从 'a'(97) 开始
+    // Lowercase: start from 'a'(97)
+    str.from-unicode(97 + idx)
+  } else if format-char == "1" {
+    // 阿拉伯数字：从 1 开始
+    // Arabic numerals: start from 1
+    str(idx + 1)
+  } else if format-char == "I" {
+    // 大写罗马数字：使用预定义映射表（支持1-20）
+    // Uppercase Roman numerals: use predefined map (supports 1-20)
+    let roman-map = ("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X",
+                     "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX")
+    if idx < roman-map.len() { roman-map.at(idx) } else { str(idx + 1) }
+  } else if format-char == "i" {
+    // 小写罗马数字
+    // Lowercase Roman numerals
+    let roman-map = ("i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x",
+                     "xi", "xii", "xiii", "xiv", "xv", "xvi", "xvii", "xviii", "xix", "xx")
+    if idx < roman-map.len() { roman-map.at(idx) } else { str(idx + 1) }
+  } else {
+    // 未知格式字符的保底处理：使用小写字母
+    // Fallback for unknown format char: use lowercase letter
+    str.from-unicode(97 + idx)
+  }
+
+  // 根据 remove-decorations 决定是否添加前缀和后缀
+  // Decide whether to add prefix/suffix based on remove-decorations
+  if remove-decorations {
+    // 只返回编号部分（用于生成交叉引用中的标签字符）
+    // Return only the number part (for cross-reference label character)
+    number-text
+  } else {
+    // 返回完整标签：前缀 + 编号 + 后缀
+    // Return full label: prefix + number + suffix
+    parsed.prefix + number-text + parsed.suffix
+  }
+}
+
+/// 在图片内容上叠加标签
+/// Add an overlay label on top of figure content
+///
+/// 将标签放置在子图的左上角（通过 place(top + left, ...) 实现）。
+/// 标签可以有多种背景样式：无背景、矩形背景、圆形背景。
+/// 每个子图可以通过 label-style-override 字典覆盖部分样式。
+///
+/// Places the label at the top-left of the subfigure via place(top + left, ...).
+/// Labels can have: no background, rectangular background, or circular background.
+/// Each subfigure can override partial styles via label-style-override dict.
+///
+/// 可覆盖的样式键 / Overridable style keys:
+/// - text-color: 文字颜色 / Text color
+/// - stroke: 描边 / Stroke
+/// - bg: 背景色 / Background color
+/// - bg-shape: 背景形状 / Background shape
+/// - bg-radius: 背景圆角 / Background radius
+/// - bg-inset: 背景内边距 / Background padding
+/// - style: 该子图 overlay 的 label-style 字符串（如 "(I)"）/ Per-subfig overlay label-style
+/// - font: 字体列表 / Font list
+/// - size: 字号 / Font size
+/// - offset: (dx, dy) 偏移量 / Offset from top-left
+///
+/// - content (content): 子图内容 / Subfigure content
+/// - idx (int): 子图索引 / Subfigure index
+/// - label-style (str): 标签样式字符串 / Label style string
+/// - label-font (array): 字体列表 / Font list
+/// - label-size (length): 字号 / Font size
+/// - label-offset (tuple): (dx, dy) 偏移量，从左上角算起 / Offset from top-left
+/// - label-text-color (color): 文字颜色 / Text color
+/// - label-stroke (none | stroke): 描边 / Stroke
+/// - label-bg (none | color): 背景色 / Background color
+/// - label-bg-shape (str): 背景形状 "rect" 或 "circle" / "rect" or "circle"
+/// - label-bg-radius (length): 矩形圆角 / Rect border radius
+/// - label-bg-inset (length): 背景内边距 / Background padding
+/// - override-style (none | dictionary): 针对此子图的样式覆盖 / Per-subfigure overrides
+/// -> content: 含叠加标签的图片内容 / Figure content with overlay label
+#let _add-overlay-label(
+  content,
+  idx,
+  label-style,
+  label-font,
+  label-size,
+  label-offset,
+  label-text-color,
+  label-stroke,
+  label-bg,
+  label-bg-shape,
+  label-bg-radius,
+  label-bg-inset,
+  override-style: none,
+) = {
+  // 解析各样式参数：覆盖样式优先于全局样式
+  // Resolve each style param: override takes priority over global
+  let pick(key, fallback) = if override-style != none and key in override-style {
+    override-style.at(key)
+  } else {
+    fallback
+  }
+  let overlay-text-color = pick("text-color", label-text-color)
+  let overlay-stroke     = pick("stroke", label-stroke)
+  let overlay-bg         = pick("bg", label-bg)
+  let overlay-bg-shape   = pick("bg-shape", label-bg-shape)
+  let overlay-bg-radius  = pick("bg-radius", label-bg-radius)
+  let overlay-bg-inset   = pick("bg-inset", label-bg-inset)
+  let overlay-style      = pick("style", label-style)
+  let overlay-font       = pick("font", label-font)
+  let overlay-size       = pick("size", label-size)
+  let overlay-offset     = pick("offset", label-offset)
+
+  // 用 box 包装图片内容，使 place() 相对于图片而非页面定位
+  // Wrap figure content in box so place() positions relative to the figure, not the page
+  box({
+    // 图片内容
+    content
+    // 叠加标签（place 不占据文档流空间）
+    // Overlay label (place doesn't take up document flow space)
+    place(
+      top + left,                 // 定位到左上角 / Anchor to top-left
+      dx: overlay-offset.at(0),   // 水平偏移 / Horizontal offset
+      dy: overlay-offset.at(1),   // 垂直偏移 / Vertical offset
+      {
+        // 生成标签文字内容（含前缀+编号+后缀）
+        // Generate label text (with prefix+number+suffix)
+        let label-content = text(
+          font: overlay-font,
+          size: overlay-size,
+          weight: "bold",           // 标签通常加粗 / Labels are usually bold
+          fill: overlay-text-color,
+          stroke: overlay-stroke,
+        )[#_make-label-text(idx, overlay-style, remove-decorations: false)]
+
+        if overlay-bg != none {
+          if overlay-bg-shape == "circle" {
+            // ─ 圆形背景：使用 circle() 元素 ─
+            // ─ Circular background: use circle() element ─
+            circle(
+              radius: overlay-size * 0.8,  // 圆的半径基于字号 / Radius based on font size
+              fill: overlay-bg,
+              stroke: overlay-stroke,
+            )[
+              #align(center + horizon)[#label-content]
+            ]
+          } else {
+            // ─ 矩形背景（默认）：使用 box() 元素 ─
+            // ─ Rectangular background (default): use box() element ─
+            box(
+              fill: overlay-bg,
+              inset: overlay-bg-inset,
+              radius: overlay-bg-radius,
+              stroke: overlay-stroke,
+            )[#label-content]
+          }
+        } else {
+          // ─ 无背景：直接显示标签文字 ─
+          // ─ No background: show label text directly ─
+          label-content
+        }
+      }
+    )
+  })
+}
+
+// ============================================================
+// 子图布局函数 (Subfigure Layout Function)
+// ============================================================
+
+/// 创建多子图网格布局，支持子标题、覆盖标签和主双语标题。
+/// Create a multi-subfigure grid layout with subcaptions, overlay labels, and bilingual main caption.
+///
+/// 每个子图为字典：`(content: ..., subcaption: ..., label: ..., label-style-override: (...))` 。
+/// Each subfigure is a dict: `(content: ..., subcaption: ..., label: ..., label-style-override: (...))`.
+///
+/// - subfigs (array): 子图字典数组 / Array of subfigure dicts
+/// - columns (auto | int): 每行列数，auto=所有子图在一行 / Columns per row
+/// - caption (none | content): 主标题（主语言）/ Main caption (main language)
+/// - caption-en (none | content): 主标题（英文）/ Main caption (English)
+/// - label (none | label): 主图标签 / Main figure label
+/// - refer-to (none | label): 续图引用的原图标签 / Original label for continuation
+/// - show-caption (auto | bool): 续图是否显示标题 / Show caption in continuation
+/// - gutter (auto | length): 子图水平间距 / Horizontal gap between subfigures
+/// - subcaption-pos (auto | str): 子标题位置 "top"/"bottom"
+/// - show-subcaption (auto | bool): 是否显示子标题 / Show subcaptions
+/// - show-subcaption-label (auto | bool): 子标题是否含标签 / Subcaption includes label
+/// - align (auto | str): 垂直对齐 "top"/"horizon"/"bottom"
+/// - label-mode (auto | none | str): 标签模式 / Label mode (none or "overlay")
+/// - label-style (auto | str): 标签样式，如 "(a)"/"图a" / Label style
+/// - label-font (auto | array): 标签字体 / Label font
+/// - label-size (auto | length): 标签大小 / Label size
+/// - label-offset (auto | tuple): 标签偏移 (dx, dy) / Label offset
+/// - label-text-color (auto | color): 标签颜色 / Label text color
+/// - label-stroke (auto | none | stroke): 标签描边 / Label stroke
+/// - label-bg (auto | none | color): 标签背景 / Label background
+/// - label-bg-shape (auto | str): 背景形状 / Background shape
+/// - label-bg-radius (auto | length): 背景圆角 / Background radius
+/// - label-bg-inset (auto | length): 背景内边距 / Background padding
+/// - label-sep (auto | str): 子图引用分隔符 / Subfigure reference separator
+/// - figure-above (auto | length): 图片上方间距 / Space above figure
+/// - figure-below (auto | length): 图片下方间距 / Space below figure
+/// - caption-above (auto | length): 主标题上方间距 / Space above main caption
+/// - subcaption-above (auto | length): 子标题上方间距 / Space above subcaption
+/// - subcaption-below (auto | length): 子标题下方间距 / Space below subcaption
+#let capsubfig(
+  subfigs,
+  columns: auto,
+  caption: none,
+  caption-en: none,
+  label: none,
+  refer-to: none,
+  show-caption: auto,
+  gutter: auto,
+  subcaption-pos: auto,
+  show-subcaption: auto,
+  show-subcaption-label: auto,
+  align: auto,
+  label-mode: auto,
+  label-style: auto,
+  label-font: auto,
+  label-size: auto,
+  label-offset: auto,
+  label-text-color: auto,
+  label-stroke: auto,
+  label-bg: auto,
+  label-bg-shape: auto,
+  label-bg-radius: auto,
+  label-bg-inset: auto,
+  label-sep: auto,
+  figure-above: auto,
+  figure-below: auto,
+  caption-above: auto,
+  subcaption-above: auto,
+  subcaption-below: auto,
+  subcaption-number-title-spacing: auto,
+  // 浮动定位：none / top / bottom；auto 跟随全局
+  // Floating placement; auto follows global
+  placement: (),
+) = {
+  // ★ 重要：立即重命名 align 参数，因为 Typst 中 `align` 既是函数又是关键字，
+  // 如果不重命名，在函数体内调用 align(center, ...) 时会发生参数名遮蔽冲突。
+  // ★ Important: Rename `align` parameter immediately because in Typst,
+  // `align` is both a function and a keyword. Without renaming, calling
+  // align(center, ...) inside would shadow/conflict with the parameter name.
+  let vertical-align-param = align
+
+  context {
+    // 读取合并后的图片/子图配置 / Read merged figure/subfigure config
+    let config = figure-style-config.get()
+
+    // ── 解析所有参数（参数优先于全局配置）────────────────────────
+    // ── Resolve all parameters (params take priority over global config) ──
+    let final-gutter = if gutter != auto { gutter } else { config.gutter }
+    let final-subcaption-pos = if subcaption-pos != auto { subcaption-pos } else { config.subcaption-pos }
+    let final-show-subcaption = if show-subcaption != auto { show-subcaption } else { config.show-subcaption }
+    let final-show-subcaption-label = if show-subcaption-label != auto { show-subcaption-label } else { config.show-subcaption-label }
+    let final-align = if vertical-align-param != auto { vertical-align-param } else { config.align }
+    let final-label-mode = if label-mode != auto { label-mode } else { config.label-mode }
+    let final-label-style = if label-style != auto { label-style } else { config.label-style }
+    let final-label-font = if label-font != auto { label-font } else { config.label-font }
+    let final-label-size = if label-size != auto { label-size } else { config.label-size }
+    let final-label-offset = if label-offset != auto { label-offset } else { config.label-offset }
+    let final-label-text-color = if label-text-color != auto { label-text-color } else { config.label-text-color }
+    let final-label-stroke = if label-stroke != auto { label-stroke } else { config.label-stroke }
+    let final-label-bg = if label-bg != auto { label-bg } else { config.label-bg }
+    let final-label-bg-shape = if label-bg-shape != auto { label-bg-shape } else { config.label-bg-shape }
+    let final-label-bg-radius = if label-bg-radius != auto { label-bg-radius } else { config.label-bg-radius }
+    let final-label-bg-inset = if label-bg-inset != auto { label-bg-inset } else { config.label-bg-inset }
+    let final-label-sep = if label-sep != auto { label-sep } else { config.label-sep }
+
+    let final-subcaption-above = if subcaption-above != auto { subcaption-above } else { config.subcaption-above }
+    let final-subcaption-below = if subcaption-below != auto { subcaption-below } else { config.subcaption-below }
+
+    // 子标题"编号-正文"分隔符：per-call > 全局 state > auto（继承大题注的 number-title-spacing）。
+    // 大题注本身的 number-title-spacing 也可能是 auto（默认），此时再退回到语言表。
+    // Subcaption number-text separator: per-call > global state > auto (inherit main
+    // caption's number-title-spacing). The main number-title-spacing itself may be auto
+    // (the default), in which case we fall back to the language table — same path bicap uses.
+    let final-subcap-num-sep = {
+      let configured = if subcaption-number-title-spacing != auto {
+        subcaption-number-title-spacing
+      } else {
+        config.at("subcaption-number-title-spacing", default: auto)
+      }
+      if configured != auto {
+        configured
+      } else {
+        let main-spacing = config.at("number-title-spacing", default: auto)
+        if main-spacing != auto {
+          main-spacing
+        } else {
+          get-table-text(resolve-lang-code(config.lang), "number-title-spacing")
+        }
+      }
+    }
+
+    // ── 将字符串对齐参数转换为 Typst 对齐值 ─────────────────────
+    // ── Convert string alignment param to Typst alignment value ──
+    let vertical-align = if final-align == "top" {
+      top
+    } else if final-align == "bottom" {
+      bottom
+    } else {
+      horizon   // 默认居中对齐 / Default: center alignment
+    }
+
+    // ── 确定列数 ─────────────────────────────────────────────────
+    // ── Determine number of columns ───────────────────────────────
+    let cols = if columns == auto {
+      // auto：所有子图放在同一行
+      // auto: all subfigures in one row
+      subfigs.len()
+    } else {
+      columns
+    }
+
+    // ── 确定子图引用分隔符 ────────────────────────────────────────
+    // ── Determine subfigure reference separator ───────────────────
+    // 分隔符用于交叉引用中主编号与子图标签之间（如 "图1.1a" 中的连接）
+    // Separator between main number and subfig label in cross-references (e.g., "Figure 1.1a")
+    // 解析 label-style 为 overlay / subcaption 两个分支的字符串样式。
+    // Resolve label-style into per-kind strings.
+    let final-label-style-overlay   = _resolve-label-style(final-label-style, "overlay")
+    let final-label-style-subcap    = _resolve-label-style(final-label-style, "subcaption")
+
+    // 交叉引用字母的样式来源：跟随"实际可见"的那一侧。
+    //   - subcaption 可见（show-subcaption + show-subcaption-label）→ 取 subcaption
+    //   - 否则若有 overlay → 取 overlay
+    //   - 都不可见（用户既不显示 overlay，又关掉 subcaption-label）→ 仍以 subcaption
+    //     作为兜底（语义上与正文最近；该情形下 @ref 也几乎无视觉锚点）。
+    // 这样保证用户在图上/标题里"看到的字母"与 `@ref` 渲染出的字母一致。
+    //
+    // Cross-ref letter source follows whichever side is actually *visible*:
+    //   - subcaption visible (show-subcaption + show-subcaption-label) → use subcaption
+    //   - else overlay drawn → use overlay
+    //   - neither visible → fall back to subcaption (defensive; user has no visual anchor)
+    // This keeps the letter in `@ref` consistent with what the reader actually sees.
+    let final-label-style-ref = if final-show-subcaption and final-show-subcaption-label {
+      final-label-style-subcap
+    } else if final-label-mode == "overlay" {
+      final-label-style-overlay
+    } else {
+      final-label-style-subcap
+    }
+
+    let sep = if final-label-sep == auto {
+      let parsed = _parse-label-style(final-label-style-ref)
+      // 数字格式用点分隔（如 "图1.1.2"），字母格式无分隔（如 "图1.1a"）
+      // Numeric format uses dot (e.g., "Fig.1.1.2"), letter format uses none (e.g., "Fig.1.1a")
+      if parsed.format == "1" { "." } else { "" }
+    } else {
+      final-label-sep
+    }
+
+    // ── 将子图数组按行分组 ────────────────────────────────────────
+    // ── Group subfigures into rows ────────────────────────────────
+    let rows = ()
+    let current-row = ()
+    for (idx, subfig) in subfigs.enumerate() {
+      current-row.push(subfig)
+      // 每当当前行满了（达到列数）或者是最后一个子图时，封装当前行
+      // Seal the current row when it's full (reached column count) or at the last subfig
+      if current-row.len() == cols or idx == subfigs.len() - 1 {
+        rows.push(current-row)
+        current-row = ()
+      }
+    }
+
+    // ── 构建子图内容（需要在 context 中进行，因为要读取计数器）──
+    // ── Build subfigure content (needs context to read counters) ──
+    let subfig-content = context {
+      let fig-config = figure-style-config.get()
+      // 计算主图编号字符串（与 _make_caption_content 中的逻辑保持一致）。
+      // 支持 use-chapter=false（默认，仅编号）和 use-chapter=true（带章节前缀）。
+      // Compute the main figure number string (matches _make_caption_content).
+      // Supports both use-chapter=false (default, plain number) and true (with chapter prefix).
+      let fig-num = counter(figure.where(kind: image)).get().first() + 1
+      let main-num = if fig-config.use-chapter {
+        let h = counter(heading).get()
+        let chapter-nums = if type(fig-config.numbering-format) == str {
+          h.slice(0, calc.min(fig-config.chapter-level, h.len()))
+        } else {
+          h
+        }
+        numbering(fig-config.numbering-format, ..chapter-nums, fig-num)
+      } else {
+        numbering(fig-config.numbering-format, fig-num)
+      }
+
+      // ════════════════════════════════════════════════════════════
+      // 子图交叉引用注册（Hidden Figure Trick）
+      // Subfigure Cross-Reference Registration (Hidden Figure Trick)
+      // ════════════════════════════════════════════════════════════
+      //
+      // 对于每个有 label 的子图，我们需要：
+      // For each subfig with a label, we need to:
+      //
+      // 1. 创建一个可引用的 figure（注册到计数器，可被 @ 引用）
+      //    Create a referenceable figure (registered to counter, usable via @)
+      // 2. 但该 figure 不应该：出现在目录、占据页面空间、显示内容
+      //    But the figure should NOT: appear in outline, take page space, show content
+      //
+      // 解决方案：用 place(hide[#figure(...)#label]) 在当前位置"注册"一个
+      // 不可见、不占空间的隐藏 figure，并绑定标签。
+      // Solution: Use place(hide[#figure(...)#label]) to "register" an
+      // invisible, zero-space hidden figure at current location with the label.
+      //
+      // 隐藏 figure 的编号格式设置为 "章号.图号+分隔符+子图字母"，
+      // 例如 idx=0, style="(a)" → 编号函数返回 "1.1a"
+      // The hidden figure's numbering is set to "chapter.fig-num+sep+label",
+      // e.g. idx=0, style="(a)" → numbering returns "1.1a"
+      //
+      // 注意：每个隐藏 figure 都会使计数器 +1，所以最后需要批量减回去
+      // Note: each hidden figure increments counter, so we batch-decrement afterwards
+
+      let hidden-figures = ()
+      let subfig-label-count = 0
+
+      for (idx, subfig) in subfigs.enumerate() {
+        if "label" in subfig and subfig.label != none {
+          subfig-label-count = subfig-label-count + 1
+
+          // 当 ref 跟随 overlay（subcaption 不可见、overlay 可见）时，需要让
+          // 单图的 label-style-override.style 也参与计算——否则子图叠加显示
+          // "(I)" 但 @ref 仍渲染 "a"。
+          // 当 ref 跟随 subcaption 时，subcaption 没有逐子图覆盖，使用全局即可。
+          //
+          // When ref follows overlay (subcaption hidden, overlay drawn), we have
+          // to honour the per-subfig label-style-override.style — otherwise the
+          // overlay shows "(I)" while @ref still renders "a". When ref follows
+          // subcaption there is no per-subfig override, so the global value is fine.
+          let override = subfig.at("label-style-override", default: none)
+          let subfig-overlay-style = if override != none and "style" in override {
+            override.style
+          } else {
+            final-label-style-overlay
+          }
+
+          let subfig-ref-style = if final-show-subcaption and final-show-subcaption-label {
+            final-label-style-subcap
+          } else if final-label-mode == "overlay" {
+            subfig-overlay-style
+          } else {
+            final-label-style-subcap
+          }
+
+          // 获取此子图的标签字母（不含修饰，如 "(a)" → "a"）
+          // Get the label letter without decorations (e.g., "(a)" → "a")
+          let sublabel = _make-label-text(idx, subfig-ref-style, remove-decorations: true)
+
+          // sep 也跟随 ref-style：数字格式用 "."，字母格式用 ""。
+          // 全局 label-sep 已显式设置时仍优先。
+          // sep follows ref-style too: "." for numeric, "" for alpha.
+          // Explicit global label-sep still takes priority.
+          let subfig-sep = if final-label-sep == auto {
+            let parsed = _parse-label-style(subfig-ref-style)
+            if parsed.format == "1" { "." } else { "" }
+          } else {
+            final-label-sep
+          }
+
+          hidden-figures = hidden-figures + (
+            place(
+              hide[
+                #figure(
+                  kind: image,
+                  supplement: if fig-config.supplement != auto {
+                    fig-config.supplement
+                  } else {
+                    // 从语言配置获取图片前缀词（如 "图" 或 "Figure"）
+                    // Get figure prefix from language config (e.g., "图" or "Figure")
+                    get-table-text(resolve-lang-code(fig-config.lang), "figure")
+                  },
+                  // 设置子图的引用显示格式：主图编号 + 分隔符 + 子图字母
+                  // Set subfig reference display: main-num + sep + sublabel
+                  // 例如 main-num="1", sep="", sublabel="a" → "1a"
+                  // 或 main-num="1.2", sep="", sublabel="a" → "1.2a"
+                  // e.g. main-num="1", sep="", sublabel="a" → "1a"
+                  //   or main-num="1.2", sep="", sublabel="a" → "1.2a"
+                  numbering: _ => [#main-num#subfig-sep#sublabel],
+                  outlined: false,    // 不出现在目录 / Not in outline
+                  []
+                )#subfig.label    // 绑定子图标签 / Bind subfigure label
+              ]
+            ),
+          )
+        }
+      }
+
+      // ── 逐行构建子图布局内容 ─────────────────────────────────
+      // ── Build subfigure layout content row by row ─────────────
+      let row-contents = ()
+      for (row-idx, row-subfigs) in rows.enumerate() {
+        let start-idx = row-idx * cols         // 此行第一个子图的全局索引
+        let num-in-row = row-subfigs.len()     // 此行实际子图数
+        // 最后一行且不满列（需要特殊处理 columns 参数）
+        // Last row with fewer than full columns (needs special columns handling)
+        let is-last-incomplete = num-in-row < cols and row-idx == rows.len() - 1
+
+        // 提取共享的"处理单张子图内容"闭包：应用 overlay 标签（如有）
+        // Shared "process one subfig content" closure: applies overlay label if needed
+        let process-content(subfig, idx) = {
+          let override = subfig.at("label-style-override", default: none)
+          if final-label-mode == "overlay" {
+            _add-overlay-label(
+              subfig.content, idx,
+              final-label-style-overlay, final-label-font, final-label-size,
+              final-label-offset, final-label-text-color, final-label-stroke,
+              final-label-bg, final-label-bg-shape, final-label-bg-radius, final-label-bg-inset,
+              override-style: override,
+            )
+          } else {
+            subfig.content
+          }
+        }
+
+        // 统一处理本行所有子图 / Uniformly process all subfigs in this row
+        let contents = ()
+        let subcaptions = ()
+        for (col-idx, subfig) in row-subfigs.enumerate() {
+          let idx = start-idx + col-idx
+          contents.push(process-content(subfig, idx))
+          if final-show-subcaption {
+            let cap-body = if final-show-subcaption-label {
+              // 注意：markup 里 `#a #b` 之间会硬编码一个空格；
+              // 这里改用 block 形式手动控制分隔符。
+              // Note: markup `#a #b` hard-codes a space between them;
+              // use block form to control the separator explicitly.
+              {
+                _make-label-text(idx, final-label-style-subcap, remove-decorations: false)
+                final-subcap-num-sep
+                subfig.subcaption
+              }
+            } else {
+              subfig.subcaption
+            }
+            subcaptions.push(text(size: 10pt, cap-body))
+          }
+        }
+
+        let row-cols = (1fr,) * (if is-last-incomplete { num-in-row } else { cols })
+
+        if final-show-subcaption {
+          // 有子标题：用 table 同时控制列间距和行间距
+          // With subcaption: use table for both column-gutter and row-gutter
+          row-contents.push(table(
+            columns: row-cols,
+            column-gutter: final-gutter,
+            row-gutter: final-subcaption-above,
+            stroke: none,
+            align: center + vertical-align,
+            ..if final-subcaption-pos == "top" {
+              (..subcaptions, ..contents)
+            } else {
+              (..contents, ..subcaptions)
+            }
+          ))
+        } else {
+          // 无子标题：grid 更轻量 / No subcaption: grid is lighter
+          row-contents.push(grid(
+            columns: row-cols,
+            column-gutter: final-gutter,
+            align: center + vertical-align,
+            ..contents
+          ))
+        }
+      }
+
+      // 将所有行内容垂直堆叠（使用 stack 而非 v() 以避免额外的空间）
+      // Stack all row contents vertically (use stack instead of v() for precise spacing)
+      //
+      // ⚠ 计数器回退必须发生在 hidden-figures.join() 之后。
+      // 在代码块里 `counter.update(...)` 作为裸语句会被拼进返回内容里，
+      // 如果写在 hidden-figures 之前，布局时回退会早于 figure 增量执行，
+      // 于是 `max(0, n - k)` 对初始为 0 的计数器无效、最终净多 +k，
+      // 主图编号会变成"章号.(k+1)"（如 "1.3" 而非 "1.1"）。
+      // ⚠ The counter rollback MUST emit AFTER hidden-figures.join().
+      // Inside a code block, a bare `counter.update(...)` is concatenated into
+      // the returned content stream; placing it before hidden-figures would
+      // make the rollback fire before the figure increments. With an initial
+      // counter of 0, `max(0, n - k)` is a no-op, leaving a net +k offset —
+      // so the main caption renders as "chapter.(k+1)" (e.g. "1.3" not "1.1").
+      [
+        #hidden-figures.join()   // 先输出所有隐藏 figure（注册标签）/ Output hidden figures first
+        // 批量减回隐藏 figure 造成的计数器增量；calc.max 保护避免布局迭代中 n<k 时报错
+        // Batch-rollback the hidden-figure increments; calc.max guards against n<k during layout iterations
+        #counter(figure.where(kind: image)).update(n => calc.max(0, n - subfig-label-count))
+        #stack(dir: ttb, spacing: 1em, ..row-contents)   // 再垂直堆叠子图行 / Then stack rows
+      ]
+    }
+
+    // ── 用 cap-figure 包装整个子图组合并添加主标题 ──────────────
+    // ── Wrap the entire subfigure assembly with cap-figure for main caption ──
+    capfig(
+      subfig-content,
+      caption: caption,
+      caption-en: caption-en,
+      label: label,
+      refer-to: refer-to,
+      show-caption: show-caption,
+      figure-above: figure-above,
+      figure-below: figure-below,
+      caption-above: caption-above,
+      placement: placement,
+    )
+  }
+}

--- a/packages/preview/cap-able/0.1.0/src/note.typ
+++ b/packages/preview/cap-able/0.1.0/src/note.typ
@@ -1,0 +1,131 @@
+// ============================================================
+// 表注和图注模块 (Table and Figure Note Module)
+// ============================================================
+//
+// 本模块提供表格和图片的注释（脚注式说明文字）功能。
+// This module provides note/annotation functionality for tables and figures.
+//
+// 什么是表注/图注 / What are table/figure notes:
+// 表注（表格注释）和图注（图片注释）是位于表格或图片下方的补充说明文字，
+// 通常用于以下场景：
+// Table/figure notes are supplementary text placed below tables or figures,
+// commonly used for:
+//
+// - 数据来源说明（如"数据来源：国家统计局"）
+//   Data source attribution (e.g., "Source: National Bureau of Statistics")
+// - 统计显著性标记说明（如"* p < 0.05, ** p < 0.01"）
+//   Statistical significance markers (e.g., "* p < 0.05, ** p < 0.01")
+// - 缩写或专业术语解释
+//   Abbreviation or technical term explanations
+// - 补充说明信息
+//   Supplementary information
+//
+// 设计特性 / Design Features:
+// - 自动宽度匹配：默认宽度与所属表格/图片一致
+//   Auto-width matching: default width matches containing table/figure
+// - 灵活宽度控制：支持 auto、百分比（ratio）、绝对长度三种宽度模式
+//   Flexible width: supports auto, percentage (ratio), and absolute length
+// - 语言感知：检测是否需要首行缩进修复
+//   Language-aware: detects if indentation fix is needed
+// - 样式继承：从全局配置读取样式
+//   Style inheritance: reads style from global config
+//
+// 导出函数 / Exported Functions:
+// - captnote(): 表注 / Table note
+// - capfnote(): 图注 / Figure note
+//
+// 依赖 / Dependencies:
+// - src/config.typ: 全局配置和辅助函数 / Global config and utilities
+//
+// ============================================================
+
+#import "config.typ": *
+
+// 内部：统一的 note 渲染函数，处理 auto / ratio / length 三种宽度模式。
+// Internal: unified note renderer handling auto / ratio / length width modes.
+//
+// - config:       note 样式字段来源（含 note-size、note-leading、note-above、note-below、note-justify、lang、after-indent）
+// - width:        用户传入的 width 参数（auto / ratio / length）
+// - global-width: 全局表/图宽度状态，width 为 auto 时使用（auto / int / ratio / length）
+//                 兼容旧 figure-width-config 的 int 形式（自动转 ratio）
+// - justify:      用户传入的 justify 参数（auto 或 bool）
+// - content:      注释内容
+#let _render-note(config, width, global-width, justify, content) = {
+  let (_, should-indent) = resolve-lang-indent(config)
+  let final-justify = if justify == auto { config.note-justify } else { justify }
+
+  // 解析有效宽度：用户 width 优先，auto 时 fallback 到全局 state；
+  // 同时把旧 int 形式（来自 figure-width-config 默认 100，或 0.0.x set-table-width）转成 ratio。
+  // Resolve effective width: user width wins; auto → fall back to global state.
+  // Convert legacy int (figure-width-config default 100, or 0.0.x set-table-width) to ratio.
+  let effective = if width != auto { width } else { global-width }
+  let effective = if type(effective) == int { effective * 1% } else { effective }
+
+  // 内层块构造：按需追加首行缩进修复用的前导空间
+  // Inner block: optionally prepend leading space for indent-fix languages
+  let inner(add-leading-space) = {
+    set text(size: config.note-size)
+    if add-leading-space and should-indent { v(0.8em) }
+    set par(first-line-indent: 0pt, leading: config.note-leading, justify: final-justify)
+    content
+  }
+
+  block(
+    above: config.note-above,
+    below: config.note-below,
+  )[
+    #if effective == auto {
+      // ─ auto：占满文本宽，不缩窄 ─
+      // ─ auto: full text width, no narrowing ─
+      block(width: 100%, inner(true))
+    } else if type(effective) == ratio {
+      // ─ ratio：按百分比缩窄并居中（pad 加左右相等留白） ─
+      // ─ ratio: narrow + center via equal left/right padding ─
+      let margin = (100% - effective) / 2
+      pad(left: margin, right: margin, block(width: 100%, inner(true)))
+    } else {
+      // ─ length：绝对宽度，居中显示，无额外前导空间 ─
+      // ─ length: absolute width, centered, no leading space ─
+      align(center, block(width: effective, inner(false)))
+    }
+  ]
+
+  // 首行缩进敏感语言需要假段落修复 / Indent-sensitive langs need fake-para fix
+  if should-indent { _fakepar }
+}
+
+/// 创建表格注释（表注），默认宽度自动匹配 `captab` 表格宽度。
+/// Create a table note; default width auto-matches `captab` width.
+///
+/// - width (auto | ratio | length): 表注宽度 / Note width
+/// - justify (auto | bool): 是否两端对齐（auto=使用全局配置）/ Text justification
+/// - content (content): 表注内容 / Note content
+#let captnote(
+  width: auto,
+  justify: auto,
+  content
+) = {
+  context {
+    let config = table-style-config.get()
+    let percent = table-width-config.get()
+    _render-note(config, width, percent, justify, content)
+  }
+}
+
+/// 创建图片注释（图注），从 `figure-style-config` 读取样式，默认宽度自动匹配。
+/// Create a figure note; reads style from `figure-style-config`, auto-matches figure width.
+///
+/// - width (auto | ratio | length): 图注宽度 / Note width
+/// - justify (auto | bool): 是否两端对齐 / Text justification
+/// - content (content): 图注内容 / Note content
+#let capfnote(
+  width: auto,
+  justify: auto,
+  content
+) = {
+  context {
+    let config = figure-style-config.get()
+    let percent = figure-width-config.get()
+    _render-note(config, width, percent, justify, content)
+  }
+}

--- a/packages/preview/cap-able/0.1.0/src/table.typ
+++ b/packages/preview/cap-able/0.1.0/src/table.typ
@@ -1,0 +1,675 @@
+// ============================================================
+// 三线表模块 (Three-line Table Module)
+// ============================================================
+//
+// 本模块提供符合学术规范的三线表功能。
+// This module provides academic-standard three-line table functionality.
+//
+// 什么是三线表 / What is a three-line table:
+// 三线表是学术出版物中最常用的表格样式，以三条水平线为特征，
+// 无竖线，视觉简洁、信息层次清晰：
+// The three-line table is the most common table style in academic publications,
+// characterized by three horizontal rules and no vertical rules:
+//
+//  ═══════════════════════  ← 顶线 1.5pt（粗）/ Top rule 1.5pt (heavy)
+//  Header | Header | Header
+//  ───────────────────────  ← 中线 0.5pt（细）/ Middle rule 0.5pt (light)
+//  Data   | Data   | Data
+//  Data   | Data   | Data
+//  ═══════════════════════  ← 底线 1.5pt（粗）/ Bottom rule 1.5pt (heavy)
+//
+// 表格语法（基于 tablem）/ Table syntax (powered by tablem):
+// 使用 Markdown 风格的管道符语法：
+// Uses Markdown-style pipe syntax:
+//
+//  | Header 1 | Header 2 | Header 3 |
+//  | -------- | -------- | -------- |   ← 分隔行，必须存在 / Required separator row
+//  | Cell 1   | Cell 2   | Cell 3   |
+//
+// 对齐控制 / Alignment control:
+//  | :Left | :Center: | Right: |
+//
+// 单元格合并 / Cell merging:
+//  | Span | <    |    ← < 向左合并 / < merges left
+//  | A    | Span |
+//  | ^    | B    |    ← ^ 向上合并 / ^ merges up
+//
+// 导出函数 / Exported Functions:
+// - cap-table(): 三线表主函数（Three-line table main function）
+// - tlt: cap-table 的国际化别名（International alias）
+// - biaoge: cap-table 的中文拼音别名（Chinese alias）
+//
+// 依赖 / Dependencies:
+// - @preview/tablem:0.3.0 — Markdown 表格解析
+// - src/config.typ         — 全局配置和辅助函数
+// - src/bicap.typ          — 标题内容生成引擎
+//
+// ============================================================
+
+#import "@preview/tablem:0.3.0": tablem
+#import "config.typ": *
+#import "bicap.typ": _make_caption_content
+
+/// 创建三线表，支持 Markdown 语法、双语标题、续表和自定义线条。
+/// Create a three-line table with Markdown syntax, bilingual captions, continuation, and custom lines.
+///
+/// - columns (auto | int | array): 列配置 / Column config（推荐用法 / preferred）
+/// - cols (auto | int | array): columns 的向后兼容别名 / Back-compat alias for columns
+/// - align (auto | alignment | array | function): 单元格对齐（与 tablem 的 :---: 语法合并）/ Cell alignment
+/// - size (auto | length): 表格内容字号 / Table content font size
+/// - leading (auto | length): 表格内容行距 / Table content line spacing
+/// - inset (auto | length | dictionary): 单元格内边距 / Cell padding
+/// - caption (none | content): 主语言标题 / Main language caption
+/// - caption-en (none | content): 英文标题 / English caption
+/// - refer-to (none | label): 续表引用的原表标签 / Original label for continuation
+/// - show-caption (auto | bool): 续表是否显示标题文本 / Show caption in continuation
+/// - three-line-table (auto | bool): 是否使用三线表样式（默认 true；false 时跳过手动三线，使用 Typst 默认 table 边框）/ Three-line table mode
+/// - top-rule (auto | stroke): 顶线粗细，接受任何 stroke 值（如 1.5pt + red）/ Top rule stroke
+/// - middle-rule (auto | stroke): 中线粗细 / Middle rule stroke
+/// - bottom-rule (auto | stroke): 底线粗细 / Bottom rule stroke
+/// - breakable (auto | bool): 表格能否跨页（默认从全局读取，初始 true）/ Whether table may break across pages
+/// - repeat-header (auto | bool | int): 跨页时重复表头行 / Repeat the markdown header row on page-break
+/// - continued-caption (auto | bool): 跨页时是否在每页表头之上重复题注（题注会进入 `table.header` 内）/ Repeat caption on every page
+/// - hlines (array): 额外横线，每项为 `(row: int, start: int, end: none|int, stroke: stroke)` / Extra h-rules
+/// - vlines (array): 额外竖线，每项为 `(col: int, start: int, end: none|int, stroke: stroke)` / Extra v-rules
+/// - label (none | label): 表格标签，用于交叉引用 / Label for cross-reference
+/// - ..extra-args: 任何其它命名参数（如 `fill`, `stroke`, `gutter`, `column-gutter`, `row-gutter`, `rows`）会
+///   原样透传给底层 `table(...)`，与 `tablem` 的高级用法保持一致。
+///   `stroke` 用户传值时会覆盖我们三线模式默认的 `stroke: none`（建议这种情况下同时设
+///   `three-line-table: false`，否则三条手画 hline 会叠在用户 stroke 之上）。
+///   Any other named args (e.g. `fill`, `stroke`, `gutter`, `column-gutter`, `row-gutter`, `rows`) are
+///   passed through to the underlying `table(...)`, mirroring tablem's advanced-usage surface.
+///   A user-provided `stroke` overrides the `stroke: none` we use in three-line mode (consider also
+///   passing `three-line-table: false`, otherwise the three manual hlines stack on top of user stroke).
+/// - content (content): Markdown 风格的表格内容 / Markdown-style table content
+#let captab(
+  columns: auto,
+  cols: auto,        // 向后兼容别名 / back-compat alias for columns
+  align: auto,       // 透传给 tablem 的对齐 / Forwarded to tablem
+  size: auto,
+  leading: auto,
+  inset: auto,
+  cell-inset: auto,  // ← inset 的别名（与全局 captab-style 的 cell-inset 命名一致）/ alias of inset
+  caption: none,
+  caption-en: none,
+  refer-to: none,
+  show-caption: auto,
+  caption-position: auto,   // top / bottom；auto 取全局 / per-call override
+  caption-align: auto,      // center / left / right / text-left / text-right；也接 dict (main, continued)
+  placement: (),          // none（原地）/ top / bottom（浮动到当前页或下一页顶/底，禁止跨页）
+  width: auto,       // 表格宽度（auto / length / ratio）/ Table width (auto / length / ratio)
+  three-line-table: auto,
+  top-rule: auto,
+  middle-rule: auto,
+  bottom-rule: auto,
+  breakable: auto,
+  repeat-header: auto,
+  continued-caption: auto,
+  hlines: (),
+  vlines: (),
+  label: none,
+  ..extra-args,        // 透传给底层 table() / Forwarded to underlying table()
+  content
+) = {
+  // columns 优先；cols 作为兼容别名 / columns wins; cols is back-compat alias
+  let columns = if columns != auto { columns } else { cols }
+
+  // ..extra-args 只接受命名参数；位置参数应当通过 trailing content block 传入
+  // ..extra-args only accepts named args; positional content goes via the trailing block
+  assert(
+    extra-args.pos().len() == 0,
+    message: "captab: unexpected positional argument(s) — pass markdown content as the trailing block.",
+  )
+
+  context {
+    // 读取全局配置状态（在 context 中才能读取）
+    // Read global config state (only readable inside context)
+    let global-width = table-width-config.get()
+    let config = table-style-config.get()
+
+    // 解析表宽：per-call width > 全局 state > auto
+    // 兼容旧 set-table-width(percentage: int) 写入的 int → 当作百分比
+    // Resolve width: per-call > global state > auto.
+    // Backward compat: legacy int (from set-table-width(percentage: ...)) → ratio.
+    let user-width = if width != auto { width } else { global-width }
+    let final-width = if type(user-width) == int { user-width * 1% } else { user-width }
+
+    // 解析样式参数：优先使用传入值，否则使用全局配置
+    // Resolve style params: prefer passed value, fall back to global config
+    let final-size = if size == auto { config.body-size } else { size }
+    let final-leading = if leading == auto { config.body-leading } else { leading }
+    // 接受 inset 或 cell-inset；同时传入时 cell-inset 优先（与全局命名一致）
+    // Accept either inset or cell-inset; cell-inset wins when both provided (matches global name)
+    let user-inset = if cell-inset != auto { cell-inset } else { inset }
+    let final-inset = if user-inset == auto { config.cell-inset } else { user-inset }
+    let final-three-line-table = if three-line-table != auto { three-line-table } else { config.at("three-line-table", default: true) }
+    let final-top-rule = if top-rule != auto { top-rule } else { config.at("top-rule", default: 1.5pt) }
+    let final-middle-rule = if middle-rule != auto { middle-rule } else { config.at("middle-rule", default: 0.5pt) }
+    let final-bottom-rule = if bottom-rule != auto { bottom-rule } else { config.at("bottom-rule", default: 1.5pt) }
+    let final-breakable = if breakable != auto { breakable } else { config.at("breakable", default: true) }
+    let final-repeat-header = if repeat-header != auto { repeat-header } else { config.at("repeat-header", default: true) }
+    let final-continued-caption = if continued-caption != auto { continued-caption } else { config.at("continued-caption", default: false) }
+    // 题注位置：top（默认）/ bottom。per-call > state > top
+    // Caption position: top (default) / bottom. per-call > state > top
+    let final-caption-position = if caption-position != auto {
+      caption-position
+    } else {
+      config.at("caption-position", default: top)
+    }
+
+    // 题注水平对齐：字符串 "center" / "left" / "right" / "text-left" / "text-right"
+    // 也接受 dict (main: ..., continued: ...) 拆分主与续；per-call > state > "center"
+    // Horizontal alignment of caption: strings "center" / "left" / "right" (table-local)
+    // / "text-left" / "text-right" (text-area-local). Also accepts dict (main, continued).
+    let raw-caption-align = if caption-align != auto {
+      caption-align
+    } else {
+      config.at("caption-align", default: "center")
+    }
+    let final-caption-align-main = if type(raw-caption-align) == dictionary {
+      raw-caption-align.at("main", default: "center")
+    } else {
+      raw-caption-align
+    }
+    let _continued-raw = if type(raw-caption-align) == dictionary {
+      raw-caption-align.at("continued", default: "center")
+    } else {
+      raw-caption-align
+    }
+    // 续表标题嵌在 table.header 内，列宽锁住——text-left/text-right 静默降级为 left/right。
+    // 必要时用户应改用 *手动 refer-to* 拆段，把续题放到表外、走正文宽。
+    // Continuation caption lives inside table.header (locked to column width):
+    // text-left/text-right silently degrade to left/right. When users need true
+    // text-area-anchored continuation captions, they should fall back to manual
+    // refer-to split (a separate captab outside the original table).
+    let final-caption-align-continued = if _continued-raw == "text-left" { "left" }
+      else if _continued-raw == "text-right" { "right" }
+      else { _continued-raw }
+
+    // Resolver: 把字符串 caption-align 翻译成 (kind, alignment-value)。
+    // kind="local" 表示表/图局部对齐；kind="text" 表示正文宽对齐。
+    // Resolver: translate the string into (kind, alignment) pair.
+    let _resolve-cap-align(s) = {
+      if s == "left"        { (kind: "local", value: left) }
+      else if s == "right"  { (kind: "local", value: right) }
+      else if s == "text-left"  { (kind: "text", value: left) }
+      else if s == "text-right" { (kind: "text", value: right) }
+      else                  { (kind: "local", value: center) }   // "center" / fallback
+    }
+    let main-align-resolved      = _resolve-cap-align(final-caption-align-main)
+    let continued-align-resolved = _resolve-cap-align(final-caption-align-continued)
+
+    // 浮动定位：per-call > state > none
+    // Floating placement: per-call > state > none
+    let final-placement = if placement != () {
+      placement
+    } else {
+      config.at("placement", default: none)
+    }
+    // 浮动启用时强制 breakable: false（Typst float 不允许跨页）。
+    // 同时与 continued-caption: true 不兼容（续页机制依赖跨页）；此组合下
+    // continued-caption 由 cap-in-header 已经控制，浮动会让长表渲染异常或溢出，
+    // 用户应当自行避免。
+    // When floating, force breakable: false (Typst floats can't break across pages).
+    // Incompatible with continued-caption: true (which requires page breaks); user is
+    // responsible for avoiding the combo — long tables shouldn't be floated.
+    let final-breakable = if final-placement != none { false } else { final-breakable }
+    // continued-caption 需要一个 label 以便续页通过 query(label) 找到原表的位置/编号。
+    // 用户没传 label 时，自动合成一个唯一隐藏 label，仅用于 continued-caption 内部检索。
+    // continued-caption needs a label so continuation pages can locate the original table via query(label).
+    // If the user didn't supply one, auto-synthesise a hidden unique label for internal lookup only.
+    // continued-caption 与 caption-position: bottom 不兼容：
+    // table.footer 会把 caption 锁在 table 的列宽内、视觉上"嵌进表里"，
+    // 不符合 caption-position: bottom 应有的"在表格之外、表下方"语义。
+    // 此组合下 *静默关闭 repeat*，等价 continued-caption: false——
+    // 题注只在最后一页底部出现一次。
+    // continued-caption is incompatible with caption-position: bottom because
+    // table.footer keeps the caption within the table column boundaries (visually
+    // inside the table), which contradicts the "outside, below the table" semantic.
+    // In this combo we silently disable repetition (effectively continued-caption: false);
+    // the caption shows only once at the bottom of the last page.
+    let cap-in-header = (final-continued-caption
+                         and caption != none
+                         and refer-to == none
+                         and final-caption-position != bottom)
+    // 用 counter("__captab-synth-id") 给每个 captab 调用分配一个唯一编号；
+    // step 在下面以 content 形式发射出去（看 cap-in-header 块里的 emit 段落）。
+    // counter assigns each captab call a unique id; step is emitted as content below.
+    let synth-id = if cap-in-header and label == none {
+      counter("__captab-synth-id").get().first()
+    } else { 0 }
+    let effective-label = if label != none {
+      label
+    } else if cap-in-header {
+      std.label("__captab_repeat_" + str(synth-id))
+    } else {
+      none
+    }
+
+    // 解析文档语言和首行缩进修复标志 / Resolve language and indent-fix flag
+    let (doc-lang, should-indent) = resolve-lang-indent(config)
+
+    // ── 构建表格主体 ─────────────────────────────────────────────
+    // ── Build table body ─────────────────────────────────────────
+    let table-body = {
+      let raw-table = {
+        // 设置文本和段落样式（在 tablem 解析前设置，会应用到所有单元格）
+        // Set text/paragraph style before tablem parsing (applies to all cells)
+        set text(size: final-size)
+        set par(leading: final-leading)
+
+        // 把外层的 columns / align 闭包别名，避免与 tablem render 回调里同名形参发生遮蔽
+        // 也避免 align 撞到 Typst 内建 align() 函数
+        // Alias the outer params to avoid shadowing render's same-name params
+        // and to keep `align` from clashing with Typst's builtin `align()` function.
+        let user-columns = columns
+        let user-align = align
+        tablem(
+          columns: user-columns,
+          align: user-align,
+          ..extra-args.named(),
+          // tablem 的 render 回调：接收解析好的列数/对齐/单元格内容，
+          // 由我们来决定如何渲染最终的 table
+          // tablem's render callback: receives parsed columns/alignment/cells,
+          // we decide how to render the final table
+          render: (columns: auto, align: auto, ..args) => {
+            // ── 处理列宽 ──────────────────────────────────────────
+            // ── Handle column widths ──────────────────────────────
+            let final-columns = if user-columns != auto {
+              // 用户指定了 columns：直接使用（不管 tablem 解析到的列数）
+              // User specified columns: use directly (ignore tablem-parsed column count)
+              user-columns
+            } else if type(columns) == int {
+              // tablem 检测到 n 列（返回整数）。默认列宽视乎 width：
+              //   width == auto（不固定表宽）→ 用 n 个 auto 列，表按内容宽度自然撑开。
+              //   width 是 length / ratio（固定表宽）→ 用 n 个 1fr 列填满该宽度。
+              // tablem returned an int column count. Pick column default based on width:
+              //   width == auto (no fixed width) → n auto columns, table sized by content.
+              //   width is length / ratio (fixed)  → n 1fr columns to fill that width.
+              if final-width == auto {
+                (auto,) * columns
+              } else {
+                (1fr,) * columns
+              }
+            } else {
+              // tablem 返回了列宽数组（来自 Markdown 对齐语法）：直接使用
+              // tablem returned column width array (from Markdown alignment syntax): use directly
+              columns
+            }
+
+            // ── 处理对齐 ──────────────────────────────────────────
+            // ── Handle alignment ──────────────────────────────────
+            // 默认强制 horizon（垂直居中），但要分辨用户传的 alignment 是否已经是 2D：
+            // 1D `left` → 加 horizon → `left + horizon`；
+            // 2D `left + bottom` → 已经指定了垂直方向，原样保留，*不再覆盖*。
+            // Force horizon for vertical centering by default, but only if the user
+            // hasn't already specified a vertical component (avoid the
+            // "cannot add a vertical and a 2D alignment" error).
+            let _ensure-horizon = a => {
+              if a == auto {
+                center + horizon
+              } else if type(a) == alignment {
+                if a.y == none { a + horizon } else { a }
+              } else {
+                a
+              }
+            }
+            let final-align = if type(align) == array {
+              align.map(_ensure-horizon)
+            } else if type(align) == function {
+              // 函数式 align：(col, row) => alignment，用 wrap 包一层补 horizon
+              // Functional align: wrap to add horizon when missing
+              (col, row) => _ensure-horizon(align(col, row))
+            } else {
+              _ensure-horizon(align)
+            }
+
+            // ── 解构 tablem 已经构造好的 table.header ─────────────────
+            // ── Unpack the table.header tablem produced ───────────────
+            // tablem 把表头行包成 table.header(...)，作为 args.pos() 的第一个元素，
+            // 后面才是 body cells。我们读取它的 children，再重建一个带正确 repeat
+            // 与可选题注行的 table.header。
+            // tablem wraps the markdown header row in `table.header(...)` and passes
+            // it as args.pos().first(); body cells follow. We extract its children
+            // and rebuild a fresh table.header with the right repeat + optional caption row.
+            let received = args.pos()
+            let tablem-header-elem = if received.len() > 0 and received.first().func() == table.header {
+              received.first()
+            } else {
+              none
+            }
+            let header-cells = if tablem-header-elem != none {
+              tablem-header-elem.children
+            } else {
+              ()
+            }
+            let body-cells = if tablem-header-elem != none {
+              received.slice(1)
+            } else {
+              received
+            }
+            let ncols = if type(final-columns) == array {
+              final-columns.len()
+            } else if type(final-columns) == int {
+              final-columns
+            } else if header-cells.len() > 0 {
+              header-cells.len()
+            } else {
+              1  // 兜底 / fallback
+            }
+
+            // ── 构建 table.header（用于跨页重复）─────────────────────
+            // ── Build table.header (for cross-page repetition) ────────
+            // 我们 *始终* 用自己的 table.header 替换 tablem 默认产出的版本，
+            // 这样 repeat-header: false 才能真正关掉重复（tablem 默认 repeat=auto≈true）。
+            // We *always* replace tablem's default table.header with our own,
+            // so that repeat-header: false actually disables repetition (tablem defaults to auto≈true).
+            //
+            // cap-in-header：把"题注嵌入表内"用 table.header(level: 1, repeat: true)
+            // 在每页顶部重复。注意 caption-position: bottom 与 continued-caption 的组合
+            // 在 cap-in-header 处已被排除（见上），所以这里只剩 top 一条路径。
+            // cap-in-header: embed the caption row inside table.header(level: 1, repeat: true)
+            // so it repeats at every page top. The bottom + continued-caption combo is already
+            // excluded in cap-in-header above, so only the top path remains here.
+            let cap-row-count = if cap-in-header { 1 } else { 0 }
+
+            // 跨页时显示的"续表 X.Y caption"内容：仅在续页（here().page() 不等于
+            // 表起始页）时通过 _make_caption_content 走 refer-to 分支生成；这样
+            // 不会重复登记 figure，编号也通过 query(label) 锁定到第一页。
+            // 把 caption-above/-below 间距放进内容里（而不是 cell inset），这样
+            // 第一页空 cell 不会撑出多余空白。
+            // Continuation caption shown on each subsequent page: rendered via the
+            // refer-to branch of _make_caption_content (no figure registration). The
+            // table number is anchored to the main table via query(label).
+            // The caption-above/-below spacing is baked into the content (rather than
+            // the cell inset) so the empty cell on page 1 stays collapsed.
+            let cap-cell-content = if cap-in-header {
+              context {
+                let originals = query(effective-label)
+                if originals.len() > 0 {
+                  let start-page = originals.first().location().page()
+                  let cur-page = here().page()
+                  if cur-page != start-page {
+                    v(config.caption-above)
+                    _make_caption_content(
+                      caption: caption,
+                      caption-en: caption-en,
+                      refer-to: effective-label,
+                      label: none,
+                      config: config,
+                      kind: "table",
+                      show-caption: true,
+                    )
+                    v(config.caption-below)
+                  }
+                  // else: 第一页，外层标题块已渲染原标题，本 cell 留空 / page 1 stays empty
+                }
+              }
+            } else { none }
+
+            // ── 构建表格内容列表 ───────────────────────────────────
+            // ── Build table content list ───────────────────────────
+            let table-content = ()
+
+            // 顶线 / 中线 y 索引随 cap-in-header 上移一行（caption 行无顶线，看起来像题注）
+            // Shift top/middle hline y indices down if caption row is included in header
+            let top-hline-y = cap-row-count
+            let middle-hline-y = cap-row-count + 1
+
+            // 三线表模式才手动加顶/中/底线；非三线表模式让 Typst 用默认 table 边框
+            // Only add manual top/middle/bottom rules in three-line mode;
+            // otherwise rely on Typst's default table stroke.
+            if final-three-line-table {
+              // 顶线（在表头行上方；若有 caption 行，caption 在顶线之上无 stroke 看起来像题注）
+              // Top rule above header row; caption row (if any) sits above without strokes
+              table-content.push(table.hline(y: top-hline-y, stroke: final-top-rule))
+              // 中线（表头行下方）/ Middle rule (below header row)
+              table-content.push(table.hline(y: middle-hline-y, stroke: final-middle-rule))
+            }
+
+            // ── continued-caption + top：把 caption 行放进独立的 table.header（level: 1, repeat: true），
+            // 让它在每页顶部重复，跟 markdown header（level: 2, repeat: final-repeat-header）解耦。
+            // For continued-caption + top: caption lives in its own table.header (level 1, repeat: true)
+            // so it always repeats at the top, independent of markdown header repetition (level 2).
+            // 续表 cap-cell 的水平对齐沿用 continued-align-resolved（已在前面降级为 local）
+            // Continuation cap-cell horizontal alignment uses continued-align-resolved
+            // (already degraded to a local alignment value upstream).
+            let cap-cell = table.cell(
+              colspan: ncols,
+              stroke: none,
+              align: continued-align-resolved.value,
+              inset: (x: 0pt, y: 0pt),
+              cap-cell-content,
+            )
+            if cap-in-header {
+              table-content.push(table.header(level: 1, repeat: true, cap-cell))
+            }
+
+            if header-cells.len() > 0 {
+              // 始终重建 markdown 表头 header，保证 repeat-header: false 能真正关掉重复
+              // markdown header 的 level：cap-in-header 时升到 2 让出 level 1 给 caption；其它都用 1
+              // Always rebuild the markdown header so repeat-header: false really disables repetition.
+              // markdown header level: 2 when cap-in-header (to leave level 1 for caption), else 1.
+              table-content.push(
+                table.header(
+                  level: if cap-in-header { 2 } else { 1 },
+                  repeat: final-repeat-header,
+                  ..header-cells
+                )
+              )
+              table-content += body-cells
+            } else {
+              // 没有 header（可能是空表）；直接展开所有内容
+              // No header (possibly empty table); spread all received content
+              table-content += received
+            }
+
+            // ── 添加用户自定义额外横线 ─────────────────────────────
+            // ── Add user-defined extra horizontal lines ─────────────
+            for line in hlines {
+              let y = line.at("row", default: 2)         // 默认第2行上方 / default: above row 2
+              let start = line.at("start", default: 0)   // 默认从第0列开始 / default: from col 0
+              let end = line.at("end", default: none)     // 默认到最右列 / default: to rightmost
+              let stroke-style = line.at("stroke", default: 0.5pt)
+              table-content.push(
+                table.hline(y: y, start: start, end: end, stroke: stroke-style)
+              )
+            }
+
+            // ── 添加用户自定义额外竖线 ─────────────────────────────
+            // ── Add user-defined extra vertical lines ───────────────
+            for line in vlines {
+              let x = line.at("col", default: 1)         // 默认第1列右侧 / default: right of col 1
+              let start = line.at("start", default: 0)
+              let end = line.at("end", default: none)
+              let stroke-style = line.at("stroke", default: 0.5pt)
+              table-content.push(
+                table.vline(x: x, start: start, end: end, stroke: stroke-style)
+              )
+            }
+
+            // 底线（默认 1.5pt 粗；可由 bottom-rule / 全局配置覆盖；非三线表模式跳过）
+            // Bottom rule (default 1.5pt; overridable; skipped when not in three-line mode)
+            if final-three-line-table {
+              table-content.push(table.hline(stroke: final-bottom-rule))
+            }
+
+            // ── 处理 inset（单元格内边距）─────────────────────────
+            // ── Process inset (cell padding) ───────────────────────
+            // inset 可以是字典（{x: ..., y: ...}）或标量（统一应用）
+            // inset can be a dict ({x: ..., y: ...}) or scalar (uniform)
+            let final-table-inset = if type(final-inset) == dictionary {
+              final-inset
+            } else {
+              // 标量转换为 x/y 字典
+              // Convert scalar to x/y dict
+              (x: final-inset, y: final-inset)
+            }
+
+            // 三线表模式下显式 stroke: none（线条由上面手动添加）；
+            // 非三线表模式下不传 stroke，由 Typst / 现有 set rule 决定默认网格描边。
+            // 用户通过 ..extra-args 显式传 stroke / fill / gutter 等会覆盖我们的默认。
+            // In three-line mode explicitly stroke: none (we draw the rules manually);
+            // otherwise omit the stroke arg so Typst's set rules / defaults apply.
+            // User-provided stroke / fill / gutter / etc. via ..extra-args override our defaults.
+            let stroke-args = if final-three-line-table { (stroke: none) } else { (:) }
+            table(
+              columns: final-columns,
+              ..stroke-args,
+              align: final-align,
+              inset: final-table-inset,
+              ..args.named(),           // 透传用户高级参数（fill/stroke/gutter 等）/ Pass-through user advanced args
+              ..table-content           // 展开所有内容（线条+单元格）/ Spread all content
+            )
+          },
+          content
+        )
+      }
+
+      // ── 应用表宽 ──────────────────────────────────────────────
+      // ── Apply table width ─────────────────────────────────────
+      // final-width = auto / length / ratio。
+      //   auto：raw-table 自身按 columns 内容宽渲染。
+      //   length / ratio：外面再套一层 block(width: ...) 锁定宽度。
+      // 注意这里只产出 *表本体*；居中/对齐由调用方根据 caption-align 决定。
+      // Produce the bare table only; centering / alignment is decided by the caller
+      // based on caption-align (so caption + table can share table-local alignment).
+      if final-width == auto {
+        raw-table
+      } else {
+        block(width: final-width, raw-table)
+      }
+    }
+
+    // ── 组合标题和表体 ────────────────────────────────────────────
+    // ── Combine caption and table body ───────────────────────────
+    //
+    // 三种情况：
+    // Three cases:
+    // 1. 有标题 + 续表（refer-to 非 none）
+    //    Has caption + continuation
+    // 2. 有标题 + 主表（refer-to 为 none）
+    //    Has caption + main table
+    // 3. 无标题（只有表体）
+    //    No caption (table body only)
+    //
+    // 标题和表体放在同一个不换页 block 中，防止跨页分离
+    // Caption and body are in the same non-breakable block to prevent page splits
+
+    // 如果用了 cap-in-header 且我们合成了 label，需要把 synth-id 计数器推进 1，
+    // 让下一个用同样路径的 captab 拿到不同的合成 id。
+    // If cap-in-header used a synthesised label, step the synth counter so the
+    // next captab call gets a fresh id.
+    if cap-in-header and label == none {
+      counter("__captab-synth-id").step()
+    }
+
+    if caption != none {
+      // 续表不设置标签（避免重复引用），主表才设置 label
+      // Continuation gets no label (avoid duplicate refs); main table gets the label
+      let is-continuation = refer-to != none
+
+      // 主标题原始内容（不含外层对齐；对齐由下面根据 caption-align 决定）
+      // Raw main caption content (no outer alignment; layout decides alignment below).
+      let caption-content = _make_caption_content(
+        caption: caption,
+        caption-en: caption-en,
+        refer-to: refer-to,
+        label: if is-continuation { none } else { effective-label },
+        config: config,
+        kind: "table",
+        show-caption: show-caption,
+      )
+      // 标题与表体之间的间距；减去 1em 是因为 block 的 below 已贡献默认段距
+      // Gap between caption and body; subtract 1em because block below contributes default paragraph spacing
+      let gap = v(config.caption-below - 1em)
+
+      // 根据 main-align-resolved 组合 caption + table-body：
+      //   kind == "text"  → caption 单独占一行 block(width: 100%) 走正文宽对齐；
+      //                     table 仍 std.align(center, ...) 居中。
+      //   kind == "local" → caption 与 table 一起包进一个共享 *表宽* 的内层 block，
+      //                     在该 block 内对 caption 应用 left/right/center；外层再居中。
+      // Compose caption + table-body based on main-align-resolved:
+      //   kind == "text"  → caption is a standalone full-text-width block aligned to
+      //                     text-left/right; the table stays centered independently.
+      //   kind == "local" → caption + table share an inner block whose width follows
+      //                     the table's natural / configured width; alignment is applied
+      //                     within that inner block; the outer wrapper then centers it.
+      let composed = if main-align-resolved.kind == "text" {
+        let cap-line = block(width: 100%, std.align(main-align-resolved.value, caption-content))
+        let table-centered = block(width: 100%, std.align(center, table-body))
+        if final-caption-position == bottom {
+          table-centered
+          gap
+          cap-line
+        } else {
+          cap-line
+          gap
+          table-centered
+        }
+      } else {
+        // local 分支：内层 block 宽度跟随表——固定宽度时取 final-width，auto 时让其 sizes-to-content
+        // local branch: inner block tracks table width — fixed when final-width is set,
+        // auto sizes to content (max(caption-width, table-width)).
+        let inner-width = if final-width == auto { auto } else { final-width }
+        let group = block(width: inner-width)[
+          #if final-caption-position == bottom {
+            table-body
+            gap
+            std.align(main-align-resolved.value, caption-content)
+          } else {
+            std.align(main-align-resolved.value, caption-content)
+            gap
+            table-body
+          }
+        ]
+        block(width: 100%, std.align(center, group))
+      }
+
+      // 标准/continued-caption 共享：外层 block 含 caption 与 table-body，相对顺序由
+      // final-caption-position 决定（top → 题注在上，bottom → 题注在下）。
+      // 对 continued-caption 模式，*续页* 的题注由 table.header / table.footer 内的
+      // cap-cell-content 重复输出（top / bottom 同步走 footer 路径，见 render 回调）。
+      // Caption above body (top) or below body (bottom) decided by final-caption-position.
+      // For continued-caption mode, continuation captions are emitted via the corresponding
+      // table.header (top) or table.footer (bottom) inside the table.
+      let outer-block = block(
+        breakable: final-breakable,
+        above: config.caption-above,
+        below: config.table-below,
+      )[#composed]
+      // 浮动包装：placement: top/bottom 时把 outer-block 整体 float 到当前页或下一页的
+      // 顶部/底部。隐藏 figure（_make_caption_content 里的 place(hide[#figure(...)])）一同
+      // 被 float 包进去，counter step 在 float 落地时触发，`@ref` 正确指向落地页。
+      // place() 在仅给 vertical alignment（top/bottom）时水平默认贴左——补 + center
+      // 才能保留 cap-able 一贯的居中行为，与 Typst 原生 figure(placement) 一致。
+      // 长表：Typst float 装不下时表会溢出/裁切；用户应保持 placement: none。
+      // Float wrap. The hidden figure rides along, so @ref resolves to the float's
+      // landing page. place() with vertical-only alignment (top/bottom) defaults to
+      // left-align horizontally — we add `+ center` to keep cap-able's centered look.
+      // Long tables that don't fit a float will overflow; users should keep placement: none.
+      let _normalize-placement(p) = if p == top { top + center }
+        else if p == bottom { bottom + center }
+        else { p }
+      if final-placement != none {
+        place(_normalize-placement(final-placement), float: true, outer-block)
+      } else {
+        outer-block
+      }
+      if should-indent { _fakepar }
+    } else {
+      // ─ 无标题：直接输出表体（仍居中）─ (No caption: bare body, still centered)
+      let bare = block(width: 100%, std.align(center, table-body))
+      let _normalize-placement(p) = if p == top { top + center }
+        else if p == bottom { bottom + center }
+        else { p }
+      if final-placement != none {
+        place(_normalize-placement(final-placement), float: true, bare)
+      } else {
+        bare
+      }
+      if should-indent { _fakepar }
+    }
+  }
+}
+

--- a/packages/preview/cap-able/0.1.0/typst.toml
+++ b/packages/preview/cap-able/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cap-able"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["SchrodingerBlume"]
+license = "MIT"
+description = "Professional three-line tables and figures with bilingual captions, continued tables/figures, subfigures, and 25+ language support for academic documents."
+repository = "https://github.com/SchrodingerBlume/typst-cap-able"
+keywords = ["table", "figure", "caption", "bilingual", "academic"]
+categories = ["components", "layout"]
+compiler = "0.13.0"
+exclude = ["*.pdf"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

# Added

## Tables (`captab` / `captab-style`)

- **Breakable tables** — new `breakable` parameter (default `true`). Long tables now flow naturally across pages instead of being clipped on a single page. Pass `breakable: false` to restore the old "atomic" behavior.
- **Repeat header on page break** — new `repeat-header` parameter (`true` / `false` / `<int>`, default `true`). Re-emits the markdown header row at the top of each continuation page using Typst's native `table.header(repeat: ...)`. `<int>` repeats only on the first N continuation pages.
- **Repeat caption on page break** — new `continued-caption` parameter (bool, default `false`). When enabled, each continuation page gets a "Cont. Table X.Y caption" row at its top, in the same format as `refer-to` mode. Number is anchored to the main table; no figure re-registration. Caption row and markdown header live in two separate `table.header`s (level 1/2), so `continued-caption: true` and `repeat-header: false` can coexist.
- **`width` parameter** — new `width` (accepts `auto` / `<length>` / `<ratio>`, e.g. `8cm`, `80%`, `80.5%`). Available on `captab` per-call and `captab-style` global. Replaces the previous fixed-100% behavior.
- **`three-line-table` toggle** — set to `false` to drop the manual three rules and use Typst's default table stroke instead. Custom `hlines` / `vlines` still work.
- **`cell-inset` / `inset` aliases** — both names now work in both `captab` and `captab-style`; `cell-inset` wins when both are passed.
- **`captab` accepts `align` and arbitrary `..extra-args`** — passes through `fill` / `stroke` / `gutter` / `column-gutter` / `row-gutter` / `rows` etc. to the underlying `table(...)`, matching tablem's advanced-usage surface.

## Captions (`cap-style` / `captab-style` / `capfig-style`)

- **`caption-position`** (`top` / `bottom`) — controls whether the caption sits above or below body. Defaults to `top` for tables, `bottom` for figures. Configurable globally via `cap-style` / `captab-style` / `capfig-style`, or per-call via `captab(caption-position: ...)` / `bicap(position: ...)`.
- **`caption-align`** — controls horizontal alignment with five values: `"center"` (default) / `"left"` / `"right"` (table-local) / `"text-left"` / `"text-right"` (text-area-local). Also accepts a dict `(main: ..., continued: ...)` to set main and continuation captions independently.
- **`caption-text`** — pass-through dict for the caption's `text(...)` rendering. Accepts any Typst native `text()` parameter (`font` / `fill` / `tracking` / `spacing` / `stretch` / ...). Two forms:
  - *Flat dict* (`(font: "Times")`) — applies to the whole caption.
  - *Nested dict* — uses any of `whole` / `prefix` / `supplement` / `number` / `body` as keys for layered overrides; inner overrides outer.
  Example: `caption-text: (whole: (font: "Helvetica"), number: (fill: red, weight: "bold"), body: (font: "SimSun"))`. Lets users style supplement, number and body independently — solving the "show figure.caption rule doesn't take effect" problem (cap-able's caption is manually rendered, not a real `figure.caption` element).
- **`placement`** — Typst-style float positioning. Four values: `none` (default, in-flow) / `top` / `bottom` (float to top/bottom of current or next page) / `auto` (Typst picks `top` or `bottom` — whichever edge is closer). Hidden figure (cross-ref anchor) rides along inside the float wrapper, so `@ref` resolves to the float's landing page.

## bicap

- **`bicap()[body]` form** — wrap a caption with a body in a single non-breakable block, conceptually a cap-able-flavoured `figure(body, caption: ...)`. The trailing-block form and the `body: [...]` named-arg form are equivalent.
- **`bicap(continued-caption: true)`** — when `kind: "table"`, every native `#table()` inside body gets its caption repeated on each continuation page. Same mechanism as `captab(continued-caption: true)`.
- **`bicap(repeat-header: ...)`** — overrides the markdown header `repeat` setting of any `#table()` in body. Independent of `continued-caption`.
- **`bicap(breakable: ...)`** — controls whether the outer block may break across pages (default `true`, so a breakable body flows naturally).

## Subfigures

- **`label-style` accepts `str | dict`** — passing a string keeps overlay label and subcaption prefix coupled (default behavior). Passing a dict `(overlay: "a)", subcaption: "(a)")` decouples them; missing keys fall back to package default `"(a)"`.
- **Per-subfig overlay style override** — `label-style-override` dict now accepts four new keys for individual overlays: `style` (the format string), `font`, `size`, `offset`. The previously supported visual keys (`text-color`, `stroke`, `bg`, `bg-shape`, `bg-radius`, `bg-inset`) still work.
- **`subcaption-number-title-spacing`** (default `auto`) — controls the gap between the subcaption number prefix and its body. `auto` inherits from the main caption's `number-title-spacing`. Configurable on `capfig-style` and per-call on `capsubfig`.
- **Visibility-aware cross-reference letter** — when `label-style` differs between overlay and subcaption (dict form), `@ref` follows whichever side is actually visible. If both are visible (typical), subcaption wins; if only the overlay is drawn, overlay wins.
- **Per-subfig `style` cross-ref consistency** — when ref follows overlay (subcaption hidden), `@ref` renders that subfig's own format so the letter matches what's stamped on the figure.

## Numbering (`numbering-format`)

- **Function-form support** — `numbering-format` now accepts `str | function`, matching Typst's native `numbering()` first argument. Function form receives all heading levels + the figure/table number when `use-chapter: true`, just the figure/table number when `use-chapter: false`.

# Changed

- **Default table width: `100%` → `auto`** — tables now size to content by default, not the full text width. Set `set-table-width(width: 100%)` or `captab-style.with(width: 100%)` to restore the old behavior. Tables with explicit `fr` columns still expand to fill their container.
- **Default subcaption number-text spacing** — changed from a single space to inheriting the main caption's `number-title-spacing` (e.g. `: ` or `\u{3000}`). Affects only users with `show-subcaption: true` and `show-subcaption-label: true`. To restore the old single-space, set `subcaption-number-title-spacing: " "` explicitly.
- **`use-chapter: false` now honors `numbering-format`** — previously this branch hard-coded `numbering("1", num)`, silently ignoring custom formats like `"(A)"` or `"App. 1"`. Both branches now respect the configured format. *Bug fix; no real-world content depended on the old behavior.*

# Fixed

- **`captab` align parsing** — passing an already 2D alignment (e.g. `align: horizon + center`) no longer panics with "cannot add a vertical and a 2D alignment". The auto-`+ horizon` is only applied when `.y == none`.
- **`numbering-format` UTF-8 boundary** — multi-byte literals in format strings (e.g. `"附 1"`) no longer panic on byte-level indexing. Format scanning now uses grapheme clusters (`.clusters()`).

# Known Limitations

- **`continued-caption: true` + `caption-position: bottom`**: incompatible. Continuation repetition relies on `table.header(repeat: true)` to emit the caption inside the table; using `table.footer` instead would lock the caption inside the column boundaries — visually "embedded in the table" — which contradicts what `caption-position: bottom` means. When both are set, `continued-caption` is silently disabled. Use `caption-position: top` if you need every-page repetition, or stick with `continued-caption: false` and let the original caption appear once at the bottom of the last page.
- **`continued-caption: true` + `caption-align: "text-left"` / `"text-right"`**: the continuation-side text-anchored values silently degrade to `"left"` / `"right"`. The continuation caption is structurally locked inside `table.header`'s column width and can't extend out to the text-area edges. For true text-anchored continuation captions, fall back to manual `refer-to` splitting (one `captab(refer-to: <main>, caption-align: "text-left", ...)` per continuation segment).
- **`continued-caption: true` + multiple tables in one `bicap`**: the same caption is injected above every native `#table()` in body. Convention is one table per `bicap`; for multi-table layouts, use multiple `bicap` calls or manage each table's caption with `captab` directly.
-  **`placement: top` / `bottom` / `auto` forces `breakable: false`** — Typst floats can't break across pages. A long table that doesn't fit a float will overflow; keep `placement: none` for those. Also incompatible with `continued-caption: true` (which depends on page breaks).

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
- [x] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
