### PR TITLE
presio:0.1.0

### DIFF
--- a/packages/preview/presio/0.1.0/LICENSE
+++ b/packages/preview/presio/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benedict Armstrong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/presio/0.1.0/README.md
+++ b/packages/preview/presio/0.1.0/README.md
@@ -1,0 +1,138 @@
+# presio
+
+Attach **speaker notes** and **embedded media** (GIF / MP4 / WebM) to PDF slides
+so they can be presented with the [presio.xyz](https://presio.xyz) viewer.
+
+`presio` is framework-agnostic — it works with [polylux](https://typst.app/universe/package/polylux),
+[touying](https://typst.app/universe/package/touying), or plain Typst pages. It
+only contributes two functions; layout and slide flow are up to your existing
+template.
+
+## Install
+
+```typ
+#import "@preview/presio:0.1.0": media, speaker-notes
+```
+
+## Usage
+
+### Speaker notes
+
+```typ
+= Introduction
+
+Hello world.
+
+#speaker-notes[
+  Remember to mention the funding agency before the next slide.
+]
+```
+
+A JSON sidecar `notes-slide-<N>.json` is attached to the PDF. Multiple
+`speaker-notes[…]` calls on the same slide are concatenated into a single
+attachment, in source order.
+
+### Embedded media (local file)
+
+Because of how Typst resolves file paths inside packages, the caller is
+responsible for `read`-ing the media bytes:
+
+```typ
+#media(
+  read("figures/demo.gif", encoding: none),
+  name: "demo.gif",
+  placeholder: image("figures/demo.gif"),
+  width: 60%,
+)
+```
+
+The binary is embedded in the PDF via `pdf.attach` and a placement descriptor
+JSON is written alongside it. `placeholder` is optional `content` shown in the
+slide itself (Typst can render GIFs via `image(...)` — for MP4/WebM use a still
+image or omit `placeholder` to get a dark block).
+
+### Embedded media (URL)
+
+```typ
+#media(
+  "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif",
+  width: 40%,
+  aspect-ratio: 1,
+)
+```
+
+Nothing is attached to the PDF; the viewer fetches the URL at presentation time.
+
+### YouTube / Vimeo
+
+URLs from YouTube (`youtube.com/watch?v=…`, `youtu.be/…`, `youtube.com/embed/…`,
+`youtube.com/shorts/…`, `youtube-nocookie.com/embed/…`) and Vimeo
+(`vimeo.com/<id>`, `player.vimeo.com/video/<id>`) are detected automatically and
+emitted with `kind: "youtube"` / `kind: "vimeo"` plus an extracted `video_id`
+the viewer can use to build an iframe embed.
+
+```typ
+#media("https://www.youtube.com/watch?v=dQw4w9WgXcQ", width: 60%, aspect-ratio: 16/9)
+#media("https://vimeo.com/76979871", width: 60%, aspect-ratio: 16/9)
+```
+
+## `media` parameters
+
+| Parameter      | Default | Notes                                                                                                  |
+| -------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `source`       | —       | Either `bytes` (from `read(..., encoding: none)`) or a `http(s)://` URL string                         |
+| `name`         | `none`  | Required when `source` is bytes. Used as the PDF attachment filename and to sniff the MIME type.       |
+| `placeholder`  | `none`  | Optional `content` rendered as the in-slide preview (e.g. `image(...)`)                                |
+| `width`        | `auto`  | Length, ratio of the container width, or `auto` (natural width of `placeholder`, else container width) |
+| `height`       | `auto`  | Length, ratio, or `auto` (derived from `placeholder` / `aspect-ratio` / 16:9)                          |
+| `aspect-ratio` | `none`  | Width/height ratio, e.g. `16/9`                                                                        |
+| `autoplay`     | `true`  | Forwarded to the viewer                                                                                |
+| `loop`         | `true`  | Forwarded to the viewer                                                                                |
+
+## Supported media types
+
+The MIME is sniffed from the extension of `name` (bytes mode) or the URL (URL mode):
+
+| Extension | MIME         |
+| --------- | ------------ |
+| `.gif`    | `image/gif`  |
+| `.mp4`    | `video/mp4`  |
+| `.webm`   | `video/webm` |
+
+## Sidecar JSON schemas
+
+**`notes-slide-<N>.json`** — `notes` is always an array (one entry per
+`speaker-notes` call on that slide, in source order):
+
+```json
+{ "slide": "3", "notes": [ "<typst content>", "<typst content>" ] }
+```
+
+**`media-slide-<N>-<id>.json`**
+
+Common fields: `kind`, `slide`, `id`, `mime`, `x_pt`, `y_pt`, `w_pt`, `h_pt`,
+`autoplay`, `loop`. The remaining fields depend on `kind`:
+
+| `kind`    | Extra fields                     |
+| --------- | -------------------------------- |
+| `file`    | `filename` (PDF attachment name) |
+| `url`     | `url` (direct media URL)         |
+| `youtube` | `url`, `video_id`                |
+| `vimeo`   | `url`, `video_id`                |
+
+```json
+{
+  "kind": "file",
+  "slide": 3,
+  "id": "demo_gif",
+  "mime": "image/gif",
+  "x_pt": 72.0, "y_pt": 120.0, "w_pt": 432.0, "h_pt": 243.0,
+  "autoplay": true,
+  "loop": true,
+  "filename": "media-demo_gif.gif"
+}
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/packages/preview/presio/0.1.0/src/lib.typ
+++ b/packages/preview/presio/0.1.0/src/lib.typ
@@ -1,0 +1,198 @@
+// presio: attach speaker notes and embedded media to PDF slides for presio.xyz
+
+#let _mime-for-ext(ext) = if ext == "gif" {
+  "image/gif"
+} else if ext == "mp4" {
+  "video/mp4"
+} else if ext == "webm" {
+  "video/webm"
+} else {
+  "application/octet-stream"
+}
+
+#let _youtube-id(url) = {
+  let m = url.match(
+    regex(
+      "(?:youtube\.com/watch\?(?:[^ ]*&)?v=|youtu\.be/|youtube(?:-nocookie)?\.com/embed/|youtube\.com/shorts/)([A-Za-z0-9_-]{11})",
+    ),
+  )
+  if m != none { m.captures.first() } else { none }
+}
+
+#let _vimeo-id(url) = {
+  let m = url.match(regex("vimeo\.com/(?:video/|channels/[^/]+/|groups/[^/]+/videos/)?(\d+)"))
+  if m != none { m.captures.first() } else { none }
+}
+
+// Embed a gif / mp4 / webm to be played by the presio viewer.
+//
+// `source` is one of:
+//   - bytes: the binary contents of a local file, typically produced by
+//     `read("path/to/file.ext", encoding: none)` at the call site.
+//     When `source` is bytes, `name` is REQUIRED — it is used as the
+//     PDF attachment filename and to sniff the MIME type.
+//   - a string starting with "http://" or "https://": a URL. Nothing is
+//     attached to the PDF; the viewer fetches the URL at presentation
+//     time.
+//
+// `placeholder` is optional `content` rendered in the slide where the
+// media will appear (e.g. `image("figures/demo.gif")`). If omitted, a
+// dark block is drawn.
+//
+// Videos play muted (no audio).
+#let media(
+  source,
+  name: none,
+  width: auto,
+  height: auto,
+  autoplay: true,
+  loop: true,
+  placeholder: none,
+  aspect-ratio: none,
+) = (
+  layout(container => context {
+    let page-num = counter(page).get().first()
+    let is-url = (
+      type(source) == str
+        and (
+          source.starts-with("http://") or source.starts-with("https://")
+        )
+    )
+
+    let ref-name = if is-url { source } else {
+      assert(
+        name != none,
+        message: "presio.media: `name` is required when `source` is bytes",
+      )
+      name
+    }
+    let yt-id = if is-url { _youtube-id(source) } else { none }
+    let vimeo-id = if is-url and yt-id == none { _vimeo-id(source) } else { none }
+    let kind = if not is-url {
+      "file"
+    } else if yt-id != none {
+      "youtube"
+    } else if vimeo-id != none {
+      "vimeo"
+    } else {
+      "url"
+    }
+
+    let safe-id = ref-name.replace(regex("[^A-Za-z0-9]"), "_")
+    let ext-source = ref-name.split("?").first().split("#").first()
+    let ext = lower(ext-source.split(".").last())
+    let mime = if kind == "youtube" or kind == "vimeo" {
+      "text/html"
+    } else {
+      _mime-for-ext(ext)
+    }
+
+    let w = if width == auto {
+      if placeholder != none {
+        let natural = measure(placeholder)
+        if natural.width > 0pt { natural.width } else { container.width }
+      } else {
+        container.width
+      }
+    } else if type(width) == ratio {
+      container.width * width
+    } else {
+      width
+    }
+    let h = if height != auto {
+      if type(height) == ratio { container.height * height } else { height }
+    } else if aspect-ratio != none {
+      w / aspect-ratio
+    } else if placeholder != none {
+      let natural = measure(placeholder)
+      if natural.width > 0pt {
+        w * (natural.height / natural.width)
+      } else {
+        w * 9 / 16
+      }
+    } else {
+      w * 9 / 16
+    }
+    let pos = here().position()
+
+    let media-filename = if kind == "file" {
+      "media-" + safe-id + "." + ext
+    } else { none }
+
+    if kind == "file" {
+      pdf.attach(
+        media-filename,
+        source,
+        mime-type: mime,
+        description: "Media: " + name,
+      )
+    }
+
+    let meta = (
+      kind: kind,
+      slide: page-num,
+      id: safe-id,
+      mime: mime,
+      x_pt: pos.x.pt(),
+      y_pt: pos.y.pt(),
+      w_pt: w.pt(),
+      h_pt: h.pt(),
+      autoplay: autoplay,
+      loop: loop,
+    )
+    let meta-with-source = if kind == "file" {
+      meta + (filename: media-filename)
+    } else if kind == "youtube" {
+      meta + (url: source, video_id: yt-id)
+    } else if kind == "vimeo" {
+      meta + (url: source, video_id: vimeo-id)
+    } else {
+      meta + (url: source)
+    }
+    pdf.attach(
+      "media-slide-" + str(page-num) + "-" + safe-id + ".json",
+      bytes(json.encode(meta-with-source)),
+      mime-type: "application/json",
+      description: "Media placement for slide " + str(page-num),
+    )
+
+    block(
+      width: w,
+      height: h,
+      fill: if placeholder == none { rgb("#222") } else { none },
+      radius: 6pt,
+      clip: true,
+      if placeholder != none {
+        placeholder
+      } else {
+        align(center + horizon, text(fill: white)[▶ #ref-name])
+      },
+    )
+  })
+)
+
+// Attach speaker notes to the current slide as a JSON sidecar
+// (`notes-slide-<N>.json`) consumed by the presio viewer.
+//
+// Multiple calls on the same slide are concatenated into a single
+// attachment whose `notes` field is a list, in source order.
+#let speaker-notes(notes) = {
+  [#metadata((notes: notes)) <_presio-notes>]
+  context {
+    let here-loc = here()
+    let pg = here-loc.page()
+    let on-slide = query(<_presio-notes>).filter(el => el.location().page() == pg)
+    // Only the context that follows the LAST metadata on this slide emits
+    // the pdf.attach, so we emit exactly one attachment per slide.
+    let last-meta-y = on-slide.last().location().position().y
+    if here-loc.position().y >= last-meta-y {
+      let all-notes = on-slide.map(el => el.value.notes)
+      pdf.attach(
+        "notes-slide-" + str(pg) + ".json",
+        bytes(json.encode((slide: str(pg), notes: all-notes))),
+        mime-type: "application/json",
+        description: "Speaker notes for slide " + str(pg),
+      )
+    }
+  }
+}

--- a/packages/preview/presio/0.1.0/typst.toml
+++ b/packages/preview/presio/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "presio"
+version = "0.1.0"
+entrypoint = "src/lib.typ"
+authors = ["Benedict Armstrong <benedict.armstrong@inf.ethz.ch>"]
+license = "MIT"
+description = "Attach speaker notes and embedded media to PDF slides for presio.xyz"
+repository = "https://github.com/benedict-armstrong/presio-typst-package"
+keywords = ["presentation", "slides", "speaker-notes", "video", "pdf"]
+categories = ["visualization"]
+compiler = "0.13.0"
+exclude = ["examples/**", "README.md"]

--- a/packages/preview/presio/0.1.0/typst.toml
+++ b/packages/preview/presio/0.1.0/typst.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/benedict-armstrong/presio-typst-package"
 keywords = ["presentation", "slides", "speaker-notes", "video", "pdf"]
 categories = ["visualization"]
 compiler = "0.13.0"
-exclude = ["examples/**", "README.md"]
+exclude = ["examples/**"]


### PR DESCRIPTION
This adds `presio:0.1.0`, a small framework-agnostic package that lets Typst slide decks carry **speaker notes** and **embedded media** (GIF / MP4 / WebM, or YouTube / Vimeo URLs) as PDF attachments + JSON sidecars. The companion presio viewer at https://presio.xyz reads those attachments to overlay video and show notes during a talk.

Two exported functions:

- `speaker-notes(content)` — attaches `notes-slide-<N>.json`. Multiple calls on the same slide are concatenated into one attachment.
- `media(source, ...)` — embeds local bytes via `pdf.attach` or records a URL (with auto-detection of YouTube and Vimeo links).

Works with polylux, touying, or plain Typst pages — the package contributes no layout, only attachments + a placeholder block.

Source repo: https://github.com/benedict-armstrong/presio-typst-package