### PR TITLE
non-unlabeled:0.1.0

### DIFF
--- a/packages/preview/non-unlabeled/0.1.0/LICENSE
+++ b/packages/preview/non-unlabeled/0.1.0/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Luca Ravasio
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/non-unlabeled/0.1.0/README.md
+++ b/packages/preview/non-unlabeled/0.1.0/README.md
@@ -30,7 +30,7 @@ $
 3 + 3 = 7
 $ <label>
 
-Therefore it will be numbered.
+Therefore it will be numbered. The following two equations instead won't.
 
 $
 3 + 3 = 42

--- a/packages/preview/non-unlabeled/0.1.0/README.md
+++ b/packages/preview/non-unlabeled/0.1.0/README.md
@@ -7,8 +7,8 @@ Usage:
 #import "@preview/non-unlabeled.typ": *
 
 // You need to do this to enable the package
-#show math.equation: dont_number_unlabeled(math.equation)
-#show figure: dont_number_unlabeled(figure)
+#show math.equation: dont-number-unlabeled(math.equation)
+#show figure: dont-number-unlabeled(figure)
 
 // You also need to define how you number your objects (you can do this also without using headcount)
 #import "@preview/headcount:0.1.0": *

--- a/packages/preview/non-unlabeled/0.1.0/README.md
+++ b/packages/preview/non-unlabeled/0.1.0/README.md
@@ -1,0 +1,47 @@
+# NoN Unlabeled: No Numbering for Unlabeled objects
+Prevents unlabeled objects like math.expression or figure from being automatically numbered.
+
+Usage:
+
+```
+#import "@preview/non-unlabeled.typ": *
+
+// You need to do this to enable the package
+#show math.equation: dont_number_unlabeled(math.equation)
+#show figure: dont_number_unlabeled(figure)
+
+#import "@preview/headcount:0.1.0": *
+#set ref(supplement: [Eq.])
+#set math.equation(numbering: dependent-numbering("(1.1)", levels: 1))
+#set figure(numbering: dependent-numbering("(1.1)", levels: 1))
+
+#set heading(numbering: "1.")
+
+= Suspicious additions
+
+This equation is unimportant: it will not be numbered:
+$
+3 + 3 = 4
+$
+
+This one, on the other hand, will be used later:
+$
+3 + 3 = 7
+$ <label>
+
+Therefore it will be numbered.
+
+$
+3 + 3 = 42
+$
+
+$
+3 + 3 = 24
+$
+
+This also needs to be numbered
+$
+3 + 3 = 777
+$ <label2>
+
+```

--- a/packages/preview/non-unlabeled/0.1.0/README.md
+++ b/packages/preview/non-unlabeled/0.1.0/README.md
@@ -3,13 +3,14 @@ Prevents unlabeled objects like math.expression or figure from being automatical
 
 Usage:
 
-```
+```typst
 #import "@preview/non-unlabeled.typ": *
 
 // You need to do this to enable the package
 #show math.equation: dont_number_unlabeled(math.equation)
 #show figure: dont_number_unlabeled(figure)
 
+// You also need to define how you number your objects (you can do this also without using headcount)
 #import "@preview/headcount:0.1.0": *
 #set ref(supplement: [Eq.])
 #set math.equation(numbering: dependent-numbering("(1.1)", levels: 1))

--- a/packages/preview/non-unlabeled/0.1.0/src/non-unlabeled.typ
+++ b/packages/preview/non-unlabeled/0.1.0/src/non-unlabeled.typ
@@ -1,0 +1,37 @@
+#let dont_number_unlabeled(object) = {
+  it => {
+    if object == math.equation{
+      if it.block and not it.has("label") [
+        #counter(object).update(v => v - 1)
+        #object(
+          it.body, 
+          block: true, 
+          numbering: none)#label("no_label")
+      ] else {
+        it
+      }     
+    } else if object == figure{
+      if not it.has("label") [
+        #counter(object).update(v => v - 1)
+        #object(
+          it.body, 
+          caption:it.caption, 
+          numbering: none,
+          placement: it.placement,
+          scope:it.scope,
+          kind:it.kind,
+          supplement:it.supplement,
+          gap:it.gap,
+          outlined:it.outlined
+        )#label("no_label")
+      ] else {
+        it
+      } 
+    } else [
+      \=== Error ===
+      
+      unsupported object "#repr(object)"
+    ]
+
+  }
+}

--- a/packages/preview/non-unlabeled/0.1.0/src/non-unlabeled.typ
+++ b/packages/preview/non-unlabeled/0.1.0/src/non-unlabeled.typ
@@ -1,4 +1,4 @@
-#let dont_number_unlabeled(object) = {
+#let dont-number-unlabeled(object) = {
   it => {
     if object == math.equation{
       if it.block and not it.has("label") [

--- a/packages/preview/non-unlabeled/0.1.0/typst.toml
+++ b/packages/preview/non-unlabeled/0.1.0/typst.toml
@@ -1,0 +1,7 @@
+[package]
+name = "non-unlabeled"
+version = "0.1.0"
+entrypoint = "src/non-unlabeled.typ"
+authors = ["Luca Ravasio"]
+license = "MIT"
+description = "Don't number unlabeled objects"


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

This package prevents unlabeled objects from being numbered. This helps keeping the look of the pdf much cleaner. Example:
```typst
#import "@preview/non-unlabeled.typ": *

// You need to do this to enable the package
#show math.equation: dont_number_unlabeled(math.equation)
#show figure: dont_number_unlabeled(figure)

// You also need to define how you number your objects (you can do this also without using headcount)
#import "@preview/headcount:0.1.0": *
#set ref(supplement: [Eq.])
#set math.equation(numbering: dependent-numbering("(1.1)", levels: 1))
#set figure(numbering: dependent-numbering("(1.1)", levels: 1))

#set heading(numbering: "1.")

= Suspicious additions

This equation is unimportant: it will not be numbered:
$
3 + 3 = 4
$

This one, on the other hand, will be used later:
$
3 + 3 = 7
$ <label>

Therefore it will be numbered. The following two equations instead won't.

$
3 + 3 = 42
$

$
3 + 3 = 24
$

This also needs to be numbered
$
3 + 3 = 777
$ <label2>
 ```

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

- [ ] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
