### PR TITLE
scoryst:0.1.2

### DIFF
--- a/packages/preview/scoryst/0.1.2/LICENSE
+++ b/packages/preview/scoryst/0.1.2/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/packages/preview/scoryst/0.1.2/README.md
+++ b/packages/preview/scoryst/0.1.2/README.md
@@ -17,7 +17,7 @@ A Typst plugin to render music notation from multiple formats using
 - **Multi-page support**: render individual pages of long scores
 - **Binary font loading**: fonts pre-compiled to binary for instant init
 
-Check the [documentation](https://github.com/bernsteining/scoryst/blob/master/test/documentation.pdf) for a full demonstration with examples.
+Check the [documentation](https://github.com/bernsteining/scoryst/blob/v0.1.2/test/documentation.pdf?raw=1) for a full demonstration with examples.
 
 ## Usage
 

--- a/packages/preview/scoryst/0.1.2/README.md
+++ b/packages/preview/scoryst/0.1.2/README.md
@@ -1,0 +1,112 @@
+![logo](https://github.com/bernsteining/scoryst/blob/v0.1.1/test/logo.svg)
+
+# Scoryst - Music Engraving Plugin for Typst
+
+A Typst plugin to render music notation from multiple formats using
+[Verovio](https://www.verovio.org/), compiled to WASM.
+
+## Features
+
+- **8 input formats**: ABC, MusicXML, MEI, Humdrum, EsAC, PAE, Volpiano, CMME
+- **5 [SMuFL](https://www.smufl.org/)-compliant music fonts**: Leipzig (default), Bravura, Gootville, Leland, Petaluma
+- **Full Verovio options**: scale, font, page layout, and all
+  [toolkit options](https://book.verovio.org/toolkit-reference/toolkit-options.html)
+- **Multi-page support**: render individual pages of long scores
+- **Binary font loading**: fonts pre-compiled to binary for instant init
+
+Check the [documentation](https://github.com/bernsteining/scoryst/blob/v0.1.2/test/documentation.pdf?raw=1) for a full demonstration with examples.
+
+## Usage
+
+Some formats are too verbose to write inline here, so only compact formats are written inline here.
+
+```typst
+#import "@preview/scoryst:0.1.2": score, pages
+
+// ABC notation (auto-detected)
+#score("X:1\nM:4/4\nK:C\nCDEF|GABc|")
+
+// MusicXML (auto-detected)
+#score(read("adagio.xml"))
+
+// MEI (auto-detected)
+#score(read("schubert.mei"))
+
+// Humdrum (auto-detected)
+#score(read("sample-humdrum.krn"))
+
+// EsAC - Essen Associative Code (auto-detected)
+#score(read("hildebrandslied.esac"))
+
+// PAE - Plaine & Easie Code (requires explicit format)
+#score("@clef:G-2\n@keysig:\n@timesig:4/4\n@data:''4CDEF/GABc", options: (inputFrom: "pae"))
+
+// Volpiano (requires explicit format)
+#score("1---g--h-ij---hgf--g--hg---k--lk--k7", options: (inputFrom: "volpiano"))
+
+// CMME (requires explicit format)
+#score(read("cmme.xml"), options: (inputFrom: "cmme"))
+
+// Change font
+#score(data, options: (font: "Petaluma"))
+
+// Multi-page
+#let data = read("adagio.xml")
+#let n = pages(data)
+#for p in range(1, n + 1) {
+  score(data, page: p)
+}
+```
+
+### API
+
+**`score(data, options: none, page: 1, ..args)`**
+
+Renders music notation to an SVG image. `data` is a string in any supported
+format. `..args` are forwarded to Typst's `image()` function (`width`,
+`height`, `fit`, `alt`).
+
+**`pages(data, options: none)`**
+
+Returns the number of pages for the given music data.
+
+### Verovio Options
+
+Options are passed as a Typst dictionary and map directly to
+[Verovio's toolkit options](https://book.verovio.org/toolkit-reference/toolkit-options.html).
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `adjustPageHeight` | `true` | Crop SVG height to content |
+| `adjustPageWidth` | `false` | Crop SVG width to content |
+| `scale` | `100` | Scale factor (percent) |
+| `font` | `"Leipzig"` | Music font: Leipzig, Bravura, Gootville, Leland, Petaluma |
+| `inputFrom` | `"auto"` | Format: auto, mei, musicxml, abc, humdrum, esac, pae, volpiano, cmme |
+| `pageWidth` | `2100` | Page width (MEI units) |
+| `pageHeight` | `2970` | Page height (MEI units) |
+| `pageMarginTop` | `50` | Top margin |
+| `pageMarginBottom` | `50` | Bottom margin |
+| `pageMarginLeft` | `50` | Left margin |
+| `pageMarginRight` | `50` | Right margin |
+| `landscape` | `false` | Landscape orientation |
+| `breaks` | `"auto"` | Line breaks: auto, line, encoded, none |
+| `condense` | `"auto"` | Condense: auto, none, encoded |
+| `transpose` | `""` | Transpose (e.g. "M2" for major second up) |
+| `header` | `"auto"` | Header: auto, none, encoded |
+| `footer` | `"auto"` | Footer: auto, none, encoded |
+| `spacingStaff` | `12` | Spacing between staves |
+| `spacingSystem` | `12` | Spacing between systems |
+| `spacingLinear` | `0.25` | Linear spacing factor |
+| `spacingNonLinear` | `0.6` | Non-linear spacing factor |
+| `unit` | `9` | Base unit size (half staff space) |
+| `stemWidth` | `0.2` | Stem width |
+| `barLineWidth` | `0.3` | Bar line width |
+| `staffLineWidth` | `0.15` | Staff line width |
+| `lyricSize` | `4.5` | Lyrics font size |
+| `hairpinSize` | `3.0` | Hairpin height |
+| `svgViewBox` | `false` | Use viewBox instead of width/height |
+| `svgRemoveXlink` | `false` | Use href instead of xlink:href |
+| `svgBoundingBoxes` | `false` | Add bounding box rects (debug) |
+| `removeIds` | `false` | Strip element IDs from SVG |
+| `smuflTextFont` | `"embedded"` | SMuFL text font: embedded, linked, none |
+

--- a/packages/preview/scoryst/0.1.2/README.md
+++ b/packages/preview/scoryst/0.1.2/README.md
@@ -1,4 +1,7 @@
-![logo](https://github.com/bernsteining/scoryst/blob/v0.1.1/test/logo.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/bernsteining/scoryst/blob/v0.1.2/test/logo.svg">
+  <img alt="logo" src="https://github.com/bernsteining/scoryst/blob/v0.1.1/test/logo.svg">
+</picture>
 
 # Scoryst - Music Engraving Plugin for Typst
 
@@ -7,14 +10,14 @@ A Typst plugin to render music notation from multiple formats using
 
 ## Features
 
-- **8 input formats**: ABC, MusicXML, MEI, Humdrum, EsAC, PAE, Volpiano, CMME
+- **8 input formats**: [ABC](https://en.wikipedia.org/wiki/ABC_notation), [MusicXML](https://en.wikipedia.org/wiki/MusicXML), [MEI](https://music-encoding.org/), [Humdrum](https://wiki.ccarh.org/images/6/6e/Humdrum-File-Format.pdf), [EsAC](https://wiki.ccarh.org/wiki/EsAC), [PAE](https://www.iaml.info/plaine-easie-code/), [Volpiano](https://cantusdatabase.org/static/documents/2.%20Volpiano%20Protocols.pdf), [CMME](https://www.cmme.org/)
 - **5 [SMuFL](https://www.smufl.org/)-compliant music fonts**: Leipzig (default), Bravura, Gootville, Leland, Petaluma
 - **Full Verovio options**: scale, font, page layout, and all
   [toolkit options](https://book.verovio.org/toolkit-reference/toolkit-options.html)
 - **Multi-page support**: render individual pages of long scores
 - **Binary font loading**: fonts pre-compiled to binary for instant init
 
-Check the [documentation](https://github.com/bernsteining/scoryst/blob/v0.1.2/test/documentation.pdf?raw=1) for a full demonstration with examples.
+Check the [documentation](https://github.com/bernsteining/scoryst/blob/master/test/documentation.pdf) for a full demonstration with examples.
 
 ## Usage
 
@@ -39,13 +42,13 @@ Some formats are too verbose to write inline here, so only compact formats are w
 #score(read("hildebrandslied.esac"))
 
 // PAE - Plaine & Easie Code (requires explicit format)
-#score("@clef:G-2\n@keysig:\n@timesig:4/4\n@data:''4CDEF/GABc", options: (inputFrom: "pae"))
+#score("@clef:G-2\n@keysig:\n@timesig:4/4\n@data:''4CDEF/GABc", options: (input-from: "pae"))
 
 // Volpiano (requires explicit format)
-#score("1---g--h-ij---hgf--g--hg---k--lk--k7", options: (inputFrom: "volpiano"))
+#score("1---g--h-ij---hgf--g--hg---k--lk--k7", options: (input-from: "volpiano"))
 
 // CMME (requires explicit format)
-#score(read("cmme.xml"), options: (inputFrom: "cmme"))
+#score(read("cmme.xml"), options: (input-from: "cmme"))
 
 // Change font
 #score(data, options: (font: "Petaluma"))
@@ -74,39 +77,40 @@ Returns the number of pages for the given music data.
 
 Options are passed as a Typst dictionary and map directly to
 [Verovio's toolkit options](https://book.verovio.org/toolkit-reference/toolkit-options.html).
+Both kebab-case and camelCase keys are accepted (e.g. `adjust-page-height` or `adjustPageHeight`).
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `adjustPageHeight` | `true` | Crop SVG height to content |
-| `adjustPageWidth` | `false` | Crop SVG width to content |
+| `adjust-page-height` | `true` | Crop SVG height to content |
+| `adjust-page-width` | `false` | Crop SVG width to content |
 | `scale` | `100` | Scale factor (percent) |
 | `font` | `"Leipzig"` | Music font: Leipzig, Bravura, Gootville, Leland, Petaluma |
-| `inputFrom` | `"auto"` | Format: auto, mei, musicxml, abc, humdrum, esac, pae, volpiano, cmme |
-| `pageWidth` | `2100` | Page width (MEI units) |
-| `pageHeight` | `2970` | Page height (MEI units) |
-| `pageMarginTop` | `50` | Top margin |
-| `pageMarginBottom` | `50` | Bottom margin |
-| `pageMarginLeft` | `50` | Left margin |
-| `pageMarginRight` | `50` | Right margin |
+| `input-from` | `"auto"` | Format: auto, mei, musicxml, abc, humdrum, esac, pae, volpiano, cmme |
+| `page-width` | `2100` | Page width (MEI units) |
+| `page-height` | `2970` | Page height (MEI units) |
+| `page-margin-top` | `50` | Top margin |
+| `page-margin-bottom` | `50` | Bottom margin |
+| `page-margin-left` | `50` | Left margin |
+| `page-margin-right` | `50` | Right margin |
 | `landscape` | `false` | Landscape orientation |
 | `breaks` | `"auto"` | Line breaks: auto, line, encoded, none |
 | `condense` | `"auto"` | Condense: auto, none, encoded |
 | `transpose` | `""` | Transpose (e.g. "M2" for major second up) |
 | `header` | `"auto"` | Header: auto, none, encoded |
 | `footer` | `"auto"` | Footer: auto, none, encoded |
-| `spacingStaff` | `12` | Spacing between staves |
-| `spacingSystem` | `12` | Spacing between systems |
-| `spacingLinear` | `0.25` | Linear spacing factor |
-| `spacingNonLinear` | `0.6` | Non-linear spacing factor |
+| `spacing-staff` | `12` | Spacing between staves |
+| `spacing-system` | `12` | Spacing between systems |
+| `spacing-linear` | `0.25` | Linear spacing factor |
+| `spacing-non-linear` | `0.6` | Non-linear spacing factor |
 | `unit` | `9` | Base unit size (half staff space) |
-| `stemWidth` | `0.2` | Stem width |
-| `barLineWidth` | `0.3` | Bar line width |
-| `staffLineWidth` | `0.15` | Staff line width |
-| `lyricSize` | `4.5` | Lyrics font size |
-| `hairpinSize` | `3.0` | Hairpin height |
-| `svgViewBox` | `false` | Use viewBox instead of width/height |
-| `svgRemoveXlink` | `false` | Use href instead of xlink:href |
-| `svgBoundingBoxes` | `false` | Add bounding box rects (debug) |
-| `removeIds` | `false` | Strip element IDs from SVG |
-| `smuflTextFont` | `"embedded"` | SMuFL text font: embedded, linked, none |
+| `stem-width` | `0.2` | Stem width |
+| `bar-line-width` | `0.3` | Bar line width |
+| `staff-line-width` | `0.15` | Staff line width |
+| `lyric-size` | `4.5` | Lyrics font size |
+| `hairpin-size` | `3.0` | Hairpin height |
+| `svg-view-box` | `false` | Use viewBox instead of width/height |
+| `svg-remove-xlink` | `false` | Use href instead of xlink:href |
+| `svg-bounding-boxes` | `false` | Add bounding box rects (debug) |
+| `remove-ids` | `false` | Strip element IDs from SVG |
+| `smufl-text-font` | `"embedded"` | SMuFL text font: embedded, linked, none |
 

--- a/packages/preview/scoryst/0.1.2/README.md
+++ b/packages/preview/scoryst/0.1.2/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/bernsteining/scoryst/blob/v0.1.2/test/logo.svg">
-  <img alt="logo" src="https://github.com/bernsteining/scoryst/blob/v0.1.1/test/logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/bernsteining/scoryst/refs/tags/v0.1.2/test/logo.svg">
+  <img alt="logo" src="https://raw.githubusercontent.com/bernsteining/scoryst/refs/tags/v0.1.1/test/logo.svg">
 </picture>
 
 # Scoryst - Music Engraving Plugin for Typst
@@ -113,4 +113,12 @@ Both kebab-case and camelCase keys are accepted (e.g. `adjust-page-height` or `a
 | `svg-bounding-boxes` | `false` | Add bounding box rects (debug) |
 | `remove-ids` | `false` | Strip element IDs from SVG |
 | `smufl-text-font` | `"embedded"` | SMuFL text font: embedded, linked, none |
+| `pedal-style` | `"auto"` | Pedal marking style: auto, line, pedstar, altpedstar |
+| `font-fallback` | `"Leipzig"` | Music font fallback for missing glyphs: Leipzig, Bravura |
+| `lyric-elision` | `"regular"` | Lyric elision width: regular, narrow, wide, unicode |
+| `multi-rest-style` | `"auto"` | Multi-measure rest style: auto, default, block, symbols |
+| `system-divider` | `"none"` | System divider display: none, auto, left, left-right |
+| `duration-equivalence` | `"brevis"` | Mensural duration equivalence: brevis, semibrevis, minima |
+| `ligature-oblique` | `"auto"` | Ligature oblique shape: auto, straight, curved |
+| `mensural-responsive-view` | `"none"` | Mensural responsive view: none, auto, selection |
 

--- a/packages/preview/scoryst/0.1.2/scoryst.typ
+++ b/packages/preview/scoryst/0.1.2/scoryst.typ
@@ -6,6 +6,24 @@
   parts.at(0) + parts.slice(1).map(p => upper(p.at(0)) + p.slice(1)).join()
 }
 
+// Verovio enum options: string→int mapping.
+// Passing these as integers avoids a WASM hang in OptionIntMap::SetValue(string).
+#let _enum-options = (
+  breaks: ("none": 0, "auto": 1, "line": 2, "smart": 3, "encoded": 4),
+  condense: ("none": 0, "auto": 1, "encoded": 2),
+  footer: ("none": 0, "auto": 1, "always": 2, "encoded": 3),
+  header: ("none": 0, "auto": 1, "encoded": 2),
+  smuflTextFont: ("embedded": 0, "linked": 1, "none": 2),
+  mensuralResponsiveView: ("none": 0, "auto": 1, "selection": 2),
+  pedalStyle: ("auto": 0, "line": 1, "pedstar": 3, "altpedstar": 4),
+  fontFallback: ("Leipzig": 0, "Bravura": 1),
+  lyricElision: ("regular": 58705, "narrow": 58704, "wide": 58706, "unicode": 8255),
+  multiRestStyle: ("auto": 0, "default": 1, "block": 2, "symbols": 3),
+  systemDivider: ("none": 0, "auto": 1, "left": 2, "left-right": 3),
+  durationEquivalence: ("brevis": 0, "semibrevis": 1, "minima": 2),
+  ligatureOblique: ("auto": 0, "straight": 1, "curved": 2),
+)
+
 /// Serialize a Typst dictionary to a JSON options string for Verovio.
 /// Merges with default options (adjustPageHeight crops SVG to content).
 /// Accepts both kebab-case and camelCase option keys.
@@ -14,7 +32,13 @@
   let merged = if options != none { defaults + options } else { defaults }
   let pairs = merged.pairs().map(((k, v)) => {
     let key = _to-camel(k)
-    let val = if type(v) == str { "\"" + v + "\"" } else if v == true { "true" } else if v == false { "false" } else { str(v) }
+    let val = if type(v) == str and key in _enum-options {
+      let mapping = _enum-options.at(key)
+      assert(v in mapping, message: "invalid value \"" + v + "\" for option " + k + ", expected: " + mapping.keys().join(", "))
+      str(mapping.at(v))
+    } else if type(v) == str {
+      "\"" + v + "\""
+    } else if v == true { "true" } else if v == false { "false" } else { str(v) }
     "\"" + key + "\":" + val
   })
   "{" + pairs.join(",") + "}"

--- a/packages/preview/scoryst/0.1.2/scoryst.typ
+++ b/packages/preview/scoryst/0.1.2/scoryst.typ
@@ -1,0 +1,45 @@
+#let plugin = plugin("scoryst.wasm")
+
+/// Serialize a Typst dictionary to a JSON options string for Verovio.
+/// Merges with default options (adjustPageHeight crops SVG to content).
+#let _serialize-options(options) = {
+  let defaults = (adjustPageHeight: true, inputFrom: "auto")
+  let merged = if options != none { defaults + options } else { defaults }
+  let pairs = merged.pairs().map(((k, v)) => {
+    let val = if type(v) == str { "\"" + v + "\"" } else if v == true { "true" } else if v == false { "false" } else { str(v) }
+    "\"" + k + "\":" + val
+  })
+  "{" + pairs.join(",") + "}"
+}
+
+/// Render music notation to an SVG image.
+///
+/// - data: Music data as a string (MusicXML, MEI, ABC, Humdrum, etc.)
+/// - options: Verovio options as a dictionary (optional)
+/// - page: Page number to render (default: 1)
+/// - ..args: Additional arguments forwarded to Typst's `image` function
+///           (e.g., `width`, `height`, `fit`, `alt`)
+#let score(data, options: none, page: 1, ..args) = {
+  let data-bytes = bytes(data)
+  let options-bytes = bytes(_serialize-options(options))
+
+  let svg-bytes = if page == 1 {
+    plugin.render(data-bytes, options-bytes)
+  } else {
+    plugin.render_page(data-bytes, options-bytes, bytes(str(page)))
+  }
+
+  image(svg-bytes, format: "svg", ..args.named())
+}
+
+/// Get the number of pages for a music document.
+///
+/// - data: Music data as a string
+/// - options: Verovio options as a dictionary (optional)
+#let pages(data, options: none) = {
+  int(str(plugin.page_count(bytes(data), bytes(_serialize-options(options)))))
+}
+
+// Deprecated aliases for backward compatibility
+#let render-music(data, options: none, page: 1, ..args) = score(data, options: options, page: page, ..args)
+#let music-page-count(data, options: none) = pages(data, options: options)

--- a/packages/preview/scoryst/0.1.2/scoryst.typ
+++ b/packages/preview/scoryst/0.1.2/scoryst.typ
@@ -1,13 +1,21 @@
 #let plugin = plugin("scoryst.wasm")
 
+/// Convert kebab-case to camelCase. Keys already in camelCase pass through unchanged.
+#let _to-camel(s) = {
+  let parts = s.split("-")
+  parts.at(0) + parts.slice(1).map(p => upper(p.at(0)) + p.slice(1)).join()
+}
+
 /// Serialize a Typst dictionary to a JSON options string for Verovio.
 /// Merges with default options (adjustPageHeight crops SVG to content).
+/// Accepts both kebab-case and camelCase option keys.
 #let _serialize-options(options) = {
-  let defaults = (adjustPageHeight: true, inputFrom: "auto")
+  let defaults = (adjust-page-height: true, input-from: "auto")
   let merged = if options != none { defaults + options } else { defaults }
   let pairs = merged.pairs().map(((k, v)) => {
+    let key = _to-camel(k)
     let val = if type(v) == str { "\"" + v + "\"" } else if v == true { "true" } else if v == false { "false" } else { str(v) }
-    "\"" + k + "\":" + val
+    "\"" + key + "\":" + val
   })
   "{" + pairs.join(",") + "}"
 }

--- a/packages/preview/scoryst/0.1.2/typst.toml
+++ b/packages/preview/scoryst/0.1.2/typst.toml
@@ -34,4 +34,4 @@ keywords = [
   "CMME",
 ]
 categories = ["visualization", "integration"]
-compiler = "0.14.2"
+compiler = "0.14.0"

--- a/packages/preview/scoryst/0.1.2/typst.toml
+++ b/packages/preview/scoryst/0.1.2/typst.toml
@@ -1,0 +1,37 @@
+[package]
+name = "scoryst"
+version = "0.1.2"
+entrypoint = "scoryst.typ"
+authors = ["bernsteining"]
+license = "LGPL-3.0-only"
+description = "🎼 Music engraving in Typst — render ABC, MusicXML, MEI, Humdrum, Volpiano, EsAC, PAE, and CMME notations"
+repository = "https://github.com/bernsteining/scoryst"
+keywords = [
+  "music",
+  "musique",
+  "sound",
+  "son",
+  "track",
+  "mp3",
+  "notation",
+  "note",
+  "morceau",
+  "score",
+  "scoring",
+  "partition",
+  "tablature",
+  "engraving",
+  "verovio",
+  "abc",
+  "musicxml",
+  "mei",
+  "humdrum",
+  "PAE",
+  "Plaine & Easie Code",
+  "EsAC",
+  "Essen Associative Code",
+  "Volpiano",
+  "CMME",
+]
+categories = ["visualization", "integration"]
+compiler = "0.14.2"

--- a/packages/preview/scoryst/0.1.2/typst.toml
+++ b/packages/preview/scoryst/0.1.2/typst.toml
@@ -34,4 +34,5 @@ keywords = [
   "CMME",
 ]
 categories = ["visualization", "integration"]
+disciplines = ["music", "education"]
 compiler = "0.14.0"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

# 0.1.2 Changelog

* added [PAE](https://en.wikipedia.org/wiki/Plaine_%26_Easie_Code) support
* added [EsAC](https://wiki.ccarh.org/wiki/EsAC) support
* verovio error messages are now redirected to typst errors
* removed monospace in lyrics fonts (Liberation Serif is now used)
* fine tuned `wasm-opt` flags 
* way better memory footprint: 
   * INITIAL_MEMORY 512MB -> 16 MB
   * same for stack 128MB -> 2MB
* changed the API:
   * render-music -> score
   * music-page-count -> pages
* added "integration" category in typst.toml and a few keywords
* better examples in the README

NB: in README.md the logo links to the v0.1.1 one on purpose. the v0.1.2 is white to handle dark theme on github, and typst universe I want it to remain black.