### PR TITLE
kauderwelsch:0.1.0

### DIFF
--- a/packages/preview/kauderwelsch/0.1.0/LICENSE
+++ b/packages/preview/kauderwelsch/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/kauderwelsch/0.1.0/README.md
+++ b/packages/preview/kauderwelsch/0.1.0/README.md
@@ -1,0 +1,69 @@
+# kauderwelsch
+
+An organic, multilingual dummy text and document generator for Typst, heavily inspired by the classic LaTeX blindtext package. 
+
+Unlike static "Lorem Ipsum" generators, kauderwelsch provides meaningful, flowing public-domain literature across multiple languages, realistic asymmetrical section nesting, and automated distribution of advanced document features (like multi-level lists, tables, mathematical formulas, and raw code blocks).
+
+## Features
+
+- **Puristic & Organic:** No forced pagebreaks. Layout flow is entirely organic, allowing you to test your custom show-rules and document structures precisely.
+- **Multilingual Support:** Switch seamlessly between English ("en" - *The 39 Steps*), German ("de" - *Winnetou*), French ("fr" - *Arsène Lupin*), and classical Latin ("la" - Ovid's *Metamorphoses*).
+- **Deterministic Smart Distribution:** Even in a small document layout, the package guarantees that all activated features (code snippets, tables, nested lists) are rendered at least once and distributed evenly across your headings.
+- **Strict Validation:** Integrated assertions safeguard your compilation against invalid arguments.
+
+## Usage
+
+### Basic Text Generation
+Generate quick paragraphs with optional math formulas:
+
+```typst
+#import "@local/kauderwelsch:0.1.0": *
+
+// Generate 3 medium-sized paragraphs in German
+#blindtext(paragraphs: 3, length: "medium", lang: "de")
+
+// Generate short paragraphs with inline math formulas embedded every 2 paragraphs
+#blindtext(paragraphs: 5, length: "short", lang: "en", math: true, math-frequency: 2)
+```
+
+### Full Document Mocking
+Test complex templates, styling, headers, and outlines with a deeply structured document:
+
+```typst
+#import "@local/kauderwelsch:0.1.0": *
+
+// Generate a massive 10+ page document to test complex document constraints
+#blinddocument(
+  size: "large",
+  length: "long",
+  lang: "de",
+  math: true,
+  lists: true,
+  tables: true,
+  figures: true,
+  code: true
+)
+```
+
+## Function Reference
+
+### blindtext
+- `paragraphs` (int): Number of paragraphs to generate. Default is 3.
+- `length` (string): Length of each paragraph ("short", "medium", "long"). Default is "long".
+- `lang` (string): Language identifier ("en", "de", "fr", "la"). Default is "en".
+- `math` (boolean): Whether to scatter mathematical formulas into the text. Default is false.
+- `math-frequency` (int): Density of formulas. Default is 1.
+- `offset` (int): Shifts the starting index within the text arrays. Default is 0.
+
+### blinddocument
+- `size` (string): Overall structure size ("small", "medium", "large"). Default is "medium".
+- `length` (string): Individual paragraph length inside the sections. Default is "long".
+- `lang` (string): Language identifier ("en", "de", "fr", "la"). Default is "en".
+- `math` (boolean): Scatters math formulas into the document text blocks. Default is false.
+- `lists` (boolean): Includes simple, nested, and definition lists. Default is true.
+- `tables` (boolean): Includes standard and large matrix data tables. Default is true.
+- `figures` (boolean): Includes grey layout rects wrapped in captioned figures. Default is false.
+- `code` (boolean): Includes highlighted raw programming snippets (Python / R). Default is false.
+
+## License
+This project is licensed under the MIT License.

--- a/packages/preview/kauderwelsch/0.1.0/data.typ
+++ b/packages/preview/kauderwelsch/0.1.0/data.typ
@@ -1,0 +1,143 @@
+// data.typ
+
+// ==========================================
+// 1. TEXTE (Vielsprachig: en, de, fr, la)
+// ==========================================
+#let texts = (
+  en: (
+    "I returned from the City about three o'clock on that May afternoon pretty well disgusted with life. I had been three months in the Old Country, and was fed up with it. If anyone had told me a year ago that I would have been feeling like that I should have laughed at him; but there was the fact. The weather made me liverish, the talk of the ordinary Englishman made me sick, I couldn't get enough exercise, and the amusements of London seemed as flat as soda-water that has been standing in the sun. It is a miserable thing to feel useless, and that was exactly how I was feeling. I wanted something to do, something that would take a bit of doing and have a bit of risk in it. But here I was, a man of thirty-seven, healthy, with enough money to have a good time, and I was yawning my head off all day.",
+    "That evening I went out to dinner at a club in Pall Mall, and there I met an old schoolfellow, who was making a lot of money in the City. He took me to the theatre, and later to supper at the Savoy. It was all very well, but I felt that I was watching a play in which I had no part. I wanted to be doing something, to be in the thick of the fray, instead of a spectator. The whole glittering, noisy world around me seemed like a hollow shell. I looked at the men with their smooth faces and the women with their jewels, and I wondered how many of them had ever faced real danger or known what it was to be desperately afraid. Probably none, I thought. And yet, beneath the surface of this civilized society, there must be currents of intrigue and violence.",
+    "I was smoking a cigar and thinking of turning in, when there came a knock at the door. I opened it, and there stood a man who looked like he had been running hard. His clothes were torn, and he had a scared look in his eyes. 'Can I come in?' he asked breathlessly. 'I'm in trouble.' I let him in and locked the door. He sank into a chair and wiped his forehead. 'They're after me,' he said. 'Who?' I asked. 'The police?' 'No, not the police. Worse. You've got to help me.' He looked round the room like a hunted animal. 'Are we safe here?' he whispered, creeping closer to the window.",
+    "Then I realised that the man was dead. I had seen too many dead men in the bush not to know the signs. He lay on his back, his eyes staring blankly at the ceiling. I stood there for a moment, stunned. This was not what I had bargained for when I opened the door. I sat down in an armchair and felt very sick. That lasted for maybe five minutes, and was succeeded by a fit of the shivers. It was a hot night, but I had to pour out a stiff whisky-and-soda before I could feel my legs. I was pretty well used to being in tight corners, but this was a bit too much for my stomach."
+  ),
+  de: (
+    "Man versteht unter einem Greenhorn einen Menschen, welcher noch grün, also neu und unerfahren im Lande ist und sich an die dortigen Sitten und Gebräuche erst gewöhnen muss. Ein Greenhorn wird sich von einem feindlichen Indianer erschießen lassen, weil er ihn für einen friedlichen Jäger hält. Ein Greenhorn wird den Spuren eines Truthuhns folgen und dabei in die Hände von Komantschen geraten. Ein Greenhorn ist ein Mann, der beim Anblick eines Bären seine Flinte wegwirft und sich auf den nächsten Baum flüchtet, um dann dort festzustellen, dass der Bär ihm mühelos nachklettert. Kurz und gut, ich war damals ein solches Greenhorn.",
+    "Winnetou, der edle Häuptling der Apachen, war mein Freund und Blutsbruder. Wir hatten Gefahren geteilt und Seite an Seite gekämpft. Wenn ich an jene Tage zurückdenke, sehe ich ihn noch immer vor mir: die hohe, stolze Gestalt, den ernsten Blick und die unerschütterliche Ruhe, die ihn selbst in der größten Gefahr nicht verließ. Er war ein Meister darin, Spuren zu lesen, wo das Auge eines weißen Mannes nichts als nackten Fels oder windverwehten Sand erblicken konnte. Nie hat er ein überflüssiges Wort gesprochen, und doch war jede seiner Gesten voller Bedeutung.",
+    "Das Lagerfeuer knisterte leise vor sich hin und warf flackernde Schatten auf die Gesichter der Männer, die sich ringsum versammelt hatten. Es war eine jener Nächte in der Prärie, in denen die Luft so klar ist, dass die Sterne wie greifbare Diamanten am schwarzen Samt des Himmels zu hängen scheinen. Niemand sprach ein Wort. Wir wussten alle, dass am morgigen Tag eine Entscheidung fallen musste. Das Heulen eines einsamen Kojoten durchbrach die Stille, ein Geräusch, das mir noch Jahre später Schauer über den Rücken jagen sollte.",
+    "Plötzlich schnellte Winnetou lautlos in die Höhe. Seine Haltung war gespannt wie die Sehne seines Bogens, der Kopf leicht zur Seite geneigt, um in die Dunkelheit zu horchen. Ich griff instinktiv nach meinem Bärentöter. 'Was ist, mein Bruder?' flüsterte ich kaum hörbar. Er hob nur beschwichtigend die Hand. Dann hörte auch ich es: ein kaum wahrnehmbares Rascheln im trockenen Gras, viel zu gleichmäßig, um von einem Tier zu stammen. Feinde schlichen sich an unser Lager heran, und der Kampf ums Überleben stand uns unmittelbar bevor."
+  ),
+  fr: (
+    "L'étrange voyage que nous fîmes ! Il avait si bien commencé cependant. Pour ma part, je n'en fis jamais qui s'annonçât sous de plus heureuses couleurs. La Provence est un transatlantique rapide, confortable, commandé par le plus affable des hommes. La société y était des plus choisies. Des relations se formaient, des amusements s'organisaient. Nous avions cette impression délicieuse d'être séparés du monde, réduits à nous-mêmes comme sur une île inconnue.",
+    "On se cherchait, on s'étudiait. Et l'on pensait qu'il y avait parmi nous Arsène Lupin, le mystérieux cambrioleur dont l'énigmatique audace défrayait la chronique de tous les journaux. On savait qu'il avait voyagé sous un faux nom, et l'on se regardait avec une curiosité mêlée de crainte. Était-ce ce jeune homme élégant au regard moqueur ? Ou bien ce vieux monsieur silencieux qui ne quittait jamais sa cabine ? Arsène Lupin, l'homme aux mille déguisements, était là, tout près de nous.",
+    "Le soir, on dansait sur le pont. L'orchestre jouait une valse mélancolique. Soudain, un cri retentit dans la nuit, brisant le charme de l'instant. Une femme s'était évanouie près du grand mât, ses bijoux envolés comme par magie. L'inspecteur Ganimard, vieux loup de la Préfecture, souriait dans sa moustache. Il avait flairé la piste, une piste invisible pour le commun des mortels.",
+    "Cependant, le vol avait été commis avec une adresse prodigieuse. Pas une trace d'effraction, pas un témoin. Le commissaire du bord mena une enquête rigoureuse, fouillant les moindres recoins du navire. Mais Arsène Lupin ne pouvait être pris si facilement. Il jouait avec nous, un jeu dangereux et fascinant, démontrant une fois de plus que son génie criminel ne connaissait aucune limite."
+  ),
+  la: (
+    "In nova fert animus mutatas dicere formas corpora. Di, coeptis nam vos mutastis et illas adspirate meis primaque ab origine mundi ad mea perpetuum deducite tempora carmen. Ante mare et terras et quod tegit omnia caelum unus erat toto naturae vultus in orbe, quem dixere chaos. Rudis indigestaque moles nec quicquam nisi pondus iners congestaque eodem non bene iunctarum discordia semina rerum.",
+    "Nullus adhuc mundo praebebat lumina Titan, nec nova crescendo reparabat cornua Phoebe, nec circumfuso pendebat in aere tellus ponderibus librata suis, nec bracchia longo margine terrarum porrexerat Amphitrite. Utque erat et tellus illic et pontus et aer, sic erat instabilis tellus, innabilis unda, lucis egens aer. Nulli sua forma manebat, obstabatque aliis aliud, quia corpore in uno frigida pugnabant calidis, umentia siccis.",
+    "Hanc deus et melior litem natura diremit. Nam caelo terras et terris abscidit undas et liquidum spisso secrevit ab aere caelum. Quae postquam evolvit caecoque exemit acervo, dissociata locis concordi pace ligavit. Ignea convexi vis et sine pondere caeli emicuit summaque locum sibi fecit in arce. Proximus est aer illi levitate locoque.",
+    "Densior his tellus elementaque grandia traxit et pressa est gravitate sua. Circumfluus umor ultima possedit solidumque coercuit orbem. Sic ubi dispositam quisquis fuit ille deorum congeriem secuit sectamque in membra redegit, principio terram, ne non aequalis ab omni parte foret, magni speciem glomeravit in orbis. Tum freta diffudit rapidisque tumescere ventis iussit."
+  )
+)
+
+// ==========================================
+// 2. STRUKTURELEMENTE
+// ==========================================
+#let headings = (
+  en: (
+    level1: ("The Man Who Died", "The Milkman Sets Out", "The Radical Candidate", "The Black Stone"),
+    level2: ("A Knock at the Door", "The Escape", "A Strange Encounter", "Flight over the Moors"),
+    level3: ("The First Clue", "Hiding in the Dark", "A Desperate Plan"),
+    level4: ("A Minor Detail", "Further Considerations")
+  ),
+  de: (
+    level1: ("Das Greenhorn", "Auf dem Kriegspfad", "Der Blutsbruder", "Das Silber der Apachen"),
+    level2: ("Gefahr in der Prärie", "Die Verfolgung", "Am Lagerfeuer", "Eine List"),
+    level3: ("Verborgen im Gebüsch", "Spuren im Sand", "Der Pakt"),
+    level4: ("Nähere Beobachtungen", "Ein unerwartetes Ereignis")
+  ),
+  fr: (
+    level1: ("L'Arrestation", "En Prison", "L'Évasion", "Le Collier de la Reine"),
+    level2: ("Le Passager Mystère", "Un Télégramme", "La Recherche", "Le Coupable"),
+    level3: ("L'Interrogatoire", "Un Indice", "La Confession"),
+    level4: ("Détail Oublié", "Conclusion")
+  ),
+  la: (
+    level1: ("De Origine Mundi", "Aurea Aetas", "Fabula Lycaonis", "Diluvium"),
+    level2: ("Chaos", "Creatio Hominis", "Ira Deorum", "Deucalion et Pyrrha"),
+    level3: ("Quattuor Ventorum", "Flumina", "Saxa"),
+    level4: ("Minora Argumenta", "Conclusio")
+  )
+)
+
+#let captions = (
+  en: ("A rough sketch.", "The layout of the house.", "A suspicious vehicle."),
+  de: ("Eine hastige Skizze.", "Der Grundriss der Schlucht.", "Eine verdächtige Fährte."),
+  fr: ("Un croquis rapide.", "Le plan du château.", "Un indice caché."),
+  la: ("Delineatio antiqua.", "Forma aedificii.", "Vestigium obscurum.")
+)
+
+#let lists = (
+  en: ("A pack of playing cards.", "Three notebooks with ciphers.", "A loaded revolver."),
+  de: ("Ein alter, abgegriffener Kompass.", "Eine Silberbüchse.", "Drei Reserveladungen Schwarzpulver."),
+  fr: ("Un monocle brisé.", "Une carte de visite parfumée.", "Un revolver à crosse d'ivoire."),
+  la: ("Ignis et aer.", "Tellus et aqua.", "Semen rerum.")
+)
+
+#let nested-lists = (
+  en: (
+    list: [- First level item \ - Second level item \ - Third level item \ - Another third level item \ - Back to second level \ - Another first level item],
+    enum: [+ First step \ + Sub-step one \ + Deep detail \ + Another detail \ + Sub-step two \ + Second step]
+  ),
+  de: (
+    list: [- Hauptpunkt eins \ - Unterpunkt eins \ - Detailpunkt eins \ - Weiterer Detailpunkt \ - Unterpunkt zwei \ - Hauptpunkt zwei],
+    enum: [+ Erster Schritt \ + Teilschritt A \ + Detaillierter Schritt \ + Weiterer Schritt \ + Teilschritt B \ + Zweiter Schritt]
+  ),
+  fr: (
+    list: [- Premier point \ - Sous-point un \ - Détail un \ - Détail deux \ - Sous-point deux \ - Deuxième point],
+    enum: [+ Première étape \ - Sous-étape A \ - Détail complexe \ - Autre détail \ - Sous-étape B \ + Seconde étape]
+  ),
+  la: (
+    list: [- Prima pars \ - Secunda pars \ - Tertia pars \ - Altera tertia pars \ - Ad secundam partem \ - Altera prima pars],
+    enum: [+ Primus gradus \ + Gradus minor \ + Minimus gradus \ + Alter minimus gradus \ + Alter gradus minor \ + Secundus gradus]
+  )
+)
+
+#let terms = (
+  en: (("Scudder", "A man who knew too much."), ("The Black Stone", "A mysterious organization.")),
+  de: (("Old Shatterhand", "Ein legendärer weißer Jäger."), ("Mustang", "Ein kleines, ausdauerndes Präriepferd.")),
+  fr: (("Ganimard", "Un vieil inspecteur têtu."), ("Lupin", "Le gentleman cambrioleur.")),
+  la: (("Chaos", "Rudis indigestaque moles."), ("Titan", "Qui mundo lumina praebebat."))
+)
+
+#let table-data = (
+  header: ("Location", "Date", "Event"), 
+  cells: ("London", "May 15", "Meeting", "Galloway", "May 18", "The chase")
+)
+
+#let large-table-data = (
+  header: ("ID", "Name", "Role", "Department", "Status"),
+  cells: (
+    "001", "John Doe", "Engineer", "IT", "Active",
+    "002", "Jane Smith", "Manager", "Sales", "Active",
+    "003", "Bob Johnson", "Analyst", "Finance", "On Leave",
+    "004", "Alice Brown", "Designer", "Marketing", "Active",
+    "005", "Charlie Davis", "Developer", "IT", "Inactive",
+    "006", "Diana Evans", "HR", "Human Res.", "Active",
+    "007", "Evan Wright", "Director", "Board", "Active",
+    "008", "Fiona Green", "Consultant", "External", "Active"
+  )
+)
+
+// ==========================================
+// 3. MATHE & CODE
+// ==========================================
+#let formulas = (
+  $ e^(i pi) + 1 = 0 $,
+  $ x = (-b plus.minus sqrt(b^2 - 4 a c)) / (2 a) $,
+  $ sum_(n=1)^oo 1/n^2 = pi^2/6 $,
+  $ f(x) = 1/(sigma sqrt(2 pi)) e^(- 1/2 ((x-mu)/sigma)^2) $,
+  $ integral_0^oo x^3/(e^x - 1) dif x = pi^4/15 $,
+  $ mat(1, 2; 3, 4) times mat(a, b; c, d) = mat(1a + 2c, 1b + 2d; 3a + 4c, 3b + 4d) $
+)
+
+#let code-snippets = (
+  (
+    lang: "python",
+    code: "def calculate_fibonacci(n):\n    if n <= 0:\n        return []\n    elif n == 1:\n        return [0]\n    seq = [0, 1]\n    while len(seq) < n:\n        seq.append(seq[-1] + seq[-2])\n    return seq"
+  ),
+  (
+    lang: "r",
+    code: "library(ggplot2)\nlibrary(dplyr)\n\n# Calculate basic summary statistics\n# Ensuring lines are kept strictly short\nmtcars %>%\n  group_by(cyl) %>%\n  summarise(\n    mean_mpg = mean(mpg),\n    sd_mpg = sd(mpg)\n  ) %>%\n  ggplot(aes(x = factor(cyl), y = mean_mpg)) +\n  geom_col(fill = \"steelblue\") +\n  theme_minimal()"
+  )
+)

--- a/packages/preview/kauderwelsch/0.1.0/lib.typ
+++ b/packages/preview/kauderwelsch/0.1.0/lib.typ
@@ -1,0 +1,175 @@
+// lib.typ
+#import "data.typ"
+
+/// Generiert Platzhaltertext.
+#let blindtext(
+  paragraphs: 4,
+  length: "long", 
+  lang: "en",
+  math: false,
+  math-frequency: 1,
+  offset: 0
+) = {
+  // Input Validation
+  assert(type(paragraphs) == int and paragraphs >= 0, message: "blindtext: 'paragraphs' must be a non-negative integer.")
+  assert(length in ("short", "medium", "long"), message: "blindtext: 'length' must be 'short', 'medium', or 'long'.")
+  assert(lang in data.texts.keys(), message: "blindtext: 'lang' must be one of: " + data.texts.keys().join(", "))
+  assert(type(offset) == int, message: "blindtext: 'offset' must be an integer.")
+
+  let source = data.texts.at(lang)
+
+  for i in range(paragraphs) {
+    let raw-text = source.at(calc.rem(i + offset, source.len()))
+    let sentences = raw-text.split(". ").filter(s => s != "")
+    
+    let target-count = if length == "short" {
+      calc.min(2, sentences.len())
+    } else if length == "medium" {
+      calc.max(2, calc.min(5, sentences.len()))
+    } else {
+      sentences.len()
+    }
+
+    let output-text = sentences.slice(0, target-count).join(". ") + "."
+    output-text = output-text.replace("..", ".") 
+
+    if math and calc.rem(i + 1, math-frequency) == 0 {
+      let formula = data.formulas.at(calc.rem(i, data.formulas.len()))
+      [#output-text #formula]
+    } else {
+      [#output-text]
+    }
+    
+    parbreak()
+  }
+}
+
+/// Generiert ein komplettes, organisches Dummy-Dokument.
+#let blinddocument(
+  size: "medium",
+  length: "long",
+  lang: "en",
+  math: false,
+  lists: true,
+  tables: true,
+  figures: false,
+  code: false
+) = {
+  // Input Validation
+  assert(size in ("small", "medium", "large"), message: "blinddocument: 'size' must be 'small', 'medium', or 'large'.")
+  assert(length in ("short", "medium", "long"), message: "blinddocument: 'length' must be 'short', 'medium', or 'long'.")
+  assert(lang in data.texts.keys(), message: "blinddocument: 'lang' must be one of: " + data.texts.keys().join(", "))
+  
+  let active-features = ()
+  if lists { active-features.push("list-simple"); active-features.push("enum-simple"); active-features.push("list-nested"); active-features.push("enum-nested"); active-features.push("terms") }
+  if tables { active-features.push("table-simple"); active-features.push("table-large") }
+  if figures { active-features.push("figure") }
+  if code { active-features.push("code") }
+
+  let total-features = active-features.len()
+
+  let organic-patterns = (
+    (1, 2, 2, 3, 2, 3, 2),
+    (1, 2, 3, 4, 3, 2, 2),
+    (1, 2, 2),
+    (1, 2, 3, 2, 2, 3, 2),
+    (1, 2, 2, 3, 2)
+  )
+
+  let chapter-count = if size == "small" { 1 } else if size == "medium" { 3 } else { 12 }
+  
+  let total-headings = 0
+  for c in range(chapter-count) {
+    total-headings += organic-patterns.at(calc.rem(c, organic-patterns.len())).len()
+  }
+
+  let element-counter = 0
+
+  for c in range(chapter-count) {
+    let pattern = organic-patterns.at(calc.rem(c, organic-patterns.len()))
+    
+    for lvl in pattern {
+      element-counter += 1
+      
+      let heading-list = data.headings.at(lang).at("level" + str(lvl))
+      let heading-text = heading-list.at(calc.rem(element-counter, heading-list.len()))
+      
+      heading(level: lvl, heading-text)
+
+      let p-count = if lvl == 1 { 1 } else if lvl == 4 { 1 } else { calc.rem(element-counter, 3) + 2 }
+      
+      blindtext(
+        paragraphs: p-count, 
+        length: length, 
+        lang: lang,
+        math: math, 
+        math-frequency: 4,
+        offset: element-counter // Shiftet den Startabsatz organisch weiter
+      )
+
+      if total-features > 0 {
+        let features-per-heading = calc.ceil(total-features / total-headings)
+        let start-idx = (element-counter - 1) * features-per-heading
+        let end-idx = start-idx + features-per-heading
+
+        for i in range(start-idx, end-idx) {
+          let feature-idx = if total-headings >= total-features { calc.rem(i, total-features) } else { i }
+
+          if feature-idx < total-features {
+            let feature = active-features.at(feature-idx)
+
+            if feature == "list-simple" {
+              for item in data.lists.at(lang) { list.item(item) }
+              parbreak()
+            } else if feature == "enum-simple" {
+              for item in data.lists.at(lang) { enum.item(item) }
+              parbreak()
+            } else if feature == "list-nested" {
+              [#data.nested-lists.at(lang).list]
+              parbreak()
+            } else if feature == "enum-nested" {
+              [#data.nested-lists.at(lang).enum]
+              parbreak()
+            } else if feature == "terms" {
+              for item in data.terms.at(lang) { terms.item(item.at(0), item.at(1)) }
+              parbreak()
+            } else if feature == "table-simple" {
+              let table-args = ()
+              for h in data.table-data.header { table-args.push(strong(h)) }
+              for cell in data.table-data.cells { table-args.push(cell) }
+              figure(
+                table(
+                  columns: data.table-data.header.len(),
+                  fill: (col, row) => if row == 0 { luma(230) } else { none },
+                  ..table-args
+                ),
+                caption: if lang == "de" [Eine einfache Übersicht.] else if lang == "fr" [Un simple aperçu.] else if lang == "la" [Conspectus simplex.] else [A simple overview.]
+              )
+            } else if feature == "table-large" {
+              let table-args = ()
+              for h in data.large-table-data.header { table-args.push(strong(h)) }
+              for cell in data.large-table-data.cells { table-args.push(cell) }
+              figure(
+                table(
+                  columns: data.large-table-data.header.len(),
+                  fill: (col, row) => if row == 0 { luma(230) } else { none },
+                  ..table-args
+                ),
+                caption: if lang == "de" [Ein größerer Datensatz.] else if lang == "fr" [Un jeu de données.] else if lang == "la" [Notitiae ampliores.] else [A larger dataset.]
+              )
+            } else if feature == "figure" {
+              let cap = data.captions.at(lang).at(calc.rem(element-counter, data.captions.at(lang).len()))
+              figure(
+                rect(width: 80%, height: 150pt, fill: luma(240), radius: 4pt),
+                caption: cap
+              )
+            } else if feature == "code" {
+              let snippet = data.code-snippets.at(calc.rem(element-counter, data.code-snippets.len()))
+              raw(snippet.code, lang: snippet.lang, block: true)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/preview/kauderwelsch/0.1.0/typst.toml
+++ b/packages/preview/kauderwelsch/0.1.0/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kauderwelsch"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Benedikt Schäfer"]
+license = "MIT"
+description = "An organic, multilingual dummy text and document generator inspired by the LaTeX blindtext package. Supports English, German, French, and Latin with structured layouts."
+repository = "https://github.com/benediktschfr/kauderwelsch"
+keywords = ["dummy", "text", "lorem-ipsum", "placeholder", "layout-test"]
+compiler = "0.11.0"


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description:
"kauderwelsch" is an organic, multilingual dummy text and structured document generator for Typst, heavily inspired by the classic LaTeX "blindtext" package. 

Unlike static "Lorem Ipsum" generators, kauderwelsch provides meaningful, flowing public-domain literature across multiple languages (English: John Buchan, German: Karl May, French: Maurice Leblanc, Latin: Ovid). It features realistic, asymmetrical section nesting (up to Level 4) and handles the automated, even distribution of advanced layout elements such as nested lists, mathematical formulas, raw programming code blocks (Python/R), and captioned figures.

When designing Typst templates, book layouts, or complex corporate designs, developers need to test how their styles, headers, and custom show-rules handle actual document constraints. Static placeholder text often fails to trigger realistic line-wrapping, list-nesting, or multi-page layout shifts.

kauderwelsch solves this by acting as a highly flexible layout stress-test. It is uniquely useful to the community because:
1. It is purely non-intrusive (puristic): It completely avoids forced pagebreaks, leaving layout control entirely to the user's custom environment.
2. It features a deterministic distribution algorithm: Even when generating a "small" layout, it mathematically guarantees that all activated document features (such as tables or code blocks) are rendered at least once.
3. It provides strict input validation via assertions to ensure a seamless developer experience.

This is the initial release (v0.1.0) of the package.

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
  - Explanation:
    "Kauderwelsch" is a traditional German word meaning gibberish, jargon, or double-talk, which perfectly captures the playful nature of generating filler text. Instead of claiming a canonical/descriptive term like "blindtext", the name uses this culturally related and creative term to remain distinct and compliant with the naming rules.
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE