### PR TITLE
calendaring:0.1.0

### DIFF
--- a/packages/preview/calendaring/0.1.0/CHANGELOG.md
+++ b/packages/preview/calendaring/0.1.0/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to `calendaring` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## 0.1.0 — unreleased
+
+Initial release.
+
+### Functions
+
+- `month-grid(year, month, ...)` — render a month as a 7-column grid with
+  correct leading and trailing blank days. Optional rotation, custom cell
+  rendering, weekday-name localization, per-day events, today highlight,
+  and an ISO 8601 week-number column.
+- `year-grid(year, columns: 3, ...)` — compose twelve `month-grid` instances
+  on one page.
+- `is-leap-year(year)` — Gregorian leap-year predicate.
+
+### Notes
+
+- The `cell-content` callback receives a `datetime`, so `date.weekday()` and
+  `date.day()` are available without closing over scope.
+- `weekday-names`, when overridden, must be in the same order as `week-start`
+  (e.g. for `week-start: "sun"`, the array starts with the Sunday label).
+- ISO 8601 week numbers are always anchored to the row's Monday, even when
+  `week-start: "sun"`.

--- a/packages/preview/calendaring/0.1.0/LICENSE
+++ b/packages/preview/calendaring/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thomas Dickson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OR OTHER DEALING IN
+THE SOFTWARE.

--- a/packages/preview/calendaring/0.1.0/README.md
+++ b/packages/preview/calendaring/0.1.0/README.md
@@ -4,12 +4,14 @@ Lay out month calendar grids from a year and month.
 
 A small Typst utility that takes `(year, month)` and renders a 7-column grid
 with correct leading and trailing blank days, sized for handwritten notes.
-Designed for personal planners and training logs, not for displaying events.
+Designed for personal planners, training logs, and habit trackers — not for
+displaying scheduled events (see [`cineca`](https://typst.app/universe/package/cineca/)
+for that).
 
 ## Install
 
 ```typst
-#import "@preview/calendaring:0.1.0": month-grid
+#import "@preview/calendaring:0.1.0": month-grid, year-grid
 ```
 
 ## Basic usage
@@ -20,48 +22,61 @@ Designed for personal planners and training logs, not for displaying events.
 #month-grid(2026, 6)
 ```
 
-Renders a Monday-first grid for June 2026 (Mon 1 → Tue 30, two trailing blanks),
-with each cell ~3.5cm × 3.3cm and the day number in the top-left.
+Renders a Monday-first grid for June 2026, sized 3.5cm × 3.3cm per cell
+(tuned for a rotated A4 page). For unrotated portrait layouts, pass
+`cell-width: 1fr` so the grid fills the page width.
 
-## Parameters
+## Functions
 
-| Parameter      | Type      | Default          | Notes                                                  |
-|----------------|-----------|------------------|--------------------------------------------------------|
-| `year`         | int       | —                | Required.                                              |
-| `month`        | int       | —                | Required. 1..12.                                       |
-| `cell-height`  | length    | `3.3cm`          | Height of each day cell.                               |
-| `cell-width`   | length    | `3.5cm`          | Width of each day cell.                                |
-| `week-start`   | str       | `"mon"`          | `"mon"` or `"sun"`.                                    |
-| `rotated`      | bool      | `false`          | If `true`, rotates 90° (useful for portrait A4 pages). |
-| `header-fill`  | color     | `luma(230)`      | Background of the weekday header row.                  |
-| `stroke`       | stroke    | `0.5pt`          | Cell border.                                           |
-| `inset`        | length    | `3pt`            | Cell padding.                                          |
-| `cell-content` | function  | day-number       | `(day-number) => content`. Override to add labels.     |
+### `month-grid(year, month, ...)`
 
-## Rotated A4 example (training log)
+| Parameter        | Type                       | Default      | Notes                                                          |
+|------------------|----------------------------|--------------|----------------------------------------------------------------|
+| `year`           | int                        | —            | Required.                                                      |
+| `month`          | int                        | —            | Required. 1..12.                                               |
+| `cell-height`    | length                     | `3.3cm`      | Height of each day cell.                                       |
+| `cell-width`     | length / fraction          | `3.5cm`      | Width of each day cell. Use `1fr` to fit the page width.       |
+| `week-start`     | str                        | `"mon"`      | `"mon"` or `"sun"`.                                            |
+| `rotated`        | bool                       | `false`      | Rotate 90° (useful for portrait A4).                           |
+| `weekday-names`  | array of 7 strings         | `none`       | Override header labels for localization.                       |
+| `header-fill`    | color                      | `luma(230)`  | Background of the weekday header row.                          |
+| `today-fill`     | color                      | `luma(220)`  | Background of the cell matching `today`.                       |
+| `today`          | datetime or `none`         | `none`       | Highlight the matching day, if in this month.                  |
+| `events`         | `((datetime, content),)`   | `()`         | Each event renders below the day number in its matching cell.  |
+| `stroke`         | stroke                     | `0.5pt`      | Cell border.                                                   |
+| `inset`          | length                     | `3pt`        | Cell padding.                                                  |
+| `cell-content`   | `(datetime) -> content`    | built-in     | Override per-cell rendering. Receives a `datetime`.            |
 
-```typst
-#set page(paper: "a4", margin: (x: 1.5cm, y: 1.2cm))
-#import "@preview/calendaring:0.1.0": month-grid
+### `year-grid(year, columns: 3)`
 
-#align(center, text(16pt)[*June 2026 — Workout Log*])
-#v(0.3cm)
+Lay out all twelve months of `year` on one page, three columns by four rows
+by default. Composes twelve small `month-grid` calls.
 
-#month-grid(2026, 6, rotated: true)
-```
+## Inspirations
 
-## Custom cell content
+The API borrows patterns from established LaTeX calendar packages:
 
-Pass a function that takes the day number and returns content:
+- **`events`** parameter — TikZ calendar's `\if (equals: <date>) { ... }` conditional rendering.
+- **`today`** highlight — wallcalendar's `\today` macro.
+- **`weekday-names`** — wallcalendar's localization hooks.
+- **`year-grid`** — TikZ calendar's `month list` layout.
+- **`cell-content` receiving a `datetime`** — TikZ calendar's date conditions (`Monday`, `weekend`).
 
-```typst
-#let rotation = ("KB-S&C", "KB-cond", "Cardio", "Gym", "Hyrox", "rest", "rest")
+## Examples
 
-#month-grid(2026, 6, cell-content: day => [
-  #text(8pt, weight: "bold")[#day]
-  #v(2pt)
-  #text(7pt, fill: luma(120))[#rotation.at(calc.rem(day - 1, 7))]
-])
+| File                                                          | What it shows                                                       |
+|---------------------------------------------------------------|---------------------------------------------------------------------|
+| [`basic.typ`](examples/basic.typ)                             | Minimal usage, leap year, Sunday-first weeks, custom-cell rotation. |
+| [`workout-log.typ`](examples/workout-log.typ)                 | Rotated A4 monthly training log with large handwriting cells.       |
+| [`habit-tracker.typ`](examples/habit-tracker.typ)             | Daily habit checkboxes per cell.                                    |
+| [`weekend-shading.typ`](examples/weekend-shading.typ)         | Grey-shade Sat/Sun by inspecting `date.weekday()` in the callback.  |
+| [`training-calendar.typ`](examples/training-calendar.typ)     | `events` and `today` highlight — peak/deload/race periodization.    |
+| [`year-at-a-glance.typ`](examples/year-at-a-glance.typ)       | All twelve months on one A4 via `year-grid`.                        |
+
+Compile any of them locally:
+
+```bash
+typst compile --root . examples/training-calendar.typ
 ```
 
 ## License

--- a/packages/preview/calendaring/0.1.0/README.md
+++ b/packages/preview/calendaring/0.1.0/README.md
@@ -43,6 +43,8 @@ Renders a Monday-first grid for June 2026, sized 3.5cm × 3.3cm per cell
 | `today-fill`     | color                      | `luma(220)`  | Background of the cell matching `today`.                       |
 | `today`          | datetime or `none`         | `none`       | Highlight the matching day, if in this month.                  |
 | `events`         | `((datetime, content),)`   | `()`         | Each event renders below the day number in its matching cell.  |
+| `week-numbers`   | bool                       | `false`      | Prepend an ISO 8601 week-number column.                        |
+| `week-number-width` | length                  | `0.8cm`      | Width of the week-number column when shown.                    |
 | `stroke`         | stroke                     | `0.5pt`      | Cell border.                                                   |
 | `inset`          | length                     | `3pt`        | Cell padding.                                                  |
 | `cell-content`   | `(datetime) -> content`    | built-in     | Override per-cell rendering. Receives a `datetime`.            |
@@ -59,6 +61,7 @@ The API borrows patterns from established LaTeX calendar packages:
 - **`events`** parameter — TikZ calendar's `\if (equals: <date>) { ... }` conditional rendering.
 - **`today`** highlight — wallcalendar's `\today` macro.
 - **`weekday-names`** — wallcalendar's localization hooks.
+- **`week-numbers`** — wallcalendar's ISO 8601 week column.
 - **`year-grid`** — TikZ calendar's `month list` layout.
 - **`cell-content` receiving a `datetime`** — TikZ calendar's date conditions (`Monday`, `weekend`).
 
@@ -71,6 +74,7 @@ The API borrows patterns from established LaTeX calendar packages:
 | [`habit-tracker.typ`](examples/habit-tracker.typ)             | Daily habit checkboxes per cell.                                    |
 | [`weekend-shading.typ`](examples/weekend-shading.typ)         | Grey-shade Sat/Sun by inspecting `date.weekday()` in the callback.  |
 | [`training-calendar.typ`](examples/training-calendar.typ)     | `events` and `today` highlight — peak/deload/race periodization.    |
+| [`wall-calendar.typ`](examples/wall-calendar.typ)             | ISO 8601 week-number column in a wall-calendar layout.              |
 | [`year-at-a-glance.typ`](examples/year-at-a-glance.typ)       | All twelve months on one A4 via `year-grid`.                        |
 
 Compile any of them locally:

--- a/packages/preview/calendaring/0.1.0/README.md
+++ b/packages/preview/calendaring/0.1.0/README.md
@@ -1,0 +1,69 @@
+# calendaring
+
+Lay out month calendar grids from a year and month.
+
+A small Typst utility that takes `(year, month)` and renders a 7-column grid
+with correct leading and trailing blank days, sized for handwritten notes.
+Designed for personal planners and training logs, not for displaying events.
+
+## Install
+
+```typst
+#import "@preview/calendaring:0.1.0": month-grid
+```
+
+## Basic usage
+
+```typst
+#import "@preview/calendaring:0.1.0": month-grid
+
+#month-grid(2026, 6)
+```
+
+Renders a Monday-first grid for June 2026 (Mon 1 → Tue 30, two trailing blanks),
+with each cell ~3.5cm × 3.3cm and the day number in the top-left.
+
+## Parameters
+
+| Parameter      | Type      | Default          | Notes                                                  |
+|----------------|-----------|------------------|--------------------------------------------------------|
+| `year`         | int       | —                | Required.                                              |
+| `month`        | int       | —                | Required. 1..12.                                       |
+| `cell-height`  | length    | `3.3cm`          | Height of each day cell.                               |
+| `cell-width`   | length    | `3.5cm`          | Width of each day cell.                                |
+| `week-start`   | str       | `"mon"`          | `"mon"` or `"sun"`.                                    |
+| `rotated`      | bool      | `false`          | If `true`, rotates 90° (useful for portrait A4 pages). |
+| `header-fill`  | color     | `luma(230)`      | Background of the weekday header row.                  |
+| `stroke`       | stroke    | `0.5pt`          | Cell border.                                           |
+| `inset`        | length    | `3pt`            | Cell padding.                                          |
+| `cell-content` | function  | day-number       | `(day-number) => content`. Override to add labels.     |
+
+## Rotated A4 example (training log)
+
+```typst
+#set page(paper: "a4", margin: (x: 1.5cm, y: 1.2cm))
+#import "@preview/calendaring:0.1.0": month-grid
+
+#align(center, text(16pt)[*June 2026 — Workout Log*])
+#v(0.3cm)
+
+#month-grid(2026, 6, rotated: true)
+```
+
+## Custom cell content
+
+Pass a function that takes the day number and returns content:
+
+```typst
+#let rotation = ("KB-S&C", "KB-cond", "Cardio", "Gym", "Hyrox", "rest", "rest")
+
+#month-grid(2026, 6, cell-content: day => [
+  #text(8pt, weight: "bold")[#day]
+  #v(2pt)
+  #text(7pt, fill: luma(120))[#rotation.at(calc.rem(day - 1, 7))]
+])
+```
+
+## License
+
+MIT. See `LICENSE`.

--- a/packages/preview/calendaring/0.1.0/README.md
+++ b/packages/preview/calendaring/0.1.0/README.md
@@ -49,10 +49,23 @@ Renders a Monday-first grid for June 2026, sized 3.5cm × 3.3cm per cell
 | `inset`          | length                     | `3pt`        | Cell padding.                                                  |
 | `cell-content`   | `(datetime) -> content`    | built-in     | Override per-cell rendering. Receives a `datetime`.            |
 
-### `year-grid(year, columns: 3)`
+### `year-grid(year, columns: 3, cell-height: 0.55cm, inset: 1pt, month-label-size: 9pt)`
 
 Lay out all twelve months of `year` on one page, three columns by four rows
 by default. Composes twelve small `month-grid` calls.
+
+### `is-leap-year(year)`
+
+Returns `true` for Gregorian leap years (divisible by 4 but not by 100,
+unless also divisible by 400). Exposed for user code that needs the same
+predicate the grid uses internally.
+
+## Notes
+
+- `weekday-names`, when overridden, must be in the same order as `week-start`.
+  For `week-start: "sun"`, the array starts with the Sunday label.
+- ISO 8601 week numbers are always anchored to the row's Monday, even in
+  Sunday-first layouts.
 
 ## Inspirations
 
@@ -75,6 +88,7 @@ The API borrows patterns from established LaTeX calendar packages:
 | [`weekend-shading.typ`](examples/weekend-shading.typ)         | Grey-shade Sat/Sun by inspecting `date.weekday()` in the callback.  |
 | [`training-calendar.typ`](examples/training-calendar.typ)     | `events` and `today` highlight — peak/deload/race periodization.    |
 | [`wall-calendar.typ`](examples/wall-calendar.typ)             | ISO 8601 week-number column in a wall-calendar layout.              |
+| [`leap-year.typ`](examples/leap-year.typ)                     | Leap-year handling (Feb 2024 vs Feb 2025) and `is-leap-year`.       |
 | [`year-at-a-glance.typ`](examples/year-at-a-glance.typ)       | All twelve months on one A4 via `year-grid`.                        |
 
 Compile any of them locally:

--- a/packages/preview/calendaring/0.1.0/examples/basic.typ
+++ b/packages/preview/calendaring/0.1.0/examples/basic.typ
@@ -1,5 +1,4 @@
-// Published package: #import "@preview/calendaring:0.1.0": month-grid
-#import "../lib.typ": month-grid
+#import "@preview/calendaring:0.1.0": month-grid
 
 #set page(paper: "a4")
 

--- a/packages/preview/calendaring/0.1.0/examples/basic.typ
+++ b/packages/preview/calendaring/0.1.0/examples/basic.typ
@@ -1,3 +1,4 @@
+// Published package: #import "@preview/calendaring:0.1.0": month-grid
 #import "../lib.typ": month-grid
 
 #set page(paper: "a4")

--- a/packages/preview/calendaring/0.1.0/examples/basic.typ
+++ b/packages/preview/calendaring/0.1.0/examples/basic.typ
@@ -1,0 +1,31 @@
+#import "../lib.typ": month-grid
+
+#set page(paper: "a4")
+
+= June 2026
+
+#month-grid(2026, 6)
+
+#pagebreak()
+
+= February 2024 (leap day)
+
+#month-grid(2024, 2)
+
+#pagebreak()
+
+= Sunday-first, smaller cells
+
+#month-grid(2026, 1, week-start: "sun", cell-height: 1.8cm, cell-width: 2.5cm)
+
+#pagebreak()
+
+= Custom cell content (datetime callback)
+
+#let rotation = ("KB-S&C", "KB-cond", "Cardio", "Gym", "Hyrox", "rest", "rest")
+
+#month-grid(2026, 6, cell-height: 2.2cm, cell-content: date => [
+  #text(8pt, weight: "bold")[#date.day()]
+  #v(2pt)
+  #text(7pt, fill: luma(120))[#rotation.at(date.weekday() - 1)]
+])

--- a/packages/preview/calendaring/0.1.0/examples/habit-tracker.typ
+++ b/packages/preview/calendaring/0.1.0/examples/habit-tracker.typ
@@ -1,5 +1,4 @@
-// Published package: #import "@preview/calendaring:0.1.0": month-grid
-#import "../lib.typ": month-grid
+#import "@preview/calendaring:0.1.0": month-grid
 
 #set page(paper: "a4", margin: 1.5cm)
 

--- a/packages/preview/calendaring/0.1.0/examples/habit-tracker.typ
+++ b/packages/preview/calendaring/0.1.0/examples/habit-tracker.typ
@@ -1,3 +1,4 @@
+// Published package: #import "@preview/calendaring:0.1.0": month-grid
 #import "../lib.typ": month-grid
 
 #set page(paper: "a4", margin: 1.5cm)

--- a/packages/preview/calendaring/0.1.0/examples/habit-tracker.typ
+++ b/packages/preview/calendaring/0.1.0/examples/habit-tracker.typ
@@ -1,0 +1,20 @@
+#import "../lib.typ": month-grid
+
+#set page(paper: "a4", margin: 1.5cm)
+
+#align(center, text(16pt, weight: "bold")[June 2026 — Daily Habits])
+
+#v(0.3cm)
+
+#let habits = ("Mobility", "Read 20m", "Walk", "Water 2L")
+
+#month-grid(
+  2026, 6,
+  cell-width: 1fr,
+  cell-height: 2.4cm,
+  cell-content: date => {
+    text(8pt, weight: "bold")[#date.day()]
+    v(2pt)
+    stack(spacing: 2pt, ..habits.map(h => text(6.5pt)[☐ #h]))
+  },
+)

--- a/packages/preview/calendaring/0.1.0/examples/leap-year.typ
+++ b/packages/preview/calendaring/0.1.0/examples/leap-year.typ
@@ -1,8 +1,7 @@
 // February renders correctly in both leap and non-leap years.
 // The `is-leap-year` helper is exported for user code.
 
-// Published package: #import "@preview/calendaring:0.1.0": month-grid, is-leap-year
-#import "../lib.typ": month-grid, is-leap-year
+#import "@preview/calendaring:0.1.0": month-grid, is-leap-year
 
 #set page(paper: "a4", margin: 1.5cm)
 

--- a/packages/preview/calendaring/0.1.0/examples/leap-year.typ
+++ b/packages/preview/calendaring/0.1.0/examples/leap-year.typ
@@ -1,6 +1,7 @@
 // February renders correctly in both leap and non-leap years.
 // The `is-leap-year` helper is exported for user code.
 
+// Published package: #import "@preview/calendaring:0.1.0": month-grid, is-leap-year
 #import "../lib.typ": month-grid, is-leap-year
 
 #set page(paper: "a4", margin: 1.5cm)

--- a/packages/preview/calendaring/0.1.0/examples/leap-year.typ
+++ b/packages/preview/calendaring/0.1.0/examples/leap-year.typ
@@ -1,0 +1,33 @@
+// February renders correctly in both leap and non-leap years.
+// The `is-leap-year` helper is exported for user code.
+
+#import "../lib.typ": month-grid, is-leap-year
+
+#set page(paper: "a4", margin: 1.5cm)
+
+#align(center, text(18pt, weight: "bold")[February 2024 — leap year])
+#align(center, text(10pt, fill: luma(120))[is-leap-year(2024) = #is-leap-year(2024)])
+
+#v(0.3cm)
+
+#month-grid(
+  2024, 2,
+  cell-width: 1fr,
+  cell-height: 2.2cm,
+  events: (
+    (datetime(year: 2024, month: 2, day: 29), [Leap day]),
+  ),
+)
+
+#pagebreak()
+
+#align(center, text(18pt, weight: "bold")[February 2025 — not a leap year])
+#align(center, text(10pt, fill: luma(120))[is-leap-year(2025) = #is-leap-year(2025)])
+
+#v(0.3cm)
+
+#month-grid(
+  2025, 2,
+  cell-width: 1fr,
+  cell-height: 2.2cm,
+)

--- a/packages/preview/calendaring/0.1.0/examples/training-calendar.typ
+++ b/packages/preview/calendaring/0.1.0/examples/training-calendar.typ
@@ -1,8 +1,7 @@
 // Periodization view: events render below the day number,
 // and `today` highlights the current training day.
 
-// Published package: #import "@preview/calendaring:0.1.0": month-grid
-#import "../lib.typ": month-grid
+#import "@preview/calendaring:0.1.0": month-grid
 
 #set page(paper: "a4", margin: 1.5cm)
 

--- a/packages/preview/calendaring/0.1.0/examples/training-calendar.typ
+++ b/packages/preview/calendaring/0.1.0/examples/training-calendar.typ
@@ -1,0 +1,24 @@
+// Periodization view: events render below the day number,
+// and `today` highlights the current training day.
+
+#import "../lib.typ": month-grid
+
+#set page(paper: "a4", margin: 1.5cm)
+
+#align(center, text(16pt, weight: "bold")[June 2026 — Training Calendar])
+
+#v(0.3cm)
+
+#month-grid(
+  2026, 6,
+  cell-width: 1fr,
+  cell-height: 2.4cm,
+  today: datetime(year: 2026, month: 6, day: 11),
+  events: (
+    (datetime(year: 2026, month: 6, day: 1),  [Peak block]),
+    (datetime(year: 2026, month: 6, day: 7),  [1RM test]),
+    (datetime(year: 2026, month: 6, day: 15), [Deload]),
+    (datetime(year: 2026, month: 6, day: 21), [Race]),
+    (datetime(year: 2026, month: 6, day: 22), [Recovery]),
+  ),
+)

--- a/packages/preview/calendaring/0.1.0/examples/training-calendar.typ
+++ b/packages/preview/calendaring/0.1.0/examples/training-calendar.typ
@@ -1,6 +1,7 @@
 // Periodization view: events render below the day number,
 // and `today` highlights the current training day.
 
+// Published package: #import "@preview/calendaring:0.1.0": month-grid
 #import "../lib.typ": month-grid
 
 #set page(paper: "a4", margin: 1.5cm)

--- a/packages/preview/calendaring/0.1.0/examples/wall-calendar.typ
+++ b/packages/preview/calendaring/0.1.0/examples/wall-calendar.typ
@@ -1,5 +1,6 @@
 // Wall-calendar layout: ISO 8601 week numbers in a leading column.
 
+// Published package: #import "@preview/calendaring:0.1.0": month-grid
 #import "../lib.typ": month-grid
 
 #set page(paper: "a4", margin: 1.5cm)

--- a/packages/preview/calendaring/0.1.0/examples/wall-calendar.typ
+++ b/packages/preview/calendaring/0.1.0/examples/wall-calendar.typ
@@ -1,7 +1,6 @@
 // Wall-calendar layout: ISO 8601 week numbers in a leading column.
 
-// Published package: #import "@preview/calendaring:0.1.0": month-grid
-#import "../lib.typ": month-grid
+#import "@preview/calendaring:0.1.0": month-grid
 
 #set page(paper: "a4", margin: 1.5cm)
 

--- a/packages/preview/calendaring/0.1.0/examples/wall-calendar.typ
+++ b/packages/preview/calendaring/0.1.0/examples/wall-calendar.typ
@@ -1,0 +1,16 @@
+// Wall-calendar layout: ISO 8601 week numbers in a leading column.
+
+#import "../lib.typ": month-grid
+
+#set page(paper: "a4", margin: 1.5cm)
+
+#align(center, text(22pt, weight: "bold")[June 2026])
+
+#v(0.4cm)
+
+#month-grid(
+  2026, 6,
+  cell-width: 1fr,
+  cell-height: 2.6cm,
+  week-numbers: true,
+)

--- a/packages/preview/calendaring/0.1.0/examples/weekend-shading.typ
+++ b/packages/preview/calendaring/0.1.0/examples/weekend-shading.typ
@@ -1,6 +1,7 @@
 // The cell-content callback receives a `datetime`, so the weekday
 // can be computed directly without closing over year/month.
 
+// Published package: #import "@preview/calendaring:0.1.0": month-grid
 #import "../lib.typ": month-grid
 
 #set page(paper: "a4", margin: 2cm)

--- a/packages/preview/calendaring/0.1.0/examples/weekend-shading.typ
+++ b/packages/preview/calendaring/0.1.0/examples/weekend-shading.typ
@@ -1,0 +1,25 @@
+// The cell-content callback receives a `datetime`, so the weekday
+// can be computed directly without closing over year/month.
+
+#import "../lib.typ": month-grid
+
+#set page(paper: "a4", margin: 2cm)
+
+#align(center, text(16pt, weight: "bold")[June 2026])
+
+#v(0.3cm)
+
+#month-grid(
+  2026, 6,
+  cell-width: 1fr,
+  cell-height: 2cm,
+  cell-content: date => {
+    if date.weekday() >= 6 {
+      table.cell(fill: luma(240))[
+        #text(8pt, weight: "bold", fill: luma(110))[#date.day()]
+      ]
+    } else {
+      text(8pt, weight: "bold")[#date.day()]
+    }
+  },
+)

--- a/packages/preview/calendaring/0.1.0/examples/weekend-shading.typ
+++ b/packages/preview/calendaring/0.1.0/examples/weekend-shading.typ
@@ -1,8 +1,7 @@
 // The cell-content callback receives a `datetime`, so the weekday
 // can be computed directly without closing over year/month.
 
-// Published package: #import "@preview/calendaring:0.1.0": month-grid
-#import "../lib.typ": month-grid
+#import "@preview/calendaring:0.1.0": month-grid
 
 #set page(paper: "a4", margin: 2cm)
 

--- a/packages/preview/calendaring/0.1.0/examples/workout-log.typ
+++ b/packages/preview/calendaring/0.1.0/examples/workout-log.typ
@@ -1,0 +1,9 @@
+#import "../lib.typ": month-grid
+
+#set page(paper: "a4", margin: (x: 1.5cm, y: 1.2cm))
+
+#align(center, text(16pt, weight: "bold")[June 2026 — Workout Log])
+
+#v(0.3cm)
+
+#month-grid(2026, 6, rotated: true)

--- a/packages/preview/calendaring/0.1.0/examples/workout-log.typ
+++ b/packages/preview/calendaring/0.1.0/examples/workout-log.typ
@@ -1,5 +1,4 @@
-// Published package: #import "@preview/calendaring:0.1.0": month-grid
-#import "../lib.typ": month-grid
+#import "@preview/calendaring:0.1.0": month-grid
 
 #set page(paper: "a4", margin: (x: 1.5cm, y: 1.2cm))
 

--- a/packages/preview/calendaring/0.1.0/examples/workout-log.typ
+++ b/packages/preview/calendaring/0.1.0/examples/workout-log.typ
@@ -1,3 +1,4 @@
+// Published package: #import "@preview/calendaring:0.1.0": month-grid
 #import "../lib.typ": month-grid
 
 #set page(paper: "a4", margin: (x: 1.5cm, y: 1.2cm))

--- a/packages/preview/calendaring/0.1.0/examples/year-at-a-glance.typ
+++ b/packages/preview/calendaring/0.1.0/examples/year-at-a-glance.typ
@@ -1,5 +1,4 @@
-// Published package: #import "@preview/calendaring:0.1.0": year-grid
-#import "../lib.typ": year-grid
+#import "@preview/calendaring:0.1.0": year-grid
 
 #set page(paper: "a4", margin: 1cm)
 

--- a/packages/preview/calendaring/0.1.0/examples/year-at-a-glance.typ
+++ b/packages/preview/calendaring/0.1.0/examples/year-at-a-glance.typ
@@ -1,0 +1,9 @@
+#import "../lib.typ": year-grid
+
+#set page(paper: "a4", margin: 1cm)
+
+#align(center, text(20pt, weight: "bold")[2026])
+
+#v(0.3cm)
+
+#year-grid(2026)

--- a/packages/preview/calendaring/0.1.0/examples/year-at-a-glance.typ
+++ b/packages/preview/calendaring/0.1.0/examples/year-at-a-glance.typ
@@ -1,3 +1,4 @@
+// Published package: #import "@preview/calendaring:0.1.0": year-grid
 #import "../lib.typ": year-grid
 
 #set page(paper: "a4", margin: 1cm)

--- a/packages/preview/calendaring/0.1.0/lib.typ
+++ b/packages/preview/calendaring/0.1.0/lib.typ
@@ -1,0 +1,76 @@
+#let _weekday-names-mon = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+#let _weekday-names-sun = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+
+#let _days-in-month(year, month) = {
+  let next = if month == 12 {
+    datetime(year: year + 1, month: 1, day: 1)
+  } else {
+    datetime(year: year, month: month + 1, day: 1)
+  }
+  (next - duration(days: 1)).day()
+}
+
+#let _default-cell(n) = text(8pt, weight: "bold")[#n]
+
+#let month-grid(
+  year,
+  month,
+  cell-height: 3.3cm,
+  cell-width: 3.5cm,
+  week-start: "mon",
+  rotated: false,
+  header-fill: luma(230),
+  stroke: 0.5pt,
+  inset: 3pt,
+  cell-content: _default-cell,
+) = {
+  assert(week-start == "mon" or week-start == "sun",
+    message: "week-start must be \"mon\" or \"sun\"")
+
+  let first = datetime(year: year, month: month, day: 1)
+  let first-weekday = first.weekday()
+
+  let leading = if week-start == "sun" {
+    calc.rem(first-weekday, 7)
+  } else {
+    first-weekday - 1
+  }
+
+  let n-days = _days-in-month(year, month)
+  let total = leading + n-days
+  let rows-needed = calc.ceil(total / 7)
+  let trailing = rows-needed * 7 - total
+
+  let names = if week-start == "sun" {
+    _weekday-names-sun
+  } else {
+    _weekday-names-mon
+  }
+
+  let header-cells = names.map(d => table.cell(fill: header-fill)[
+    #align(center, text(8pt, weight: "bold")[#d])
+  ])
+
+  let blank = []
+  let body-cells = (
+    ..((blank,) * leading),
+    ..range(1, n-days + 1).map(cell-content),
+    ..((blank,) * trailing),
+  )
+
+  let tbl = table(
+    columns: (cell-width,) * 7,
+    rows: (auto,) + (cell-height,) * rows-needed,
+    align: top + left,
+    inset: inset,
+    stroke: stroke,
+    ..header-cells,
+    ..body-cells,
+  )
+
+  if rotated {
+    rotate(90deg, reflow: true, tbl)
+  } else {
+    tbl
+  }
+}

--- a/packages/preview/calendaring/0.1.0/lib.typ
+++ b/packages/preview/calendaring/0.1.0/lib.typ
@@ -1,6 +1,11 @@
 #let _weekday-names-mon = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 #let _weekday-names-sun = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
 
+// Gregorian leap year: divisible by 4, except century years not divisible by 400.
+#let is-leap-year(year) = {
+  (calc.rem(year, 4) == 0 and calc.rem(year, 100) != 0) or calc.rem(year, 400) == 0
+}
+
 #let _days-in-month(year, month) = {
   let next = if month == 12 {
     datetime(year: year + 1, month: 1, day: 1)
@@ -67,6 +72,8 @@
   week-numbers: false,
   week-number-width: 0.8cm,
 ) = {
+  assert(type(year) == int,
+    message: "year must be an integer")
   assert(type(month) == int and 1 <= month and month <= 12,
     message: "month must be an integer between 1 and 12")
   assert(week-start == "mon" or week-start == "sun",
@@ -156,7 +163,17 @@
   }
 }
 
-#let year-grid(year, columns: 3) = {
+#let year-grid(
+  year,
+  columns: 3,
+  cell-height: 0.55cm,
+  inset: 1pt,
+  month-label-size: 9pt,
+) = {
+  assert(type(year) == int, message: "year must be an integer")
+  assert(type(columns) == int and 1 <= columns and columns <= 12,
+    message: "columns must be an integer between 1 and 12")
+
   let month-name(m) = datetime(year: year, month: m, day: 1)
     .display("[month repr:long]")
   grid(
@@ -164,9 +181,14 @@
     column-gutter: 0.4cm,
     row-gutter: 0.5cm,
     ..range(1, 13).map(m => [
-      #align(center, text(9pt, weight: "bold")[#month-name(m)])
+      #align(center, text(month-label-size, weight: "bold")[#month-name(m)])
       #v(2pt)
-      #month-grid(year, m, cell-width: 1fr, cell-height: 0.55cm, inset: 1pt)
+      #month-grid(
+        year, m,
+        cell-width: 1fr,
+        cell-height: cell-height,
+        inset: inset,
+      )
     ])
   )
 }

--- a/packages/preview/calendaring/0.1.0/lib.typ
+++ b/packages/preview/calendaring/0.1.0/lib.typ
@@ -14,6 +14,16 @@
   a.year() == b.year() and a.month() == b.month() and a.day() == b.day()
 }
 
+// ISO 8601 week number: the week of a date is the week of its Thursday;
+// week 1 is the week containing the first Thursday of the year.
+#let _iso-week(date) = {
+  let days-to-thursday = 4 - date.weekday()
+  let thursday = date + duration(days: days-to-thursday)
+  let year-start = datetime(year: thursday.year(), month: 1, day: 1)
+  let diff = (thursday - year-start) / duration(days: 1)
+  calc.floor(diff / 7) + 1
+}
+
 #let _events-for(date, events) = {
   events
     .filter(((d, _)) => _dates-equal(d, date))
@@ -54,6 +64,8 @@
   cell-content: none,
   today: none,
   events: (),
+  week-numbers: false,
+  week-number-width: 0.8cm,
 ) = {
   assert(type(month) == int and 1 <= month and month <= 12,
     message: "month must be an integer between 1 and 12")
@@ -72,7 +84,6 @@
   let n-days = _days-in-month(year, month)
   let total = leading + n-days
   let rows-needed = calc.ceil(total / 7)
-  let trailing = rows-needed * 7 - total
 
   let default-names = if week-start == "sun" {
     _weekday-names-sun
@@ -83,9 +94,17 @@
   assert(names.len() == 7,
     message: "weekday-names must have exactly 7 entries")
 
-  let header-cells = names.map(d => table.cell(fill: header-fill)[
+  let day-cell-styled = (d => table.cell(fill: header-fill)[
     #align(center, text(8pt, weight: "bold")[#d])
   ])
+  let header-cells = names.map(day-cell-styled)
+  let header-row = if week-numbers {
+    (table.cell(fill: header-fill)[
+      #align(center, text(7pt, weight: "bold", fill: luma(110))[Wk])
+    ],) + header-cells
+  } else {
+    header-cells
+  }
 
   let render = if cell-content == none {
     (date) => _default-render(date, today, events, today-fill)
@@ -93,24 +112,40 @@
     cell-content
   }
 
-  let day-cells = range(1, n-days + 1).map(d => {
-    render(datetime(year: year, month: month, day: d))
-  })
+  // Build row-by-row so a week-number cell can be prepended per row.
+  let mon-col-offset = if week-start == "mon" { 0 } else { 1 }
+  let body-cells = ()
+  for row in range(0, rows-needed) {
+    if week-numbers {
+      let row-monday = first + duration(days: row * 7 + mon-col-offset - leading)
+      body-cells.push(table.cell(align: center + horizon)[
+        #text(7pt, fill: luma(110))[#_iso-week(row-monday)]
+      ])
+    }
+    for col in range(0, 7) {
+      let pos = row * 7 + col
+      if pos < leading or pos >= leading + n-days {
+        body-cells.push([])
+      } else {
+        let d = pos - leading + 1
+        body-cells.push(render(datetime(year: year, month: month, day: d)))
+      }
+    }
+  }
 
-  let blank = []
-  let body-cells = (
-    ..((blank,) * leading),
-    ..day-cells,
-    ..((blank,) * trailing),
-  )
+  let columns = if week-numbers {
+    (week-number-width,) + (cell-width,) * 7
+  } else {
+    (cell-width,) * 7
+  }
 
   let tbl = table(
-    columns: (cell-width,) * 7,
+    columns: columns,
     rows: (auto,) + (cell-height,) * rows-needed,
     align: top + left,
     inset: inset,
     stroke: stroke,
-    ..header-cells,
+    ..header-row,
     ..body-cells,
   )
 

--- a/packages/preview/calendaring/0.1.0/lib.typ
+++ b/packages/preview/calendaring/0.1.0/lib.typ
@@ -10,7 +10,34 @@
   (next - duration(days: 1)).day()
 }
 
-#let _default-cell(n) = text(8pt, weight: "bold")[#n]
+#let _dates-equal(a, b) = {
+  a.year() == b.year() and a.month() == b.month() and a.day() == b.day()
+}
+
+#let _events-for(date, events) = {
+  events
+    .filter(((d, _)) => _dates-equal(d, date))
+    .map(((_, content)) => content)
+}
+
+#let _default-render(date, today, events, today-fill) = {
+  let day-events = _events-for(date, events)
+  let is-today = today != none and _dates-equal(date, today)
+
+  let body = {
+    text(8pt, weight: "bold")[#date.day()]
+    if day-events.len() > 0 {
+      v(1pt)
+      stack(spacing: 1pt, ..day-events.map(e => text(6.5pt)[#e]))
+    }
+  }
+
+  if is-today {
+    table.cell(fill: today-fill)[#body]
+  } else {
+    body
+  }
+}
 
 #let month-grid(
   year,
@@ -20,10 +47,16 @@
   week-start: "mon",
   rotated: false,
   header-fill: luma(230),
+  today-fill: luma(220),
   stroke: 0.5pt,
   inset: 3pt,
-  cell-content: _default-cell,
+  weekday-names: none,
+  cell-content: none,
+  today: none,
+  events: (),
 ) = {
+  assert(type(month) == int and 1 <= month and month <= 12,
+    message: "month must be an integer between 1 and 12")
   assert(week-start == "mon" or week-start == "sun",
     message: "week-start must be \"mon\" or \"sun\"")
 
@@ -41,20 +74,33 @@
   let rows-needed = calc.ceil(total / 7)
   let trailing = rows-needed * 7 - total
 
-  let names = if week-start == "sun" {
+  let default-names = if week-start == "sun" {
     _weekday-names-sun
   } else {
     _weekday-names-mon
   }
+  let names = if weekday-names == none { default-names } else { weekday-names }
+  assert(names.len() == 7,
+    message: "weekday-names must have exactly 7 entries")
 
   let header-cells = names.map(d => table.cell(fill: header-fill)[
     #align(center, text(8pt, weight: "bold")[#d])
   ])
 
+  let render = if cell-content == none {
+    (date) => _default-render(date, today, events, today-fill)
+  } else {
+    cell-content
+  }
+
+  let day-cells = range(1, n-days + 1).map(d => {
+    render(datetime(year: year, month: month, day: d))
+  })
+
   let blank = []
   let body-cells = (
     ..((blank,) * leading),
-    ..range(1, n-days + 1).map(cell-content),
+    ..day-cells,
     ..((blank,) * trailing),
   )
 
@@ -73,4 +119,19 @@
   } else {
     tbl
   }
+}
+
+#let year-grid(year, columns: 3) = {
+  let month-name(m) = datetime(year: year, month: m, day: 1)
+    .display("[month repr:long]")
+  grid(
+    columns: (1fr,) * columns,
+    column-gutter: 0.4cm,
+    row-gutter: 0.5cm,
+    ..range(1, 13).map(m => [
+      #align(center, text(9pt, weight: "bold")[#month-name(m)])
+      #v(2pt)
+      #month-grid(year, m, cell-width: 1fr, cell-height: 0.55cm, inset: 1pt)
+    ])
+  )
 }

--- a/packages/preview/calendaring/0.1.0/typst.toml
+++ b/packages/preview/calendaring/0.1.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "calendaring"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Thomas Dickson <@TAJD>"]
+license = "MIT"
+description = "Lay out month calendar grids from a year and month."
+repository = "https://github.com/TAJD/calendaring"
+keywords = ["calendar", "month", "grid", "planner", "log"]
+categories = ["components", "layout"]
+compiler = "0.12.0"


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description: `calendaring` lays out month calendar grids from a year and month. Given `(year, month)`, it computes the correct leading and trailing blank days (via `datetime` + `duration`), supports Monday- or Sunday-first weeks, optional 90° rotation for portrait pages, and a custom cell renderer for adding labels per day. It is intended for personal planners, training logs, and habit trackers where each day is a writable cell — not for displaying scheduled events (for that, see `cineca`).

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that isn't the most obvious or canonical name for what the package does
  - Explanation: `calendaring` is the gerund of "calendar", directly analogous to the example in the naming rules (`slides` → `sliding`). The canonical names `calendar`, `month`, and `month-grid` are intentionally avoided so that future packages with broader calendar functionality remain available.
- [x] added a `typst.toml` file with all required keys
- [x] added a `README.md` with documentation for my package
- [x] have chosen a license (MIT) and added a `LICENSE` file
- [x] tested my package locally on my system and it worked
- [x] excluded PDFs or README images, if any, but not the LICENSE