### PR TITLE
deixis:0.1.1

### DIFF
--- a/packages/preview/deixis/0.1.1/CHANGELOG.md
+++ b/packages/preview/deixis/0.1.1/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2026-06-03
+
+### Added
+- Added a geometric path pullback calculation for routed links when `link-marks` is enabled, ensuring thick lines stay hidden inside the arrowheads.
+
+### Changed
+- Improved the `#deixis-note-outline` rendering engine. It now allows multi-line note bodies to wrap naturally without clipping, and aligns page numbers to the bottom.
+
+### Fixed
+- Fixed a panic caused by backlinks on celibate (mark-only) endnotes.
+- Fixed an issue where multi-page region marks would calculate incorrect vertical boundaries on non-A4 paper sizes by dynamically resolving Typst's native `auto` margins.
+
+## [0.1.0] - 2026-06-01
+
+### Added
+- Initial public release of `deixis` to the Typst Universe.

--- a/packages/preview/deixis/0.1.1/LICENSE
+++ b/packages/preview/deixis/0.1.1/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2026 Hoang-Nhat TRAN
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preview/deixis/0.1.1/README.md
+++ b/packages/preview/deixis/0.1.1/README.md
@@ -4,7 +4,9 @@ deixis [![Typst Universe](https://img.shields.io/badge/dynamic/xml?url=https%3A%
 Typeset decoupled annotations, visual connectors, and spatial highlights in [Typst](https://typst.app/).
 
 <div align="center">
+<picture>
 <img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/logo.svg" width="200px" alt="Deixis logo">
+</picture>
 </div>
 
 `deixis` is a unified layout engine for inline notes, footnotes, endnotes, margin notes, inset notes, and inline spatial highlights with visual connectors.
@@ -15,7 +17,7 @@ Typeset decoupled annotations, visual connectors, and spatial highlights in [Typ
 </a>
 </div>
 
-## Main Features
+## ✨ Main Features
 
 - **Marks:**
   - [Inline mark](#inline-mark-and-inline-note)
@@ -31,11 +33,11 @@ Typeset decoupled annotations, visual connectors, and spatial highlights in [Typ
 - [Note outline](#note-outline)
 - [Minipage](#minipage)
 
-## News
+## 📢 News
 
-📖 **[Read the Changelog][changelog]** to see what is new in the latest version!
+**[Read the Changelog 📖][changelog]** to see what is new in the latest version!
 
-## Installation
+## 📦 Installation
 
 ### From Typst Universe
 
@@ -61,7 +63,7 @@ Once installed, you can import the package with:
 #import "@local/deixis:0.1.1": *
 ```
 
-## Usage and Examples
+## 🚀 Usage and Examples
 
 For detailed information, please see the [manual (PDF)][manual].
 
@@ -963,15 +965,25 @@ Notice the numbers#deixis-footnote[A page-level footnote.].
 
 </details>
 
-## Acknowledgements
+## 🙌 Acknowledgements
 
 This package has some similar functionalities inspired by existing packages:
 - [drafting](https://github.com/ntjess/typst-drafting): Inline mark, inline note, and margin note, without numbering.
+- [dashy-todo](https://github.com/Otto-AA/dashy-todo): Margin note, without numbering.
 - [marge](https://github.com/EpicEricEE/typst-marge): Margin note, without links.
 - [pinit](https://github.com/OrangeX4/typst-pinit): Equivalent to region mark and inset note, without numbering.
 - [Rik's endnote](https://forum.typst.app/t/an-endnotes-implementation-with-headings-and-cross-referencing/7760): An early attempt to implement endnote.
 
-## License
+## 🤝 Contributing
+
+Any contribution would be greatly appreciated.
+Here is how you can contribute:
+
+- **Report Bugs & Request Features** by openning an issue on our [GitHub Issues](https://github.com/inspiros/typst-deixis/issues).
+- **Submit Pull Requests** if you want to fix a bug or add a feature yourself.
+- **Show your Support:** If you find `deixis` useful, please consider giving the repository a ⭐.
+
+## ⚖️ License
 
 MIT licensed, see [LICENSE](LICENSE).
 

--- a/packages/preview/deixis/0.1.1/README.md
+++ b/packages/preview/deixis/0.1.1/README.md
@@ -1,0 +1,979 @@
+deixis [![Typst Universe](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fdeixis&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE)](https://typst.app/universe/package/deixis) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![User Manual](https://img.shields.io/badge/manual-.pdf-purple)][manual]
+------
+
+Typeset decoupled annotations, visual connectors, and spatial highlights in [Typst](https://typst.app/).
+
+<div align="center">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/logo.svg" width="200px" alt="Deixis logo">
+</div>
+
+`deixis` is a unified layout engine for inline notes, footnotes, endnotes, margin notes, inset notes, and inline spatial highlights with visual connectors.
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/showcase.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/showcase-1.svg" width="500px" alt="Deixis functionalities showcase">
+</a>
+</div>
+
+## Main Features
+
+- **Marks:**
+  - [Inline mark](#inline-mark-and-inline-note)
+  - Phantom mark _(invisible inline mark)_
+  - [Region mark](#pin-and-region-mark)
+- **Notes:**
+  - [Inline note](#inline-mark-and-inline-note)
+  - [Footnote](#footnote)
+  - [Endnote](#endnote)
+  - [Margin note](#margin-note)
+  - [Inset note](#inset-note)
+- [Cross-reference & bi-directional backlinks](#cross-reference-and-backlink)
+- [Note outline](#note-outline)
+- [Minipage](#minipage)
+
+## News
+
+📖 **[Read the Changelog][changelog]** to see what is new in the latest version!
+
+## Installation
+
+### From Typst Universe
+
+This package is available in the [Typst Universe](https://typst.app/universe/package/deixis), you can download and use it by simply adding the following line to your document.
+
+```typst
+#import "@preview/deixis:0.1.1": *
+```
+
+### Local Use
+
+For local use, first you need to clone the repo and run the install script:
+
+```bash
+git clone https://github.com/inspiros/typst-deixis
+python scripts/install.py
+ ```
+
+This Python script stores the package files in the right location following the instructions [here](https://github.com/typst/packages?tab=readme-ov-file#local-packages).
+Once installed, you can import the package with:
+
+```typst
+#import "@local/deixis:0.1.1": *
+```
+
+## Usage and Examples
+
+For detailed information, please see the [manual (PDF)][manual].
+
+### Quick Start
+
+No `deixis` functionality can be used before applying this setup show rule:
+
+```typst
+#show: deixis-setup-notes
+```
+
+> ⚠️ **Warning**
+>
+> `deixis` uses the page foreground/background for rendering notes.
+> If you have your custom foreground/background, it needs to be set before `#show: deixis-setup-notes`.
+
+#### Anatomy of a Note
+
+`deixis` notes are decoupled by nature.
+To create a complete note, you need to put a mark with `-mark` functions, and a note body with `-body` functions. They are linked together via `id`.
+
+Alternatively, you can call wrapper functions, which internally generate a unique `id` and delegate the tasks to appropriate mark-only and body-only functions.
+Note that not all notes have a wrapper function.
+
+<div align="center">
+<table>
+<tr>
+  <td width="50%">
+
+```typst
+#deixis-inline-mark(
+  id: <note1>,
+)
+#deixis-footnote-body(
+  id: <note1>,
+)[Body]
+```
+
+  </td>
+  <td width="50%">
+
+```typst
+#deixis-footnote(
+  // auto-inferred
+  mark-type: "inline",
+)[Body]
+```
+
+  </td>
+</tr>
+<tr>
+  <td align="center">
+  Decoupled approach
+  </td>
+  <td align="center">
+  Wrapper approach
+  </td>
+</tr>
+</table>
+</div>
+
+---
+
+### Inline Mark and Inline Note
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/inline-note.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/inline-note-1.svg" width="500px" alt="Inline mark and note example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#set par(justify: true)
+
+Le
+#deixis-inline-mark(  // celibate mark
+  inline-mode: "underline",
+  stroke: gray,
+  fill: gray.transparentize(90%),
+)[chercheur]
+a ressenti un immense
+#deixis-inline-mark(id: <soulagement>,
+  stroke: red,
+  fill: red.transparentize(95%),
+)[soulagement]
+en découvrant enfin la
+#deixis-inline-mark(id: <cle-de-voute>,
+  stroke: teal,
+  fill: teal.transparentize(95%),
+)[clé de voûte]
+de son argumentation.
+
+#deixis-inline-note-body(id: <soulagement>)[
+  *soulagement*: Relief.
+]
+#deixis-inline-note-body(id: <cle-de-voute>)[
+  *clé de voûte*: Keystone _(metaphorically: the cornerstone or central principle of an argument)_.
+]
+#deixis-inline-note-body(  // celibate note
+  stroke: gray,
+  fill: gray.transparentize(95%),
+)[
+  Without an unique `id`, standalone bodies become celibate (no marker) like this one.
+]
+````
+
+</details>
+
+### Footnote
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/footnote.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/footnote-1.svg" width="500px" alt="Footnote example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#lorem(10)
+#deixis-footnote[A plain footnote.]
+#lorem(10)
+#deixis-footnote(marker: lorem(2))[
+  A footnote with very long marker, aligned with other notes.
+]
+#deixis-footnote-body[
+  A celibate footnote body without linked mark.
+]
+
+#lorem(10)
+#deixis-footnote(
+  marker-style: (body: it => text(fill: orange, super(it))),
+  stroke: red,
+  fill: red.transparentize(95%),
+  container-func: deixis-alert-container,
+)[A marked text][A colorful footnote.].
+````
+
+</details>
+
+### Endnote
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/endnote.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/endnote-1.svg" width="500px" alt="Endnote example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#lorem(10)
+#deixis-endnote[A plain endnote.]
+#lorem(10)
+#deixis-endnote(
+  stroke: maroon,
+  fill: maroon.transparentize(90%),
+)[
+  Endnotes use a different counter
+][
+  They default to the `"endnote"` series.
+].
+#lorem(10)
+// print all previous notes
+#deixis-print-endnotes()
+
+#lorem(5)
+#deixis-endnote[
+  ```typst #deixis-print-endnotes()``` flushes out unprinted notes by default, but it can do more than that.
+]
+#box()<split>
+This
+#deixis-endnote(
+  stroke: gray,
+  fill: none,
+)[
+  invisible note
+][
+  This note is not supposed to be printed.
+]
+is added after the label ```typst #box()<split>```.
+// print with filter
+#deixis-print-endnotes(before: <split>)
+````
+
+</details>
+
+### Margin Note
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/margin-note.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/margin-note-1.svg" width="500px" alt="Margin note example">
+</a>
+</div>
+
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#lorem(10)
+#deixis-margin-note[A plain margin note.]
+#lorem(10)
+// use rect container for subsequent notes
+#deixis-set(container-func: (margin-note: rect))
+#deixis-margin-note(
+  stroke: teal,
+  fill: teal.transparentize(95%),
+  link: "right-angle",
+)[][A colorful margin note.]
+#deixis-margin-note(
+  stroke: green,
+  fill: green.transparentize(95%),
+  link: "right-angle",
+  mark-align: (mark: horizon, body: horizon),
+)[This is a marked text][A left side note, aligned horizontally to its mark.].
+#lorem(10)
+#deixis-margin-note(
+  inline-mode: "highlight",
+  stroke: (link: stroke(paint: orange, dash: "dashed"), body: orange),
+  fill: (mark: orange.transparentize(80%), body: orange.transparentize(95%)),
+  side: right,
+  link: "curve",
+)[Another highlighted text][A note with different styling.].
+
+#import "@preview/colorful-boxes:1.4.3": stickybox
+
+#lorem(3)
+#deixis-margin-note(
+  fill: blue.lighten(85%),
+  container-func: (body, ..args) => stickybox(body, fill: args.at("fill"), rotation: args.at("rotation", default: 0deg)),
+  rotation: 10deg,  // all unknown named parameters are passed to container-func
+)[Sticky note.]
+#lorem(5)
+#deixis-margin-note(
+  marker: "",
+  stroke: red,
+  fill: red.transparentize(95%),
+  link: "right-angle",
+)[A note with empty marker.]
+#lorem(5)
+````
+
+</details>
+
+#### Spillover
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/margin-note-spillover.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/margin-note-spillover-1.svg" width="500px" alt="Margin note spillover example - page 1">
+<br>
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/margin-note-spillover-2.svg" width="500px" alt="Margin note spillover example - page 2">
+</a>
+</div>
+
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+If ```typc spillover: true```, and both margins
+#deixis-margin-note(
+  stroke: red,
+  link: "right-angle",
+  container-func: rect,
+)[
+  #lorem(20)
+]
+in one page has been filled
+#deixis-margin-note[
+  #lorem(28)
+].
+
+Subsequent notes
+#deixis-margin-note[
+  A spilled note.
+]
+will be _spilled_ to the next page
+#deixis-margin-note[
+  Margin notes cannot create new pages, one needs to use ```typst #pagebreak()``` manually.
+]
+if possible
+#deixis-margin-note(
+  stroke: orange,
+  link: "right-angle",
+  container-func: rect,
+)[
+  A spilled note with link crossing page border.
+].
+
+#pagebreak()
+````
+
+</details>
+
+### Inset Note
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/inset-note.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/inset-note-1.svg" width="500px" alt="Inset note example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+Inset notes can be placed
+#deixis-inset-note(
+  stroke: orange,
+  fill: yellow.transparentize(90%),
+  link: "right-angle",
+  link-ports: (mark: right, body: bottom),
+  link-marks: "both",
+  placement: body => deixis-absolute-place(top + right, dx: -5pt, dy: 5pt, body),
+)[anywhere][A manually placed note.]
+
+- #lorem(2)
+- #lorem(3)#deixis-inset-note(
+  marker: none,
+  stroke: red,
+  fill: red.transparentize(95%),
+  link: "straight-line",
+  link-marks: "mark",
+  width: 4.5cm,
+  dx: 1em,
+  dy: 0pt,
+  anchor: (mark: right + horizon, body: left + horizon),
+  layer: "flow",
+)[Alternatively, use `dx`, `dy`, and `anchor` to align the body.]
+- #lorem(2)
+
+#import "@preview/meander:0.4.2"
+#import "@preview/colorful-boxes:1.4.3": outline-colorbox
+
+#let note-body = deixis-inset-note-body(
+  id: <meander>,
+  width: 50%,
+  stroke: purple,
+  fill: purple.transparentize(95%),
+  layer: "flow",  // important !!!
+  container-func: (body, ..args) => outline-colorbox(body,
+    color: (stroke: args.at("stroke").paint, fill: args.at("fill")),
+    stroke: args.at("stroke").thickness,
+    title: args.at("title", default: [Note])),
+  title: [`meander` note],
+)[A _true_ inset note.]
+#meander.reflow({
+  import meander: *
+
+  placed(horizon + right, note-body)
+  container()
+  content[
+    #set par(justify: true)
+    Text will wrap around this note
+    #deixis-inline-mark(id: <meander>).
+    Note that you must set ```typc layer: "flow"``` (render immediately) for this to work.
+    #lorem(29)
+  ]
+})
+````
+
+</details>
+
+### Pin and Region Mark
+
+#### Pin
+
+To create region marks, `deixis` relies on `#deixis-pin`, an idea similar to the [pinit](https://github.com/OrangeX4/typst-pinit) package.
+A region is defined as the minimum rectangle covering an array of input pins, taking padding into account.
+
+Each pin holds its own `padding`, defaults to `"text"`, which means to pad the region around it similar to an inline mark with `inline-mode: "box"`.
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/region-mark-cat-table.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/region-mark-cat-table-1.svg" width="500px" alt="Pin placement and region mark example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+Breakdown of standard #deixis-pin("feline-l")#emoji.cat#[feline]#deixis-pin("feline-r") architecture and performance metrics:
+#deixis-region-mark(
+  stroke: none,
+  fill: yellow.transparentize(50%),
+  radius: 0pt,
+  pins: ("feline-l", "feline-r"),
+  layer: "background",
+)
+
+#{
+  set text(size: 0.8em)
+  figure(
+    table(
+      align: left + horizon,
+      columns: (auto, auto),
+
+      table.header([*Property*], [*Specification*]),
+      [\#legs], [4],
+      [Max speed], [#deixis-pin("tab-tl")48 km/h],
+      [Battery Life], [16--18 hours#deixis-pin("tab-br", padding: (bottom: 0.2em, right: 1em))],
+      [Fuel Source], [Tuna],
+      [Storage Capacity], [$infinity$]
+  ))
+}
+#deixis-footnote(
+  mark-type: "region",
+  marker-style: it => text(fill: blue, super(it)),
+  stroke: orange,
+  fill: orange.transparentize(95%),
+  pins: ("tab-tl", "tab-br"),
+)[Top performance achieved at #sym.tilde.basic#[]3:00 AM, must recharge under direct sunlight #emoji.sun.]
+````
+
+</details>
+
+#### Attach Pins
+
+`#deixis-attach` allows you to attach pins on a wrapped content by:
+- Providing a dictionary of pins and their attributes.
+- If no pins provided, it automatically attaches two pins, one on the top-left corner and one on the bottom-right corner, both with `0pt` padding.
+- Alternatively, pins can be placed with pattern matching `[prefix]pinname[postfix]`.
+  The prefix and postfix patterns can be set using `#deixis-set-pin-pattern`.
+  This is very useful for highlighting code.
+
+<table>
+<tr>
+  <td width="50%">
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/region-mark-cat.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/region-mark-cat-1.svg" width="500px" alt="Attach pins on image example">
+</a>
+</div>
+
+  </td>
+  <td width="50%">
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/region-mark-sigmoid.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/region-mark-sigmoid-1.svg" width="500px" alt="Attach pins on equation and raw example">
+</a>
+</div>
+
+  </td>
+</tr>
+<tr>
+  <td align="center">
+  Cat
+  </td>
+  <td align="center">
+  Sigmoid
+  </td>
+</tr>
+</table>
+
+<details>
+<summary><b>Show Typst Source Code for Cat</b></summary>
+
+````typst
+#align(center,
+  deixis-attach(
+  pins: (
+    cat-top-left: (dx: 40%, dy: 35%),
+    cat-bottom-right: (dx: 62%, dy: 63%),
+  )
+)[
+  #image("assets/loading-cat.jpg", width: 80%)
+])
+
+#deixis-region-mark(
+  id: <cat>,
+  pins: ("cat-top-left", "cat-bottom-right"),
+  marker-style: (mark: it => text(fill: white, super(it))),
+  marker-position: top + center,
+  stroke: red,
+  fill: red.transparentize(90%),
+)
+#deixis-footnote-body(
+  id: <cat>,
+)[A loading cat.]
+````
+
+</details>
+
+<details>
+<summary><b>Show Typst Source Code for Sigmoid</b></summary>
+
+````typst
+The Sigmoid function
+#deixis-region-mark(
+  stroke: yellow,
+  fill: yellow.transparentize(95%),
+  inline: true,
+  layer: "background",
+)[$sigma(dot)$]
+maps any value into a probability in $[0, 1]$:
+
+#align(center,  // wrapped equations cannot auto align center
+  deixis-region-mark(
+  stroke: blue,
+  fill: blue.transparentize(95%),
+  padding: "text",
+  layer: "background",
+)[
+$ sigma(z) = frac(1, 1 + #deixis-pin("e-left")e#deixis-pin("e-right")^(-#deixis-pin("z-left")z#deixis-pin("z-right"))) $
+])
+#deixis-set(
+  body-style: it => text(size: 0.6em, it),
+  side-strategy: "strict",
+  container-func: (margin-note: rect),
+)
+#deixis-inset-note(
+  pins: ("z-left", "z-right"),
+  marker-style: it => text(fill: green, super(it)),
+  stroke: (rest: green, link: stroke(paint: green, thickness: 0.5pt, dash: "dashed")),
+  fill: green.transparentize(95%),
+  link: "curve",
+  link-ports: (body: bottom),
+  link-marks: "body",
+  dx: 1em,
+  dy: -2em,
+)[
+  $z$: input value (the "logit").
+]
+#deixis-inset-note(
+  pins: ("e-left", "e-right"),
+  marker-style: it => text(fill: red, super(it)),
+  stroke: (rest: red, link: stroke(paint: red, thickness: 0.5pt, dash: "dashed")),
+  fill: red.transparentize(95%),
+  link: "curve",
+  link-ports: (mark: bottom, body: left),
+  link-marks: "body",
+  dx: 2em,
+  dy: 2em,
+)[
+  $e$: Euler's constant.
+]
+Python code:
+
+#deixis-set-pin-pattern(
+  prefix: "deixispin",
+  postfix: "deixis",
+)
+#deixis-attach(
+```python
+z = np.array([-np.inf, -1.5, 0, 1.5, np.inf])
+# this computes 1 / (1 + exp(-z))
+probability = deixispine0deixisexpitdeixispine1deixis(z)
+print(f"Logit:\n{z}")
+print(f"Probability:\n{probability}")
+```
+)
+#deixis-footnote(
+  pins: ("e0", "e1"),
+  marker-style: it => text(fill: teal, super(it)),
+  stroke: teal,
+  fill: teal.transparentize(95%),
+)[```python from scipy.special import expit```]
+````
+
+</details>
+
+
+### Routing Links
+
+`deixis` provides margin note and inset note with a simple `link` drawing mechanism.
+You can use `link-waypoints`, `link-ports`, and `link-marks` to configure the link.
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/link.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/link-1.svg" width="500px" alt="Routing link example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#deixis-margin-note(
+  stroke: blue + 0.5pt,
+  fill: blue.transparentize(95%),
+  link: "curve",
+  link-waypoints: (
+    (0pt, 20pt),
+    (50pt, 40pt),
+    (50pt, -50pt),
+    "right-angle",  // change link type
+    (60pt, 40pt),
+    "straight-line",
+  ),
+  link-marks: "body",
+  container-func: rect,
+)[][
+  Waypoints allow creating complicated links.
+]
+#deixis-margin-note(
+  inline-mode: "highlight",
+  stroke: red + 0.5pt,
+  fill: red.transparentize(95%),
+  link: "chamfer",
+  container-func: rect,
+)[
+  Margin links always exit up or down.
+][
+  *Fact:* The default margin links just follow auto-generated waypoints.
+]
+
+#v(70pt)
+#deixis-inset-note(
+  inline-mode: "highlight",
+  width: 120pt,
+  stroke: stroke(paint: green, dash: "densely-dotted"),
+  fill: green.transparentize(95%),
+  link: "ccr",
+  link-waypoints: (
+    // component anchor + alignment keywords
+    (80pt, "mark-right"),
+    (0pt, "body-right"),
+  ),
+  link-ports: (mark: right, body: right),
+  link-marks: "both",
+  layer: "flow",
+)[
+  Inset links give inline marks 3 link ports:\
+  `right, top, bottom`.
+][
+  Inset notes (and region marks) have 4 link ports:\
+  `left, right, top, bottom`.
+]
+````
+
+</details>
+
+---
+
+### Update Default Parameters
+
+Most of the parameters of a note function can be updated using `#deixis-set`.
+In fact, some parameters can only be updated this way.
+
+To update note-specific or component-specific parameters, pass a dictionary with the following keywords:
+- **Note/mark type-scope keywords:**
+  - `inline-mark`
+  - `phantom-mark`
+  - `region-mark`
+  - `inline-note`
+  - `footnote`
+  - `endnote`
+  - `margin-note`: _(applies to both `#deixis-margin-note` and `#deixis-sidenote`)_
+  - `inset-note`
+  - `rest`: applies to the rest
+- **Component-scope keywords:**
+  - `mark`
+  - `body`
+  - `link`
+  - `nodes`: applies to mark and body
+  - `rest`: applies to the rest
+
+It is possible to nest note-scope and component-scope keywords, but not to mix them in the same dictionary.
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/update-params.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/update-params-1.svg" width="500px" alt="Update parameters example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#deixis-set(container-func: (margin-note: rect))
+
+Update default parameters with ```typst #deixis-set```:
+#deixis-margin-note[A simple margin note.]
+- ```typc stroke: green```
+  #deixis-set(stroke: green)
+  #deixis-margin-note[This affects all subsequent notes.]
+- ```typc stroke: (margin-note: blue)```
+  #deixis-set(stroke: (margin-note: blue))
+  #deixis-margin-note[This affects only margin notes.]
+- ```typc stroke: (body: teal)```
+  #deixis-set(stroke: (body: teal))
+  #deixis-margin-note[][This affects all notes' bodies.]
+- ```typc stroke: (margin-note: (body: maroon))```
+  #deixis-set(stroke: (margin-note: (body: maroon)))
+  #deixis-margin-note[][This affects only margin notes' bodies.]
+````
+
+</details>
+
+### Cross-reference and Backlink
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/cross-ref.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/cross-ref-1.svg" width="500px" alt="Cross-reference and backlink example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+Test notes:
+#deixis-footnote(
+  label: <note-1>,
+  backlink: true,
+  marker-style: (mark: it => text(fill: red, super(it))),
+)[Note 1.]
+#deixis-footnote(
+  label: <note-2>,
+  backlink: "always",  // equivalent to true
+  marker-style: (mark: it => text(fill: blue, super(it))),
+)[Note 2.]
+#deixis-footnote(
+  label: <note-3>,
+  backlink: "none",  // equivalent to false
+)[Note 3.]
+#deixis-footnote(
+  label: <note-4>,
+  backlink: "multiple",  // only if they are ref-ed at least once
+)[Note 4.]
+
+*Cross-reference features supported by `deixis`:*
+#grid(
+  align: left,
+  columns: (3fr, 1fr),
+  row-gutter: 0.8em,
+  stroke: none,
+  [Ref using ```typst @label```], [#deixis-ref(<note-1>)],
+  [Ref using ```typst #deixis-ref(<label>)```], [#deixis-ref(<note-1>, <note-2>)],
+  [Ref with supplement], [@note-1[Note]],
+  [Ref 3 or more consecutive notes], [#deixis-ref(<note-1>, <note-2>, <note-3>)],
+  [Ref 2 or 3+ non-consecutive notes], [#deixis-ref(<note-1>, <note-2>, <note-4>)]
+)
+````
+
+</details>
+
+### Counter and Series
+
+Each note belongs to a counter series.
+All `deixis` notes default to the `"default"` series except for `#deixis-endnote` which default to the `"endnote"` series.
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/counter.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/counter-1.svg" width="500px" alt="Counter and series example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#let todo = deixis-margin-note.with(
+  series: "todo",
+  stroke: red,
+  fill: red.transparentize(95%),
+  link: "right-angle",
+  container-func: rect,
+)
+#let first-author = deixis-margin-note.with(
+  series: "comm",
+  stroke: blue,
+  fill: blue.transparentize(95%),
+  link: "right-angle",
+  container-func: rect,
+)
+#let second-author = deixis-margin-note.with(
+  series: "comm",
+  stroke: teal,
+  fill: teal.transparentize(95%),
+  link: "right-angle",
+  container-func: rect,
+)
+#let remark = deixis-margin-note.with(
+  marker: "",
+  series: "remark",
+  stroke: maroon,
+  fill: maroon.transparentize(95%),
+  link: "right-angle",
+  container-func: rect,
+)
+
+#lorem(3)
+#todo[Rewrite this sentence.]
+#lorem(3)
+#first-author[Good point.]
+#lorem(2)
+#deixis-update-note-counter(0, series: "todo")
+#todo[```typc "todo"``` restarts from 1 again.].
+
+#lorem(7)
+#second-author[But ```typc "comm"``` is unaffected.]
+#lorem(2)
+#deixis-update-note-counter(0)  // no effect
+#first-author[][This keeps counting up.]
+#second-author[][Use an empty mark `[]` to avoid overlapping highlight box.]
+#lorem(10)
+#remark[*Remark:* ```typst #deixis-update-note-counter``` defaults to the ```typc "default"``` series!]
+
+Counter: \
+```typc "default"```: #context deixis-note-counter(series: "default") \
+```typc "todo"```: #context deixis-note-counter(series: "todo") \
+```typc "comm"```:  #context deixis-note-counter(series: "comm")
+````
+
+</details>
+
+### Note Outline
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/note-outline.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/note-outline-1.svg" width="500px" alt="Note outline example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+#deixis-inline-mark(
+  id: <celibate>,  // linked to no note body
+)[A celibate marked text]
+#deixis-footnote(
+  stroke: gray,
+)[A footnote.]
+#deixis-endnote(
+  stroke: green,
+  fill: green.transparentize(95%),
+  numbering: "i",
+)[An endnote.]
+#deixis-margin-note(
+  stroke: orange,
+  fill: orange.transparentize(95%),
+  container-func: rect,
+)[A margin note.]
+#deixis-inset-note(
+  stroke: blue,
+  fill: blue.transparentize(95%),
+  placement: body => deixis-absolute-place(top + left, dx: 5pt, dy: 5pt, body),
+)[An inset note.]
+
+#deixis-note-outline(
+  fill: repeat[.],
+  include-celibates: "mark",
+)
+````
+
+</details>
+
+---
+
+### Minipage
+
+Minipages (basically just _glorified_ blocks) serve as an environment to sandbox notes.
+They maintains their own counter system (but can be synced with the page or together), default note parameters, and can be nested.
+
+Since `deixis` notes are decoupled and each component can target different minipages, the rules are:
+- The mark dictates the counter (numbering).
+- The body dictates the rendering context of the body.
+
+<div align="center">
+<a href="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/examples/minipage.typ">
+<img src="https://raw.githubusercontent.com/inspiros/typst-deixis/v0.1.1/assets/gallery/minipage-1.svg" width="500px" alt="Minipage example">
+</a>
+</div>
+
+<details>
+<summary><b>Show Typst Source Code</b></summary>
+
+````typst
+Notice the numbers#deixis-footnote[A page-level footnote.].
+#deixis-block(
+  id: <gray-block>,
+  fill: gray.lighten(80%),
+  inset: (right: 2cm, rest: 5pt),
+)[
+  Minipages are very handy for creating locally rendered notes
+  #deixis-footnote[A block-level footnote.]
+  #deixis-margin-note[A block-level margin note.].
+]
+
+#deixis-block(
+  sync-counters-with: <gray-block>,
+  fill: green.lighten(80%),
+  inset: 5pt,
+)[
+  Moreover, they can maintain a separate counter system, or sync with each other #deixis-footnote[This block shares the counters with ```typst <gray-block>.```].
+]
+````
+
+</details>
+
+## Acknowledgements
+
+This package has some similar functionalities inspired by existing packages:
+- [drafting](https://github.com/ntjess/typst-drafting): Inline mark, inline note, and margin note, without numbering.
+- [marge](https://github.com/EpicEricEE/typst-marge): Margin note, without links.
+- [pinit](https://github.com/OrangeX4/typst-pinit): Equivalent to region mark and inset note, without numbering.
+- [Rik's endnote](https://forum.typst.app/t/an-endnotes-implementation-with-headings-and-cross-referencing/7760): An early attempt to implement endnote.
+
+## License
+
+MIT licensed, see [LICENSE](LICENSE).
+
+[manual]: https://github.com/inspiros/typst-deixis/blob/v0.1.1/docs/manual.pdf
+[changelog]: https://github.com/inspiros/typst-deixis/blob/v0.1.1/CHANGELOG.md

--- a/packages/preview/deixis/0.1.1/src/core.typ
+++ b/packages/preview/deixis/0.1.1/src/core.typ
@@ -1,0 +1,478 @@
+#import "states.typ": *
+#import "layout.typ": *
+#import "utils.typ" as deixis-utils
+
+/// --------------------
+/// Factory Defaults
+/// --------------------
+
+#let deixis-mark-types = ("inline-mark", "phantom-mark", "region-mark")
+#let deixis-note-types = ("footnote", "endnote", "margin-note", "sidenote", "inset-note", "inline-note")
+#let deixis-note-components = ("mark", "body", "link")
+
+#let deixis-factory-defaults = (
+  numbering: "1",
+  // 1. Note Content Styling
+  marker-style: (endnote: (mark: it => super(it), body: it => it), rest: it => super(it)),
+  body-style: (inline-note: it => it, endnote: it => it, rest: deixis-default-footnote-style),
+  backlink: false,
+  // 2. Spacing
+  separator: (footnote: line(length: 30%, stroke: 0.5pt), rest: none),
+  clearance: 1em,
+  indent: (footnote: 1em, rest: 0pt),
+  gap: (endnote: 1em, rest: 0.5em),
+  marker-gap: (endnote: 0.75em, rest: 0.05em),
+  // 3. Styling
+  marker-position: (inline-mark: right, region-mark: top + right, rest: none),
+  inline-mode: "box",
+  stroke: 0.5pt + red,
+  fill: (inline-mark: red.transparentize(95%), region-mark: red.transparentize(95%), rest: none),
+  radius: 0.2em,
+  link: "none",
+  link-marks: "none",
+  // 4. Specific Layouts
+  margin-layout: "adaptive",
+  min-margin-width: 2cm,
+  side-strategy: auto,
+  mark-align: auto,
+  mark-align-strictness: "none",
+  spillover: true,
+  region-shape: deixis-rect-region,
+  layer: "foreground",
+  // 5. Engines
+  render-single: (
+    footnote: deixis-default-render-single,
+    endnote: deixis-default-render-single,
+    rest: deixis-native-render-single,
+  ),
+  render-group: (
+    footnote: deixis-default-render-group,
+    endnote: deixis-grid-render-group,
+    rest: deixis-native-render-group,
+  ),
+  container-func: (
+    inline-note: deixis-alert-container,
+    inset-note: deixis-rect-container,
+    rest: deixis-plain-container,
+  ),
+)
+
+#let deixis-scoping-keys = deixis-mark-types + deixis-note-types + deixis-note-components + ("rest", "nodes")
+
+#let deixis-param-schema = (
+  backlink: (bool, "always", "none", "never", "multiple", auto),
+  marker-position: ("left", "right", alignment, dictionary, auto),
+  inline-mode: ("box", "highlight", "underline", "parentheses", "text-fill", "none", auto, none),
+  margin-layout: ("adaptive", "flow", "exact", function, auto),
+  side: ("inside", "outside", "left", "right", auto),
+  side-strategy: ("nearest", "strict", auto),
+  mark-align: ("top", "horizon", "bottom", alignment, dictionary, auto),
+  mark-align-strictness: ("loose", "strict", "none", auto),
+  spillover: (bool, auto),
+  link: deixis-link-types + (none, auto),
+  link-marks: ("mark", "body", "both", "none", none, auto),
+  padding: ("text", auto, none, length, dictionary),
+  layer: ("foreground", "background", "flow", auto),
+)
+
+#let deixis-auto-fallbacks = (
+  marker-style: it => super(it),
+  body-style: it => it,
+  marker-position: top + right,
+  inline-mode: "box",
+  indent: 0pt,
+  gap: 0.5em,
+  marker-gap: 0.05em,
+  clearance: 1em,
+  stroke: none,
+  fill: none,
+  radius: 0pt,
+  link: "none",
+  link-marks: "none",
+  margin-layout: "adaptive",
+  side-strategy: "nearest",
+  mark-align: "top",
+  mark-align-strictness: "none",
+  spillover: true,
+  render-single: deixis-native-render-single,
+  render-group: deixis-native-render-group,
+)
+
+#let _deixis-check-setup-state() = if not deixis-setup-state.get() {
+  panic("deixis: You must wrap your document with #show: deixis-setup-notes(..) before declaring any notes!")
+}
+
+#let _deixis-validate-target(target) = if not (
+  type(target) in (str, label, int) and (type(target) != int or target <= 0)
+) {
+  panic("deixis: Target must be a string ID, a label, 0, or a negative integer.")
+}
+
+// Centralized helper to resolve target strings, labels, or integers.
+// Returns:
+// - render-id: Where should the overlay engine draw this note? If it belongs to a minipage, this is the minipage's unique ID. If it goes on the page, this evaluates to "page".
+// - count-id: Which numbering sequence does this note belong to? Usually, this is the same as the render-id. However, if you use sync-counters-with, the render-id might be block-B, but the count-id becomes block-A, allowing two physical blocks to share one continuous numbering sequence!
+// - inst-id: This tracks the specific rendering pass of a block to prevent infinite loops and state-stuttering during concurrent evaluations.
+#let _deixis-resolve-target(sys, target) = {
+  let target = if target == auto { 0 } else { target }
+  let is-named = type(target) in (str, label)
+  let target-str = if is-named { str(target) } else { "" }
+
+  if is-named and target-str == "page" { return (render-id: "page", count-id: "page", inst-id: "page") }
+
+  if type(target) == int {
+    if sys.stack.len() == 0 { return (render-id: "page", count-id: "page", inst-id: "page") }
+    let idx = sys.stack.len() - 1 + target
+    if idx >= 0 and idx < sys.stack.len() {
+      let level = sys.stack.at(idx)
+      return (render-id: level.render-id, count-id: level.count-id, inst-id: level.inst-id)
+    }
+    return (render-id: "page", count-id: "page", inst-id: "page")
+  }
+
+  if is-named {
+    let c-id = target-str
+    let i-id = target-str
+    if target-str in sys.blocks {
+      let b = sys.blocks.at(target-str)
+      c-id = b.count-id
+      i-id = b.at("inst-id", default: target-str)
+    }
+    return (render-id: target-str, count-id: c-id, inst-id: i-id)
+  }
+
+  return (render-id: "page", count-id: "page", inst-id: "page")
+}
+
+// Queries the document metadata to find the mark data.
+#let _deixis-query-mark-data(data) = {
+  if type(data) != dictionary { return none }
+
+  let internal-id = data.at("internal-id", default: none)
+  if internal-id == none {
+    if "mark-lbl" in data and data.mark-lbl != none {
+      internal-id = str(data.mark-lbl).replace("deixis-mark-", "")
+    } else if "body-lbl" in data and data.body-lbl != none {
+      internal-id = str(data.body-lbl).replace("deixis-body-", "")
+    }
+  }
+
+  if internal-id != none {
+    let marks = query(
+      selector(metadata).and(selector(<deixis-inline-mark>).or(<deixis-phantom-mark>).or(<deixis-region-mark>)),
+    )
+
+    let match = marks.find(m => (
+      type(m.value) == dictionary
+        and m.value.at("internal-id", default: none) != none
+        and str(m.value.internal-id) == str(internal-id)
+    ))
+
+    if match != none and match.value.at("marker-str", default: none) != none {
+      return match.value
+    }
+  }
+  return none
+}
+
+// Evaluates the final numbering string from a note registry.
+// Safe to use inside context blocks for cross-module evaluation.
+#let _deixis-evaluate-marker-str(reg) = {
+  if type(reg) != dictionary { return none }
+
+  // If the payload already has a computed string, use it
+  if reg.at("marker-str", default: none) != none {
+    return reg.marker-str
+  }
+
+  let c-marker = reg.at("marker", default: auto)
+  if c-marker != auto {
+    return c-marker
+  }
+
+  let c-numbering = reg.at("numbering", default: none)
+  let count = reg.at("count", default: 0)
+
+  if c-numbering != none and c-numbering != auto {
+    return std.numbering(c-numbering, count)
+  }
+
+  return none
+}
+
+// Queries the document metadata to find the exact evaluated marker-str
+// for a note. If the note is not yet fully compiled, it falls back to
+// local evaluation using the raw global state registry.
+// Must be called inside a context block.
+#let _deixis-query-marker-str(data) = {
+  if type(data) != dictionary { return none }
+
+  let internal-id = data.at("internal-id", default: none)
+  if internal-id == none {
+    if "mark-lbl" in data and data.mark-lbl != none {
+      internal-id = str(data.mark-lbl).replace("deixis-mark-", "")
+    } else if "body-lbl" in data and data.body-lbl != none {
+      internal-id = str(data.body-lbl).replace("deixis-body-", "")
+    }
+  }
+
+  if internal-id != none {
+    let marks = query(
+      selector(metadata).and(selector(<deixis-inline-mark>).or(<deixis-phantom-mark>).or(<deixis-region-mark>)),
+    )
+
+    let match = marks.find(m => (
+      type(m.value) == dictionary
+        and m.value.at("internal-id", default: none) != none
+        and str(m.value.internal-id) == str(internal-id)
+    ))
+
+    if match != none and match.value.at("marker-str", default: none) != none {
+      return match.value.marker-str
+    }
+  }
+
+  // fallback
+  let fallback-reg = data
+  if "numbering" not in data and internal-id != none {
+    let sys = deixis-system.final()
+    for (uid, reg) in sys.at("notes", default: (:)) {
+      if str(reg.at("internal-id", default: "")) == str(internal-id) {
+        fallback-reg = reg
+        break
+      }
+    }
+  }
+
+  return _deixis-evaluate-marker-str(fallback-reg)
+}
+
+/// --------------------
+/// Parameter Resolvers
+/// --------------------
+
+#let _deixis-resolve-mark-type(mark-type, pins: none) = {
+  let mark-type = if type(mark-type) == str and mark-type.ends-with("-mark") {
+    mark-type.slice(0, -5)
+  } else { mark-type }
+
+  if mark-type == "region" or (mark-type == auto and type(pins) == array and pins.len() > 0) {
+    "region"
+  } else if mark-type == "phantom" {
+    "phantom"
+  } else if mark-type in ("inline", auto) {
+    "inline"
+  } else {
+    panic("deixis: mark-type must be \"inline\", \"region\", \"phantom\". Got " + repr(mark-type))
+  }
+}
+
+#let _deixis-resolve-typed-param(sys, local-val, param-key, note-type, component: auto) = {
+  let unroll(current-val, origin) = {
+    if type(current-val) != dictionary { return current-val }
+
+    let is-scoping = true
+    let has-note-type = false
+    let has-component = false
+    let has-rest = false
+
+    for k in current-val.keys() {
+      if k not in deixis-scoping-keys {
+        is-scoping = false
+        break
+      }
+      if k in deixis-note-types { has-note-type = true }
+      if k in deixis-note-components { has-component = true }
+      if k == "rest" { has-rest = true }
+    }
+
+    if is-scoping {
+      if has-note-type and has-component {
+        panic(
+          "deixis: You cannot mix note-type keys (e.g., 'margin-note') and component keys (e.g., 'mark') at the same level. Nest them: margin-note: (mark: ...)",
+        )
+      }
+
+      if has-note-type and origin == "local" {
+        panic("deixis: Note-type scoping is not allowed on local note calls. Use #deixis-set to configure note types.")
+      }
+
+      if has-rest and not has-note-type and not has-component {
+        if origin == "local" {
+          has-component = true // Locally, 'rest' means "the rest of the components"
+        } else {
+          has-note-type = true // On the stack/factory, 'rest' means "the rest of the note types"
+        }
+      }
+
+      if has-component and not has-note-type and component == auto {
+        return current-val
+      } else {
+        let match-found = false
+        let specific-val = none
+
+        if note-type in current-val {
+          specific-val = current-val.at(note-type)
+          match-found = true
+        } else if component != auto {
+          if component in current-val {
+            specific-val = current-val.at(component)
+            match-found = true
+          } else if component in ("mark", "body") and "nodes" in current-val {
+            specific-val = current-val.at("nodes")
+            match-found = true
+          }
+        }
+
+        if not match-found and "rest" in current-val {
+          specific-val = current-val.at("rest")
+          match-found = true
+        }
+
+        if match-found { return unroll(specific-val, origin) } else { return auto }
+      }
+    }
+    return current-val
+  }
+
+  let resolve-cascade() = {
+    // local (highest priority)
+    if local-val != auto {
+      let u = unroll(local-val, "local")
+      if u != auto { return u }
+    }
+
+    // stack (#deixis-set)
+    if sys != none and sys.stack.len() > 0 {
+      for level in sys.stack.rev() {
+        let sv = level.at(param-key, default: auto)
+        if sv != auto {
+          let u = unroll(sv, "stack")
+          if u != auto { return u }
+        }
+      }
+    }
+
+    if sys != none {
+      let gv = sys.at(param-key, default: auto)
+      if gv != auto {
+        let u = unroll(gv, "global")
+        if u != auto { return u }
+      }
+    }
+
+    // factory defaults (lowest priority)
+    let fv = deixis-factory-defaults.at(param-key, default: auto)
+    if fv != auto {
+      let u = unroll(fv, "factory")
+      if u != auto { return u }
+    }
+
+    return auto
+  }
+
+  let final-val = resolve-cascade()
+
+  if final-val == auto and param-key in deixis-auto-fallbacks {
+    final-val = deixis-auto-fallbacks.at(param-key)
+  }
+
+  // type & schema validation
+  if param-key in deixis-param-schema {
+    let allowed = deixis-param-schema.at(param-key)
+    let is-valid = allowed.any(a => if type(a) == type { type(final-val) == a } else { final-val == a })
+
+    if not is-valid {
+      panic(
+        "deixis: Invalid value '"
+          + repr(final-val)
+          + "' for parameter '"
+          + param-key
+          + "'.\nAllowed values/types are: "
+          + repr(allowed),
+      )
+    }
+  }
+
+  return final-val
+}
+
+#let _deixis-resolve-component-styles(sys, note-type, component: auto, ..args) = {
+  assert(args.pos().len() == 0)
+  let resolved = (:)
+  for (name, val) in args.named() {
+    let resolved-val = _deixis-resolve-typed-param(sys, val, name, note-type, component: component)
+    if name == "stroke" and resolved-val != none and resolved-val != auto {
+      let s-obj = std.stroke(resolved-val)
+      if s-obj.thickness == auto {
+        resolved-val = std.stroke(
+          cap: s-obj.cap,
+          dash: s-obj.dash,
+          join: s-obj.join,
+          miter-limit: s-obj.miter-limit,
+          paint: s-obj.paint,
+          thickness: 1pt,
+        )
+      } else { resolved-val = s-obj }
+    }
+    resolved.insert(name, resolved-val)
+  }
+
+  return resolved
+}
+
+#let _deixis-resolve-mark-styles = _deixis-resolve-component-styles.with(component: "mark")
+
+#let _deixis-resolve-body-styles = _deixis-resolve-component-styles.with(component: "body")
+
+#let _deixis-resolve-link-styles = _deixis-resolve-component-styles.with(component: "link")
+
+// Merges a base style dictionary with an override local style dictionary.
+// - non-auto values in `override` replace values in `base`.
+// - `auto` values in `override` fall back to `base`.
+// - Performs a deep merge for dictionaries to safely handle component-scoped arguments.
+#let _deixis-merge-styles(base, override, allowed-keys: auto) = {
+  let _is-allowed(k) = if type(allowed-keys) != array {
+    true
+  } else {
+    k in allowed-keys
+  }
+
+  let result = if type(base) == dictionary {
+    if type(allowed-keys) != array {
+      base
+    } else {
+      let filtered-base = (:)
+      for (k, v) in base {
+        if _is-allowed(k) {
+          filtered-base.insert(k, v)
+        }
+      }
+      filtered-base
+    }
+  } else { (:) }
+  if type(override) != dictionary { return result }
+
+  for (k, v) in override {
+    if not _is-allowed(k) {
+      continue
+    }
+    if v == auto {
+      if k not in base {
+        result.insert(k, auto)
+      }
+    } else if type(v) == dictionary and k in base and type(base.at(k)) == dictionary {
+      let merged-sub = base.at(k)
+      for (sub-k, sub-v) in v {
+        if sub-v != auto {
+          merged-sub.insert(sub-k, sub-v)
+        }
+      }
+      result.insert(k, merged-sub)
+    } else {
+      result.insert(k, v)
+    }
+  }
+
+  return result
+}

--- a/packages/preview/deixis/0.1.1/src/counter.typ
+++ b/packages/preview/deixis/0.1.1/src/counter.typ
@@ -1,0 +1,72 @@
+#import "core.typ": *
+
+/// Retrieves the current integer count of notes for a specific target block and series.
+///
+/// Because `deixis` relies on a custom state engine to track scoped notes, you cannot use Typst's native
+/// `counter()` function to read note counts. This function provides direct access to the internal engine.
+///
+/// Note: Because it queries the document state, this function must be called within a `context` block.
+///
+/// - target (int, label, str): The specific block or minipage to query. Defaults to `0` (the current block). Accepts a label/string ID, or a negative integer to query relative parent blocks.
+/// - series (str): The specific note series to query. Defaults to `"default"`.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// #context deixis-note-counter()
+/// ```
+///
+/// -> int
+#let deixis-note-counter(
+  /// The specific block or minipage to query. Defaults to `0` (the current block). Accepts a label/string ID, or a negative integer to query relative parent blocks.
+  /// -> int | label | str
+  target: 0,
+  /// The specific note series to query.
+  /// -> str
+  series: "default",
+) = {
+  _deixis-validate-target(target)
+  let sys = deixis-system.get()
+  let resolved = _deixis-resolve-target(sys, target)
+  sys.counters.at(resolved.count-id + ":" + series, default: 0)
+}
+
+/// Set or update the note counter for a specific target block and series.
+///
+/// This is highly useful for manually resetting note counts at the start of a new chapter or section
+/// if you are not using an automatic minipage wrapper. It modifies the internal `deixis` state dictionary.
+///
+/// - value (int, function): The new integer value for the counter. Alternatively, pass a function `(current-count) => int` to modify the count relative to its current value.
+/// - target (int, label, str): The specific block or minipage whose counter should be updated. Defaults to `0` (the current block). Accepts a label/string ID, or a negative integer for relative parent blocks.
+/// - series (str): The specific note series to update. Defaults to `"default"`.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// #deixis-update-note-counter(0)
+/// #context deixis-note-counter()
+/// ```
+///
+/// -> content
+#let deixis-update-note-counter(
+  /// The new integer value for the counter. Alternatively, pass a function `(current-count) => int` to modify the count relative to its current value.
+  /// -> int | function
+  value,
+  /// The specific block or minipage whose counter should be updated. Defaults to `0` (the current block). Accepts a label/string ID, or a negative integer for relative parent blocks.
+  /// -> int | label | str
+  target: 0,
+  /// The specific note series to update.
+  /// -> str
+  series: "default",
+) = {
+  context _deixis-check-setup-state()
+
+  _deixis-validate-target(target)
+  deixis-system.update(sys => {
+    let resolved = _deixis-resolve-target(sys, target)
+    let full-c-id = resolved.count-id + ":" + series
+    let current = sys.counters.at(full-c-id, default: 0)
+    let new-val = if type(value) == function { value(current) } else { int(value) }
+    let new-counters = sys.counters
+    new-counters.insert(full-c-id, new-val)
+    return (..sys, counters: new-counters)
+  })
+}

--- a/packages/preview/deixis/0.1.1/src/endnote.typ
+++ b/packages/preview/deixis/0.1.1/src/endnote.typ
@@ -1,0 +1,675 @@
+#import "core.typ": *
+#import "inline-note.typ": *
+#import "region-note.typ": *
+
+/// A standalone body content of an endnote.
+///
+/// The body of the endnote is completely invisible when declared.
+/// It is stored as metadata and will only be rendered when you explicitly call ```ref #deixis-print-endnotes()```.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// The abandoned cathedral was a monument to #deixis-inline-mark(id: <sciamachy>, series: "endnote")[sciamachy], its crumbling walls silent witnesses to a forgotten struggle.
+/// Within its hallowed nave, a single #deixis-inline-mark(id: <glabella>, series: "endnote")[glabella] on a marble statue caught the moonlight, the only smooth surface left untouched by the decay of time.
+///
+/// #deixis-endnote-body(id: <sciamachy>)[*Sciamachy:* A battle against an imaginary enemy; literally _shadow-fighting_.]
+/// #deixis-endnote-body(id: <glabella>)[*Glabella:* The smooth part of the forehead between the eyebrows and just above the nose.]
+/// ```
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// #deixis-print-endnotes()
+/// ```
+///
+/// ```memo
+/// It is noted that endnotes default to `series: "endnote"`.
+/// Hence, you should pass `series: "endnote"` to the decoupled mark or the body, or mind @deixis-print-endnotes.series when you print them.
+/// ```
+///
+/// - body (content): The actual text or content of the note.
+/// - id (none, str, label): A unique identifier linking this body to its corresponding mark.
+/// - target (auto, int, label, str): The specific block/minipage render context this note belongs to.
+/// - series (auto, str): The counter series this note belongs to.
+/// - label (none, label): An optional `label` to attach to the note.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning to the mark.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the endnote when printed.
+/// - ..args (arguments): Only accepts named arguments, which are forwarded to `container-func`.
+///
+/// -> content
+#let deixis-endnote-body(
+  /// The actual text or content of the note.
+  /// -> content
+  body,
+  /// A unique identifier linking this body to its corresponding mark.
+  /// -> none | str | label
+  id: none,
+  /// The specific block/minipage render context this note belongs to.
+  /// -> auto | int | label | str
+  target: auto,
+  /// The counter series this note belongs to.
+  /// -> auto | str
+  series: auto,
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+  /// Only accepts named arguments, which are forwarded to `container-func`.
+  /// -> arguments
+  ..args,
+) = {
+  if args.pos().len() > 0 { panic("deixis: #deixis-endnote-body accepts at most 1 positional argument [body].") }
+  let container-args = (stroke: stroke, fill: fill, radius: radius) + args.named()
+
+  let series = if series == auto { "endnote" } else { series }
+
+  let render-celibate(sys, celibate-id) = {
+    let body = deixis-utils._deixis-trim-content(body)
+    let resolved = _deixis-resolve-target(sys, target)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "endnote", ..container-args)
+
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "endnote")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "endnote")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "endnote")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "endnote")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "endnote")
+    let c-clearance = _deixis-resolve-typed-param(sys, auto, "clearance", "endnote")
+    let c-separator = _deixis-resolve-typed-param(sys, auto, "separator", "endnote")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "endnote")
+    let active-group-renderer = _deixis-resolve-typed-param(sys, auto, "render-group", "endnote")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "endnote")
+
+    let note-data = (
+      internal-id: celibate-id,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: none,
+      marker-str: none,
+      body: body,
+      mark-lbl: none,
+      body-lbl: none,
+      label: label,
+      mark-marker-style: auto,
+      body-marker-style: auto,
+      body-style: c-body-style,
+      backlink: c-backlink,
+      indent: c-indent,
+      gap: c-gap,
+      marker-gap: c-marker-gap,
+      clearance: c-clearance,
+      separator: c-separator,
+      styles: b-styles,
+      render-single: active-renderer,
+      render-group: active-group-renderer,
+      container-func: active-container,
+    )
+
+    [#metadata(note-data)<deixis-endnote>]
+  }
+
+  if id == none {
+    return [
+      #std.counter("deixis-celibate-note").step()
+      #context {
+        _deixis-check-setup-state()
+        render-celibate(deixis-system.get(), "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      }
+    ]
+  }
+
+  let state-updater = deixis-system.update(sys => {
+    let current-target-uid = if id == deixis-auto-id {
+      sys.at("last-auto-uid", default: none)
+    } else {
+      sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+
+    if current-target-uid == none { return sys }
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-label-index = sys.at("label-index", default: (:))
+
+    let payload = new-notes.at(current-target-uid)
+    payload.insert("body-type", "endnote")
+    payload.insert("body", body)
+    new-notes.insert(current-target-uid, payload)
+
+    if label != none {
+      let lbl-str = if type(label) == str { label } else { str(label) }
+      if lbl-str in new-label-index and new-label-index.at(lbl-str) != current-target-uid {
+        panic("deixis: Duplicate note label detected: '" + lbl-str + "'.")
+      }
+      new-label-index.insert(lbl-str, current-target-uid)
+    }
+
+    return (..sys, notes: new-notes, label-index: new-label-index)
+  })
+
+  state-updater
+  context {
+    _deixis-check-setup-state()
+    let body = deixis-utils._deixis-trim-content(body)
+
+    let sys = deixis-system.get()
+    let final-sys = deixis-system.final()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      final-sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    let reg = if target-uid != none { final-sys.at("notes", default: (:)).at(target-uid, default: none) } else { none }
+
+    if reg == none {
+      return [
+        #std.counter("deixis-celibate-note").step()
+        #render-celibate(sys, "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      ]
+    }
+
+    let internal-id = reg.internal-id
+    let resolved = _deixis-resolve-target(sys, if target == auto { reg.at("target-id", default: 0) } else { target })
+
+    let series = reg.at("series", default: series)
+    let count = reg.count
+    let marker-str = _deixis-query-marker-str(reg)
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let saved-styles = reg.at("styles", default: (:))
+    let merged-styles = _deixis-merge-styles(saved-styles, container-args)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "endnote", ..merged-styles)
+
+    let mark-marker-style = _deixis-resolve-typed-param(sys, marker-style, "marker-style", "endnote", component: "mark")
+    let body-marker-style = _deixis-resolve-typed-param(sys, marker-style, "marker-style", "endnote", component: "body")
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "endnote")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "endnote")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "endnote")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "endnote")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "endnote")
+    let c-clearance = _deixis-resolve-typed-param(sys, auto, "clearance", "endnote")
+    let c-separator = _deixis-resolve-typed-param(sys, auto, "separator", "endnote")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "endnote")
+    let active-group-renderer = _deixis-resolve-typed-param(sys, auto, "render-group", "endnote")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "endnote")
+
+    let note-data = (
+      internal-id: internal-id,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: count,
+      marker-str: marker-str,
+      body: body,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+      label: label,
+      mark-marker-style: mark-marker-style,
+      body-marker-style: body-marker-style,
+      body-style: c-body-style,
+      backlink: c-backlink,
+      indent: c-indent,
+      gap: c-gap,
+      marker-gap: c-marker-gap,
+      clearance: c-clearance,
+      separator: c-separator,
+      container-func: active-container,
+      styles: b-styles,
+      render-single: active-renderer,
+      render-group: active-group-renderer,
+    )
+
+    [#metadata(note-data)<deixis-endnote>]
+  }
+}
+
+/// A wrapper for generating endnotes.
+///
+/// This function creates a mark in the text and delegates the body to ```ref #deixis-endnote-body```.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// The botanist spent years searching for the idiosyncratic
+/// #deixis-endnote[*Idiosyncratic:* Something peculiar or individual to a specific person, place, or thing.]
+/// wildflower that only bloomed in the valley’s deepest shadows.
+/// As the sun dipped below the horizon, the forest floor began to glow with a soft bioluminescence
+/// #deixis-endnote[*Bioluminescence:* The production and emission of light by a living organism.]
+/// that guided her back to camp.
+/// ```
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// #deixis-print-endnotes()
+/// ```
+///
+/// See ```ref #deixis-print-endnotes```.
+///
+/// - ..args (arguments): Accepts up to two positional arguments: `[mark][body]`. All named arguments are forwarded to `container-func`.
+/// - mark-type (auto, str): The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+/// - id (none, str, label): A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+/// - numbering (auto, str, function): The numbering style for the endnote marker.
+/// - marker (auto, content): A hardcoded marker override.
+/// - target (int, label, str): The specific block/minipage counter this note belongs to.
+/// - series (str): The counter series this note belongs to. Defaults to `"endnote"`.
+/// - label (none, label): An optional `label` to attach to the note.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - marker-position (auto, alignment, dictionary): Mark marker placement.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+/// - pins (array): Array of pin names for the region mark.
+/// - padding (auto, length, str): Internal padding for the region mark.
+/// - region-shape (auto, function): Shape drawing function for the region mark.
+/// - layer (auto, str): Rendering layer for the region mark. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - inline (bool): If `true`, force the region mark into an inline box.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - container-func (auto, function): A custom container wrapper for the endnote when printed.
+///
+/// -> content
+#let deixis-endnote(
+  /// Accepts up to two positional arguments: `[mark][body]`.
+  /// All named arguments are forwarded to ```ref #deixis-footnote-body```.
+  /// -> arguments
+  ..args,
+  /// The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+  /// -> auto | str
+  mark-type: auto,
+  /// A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+  /// -> none | str | label
+  id: none,
+  /// The numbering style for the marker.
+  /// -> auto | str | function
+  numbering: auto,
+  /// A hardcoded marker override.
+  /// -> auto | content
+  marker: auto,
+  /// The specific block/minipage counter this note belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this note belongs to.
+  ///
+  /// ```info
+  /// Note that endnotes belong to the `"endnote"` series by default, while all other note functions belong to the `"default"` series.
+  /// ```
+  ///
+  /// -> str
+  series: "endnote",
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Mark marker placement.
+  ///
+  /// See @deixis-inline-mark.marker-position and @deixis-region-mark.marker-position.
+  ///
+  /// -> auto | alignment | dictionary
+  marker-position: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+  ///
+  /// See @deixis-inline-mark.inline-mode.
+  ///
+  /// -> auto | str
+  inline-mode: auto,
+  /// Array of pin names for the region mark.
+  ///
+  /// See @deixis-region-mark.pins.
+  ///
+  /// -> array
+  pins: (),
+  /// Internal padding for the region mark.
+  ///
+  /// See @deixis-region-mark.padding.
+  ///
+  /// -> auto | length | str | dictionary
+  padding: auto,
+  /// Shape drawing function for the region mark.
+  ///
+  /// See @deixis-region-mark.region-shape.
+  ///
+  /// -> auto | function
+  region-shape: auto,
+  /// Rendering layer for the region mark. Choices: `"flow"` | `"foreground"` | `"background"`.
+  ///
+  /// See @deixis-region-mark.layer.
+  ///
+  /// -> auto | str
+  layer: auto,
+  /// If `true`, force the region mark into an inline box.
+  ///
+  /// See @deixis-region-mark.inline.
+  ///
+  /// -> bool
+  inline: false,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+) = {
+  let pos = args.pos()
+  if pos.len() > 2 { panic("deixis: #deixis-endnote accepts at most 2 positional arguments: [mark][body]") }
+  let mark-content = if pos.len() > 1 { pos.first() } else { none }
+  let body = if pos.len() > 0 { pos.last() } else { none }
+
+  let mark-type = _deixis-resolve-mark-type(mark-type, pins: pins)
+
+  if id != none {
+    return deixis-endnote-body(
+      body,
+      id: id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      backlink: backlink,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let render-mark(target-id) = {
+    if mark-type == "region" {
+      deixis-region-mark(
+        mark-content,
+        id: target-id,
+        pins: pins,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+        padding: padding,
+        region-shape: region-shape,
+        layer: layer,
+        inline: inline,
+      )
+    } else if mark-type == "phantom" {
+      deixis-phantom-mark(
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+      )
+    } else {
+      deixis-inline-mark(
+        mark-content,
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        inline-mode: inline-mode,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+      )
+    }
+  }
+
+  let render-body(target-id) = {
+    deixis-endnote-body(
+      body,
+      id: target-id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      backlink: backlink,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let m = render-mark(deixis-auto-id)
+  let b = render-body(deixis-auto-id)
+
+  let is-block-region = mark-type == "region" and inline == false
+  if is-block-region {
+    [#m#place(b)]
+  } else {
+    [#m#b]
+  }
+}
+
+#let deixis-printed-endnotes-state = std.state("deixis-printed-endnotes", (:))
+
+/// Renders a collected list of endnote bodies at the current location in the document.
+///
+/// This function queries the `deixis` state engine for all endnotes matching the specified target
+/// and series, and prints them in a formatted list. It supports extensive spatial filtering, allowing
+/// you to print endnotes specifically for a single chapter or section.
+///
+/// ````info
+/// Note bodies cannot be printed twice.
+/// `deixis-print-endnotes` keeps track of what was printed to avoid duplication.
+/// ```example
+/// //| sandbox-mode: "page"
+/// #deixis-print-endnotes()
+/// ```
+/// ````
+///
+/// - target (int, label, str): The specific block/minipage target to pull notes from.
+/// - series (auto, str, array): Filters to notes belonging to a specific series or array of series.
+/// - after (none, location, label, str): Only prints notes that appear *after* this location, label, or `<deixis-pin>` name.
+/// - before (none, location, label, str): Only prints notes that appear *before* this location, label, or `<deixis-pin>` name.
+/// - marker-style (auto, function): Overrides the marker style for the printed list.
+/// - body-style (auto, function): Overrides the text styling of the printed bodies.
+/// - backlink (auto, bool, str): Overrides the backlink generation setting for these notes. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - separator (auto, content, none): An optional separator to draw between the list of notes (e.g., a line).
+/// - clearance (auto, length): The spacing before the list of endnotes begins.
+/// - gap (auto, length): The vertical spacing between individual endnotes.
+/// - marker-gap (auto, length): The horizontal spacing between the endnote number and its text body.
+/// - indent (auto, length): Overrides the indentation applied to the note body.
+/// - render-single (auto, function): A custom rendering function `(note-data) => content` to override the local `render-single`.
+/// - render-group (auto, function): A custom rendering function `(notes-array) => content` to override the local `render-group`.
+/// - container-func (auto, function): A custom container wrapper for the entire printed block.
+///
+/// -> content
+#let deixis-print-endnotes(
+  /// The specific block/minipage target to pull notes from.
+  /// -> int | label | str
+  target: 0,
+  /// Filters to notes belonging to a specific series or array of series.
+  /// -> auto | str | array
+  series: auto,
+  /// Only prints notes that appear *after* this location, label, or `<deixis-pin>` name.
+  /// -> none | location | label | str
+  after: none,
+  /// Only prints notes that appear *before* this location, label, or `<deixis-pin>` name.
+  /// -> none | location | label | str
+  before: none,
+  /// Overrides the marker style for the printed list.
+  /// -> auto | function
+  marker-style: auto,
+  /// Overrides the text styling of the printed bodies.
+  /// -> auto | function
+  body-style: auto,
+  /// Overrides the backlink generation setting for these notes. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// An optional separator to draw between the list of notes (e.g., a line).
+  /// -> auto | content | none
+  separator: auto,
+  /// The spacing before the list of endnotes begins.
+  /// -> auto | length
+  clearance: auto,
+  /// The vertical spacing between individual endnotes.
+  /// -> auto | length
+  gap: auto,
+  /// The horizontal spacing between the endnote number and its text body.
+  /// -> auto | length
+  marker-gap: auto,
+  /// Overrides the indentation applied to the note body.
+  /// -> auto | length
+  indent: auto,
+  /// A custom rendering function `(note-data) => content` to override the local `render-single`.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom rendering function `(notes-array) => content` to override the local `render-group`.
+  /// -> auto | function
+  render-group: auto,
+  /// A custom container wrapper for the entire printed block.
+  /// -> auto | function
+  container-func: auto,
+) = context {
+  _deixis-check-setup-state()
+
+  let sys = deixis-system.get()
+  let resolved = _deixis-resolve-target(sys, target)
+
+  let printed-dict = deixis-printed-endnotes-state.get()
+  let already-printed = printed-dict.at(resolved.render-id, default: ())
+
+  let resolve-bound(b-val, b-name) = {
+    if b-val == none { return none }
+    if type(b-val) == location { return b-val }
+
+    if type(b-val) == str {
+      let pins = query(<deixis-pin>).filter(p => p.value.at("name", default: "") == b-val)
+      if pins.len() == 0 {
+        panic("deixis: Could not find pin named '" + b-val + "' for parameter '" + b-name + "'. Check your spelling!")
+      }
+      return pins.first().location()
+    } else {
+      let elems = query(b-val)
+      if elems.len() == 0 {
+        panic(
+          "deixis: Could not find target matching '"
+            + repr(b-val)
+            + "' for parameter '"
+            + b-name
+            + "'. Make sure the label/selector exists in the document.",
+        )
+      }
+      return elems.first().location()
+    }
+  }
+
+  let loc-after = resolve-bound(after, "after")
+  let loc-before = resolve-bound(before, "before")
+
+  let q-sel = selector(<deixis-endnote>)
+  if loc-after != none { q-sel = q-sel.after(loc-after) }
+
+  let actual-before = if loc-before != none { loc-before } else { here() }
+  q-sel = q-sel.before(actual-before)
+
+  let notes = query(q-sel)
+    .map(x => x.value)
+    .filter(x => x.target-id == resolved.render-id and x.internal-id not in already-printed)
+    .filter(x => {
+      if series == auto { return true }
+      if type(series) == array { return x.series in series }
+      return x.series == series
+    })
+
+  if notes.len() > 0 {
+    let first-note = notes.first()
+
+    let overrides = (:)
+    if marker-style != auto {
+      let body-marker-style = _deixis-resolve-typed-param(
+        sys,
+        marker-style,
+        "body-marker-style",
+        "endnote",
+        component: "body",
+      )
+      if body-marker-style != auto { overrides.insert("body-marker-style", body-marker-style) }
+    }
+    if body-style != auto { overrides.insert("body-style", body-style) }
+    if backlink != auto { overrides.insert("backlink", backlink) }
+    if indent != auto { overrides.insert("indent", indent) }
+    if marker-gap != auto { overrides.insert("marker-gap", marker-gap) }
+    if render-single != auto { overrides.insert("render-single", render-single) }
+    if container-func != auto { overrides.insert("container-func", container-func) }
+
+    let final-notes = notes.map(n => {
+      let original-body = n.body
+      n.insert("body-type", "endnote")
+      n.body = [#metadata(n)<deixis-rendered-start>#original-body#metadata(n)<deixis-rendered-end>]
+
+      for (k, v) in overrides { n.insert(k, v) }
+      n
+    })
+
+    let final-gap = if gap != auto { gap } else { first-note.at("gap", default: 0.5em) }
+    let final-separator = if separator != auto { separator } else { first-note.at("separator", default: none) }
+    let final-clearance = if clearance != auto { clearance } else { first-note.at("clearance", default: 1em) }
+    let final-render-group = if render-group != auto { render-group } else {
+      first-note.at("render-group", default: auto)
+    }
+    if final-render-group == auto {
+      final-render-group = _deixis-resolve-typed-param(sys, auto, "render-group", "endnote")
+    }
+
+    deixis-group-layout(
+      final-notes,
+      separator: final-separator,
+      clearance: final-clearance,
+      gap: final-gap,
+      render-group: final-render-group,
+    )
+
+    deixis-printed-endnotes-state.update(old => {
+      let cur = old.at(resolved.render-id, default: ())
+      for n in notes { cur.push(n.internal-id) }
+      old.insert(resolved.render-id, cur)
+      old
+    })
+  }
+}

--- a/packages/preview/deixis/0.1.1/src/footnote.typ
+++ b/packages/preview/deixis/0.1.1/src/footnote.typ
@@ -1,0 +1,613 @@
+#import "core.typ": *
+#import "inline-note.typ": *
+#import "region-note.typ": *
+
+/// A standalone body content of a footnote.
+///
+/// The body of the footnote is rendered at the bottom of the page or minipage.
+///
+/// ```info
+/// Since footnotes can interfere with the main layout, there is no easy way to implement a non-native footnote function.
+/// This _hacky_ function internally calls `#std.footnote` if the note is page-lavel.
+/// ```
+///
+/// ```example
+/// The evening sky was painted in a deep, haunting
+/// #deixis-inline-mark(id: <smalt>)[smalt]
+/// that made the first stars appear like diamonds on velvet.
+///
+/// #deixis-footnote-body(id: <smalt>)[A deep blue pigment made from powdered glass colored with cobalt oxide.]
+/// ```
+///
+/// - body (content): The actual text or content of the note.
+/// - id (none, str, label): A unique identifier linking this body to its corresponding mark.
+/// - target (auto, int, label, str): The specific block/minipage render context this note belongs to.
+/// - series (auto, str): The counter series this note belongs to.
+/// - label (none, label): An optional `label` to attach to the rendered body.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+/// - ..args (arguments): Only accepts named arguments, which are forwarded to `container-func`.
+///
+/// -> content
+#let deixis-footnote-body(
+  /// The actual text or content of the note.
+  /// -> content
+  body,
+  /// A unique identifier linking this body to its corresponding mark.
+  /// -> none | str | label
+  id: none,
+  /// The specific block/minipage render context this note belongs to.
+  /// -> auto | int | label | str
+  target: auto,
+  /// The counter series this note belongs to.
+  /// -> auto | str
+  series: auto,
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+  /// Only accepts named arguments, which are forwarded to `container-func`.
+  /// -> arguments
+  ..args,
+) = {
+  if args.pos().len() > 0 { panic("deixis: #deixis-footnote-body accepts at most 1 positional argument [body].") }
+  let container-args = (stroke: stroke, fill: fill, radius: radius) + args.named()
+
+  let series = if series == auto { "default" } else { series }
+
+  let render-celibate(sys, celibate-id) = {
+    let body = deixis-utils._deixis-trim-content(body)
+    let resolved = _deixis-resolve-target(sys, target)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "footnote", ..container-args)
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "footnote")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "footnote")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "footnote")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "footnote")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "footnote")
+    let c-separator = _deixis-resolve-typed-param(sys, auto, "separator", "footnote")
+    let c-clearance = _deixis-resolve-typed-param(sys, auto, "clearance", "footnote")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "footnote")
+    let active-group-renderer = _deixis-resolve-typed-param(sys, auto, "render-group", "footnote")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "footnote")
+
+    let note-data = (
+      internal-id: celibate-id,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: none,
+      marker-str: none,
+      mark-lbl: none,
+      body-lbl: none,
+      label: label,
+      body: body,
+      mark-marker-style: auto,
+      body-marker-style: auto,
+      body-style: c-body-style,
+      backlink: c-backlink,
+      indent: c-indent,
+      gap: c-gap,
+      marker-gap: c-marker-gap,
+      separator: c-separator,
+      clearance: c-clearance,
+      render-single: active-renderer,
+      container-func: active-container,
+      styles: b-styles,
+      render-group: active-group-renderer,
+    )
+
+    let target-is-page = resolved.render-id == "page"
+    let page-engine-active = sys.at("override-page-footnotes", default: true)
+    let use-reserver = target-is-page and page-engine-active
+
+    let c-size = text.size
+    let c-font = text.font
+    let c-weight = text.weight
+    let c-style = text.style
+    let c-leading = par.leading
+    let c-spacing = par.spacing
+    let c-justify = par.justify
+
+    let meta = [#metadata(note-data)<deixis-footnote>]
+    if target-is-page {
+      let exact-rendered = active-renderer(note-data + (disable-links: use-reserver), gap: c-gap)
+
+      let reserver = {
+        let freeze = counter(std.footnote).update(n => n - 1)
+        set footnote.entry(clearance: 0pt, separator: none)
+
+        let r-body = block(width: 100%, above: 0pt, below: 0pt, spacing: 0pt)[
+          #if use-reserver {
+            place(left, [#metadata(note-data)<deixis-reserver-left>])
+          }
+          #if use-reserver {
+            place(right, [#metadata(none)<deixis-reserver-right>])
+          }
+          #set text(size: c-size, font: c-font, weight: c-weight, style: c-style)
+          #set par(leading: c-leading, spacing: c-spacing, justify: c-justify)
+          #if use-reserver { hide(exact-rendered) } else { exact-rendered }
+        ]
+        box(width: 0pt, hide(std.footnote(r-body, numbering: _ => none)) + freeze)
+      }
+      [#meta#reserver]
+    } else {
+      [#meta]
+    }
+  }
+
+  if id == none {
+    return [
+      #std.counter("deixis-celibate-note").step()
+      #context {
+        _deixis-check-setup-state()
+        render-celibate(deixis-system.get(), "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      }
+    ]
+  }
+
+  let state-updater = deixis-system.update(sys => {
+    let current-target-uid = if id == deixis-auto-id {
+      sys.at("last-auto-uid", default: none)
+    } else {
+      sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+
+    if current-target-uid == none { return sys }
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-label-index = sys.at("label-index", default: (:))
+
+    let payload = new-notes.at(current-target-uid)
+    payload.insert("body-type", "footnote")
+    payload.insert("body", body)
+    new-notes.insert(current-target-uid, payload)
+
+    if label != none {
+      let lbl-str = if type(label) == str { label } else { str(label) }
+      if lbl-str in new-label-index and new-label-index.at(lbl-str) != current-target-uid {
+        panic("deixis: Duplicate note label detected: '" + lbl-str + "'.")
+      }
+      new-label-index.insert(lbl-str, current-target-uid)
+    }
+
+    return (..sys, notes: new-notes, label-index: new-label-index)
+  })
+
+  state-updater
+  context {
+    _deixis-check-setup-state()
+    let body = deixis-utils._deixis-trim-content(body)
+
+    let sys = deixis-system.get()
+    let final-sys = deixis-system.final()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      final-sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    let reg = if target-uid != none { final-sys.at("notes", default: (:)).at(target-uid, default: none) } else { none }
+
+    if reg == none {
+      return [
+        #std.counter("deixis-celibate-note").step()
+        #render-celibate(sys, "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      ]
+    }
+
+    let internal-id = reg.internal-id
+    let resolved = _deixis-resolve-target(sys, if target == auto { reg.at("target-id", default: 0) } else { target })
+
+    let series = reg.at("series", default: series)
+    let count = reg.count
+    let marker-str = _deixis-query-marker-str(reg)
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let page-engine-active = sys.at("override-page-footnotes", default: true)
+    let target-is-page = resolved.render-id == "page"
+    let use-reserver = target-is-page and page-engine-active
+
+    let saved-styles = reg.at("styles", default: (:))
+    let merged-styles = _deixis-merge-styles(saved-styles, container-args)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "footnote", ..merged-styles)
+
+    let mark-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "footnote",
+      component: "mark",
+    )
+    let body-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "footnote",
+      component: "body",
+    )
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "footnote")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "footnote")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "footnote")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "footnote")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "footnote")
+    let c-separator = _deixis-resolve-typed-param(sys, auto, "separator", "footnote")
+    let c-clearance = _deixis-resolve-typed-param(sys, auto, "clearance", "footnote")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "footnote")
+    let active-group-renderer = _deixis-resolve-typed-param(sys, auto, "render-group", "footnote")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "footnote")
+
+    let note-data = (
+      internal-id: internal-id,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: count,
+      marker-str: marker-str,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+      label: label,
+      body: body,
+      mark-marker-style: mark-marker-style,
+      body-marker-style: body-marker-style,
+      body-style: c-body-style,
+      backlink: c-backlink,
+      indent: c-indent,
+      gap: c-gap,
+      marker-gap: c-marker-gap,
+      separator: c-separator,
+      clearance: c-clearance,
+      render-single: active-renderer,
+      container-func: active-container,
+      styles: b-styles,
+      render-group: active-group-renderer,
+    )
+
+    let meta = [#metadata(note-data)<deixis-footnote>]
+    if target-is-page {
+      let c-size = text.size
+      let c-leading = par.leading
+      let c-spacing = par.spacing
+      let c-justify = par.justify
+
+      let exact-rendered = active-renderer(note-data + (disable-links: use-reserver), gap: c-gap)
+
+      let reserver = {
+        let freeze = counter(std.footnote).update(n => n - 1)
+        set footnote.entry(clearance: 0pt, separator: none)
+
+        let r-body = block(width: 100%, above: 0pt, below: 0pt, spacing: 0pt)[
+          #if use-reserver { place(left, [#metadata(note-data)<deixis-reserver-left>]) }
+          #if use-reserver { place(right, [#metadata(none)<deixis-reserver-right>]) }
+          #set text(size: c-size)
+          #set par(leading: c-leading, spacing: c-spacing, justify: c-justify)
+          #if use-reserver { hide(exact-rendered) } else { exact-rendered }
+        ]
+
+        box(width: 0pt, hide(std.footnote(r-body, numbering: _ => none)) + freeze)
+      }
+
+      [#meta#reserver]
+    } else {
+      [#meta]
+    }
+  }
+}
+
+/// A wrapper for generating footnotes.
+///
+/// This function creates a mark in the text and delegates the body to ```ref #deixis-footnote-body```.
+///
+/// ```example
+/// The library’s atmosphere was defined by a subtle
+/// #deixis-footnote[bibliosmia][The smell of old books.]
+/// that seemed to settle on the skin like a light dust.
+/// ```
+///
+/// - ..args (arguments): Accepts up to two positional arguments: `[mark][body]`. All named arguments are forwarded to ```ref #deixis-footnote-body```.
+/// - mark-type (auto, str): The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+/// - id (none, str, label): A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+/// - numbering (auto, str, function): The numbering style for the footnote marker.
+/// - marker (auto, content): A hardcoded marker to use instead of the automatic counter.
+/// - target (int, label, str): The specific block/minipage counter this note belongs to.
+/// - series (str): The counter series this note belongs to. Defaults to `"default"`.
+/// - label (none, label): An optional `label` to attach to the rendered body.
+/// - marker-style (auto, function): A custom styling function `(string) => content` for the footnote marker.
+/// - marker-position (auto, alignment, dictionary): Mark marker placement.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+/// - pins (array): Array of pin names for the region mark.
+/// - padding (auto, length, str): Internal padding for the region mark.
+/// - region-shape (auto, function): Shape drawing function for the region mark.
+/// - layer (auto, str): Rendering layer for the region mark. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - inline (bool): If `true`, force the region mark into an inline box.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+///
+/// -> content
+#let deixis-footnote(
+  /// Accepts up to two positional arguments: `[mark][body]`.
+  /// All named arguments are forwarded to ```ref #deixis-footnote-body```.
+  /// -> arguments
+  ..args,
+  /// The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+  /// -> auto | str
+  mark-type: auto,
+  /// A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+  /// -> none | str | label
+  id: none,
+  /// The numbering style for the marker.
+  /// -> auto | str | function
+  numbering: auto,
+  /// A hardcoded marker override.
+  /// -> auto | content
+  marker: auto,
+  /// The specific block/minipage counter this note belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this note belongs to.
+  /// -> str
+  series: "default",
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Mark marker placement.
+  ///
+  /// See @deixis-inline-mark.marker-position and @deixis-region-mark.marker-position.
+  ///
+  /// -> auto | alignment | dictionary
+  marker-position: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+  ///
+  /// See @deixis-inline-mark.inline-mode.
+  ///
+  /// -> auto | str
+  inline-mode: auto,
+  /// Array of pin names for the region mark.
+  ///
+  /// See @deixis-region-mark.pins.
+  ///
+  /// -> array
+  pins: (),
+  /// Internal padding for the region mark.
+  ///
+  /// See @deixis-region-mark.padding.
+  ///
+  /// -> auto | length | str | dictionary
+  padding: auto,
+  /// Shape drawing function for the region mark.
+  ///
+  /// See @deixis-region-mark.region-shape.
+  ///
+  /// -> auto | function
+  region-shape: auto,
+  /// Rendering layer for the region mark. Choices: `"flow"` | `"foreground"` | `"background"`.
+  ///
+  /// See @deixis-region-mark.layer.
+  ///
+  /// -> auto | str
+  layer: auto,
+  /// If `true`, force the region mark into an inline box.
+  ///
+  /// See @deixis-region-mark.inline.
+  ///
+  /// -> bool
+  inline: false,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+) = {
+  let pos = args.pos()
+  if pos.len() > 2 { panic("deixis: #deixis-footnote accepts at most 2 positional arguments: [mark][body]") }
+  let mark-content = if pos.len() > 1 { pos.first() } else { none }
+  let body = if pos.len() > 0 { pos.last() } else { none }
+
+  let mark-type = _deixis-resolve-mark-type(mark-type, pins: pins)
+
+  if id != none {
+    return deixis-footnote-body(
+      body,
+      id: id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      backlink: backlink,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      render-single: render-single,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let render-mark(target-id) = {
+    if mark-type == "region" {
+      deixis-region-mark(
+        mark-content,
+        id: target-id,
+        pins: pins,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+        padding: padding,
+        region-shape: region-shape,
+        layer: layer,
+        inline: inline,
+      )
+    } else if mark-type == "phantom" {
+      deixis-phantom-mark(
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+      )
+    } else {
+      deixis-inline-mark(
+        mark-content,
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        inline-mode: inline-mode,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+      )
+    }
+  }
+
+  let render-body(target-id) = {
+    deixis-footnote-body(
+      body,
+      id: target-id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      backlink: backlink,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      render-single: render-single,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let m = render-mark(deixis-auto-id)
+  let b = render-body(deixis-auto-id)
+
+  let is-block-region = mark-type == "region" and inline == false
+  if is-block-region {
+    [#m#place(b)]
+  } else {
+    [#m#b]
+  }
+}
+
+// Footnote overlay
+#let _deixis-page-footnotes-overlay() = context {
+  let current-page = here().page()
+  let left-probes = query(<deixis-reserver-left>).filter(n => n.location().page() == current-page)
+  let right-probes = query(<deixis-reserver-right>).filter(n => n.location().page() == current-page)
+
+  if left-probes.len() == 0 { return }
+
+  let columns = (:)
+  for (i, probe) in left-probes.enumerate() {
+    let x-key = str(calc.round(probe.location().position().x.pt(), digits: 1))
+    let arr = columns.at(x-key, default: ())
+    arr.push((left: probe, right: right-probes.at(i)))
+    columns.insert(x-key, arr)
+  }
+
+  for (x-key, probes-in-col) in columns {
+    let first-probe = probes-in-col.first().left
+    let start-x = first-probe.location().position().x
+    let start-y = first-probe.location().position().y
+
+    let col-width = probes-in-col.first().right.location().position().x - start-x
+
+    let col-notes-data = ()
+    let seen = ()
+    for p in probes-in-col {
+      let k = str(p.left.value.internal-id)
+      if k not in seen {
+        seen.push(k)
+        col-notes-data.push(p.left.value)
+      }
+    }
+
+    let first-note = col-notes-data.first()
+    let active-group-renderer = first-note.render-group
+    let c-gap = first-note.gap
+    let c-clearance = first-note.clearance
+    let c-separator = first-note.separator
+
+    place(
+      top + left,
+      dx: start-x,
+      dy: start-y,
+      block(width: col-width, {
+        if c-separator != none {
+          let sep-block = block(width: col-width, c-separator)
+          let sep-h = measure(sep-block).height
+          place(top + left, dy: -c-gap - sep-h, sep-block)
+        }
+
+        let unique-series = ()
+        for data in col-notes-data {
+          let s = data.at("series", default: "default")
+          if s not in unique-series { unique-series.push(s) }
+        }
+
+        for (i, current-series) in unique-series.enumerate() {
+          let series-notes = col-notes-data.filter(n => n.at("series", default: "default") == current-series)
+          // For now, page-level footnotes can/should only use the gap of the first note
+          active-group-renderer(series-notes, gap: c-gap)
+        }
+      }),
+    )
+  }
+}

--- a/packages/preview/deixis/0.1.1/src/inline-note.typ
+++ b/packages/preview/deixis/0.1.1/src/inline-note.typ
@@ -1,0 +1,789 @@
+#import "core.typ": *
+
+// Internal inline mark renderer
+#let _deixis-inline-mark(
+  body,
+  marker-style: it => super(it),
+  marker-position: auto,
+  inline-mode: auto,
+  stroke: auto,
+  fill: auto,
+  radius: auto,
+  marker-str: none,
+  mark-lbl: none,
+  body-lbl: none,
+) = context {
+  _deixis-check-setup-state()
+
+  let render-formatting(content) = {
+    if content == none { return none }
+
+    if inline-mode == "text-fill" {
+      return text(fill: stroke.paint, content)
+    }
+
+    let _underline(it, stroke: auto, ..args) = if stroke != none { std.underline(it, stroke: stroke, ..args) } else {
+      it
+    }
+
+    let new-body = content
+    if inline-mode not in ("none", none) {
+      let padding = text-padding
+      padding.x *= 2
+      if inline-mode in ("box", "underline") { new-body = _underline(stroke: stroke, offset: padding.bottom, new-body) }
+      if fill not in (auto, none) {
+        new-body = highlight(new-body, fill: fill, radius: if inline-mode not in ("box", "parentheses") {
+          radius
+        } else { 0pt })
+      }
+      let cap-line(side) = box(
+        height: 0pt,
+        width: padding.x,
+        outset: (bottom: padding.bottom, top: padding.top),
+        stroke: (rest: stroke, (if side == left { "right" } else { "left" }): none),
+        fill: fill,
+        radius: (repr(side): radius),
+      )
+      if inline-mode == "box" {
+        new-body = _underline(stroke: stroke, offset: -padding.top, [#cap-line(left)#new-body#cap-line(right)])
+      } else if inline-mode == "parentheses" {
+        new-body = [#cap-line(left)#new-body#cap-line(right)]
+      }
+    }
+    return new-body
+  }
+
+  let safe-lbl = if mark-lbl != none { [#metadata(none)#mark-lbl] } else { none }
+
+  let inline-marker = if mark-lbl != none and body-lbl != none {
+    if marker-str == none {
+      [#safe-lbl]
+    } else {
+      let body-exists = query(selector(body-lbl)).len() > 0
+      let raw-m = marker-style(marker-str)
+      if body-exists {
+        [#safe-lbl#std.link(body-lbl, raw-m)]
+      } else {
+        [#safe-lbl#raw-m]
+      }
+    }
+  } else {
+    none
+  }
+
+  let is-left = marker-position in ("left", left)
+  if body == none {
+    let glue = [#h(0pt, weak: true)#sym.wj]
+    if inline-marker != none {
+      return [#glue#inline-marker]
+    } else {
+      return [#glue]
+    }
+  } else {
+    let combined-body = if inline-marker != none {
+      if is-left { [#inline-marker#body] } else { [#body#inline-marker] }
+    } else { body }
+
+    return render-formatting(combined-body)
+  }
+}
+
+/// A standalone body content of an inline note.
+///
+/// ```example
+/// The garden was filled with the
+/// #deixis-inline-mark(id: <apricity>)[apricity]
+/// of a pale winter sun.
+///
+/// #deixis-inline-note-body(
+///   id: <apricity>,
+///   stroke: maroon,
+///   fill: maroon.transparentize(95%),
+/// )[
+///   *Apricity:* The warmth of the sun in winter.
+/// ]
+/// ```
+///
+/// - body (content): The actual text or content of the note.
+/// - id (none, str, label): A unique identifier linking this body to its corresponding mark.
+/// - target (auto, int, label, str): The specific block/minipage render context this note belongs to.
+/// - series (auto, str): The counter series this note belongs to.
+/// - label (none, label): An optional `label` to attach to the rendered body block.
+/// - marker-style (auto, function): A custom styling function `(string) => content` for the number/marker.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`. Only used when `inline: true`.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - inline (bool): If `true`, the body is rendered as if it is ```ref #deixis-inline-mark```.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+/// - ..args (arguments): Only accepts named arguments, which are forwarded to `container-func`.
+///
+/// -> content
+#let deixis-inline-note-body(
+  /// The actual text or content of the note.
+  /// -> content
+  body,
+  /// A unique identifier linking this body to its corresponding mark.
+  /// -> none | str | label
+  id: none,
+  /// The specific block/minipage render context this note belongs to.
+  /// -> auto | int | label | str
+  target: auto,
+  /// The counter series this note belongs to.
+  /// -> auto | str
+  series: auto,
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function `(string) => content` for the number/marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`. Only used when `inline: true`.
+  /// -> auto | str
+  inline-mode: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// If `true`, the body is rendered as if it is @deixis-inline-mark.
+  ///
+  /// ```example
+  /// The city streets were filled with the psithurism #deixis-inline-mark(id: <psithurism>) of swaying trees.
+  /// It was a comforting melody, #deixis-inline-note-body(id: <psithurism>, inline: true)[the sound of wind whispering through leaves].
+  /// ```
+  ///
+  /// -> bool
+  inline: false,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+  /// Only accepts named arguments, which are forwarded to `container-func`.
+  /// -> arguments
+  ..args,
+) = {
+  if args.pos().len() > 0 { panic("deixis: #deixis-inline-note-body accepts at most 1 positional argument [body].") }
+  let styles = (stroke: stroke, fill: fill, radius: radius) + args.named()
+
+  let series = if series == auto { "default" } else { series }
+
+  let render-celibate(sys, celibate-id) = {
+    let body = deixis-utils._deixis-trim-content(body)
+    let resolved = _deixis-resolve-target(sys, target)
+
+    let m-styles = _deixis-resolve-mark-styles(sys, "inline-mark", inline-mode: inline-mode, ..styles)
+    let b-styles = _deixis-resolve-body-styles(sys, "inline-note", ..styles)
+
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "inline-note")
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "inline-note")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "inline-note")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "inline-note")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "inline-note")
+
+    let note-data = (
+      internal-id: celibate-id,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      mark-lbl: none,
+      body-lbl: none,
+      label: label,
+      series: series,
+      count: none,
+      marker-str: none,
+      body: body,
+      mark-marker-style: auto,
+      body-marker-style: auto,
+      body-style: c-body-style,
+      backlink: false,
+      indent: c-indent,
+      marker-gap: c-marker-gap,
+      styles: b-styles,
+      container-func: active-container,
+    )
+
+    let meta = [#metadata(note-data)<deixis-inline-note>]
+
+    if inline {
+      [#meta#_deixis-inline-mark(body, ..m-styles)]
+    } else {
+      [#meta#active-renderer(note-data)]
+    }
+  }
+
+  if id == none {
+    return [
+      #std.counter("deixis-celibate-note").step()
+      #context {
+        _deixis-check-setup-state()
+        render-celibate(deixis-system.get(), "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      }
+    ]
+  }
+
+  let state-updater = deixis-system.update(sys => {
+    let current-target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    if current-target-uid == none { return sys }
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-label-index = sys.at("label-index", default: (:))
+
+    let payload = new-notes.at(current-target-uid)
+    payload.insert("body-type", "inline-note")
+    payload.insert("body", body)
+    new-notes.insert(current-target-uid, payload)
+
+    if label != none {
+      let lbl-str = if type(label) == str { label } else { str(label) }
+      if lbl-str in new-label-index and new-label-index.at(lbl-str) != current-target-uid {
+        panic("deixis: Duplicate note label detected: '" + lbl-str + "'.")
+      }
+      new-label-index.insert(lbl-str, current-target-uid)
+    }
+
+    return (..sys, notes: new-notes, label-index: new-label-index)
+  })
+
+  state-updater
+  context {
+    _deixis-check-setup-state()
+    let body = deixis-utils._deixis-trim-content(body)
+
+    let sys = deixis-system.get()
+    let final-sys = deixis-system.final()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      final-sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    let reg = if target-uid != none { final-sys.at("notes", default: (:)).at(target-uid, default: none) } else { none }
+
+    if reg == none {
+      return [
+        #std.counter("deixis-celibate-note").step()
+        #render-celibate(sys, "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      ]
+    }
+
+    let internal-id = reg.internal-id
+    let resolved = _deixis-resolve-target(sys, if target == auto { reg.at("target-id", default: 0) } else { target })
+
+    let series = reg.at("series", default: series)
+    let count = reg.count
+    let marker-str = _deixis-query-marker-str(reg)
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let saved-styles = reg.at("styles", default: (:))
+    let merged-styles = _deixis-merge-styles(saved-styles, styles)
+
+    let local-mode = if inline-mode != auto { inline-mode } else { reg.at("inline-mode", default: auto) }
+    let m-styles = _deixis-resolve-mark-styles(
+      sys,
+      "inline-mark",
+      inline-mode: local-mode,
+      ..merged-styles,
+    )
+    let b-styles = _deixis-resolve-body-styles(
+      sys,
+      "inline-note",
+      ..merged-styles,
+    )
+
+    let local-marker-style = if marker-style != auto { marker-style } else if reg != none {
+      reg.at("marker-style", default: auto)
+    } else { auto }
+
+    let mark-marker-style = _deixis-resolve-typed-param(
+      sys,
+      local-marker-style,
+      "marker-style",
+      "inline-mark",
+      component: "mark",
+    )
+    let body-marker-style = _deixis-resolve-typed-param(
+      sys,
+      local-marker-style,
+      "marker-style",
+      "inline-note",
+      component: "body",
+    )
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "inline-note")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "inline-note")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "inline-note")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "inline-note")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "inline-note")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "inline-note")
+
+    let note-data = (
+      internal-id: internal-id,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: count,
+      marker-str: marker-str,
+      body: body,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+      label: label,
+      mark-marker-style: mark-marker-style,
+      body-marker-style: body-marker-style,
+      body-style: c-body-style,
+      backlink: c-backlink,
+      indent: c-indent,
+      marker-gap: c-marker-gap,
+      styles: b-styles,
+      render-single: active-renderer,
+      container-func: active-container,
+    )
+
+    let meta = [#metadata(note-data)<deixis-inline-note>]
+
+    if inline {
+      let rendered-body = deixis-native-render-single(note-data + (container-func: (body, ..args) => box(body)))
+
+      [#meta#_deixis-inline-mark(
+          rendered-body,
+          marker-style: mark-marker-style,
+          ..m-styles,
+        )]
+    } else {
+      [#meta#active-renderer(note-data)]
+    }
+  }
+}
+
+/// An inline text mark with a visual marker.
+///
+/// This function drops a numbered (or custom) marker into the text and registers its location in the
+/// state engine.
+///
+/// ```example
+/// Inline note is usually just a single marker#deixis-inline-mark(id: <celibate-inline-note1>).
+/// Alternatively, it can wrap #deixis-inline-mark(id: <celibate-inline-note2>)[a text content of arbitrary length with it].
+/// ```
+///
+/// - ..args (arguments): Accepts up to one positional arguments: `[body]`.
+/// - numbering (auto, str, function): The numbering style (e.g., `"1"`, `"a"`) for the generated marker.
+/// - marker (auto, content): A hardcoded marker (like a symbol) to use instead of the automatic counter.
+/// - target (int, label, str): The specific block/minipage counter context this mark belongs to.
+/// - series (str): The counter series this mark belongs to. Defaults to `"default"`.
+/// - id (none, str, label): A unique identifier linking this mark to its corresponding body.
+/// - marker-style (auto, function): A custom styling function `(string) => content` for the generated marker.
+/// - marker-position (auto, alignment): The alignment/positioning of the marker relative to its anchor.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+///
+/// -> content
+#let deixis-inline-mark(
+  /// Accepts up to one positional arguments: `[body]`.
+  /// -> arguments
+  ..args,
+  /// The numbering style (e.g., `"1"`, `"a"`) for the generated marker.
+  /// -> auto | str | function
+  numbering: auto,
+  /// A hardcoded marker (like a symbol) to use instead of the automatic counter.
+  /// -> auto | content
+  marker: auto,
+  /// The specific block/minipage counter context this mark belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this mark belongs to.
+  /// -> str
+  series: "default",
+  /// A unique identifier linking this mark to its corresponding body.
+  /// -> none | str | label
+  id: none,
+  /// A custom styling function `(string) => content` for the generated marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// The alignment/positioning of the marker relative to its anchor.
+  ///
+  /// ```example
+  /// #deixis-inline-mark(marker-position: left, id: <celibate-inline-note3>)[
+  ///   This noted content has its mark placed on the left side.
+  /// ]
+  /// ```
+  ///
+  /// -> auto | alignment
+  marker-position: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+  ///
+  /// ```example
+  /// #deixis-inline-mark(inline-mode: "highlight")[Marked content]
+  /// ```
+  /// ```example
+  /// #deixis-inline-mark(inline-mode: "box")[Marked content]
+  /// ```
+  /// ```example
+  /// #deixis-inline-mark(inline-mode: "parentheses")[Marked content]
+  /// ```
+  /// ```example
+  /// #deixis-inline-mark(inline-mode: "underline")[Marked content]
+  /// ```
+  /// ```example
+  /// #deixis-inline-mark(inline-mode: "text-fill")[Marked content]
+  /// ```
+  /// ```example
+  /// #deixis-inline-mark(inline-mode: "none")[Marked content]
+  /// ```
+  ///
+  /// -> auto | str
+  inline-mode: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+) = {
+  let named = args.named()
+  if named.len() > 0 {
+    panic(
+      "deixis: Unknown named argument(s) "
+        + repr(args.named().keys())
+        + ". Styling arguments are not allowed in mark-only note functions.",
+    )
+  }
+
+  let styles = (stroke: stroke, fill: fill, radius: radius)
+
+  let pos = args.pos()
+  if pos.len() > 1 { panic("#deixis-inline-mark accepts at most 1 positional argument [body].") }
+  let body = if pos.len() == 1 { deixis-utils._deixis-trim-content(pos.first()) } else { none }
+
+  if id == none {
+    return context {
+      let sys = deixis-system.get()
+      let m-styles = _deixis-resolve-mark-styles(
+        sys,
+        "inline-mark",
+        marker-position: marker-position,
+        inline-mode: inline-mode,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+      )
+
+      let visual-mark = _deixis-inline-mark(
+        body,
+        marker-position: m-styles.marker-position,
+        inline-mode: m-styles.inline-mode,
+        fill: m-styles.fill,
+        stroke: m-styles.stroke,
+        radius: m-styles.radius,
+      )
+
+      let meta-payload = (
+        internal-id: none,
+        mark-lbl: none,
+        body-lbl: none,
+        marker-str: none,
+        marker-width: 0pt,
+        text-size: text.size,
+        styles: m-styles,
+      )
+
+      [#visual-mark#metadata(meta-payload)<deixis-inline-mark>]
+    }
+  }
+
+  _deixis-validate-target(target)
+
+  deixis-system.update(sys => {
+    if id != none and str(id) in sys.at("id-index", default: (:)) { return sys }
+
+    let new-note-uid = sys.at("note-uid", default: 0) + 1
+    let uid-str = str(new-note-uid)
+
+    let resolved = _deixis-resolve-target(sys, target)
+    let full-c-id = resolved.count-id + ":" + series
+
+    let new-counters = sys.counters
+    let current-count = new-counters.at(full-c-id, default: 0) + 1
+    new-counters.insert(full-c-id, current-count)
+
+    let new-blocks = sys.blocks
+    if resolved.render-id != "page" and type(target) in (str, label) and str(target) not in new-blocks {
+      new-blocks.insert(str(target), (
+        render-id: resolved.render-id,
+        count-id: resolved.count-id,
+        inst-id: resolved.inst-id,
+      ))
+    }
+
+    let c-numbering = _deixis-resolve-typed-param(sys, numbering, "numbering", "inline-mark")
+    let m-styles = _deixis-resolve-mark-styles(
+      sys,
+      "inline-mark",
+      marker-position: marker-position,
+      inline-mode: inline-mode,
+    )
+
+    let trimmed-mark = deixis-utils._deixis-trim-content(body)
+
+    let payload = (
+      internal-id: new-note-uid,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: current-count,
+      numbering: c-numbering,
+      marker: marker,
+      mark-type: "inline",
+      marker-style: marker-style,
+      marker-position: m-styles.marker-position,
+      inline-mode: m-styles.inline-mode,
+      styles: styles,
+      has-mark-body: trimmed-mark != none,
+    )
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-id-index = sys.at("id-index", default: (:))
+
+    new-notes.insert(uid-str, payload)
+
+    if id == deixis-auto-id {
+      sys.insert("last-auto-uid", uid-str)
+    } else if id != none {
+      let id-str = str(id)
+      if id-str in new-id-index and not id-str.starts-with("deixis-auto-") {
+        panic("deixis: Duplicate note ID detected: '" + id-str + "'.\nNote IDs must be unique across the document.")
+      }
+      new-id-index.insert(id-str, uid-str)
+    }
+
+    return (
+      ..sys,
+      note-uid: new-note-uid,
+      blocks: new-blocks,
+      counters: new-counters,
+      notes: new-notes,
+      id-index: new-id-index,
+    )
+  })
+
+  context {
+    let sys = deixis-system.get()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else if id != none {
+      sys.id-index.at(str(id), default: none)
+    } else { none }
+    let reg = if target-uid != none { sys.notes.at(target-uid, default: none) } else { none }
+
+    let saved-styles = if reg != none { reg.at("styles", default: (:)) } else { styles }
+    let c-styles = _deixis-merge-styles(saved-styles, styles, allowed-keys: ("stroke", "fill", "radius"))
+
+    let m-styles = _deixis-resolve-mark-styles(
+      sys,
+      "inline-mark",
+      marker-position: marker-position,
+      inline-mode: inline-mode,
+      ..c-styles,
+    )
+
+    if reg == none {
+      return _deixis-inline-mark(
+        body,
+        marker-position: m-styles.marker-position,
+        inline-mode: m-styles.inline-mode,
+        fill: m-styles.fill,
+        stroke: m-styles.stroke,
+        radius: m-styles.radius,
+      )
+    }
+
+    let internal-id = reg.internal-id
+    let count = reg.count
+    let c-numbering = reg.at("numbering", default: "1")
+    let c-marker = reg.at("marker", default: auto)
+
+    let marker-str = if c-marker != auto {
+      c-marker
+    } else if c-numbering != none {
+      std.numbering(c-numbering, count)
+    } else {
+      none
+    }
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let mark-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "inline-mark",
+      component: "mark",
+    )
+
+    let visual-mark = _deixis-inline-mark(
+      body,
+      marker-style: mark-marker-style,
+      marker-position: m-styles.marker-position,
+      inline-mode: m-styles.inline-mode,
+      fill: m-styles.fill,
+      stroke: m-styles.stroke,
+      radius: m-styles.radius,
+      marker-str: marker-str,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+    )
+
+    let meta-payload = (
+      internal-id: internal-id,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+      marker-str: marker-str,
+      marker-width: if marker-str != none { measure(mark-marker-style(marker-str)).width } else { 0pt },
+      text-size: text.size,
+      styles: m-styles,
+    )
+
+    [#visual-mark#metadata(meta-payload)<deixis-inline-mark>]
+  }
+}
+
+/// A semantic mark that is registered without leaving _any_ visible trace in the text.
+///
+/// Phantom marks do increment the counter and register their position in the state engine, but leave
+/// no visual footprint in the paragraph.
+/// This is useful for creating semantic anchors or side-channel annotations that shouldn't disrupt the reading flow.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// The library was constructed with massive stone walls to regulate the indoor climate naturally across the changing seasons.
+/// #deixis-phantom-mark(id: <phantom>, marker: none)
+/// This architectural choice ensured that centuries of fragile manuscripts remained perfectly preserved without the need for artificial climate control.
+///
+/// #deixis-margin-note-body(id: <phantom>)[Thick stone absorbs daytime heat and releases it at night.]
+/// ```
+///
+/// - id (none, str, label): A unique identifier for linking this mark to a decoupled body.
+/// - numbering (auto, str, function): The numbering style (used for the body and outline, though invisible here).
+/// - target (int, label, str): The specific block/minipage counter context this mark belongs to.
+/// - series (str): The counter series this mark belongs to. Defaults to `"default"`.
+/// - marker (auto, content): A hardcoded marker override (used for the body and outline, though invisible here).
+///
+/// -> content
+#let deixis-phantom-mark(
+  /// A unique identifier for linking this mark to a decoupled body.
+  /// -> none | str | label
+  id: none,
+  /// The numbering style (used for the body and outline, though invisible here).
+  /// -> auto | str | function
+  numbering: auto,
+  /// The specific block/minipage counter context this mark belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this mark belongs to.
+  /// -> str
+  series: "default",
+  /// A hardcoded marker override (used for the body and outline, though invisible here).
+  /// -> auto | content
+  marker: auto,
+) = {
+  if id == none {
+    return
+  }
+
+  _deixis-validate-target(target)
+
+  deixis-system.update(sys => {
+    if str(id) in sys.at("id-index", default: (:)) { return sys }
+
+    let new-note-uid = sys.at("note-uid", default: 0) + 1
+    let uid-str = str(new-note-uid)
+    let resolved = _deixis-resolve-target(sys, target)
+    let full-c-id = resolved.count-id + ":" + series
+
+    let new-counters = sys.counters
+    let current-count = new-counters.at(full-c-id, default: 0) + 1
+    new-counters.insert(full-c-id, current-count)
+
+    let c-numbering = _deixis-resolve-typed-param(sys, numbering, "numbering", "inline-mark")
+
+    let payload = (
+      internal-id: new-note-uid,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: current-count,
+      numbering: c-numbering,
+      marker: marker,
+      mark-type: "phantom",
+      styles: (:),
+      has-mark-body: false,
+    )
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-id-index = sys.at("id-index", default: (:))
+
+    new-notes.insert(uid-str, payload)
+    if id == deixis-auto-id {
+      sys.insert("last-auto-uid", uid-str)
+    } else if id != none {
+      new-id-index.insert(str(id), uid-str)
+    }
+
+    return (
+      ..sys,
+      note-uid: new-note-uid,
+      counters: new-counters,
+      notes: new-notes,
+      id-index: new-id-index,
+    )
+  })
+
+  context {
+    let sys = deixis-system.get()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      sys.id-index.at(str(id), default: none)
+    }
+    if target-uid == none { return none }
+    let reg = sys.notes.at(target-uid)
+
+    if reg == none {
+      return
+    }
+
+    let internal-id = str(reg.internal-id)
+
+    let mark-lbl = std.label("deixis-mark-" + internal-id)
+    let body-lbl = std.label("deixis-body-" + internal-id)
+
+    let meta-payload = (
+      internal-id: internal-id,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+      marker-str: none,
+      marker-width: 0pt,
+      text-size: text.size,
+      styles: (:),
+    )
+
+    [#metadata(meta-payload)<deixis-phantom-mark>#metadata(none)#mark-lbl]
+  }
+}

--- a/packages/preview/deixis/0.1.1/src/inset-note.typ
+++ b/packages/preview/deixis/0.1.1/src/inset-note.typ
@@ -1,0 +1,958 @@
+#import "core.typ": *
+#import "inline-note.typ": *
+#import "region-note.typ": *
+
+/// A standalone body content of an inset note.
+///
+/// The body of inset notes are placed at precise geometric coordinates relative an anchor (its mark or a specific pin).
+/// They are perfect for callouts.
+///
+/// ```example
+/// The artist spent months wandering the dense pine forests, completely captivated by the local #deixis-inline-mark(id: <apricharity>)[apricharity].
+///
+/// #deixis-inset-note-body(
+///   id: <apricharity>,
+///   dx: 2.5em,
+///   dy: 2em,
+/// )[
+///   warmth of the sun in winter.
+/// ]
+/// ```
+///
+/// - body (content): The actual text or content of the note.
+/// - id (none, str, label): A unique identifier linking this body to its corresponding mark.
+/// - target (auto, int, label, str): The specific block/minipage render context this note belongs to.
+/// - series (auto, str): The counter series this note belongs to.
+/// - label (none, label): An optional `label` to attach to the rendered body block.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - link (auto, str): The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+/// - link-waypoints (none, array): An array of intermediate coordinate offsets to route the connector line through.
+/// - link-ports (auto, array, dictionary): Defines the exact exit/entry ports for the connector line.
+/// - link-marks (auto, str): The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+/// - width (auto, length, relative): The width of the inset note body.
+/// - placement (none, function): A custom floating placement function (e.g., Typst's native `place`).
+/// - dx (none, length): Absolute horizontal offset for placing the note.
+/// - dy (none, length): Absolute vertical offset for placing the note.
+/// - anchor (dictionary): A dictionary defining how the note aligns to its anchor point (e.g., `(mark: horizon + right, body: horizon + left)`).
+/// - anchor-pin (none, str): A specific `#deixis-pin` name to anchor the inset note to.
+/// - layer (auto, str): The rendering layer context. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+/// - ..args (arguments): Only accepts named arguments, which are forwarded to `container-func`.
+///
+/// -> content
+#let deixis-inset-note-body(
+  /// The actual text or content of the note.
+  /// -> content
+  body,
+  /// A unique identifier linking this body to its corresponding mark.
+  /// -> none | str | label
+  id: none,
+  /// The specific block/minipage render context this note belongs to.
+  /// -> auto | int | label | str
+  target: auto,
+  /// The counter series this note belongs to.
+  /// -> auto | str
+  series: auto,
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+  /// -> auto | str
+  link: auto,
+  /// An array of intermediate coordinate offsets to route the connector line through.
+  /// -> none | array
+  link-waypoints: none,
+  /// Defines the exact exit/entry ports for the connector line.
+  /// -> auto | array | dictionary
+  link-ports: auto,
+  /// The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+  /// -> auto | str
+  link-marks: auto,
+  /// The width of the inset note body.
+  /// -> auto | length | relative
+  width: auto,
+  /// A custom floating placement function (e.g., Typst's native `place`).
+  ///
+  /// ```example
+  /// #let place-func(it) = {
+  ///   std.place(top + right, it)
+  /// }
+  /// #deixis-inset-note(placement: place-func)[Mark][Inset note placed by `placement`.]
+  /// ```
+  ///
+  /// -> none | function
+  placement: none,
+  /// Absolute horizontal offset for placing the note.
+  ///
+  /// ```example
+  /// #deixis-inset-note(dx: 10pt, dy: 10pt)[Mark][Inset note placed with `dx`, `dy`.]
+  /// ```
+  ///
+  /// -> none | length
+  dx: none,
+  /// Absolute vertical offset for placing the note.
+  ///
+  /// See @deixis-inset-note.dx.
+  ///
+  /// -> none | length
+  dy: none,
+  /// A dictionary defining how the note aligns to its anchor point (e.g., `(mark: horizon + right, body: horizon + left)`).
+  ///
+  /// ```example
+  /// #deixis-inset-note(
+  ///   anchor: (mark: bottom + right, body: top + left),
+  ///   dx: 0pt, dy: 0pt)[Mark][Inset note anchored to the mark.]
+  /// ```
+  ///
+  /// -> dictionary
+  anchor: (mark: horizon + right, body: horizon + left),
+  /// A specific `#deixis-pin` name to anchor the inset note to.
+  ///
+  /// ```example
+  /// #deixis-inset-note(
+  ///   anchor-pin: "anchor-pin",
+  ///   anchor: (mark: horizon, body: horizon + left),
+  ///   layer: "flow",
+  ///   dx: 0pt, dy: 0pt)[Mark][Inset note anchored to a pin.]
+  ///
+  /// #lorem(3)#deixis-pin("anchor-pin")
+  /// ```
+  ///
+  /// See @deixis-pin.
+  ///
+  /// -> none | str
+  anchor-pin: none,
+  /// The rendering layer context. Choices: `"flow"` | `"foreground"` | `"background"`.
+  ///
+  /// ```warning
+  /// Similar to @deixis-region-mark.layer, the `"flow"` layer will trigger a `#parbreak` and disrupt your paragraph.
+  /// However, it is still recommended to use `layer: "flow"` whenever possible for stability.
+  /// ```
+  ///
+  /// -> auto | str
+  layer: "flow",
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+  /// Only accepts named arguments, which are forwarded to `container-func`.
+  /// -> arguments
+  ..args,
+) = {
+  if args.pos().len() > 0 { panic("deixis: #deixis-inset-note-body accepts at most 1 positional argument [body].") }
+  let styles = (stroke: stroke, fill: fill, radius: radius) + args.named()
+
+  let series = if series == auto { "default" } else { series }
+
+  if placement != none and anchor-pin != none {
+    panic("deixis: `placement` cannot be used in combination with `anchor-pin`.")
+  }
+  if (
+    placement != none
+      and layer != auto
+      and (
+        layer != "flow"
+          or (
+            type(layer) == dictionary
+              and _deixis-resolve-typed-param(sys, layer, "layer", "inset-note", component: "body") != "flow"
+          )
+      )
+  ) {
+    panic("deixis: custom `placement` can only be used with layer: 'flow'.")
+  }
+
+  let render-celibate(sys, celibate-id) = {
+    let body = deixis-utils._deixis-trim-content(body)
+    let resolved = _deixis-resolve-target(sys, target)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "inset-note", ..styles)
+
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "inset-note")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "inset-note")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "inset-note")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "inset-note")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "inset-note")
+
+    let c-layer = if placement == none {
+      _deixis-resolve-typed-param(sys, layer, "layer", "inset-note", component: "body")
+    } else {
+      "flow"
+    }
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "inset-note")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "inset-note")
+
+    let note-data = (
+      (
+        internal-id: celibate-id,
+        target-id: resolved.render-id,
+        inst-id: resolved.inst-id,
+        series: series,
+        count: none,
+        marker-str: none,
+        body: body,
+        mark-lbl: none,
+        body-lbl: none,
+        label: label,
+        mark-marker-style: auto,
+        body-marker-style: auto,
+        body-style: c-body-style,
+        backlink: c-backlink,
+        indent: c-indent,
+        marker-gap: c-marker-gap,
+        container-func: active-container,
+        styles: b-styles,
+      )
+        + (
+          has-inline-box: false,
+          mark-type: none,
+          text-size: text.size,
+          marker-width: 0pt,
+          layer: c-layer,
+          placement: placement,
+          dx: dx,
+          dy: dy,
+          anchor: anchor,
+          anchor-pin: anchor-pin,
+          render-single: active-renderer,
+          width: width,
+        )
+    )
+
+    if c-layer == "flow" {
+      let meta = [#metadata(note-data)<deixis-inset-note>]
+      let c-inner-width = if width == auto { auto } else { 100% }
+      let rendered-content = active-renderer(note-data, inner-width: c-inner-width, gap: c-gap)
+
+      let final-rendered = block(width: width, {
+        place(top + left, meta)
+        rendered-content
+      })
+
+      if type(placement) == function {
+        placement(final-rendered)
+      } else if anchor-pin != none or dx != none or dy != none {
+        let dx = if dx in (none, auto) { 0pt } else { dx }
+        let dy = if dy in (none, auto) { 0pt } else { dy }
+        deixis-place-anchored(
+          final-rendered,
+          dx: dx,
+          dy: dy,
+          anchor: anchor,
+          internal-id: none,
+          pin: anchor-pin,
+        )
+      } else {
+        final-rendered
+      }
+    } else {
+      let dummy-lbl = std.label("deixis-mark-" + str(celibate-id))
+      note-data.insert("mark-lbl", dummy-lbl)
+      [#metadata(none)#dummy-lbl#metadata(note-data)<deixis-inset-note>]
+    }
+  }
+
+  if id == none {
+    return [
+      #std.counter("deixis-celibate-note").step()
+      #context {
+        _deixis-check-setup-state()
+        render-celibate(deixis-system.get(), "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      }
+    ]
+  }
+
+  let state-updater = deixis-system.update(sys => {
+    let current-target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    if current-target-uid == none { return sys }
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-label-index = sys.at("label-index", default: (:))
+
+    let payload = new-notes.at(current-target-uid)
+    payload.insert("body-type", "inset-note")
+    payload.insert("body", body)
+    new-notes.insert(current-target-uid, payload)
+
+    if label != none {
+      let lbl-str = if type(label) == str { label } else { str(label) }
+      if lbl-str in new-label-index and new-label-index.at(lbl-str) != current-target-uid {
+        panic("deixis: Duplicate note label detected: '" + lbl-str + "'.")
+      }
+      new-label-index.insert(lbl-str, current-target-uid)
+    }
+
+    return (..sys, notes: new-notes, label-index: new-label-index)
+  })
+
+  state-updater
+  context {
+    _deixis-check-setup-state()
+    let body = deixis-utils._deixis-trim-content(body)
+
+    let sys = deixis-system.get()
+    let final-sys = deixis-system.final()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      final-sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    let reg = if target-uid != none { final-sys.at("notes", default: (:)).at(target-uid, default: none) } else {
+      none
+    }
+
+    if reg == none {
+      return [
+        #std.counter("deixis-celibate-note").step()
+        #render-celibate(sys, "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      ]
+    }
+
+    let internal-id = reg.internal-id
+    let resolved = _deixis-resolve-target(sys, if target == auto { reg.at("target-id", default: 0) } else { target })
+
+    let series = reg.at("series", default: series)
+    let count = reg.count
+    let marker-str = _deixis-query-marker-str(reg)
+    let marker-position = reg.at("marker-position", default: none)
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let dest-top-lbl = std.label("deixis-dest-top-" + str(internal-id))
+    let dest-bot-lbl = std.label("deixis-dest-bot-" + str(internal-id))
+    let dest-left-lbl = std.label("deixis-dest-left-" + str(internal-id))
+    let dest-right-lbl = std.label("deixis-dest-right-" + str(internal-id))
+
+    let saved-styles = reg.at("styles", default: (:))
+    let merged-styles = _deixis-merge-styles(saved-styles, styles)
+
+    let b-styles = _deixis-resolve-body-styles(
+      sys,
+      "inset-note",
+      ..merged-styles,
+    )
+    let l-styles = _deixis-resolve-link-styles(
+      sys,
+      "inset-note",
+      stroke: merged-styles.at("stroke", default: auto),
+      radius: merged-styles.at("radius", default: auto),
+    )
+
+    let mark-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "inset-note",
+      component: "mark",
+    )
+    let body-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "inset-note",
+      component: "body",
+    )
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "inset-note")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "inset-note")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "inset-note")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "inset-note")
+
+    let c-link = _deixis-resolve-typed-param(sys, link, "link", "inset-note")
+    let c-link-ports = deixis-utils._deixis-normalize-ports(link-ports)
+    let c-link-marks = _deixis-resolve-typed-param(sys, link-marks, "link-marks", "inset-note")
+    if reg.at("mark-type", default: "inline") == "phantom" {
+      if link == auto { c-link = "none" }
+    }
+
+    let c-layer = if placement == none {
+      _deixis-resolve-typed-param(sys, layer, "layer", "inset-note", component: "body")
+    } else {
+      "flow"
+    }
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "inset-note")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "inset-note")
+
+    let has-inline-box = if reg.mark-type == "inline" {
+      reg.inline-mode == "box" and reg.at("has-mark-body", default: false)
+    } else { false }
+
+    let note-data = (
+      (
+        internal-id: internal-id,
+        target-id: resolved.render-id,
+        inst-id: resolved.inst-id,
+        series: series,
+        count: count,
+        marker-str: marker-str,
+        body: body,
+        mark-lbl: mark-lbl,
+        body-lbl: body-lbl,
+        label: label,
+        mark-marker-style: mark-marker-style,
+        body-marker-style: body-marker-style,
+        body-style: c-body-style,
+        backlink: c-backlink,
+        indent: c-indent,
+        marker-gap: c-marker-gap,
+        container-func: active-container,
+        styles: b-styles,
+      )
+        + (
+          dest-top-lbl: dest-top-lbl,
+          dest-bot-lbl: dest-bot-lbl,
+          dest-left-lbl: dest-left-lbl,
+          dest-right-lbl: dest-right-lbl,
+          link: c-link,
+          link-stroke: l-styles.stroke,
+          link-radius: l-styles.radius,
+          link-waypoints: link-waypoints,
+          link-ports: c-link-ports,
+          link-marks: c-link-marks,
+          has-inline-box: has-inline-box,
+          mark-type: reg.at("mark-type", default: "inline"),
+          text-size: text.size,
+          marker-width: if marker-str != none { measure(mark-marker-style(marker-str)).width } else { 0pt },
+          marker-position: marker-position,
+          layer: c-layer,
+          placement: placement,
+          dx: dx,
+          dy: dy,
+          anchor: anchor,
+          anchor-pin: anchor-pin,
+          render-single: active-renderer,
+          width: width,
+        )
+    )
+
+    let meta = [#metadata(note-data)<deixis-inset-note>]
+
+    if c-layer == "flow" {
+      let rendered-content = active-renderer(note-data, inner-width: if width == auto { auto } else { 100% })
+      let final-rendered = block(width: width, {
+        place(top + left, meta)
+        place(top + center, [#metadata(none)#dest-top-lbl])
+        place(bottom + center, [#metadata(none)#dest-bot-lbl])
+        place(horizon + left, [#metadata(none)#dest-left-lbl])
+        place(horizon + right, [#metadata(none)#dest-right-lbl])
+        rendered-content
+      })
+
+      if type(placement) == function {
+        placement(final-rendered)
+      } else if anchor-pin != none or dx != none or dy != none {
+        let dx = if dx in (none, auto) { 0pt } else { dx }
+        let dy = if dy in (none, auto) { 0pt } else { dy }
+        deixis-place-anchored(
+          final-rendered,
+          dx: dx,
+          dy: dy,
+          anchor: anchor,
+          internal-id: internal-id,
+          pin: anchor-pin,
+        )
+      } else {
+        [#final-rendered]
+      }
+    } else {
+      [#meta]
+    }
+  }
+}
+
+/// A wrapper for generating inset notes.
+///
+/// This function creates a mark in the text and delegates the body to ```ref #deixis-inset-note-body```.
+///
+/// ```example
+/// The city council has voted to pave the trail with
+/// #deixis-inset-note(dx: 10pt, dy: 30pt, width: 100pt)[
+///   permeable pavement
+/// ][
+///   A porous surface that lets rainwater filter directly into the ground.
+/// ].
+/// ```
+///
+/// - ..args (arguments): Accepts up to two positional arguments: `[mark][body]`. All named arguments are forwarded to ```ref #deixis-inset-note-body```.
+/// - mark-type (auto, str): The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+/// - id (none, str, label): A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+/// - numbering (auto, str, function): The numbering style for the marker.
+/// - marker (auto, content): A hardcoded marker override.
+/// - target (int, label, str): The specific block/minipage counter this note belongs to.
+/// - series (str): The counter series this note belongs to. Defaults to `"default"`.
+/// - label (none, label): An optional `label` to attach to the rendered body block.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - marker-position (auto, alignment, dictionary): Mark marker placement.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+/// - pins (array): Array of pin names for the region mark.
+/// - padding (auto, length, str, dictionary): Internal padding for the region mark.
+/// - region-shape (auto, function): Shape drawing function for the region mark.
+/// - inline (bool): If `true`, force the region mark into an inline box.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - link (auto, str): The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+/// - link-waypoints (none, array): An array of intermediate coordinate offsets to route the connector line through.
+/// - link-ports (auto, array, dictionary): Defines the exact exit/entry ports for the connector line.
+/// - link-marks (auto, str): The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+/// - width (auto, length, relative): The width of the inset note body.
+/// - placement (none, function): A custom floating placement function (e.g., Typst's native `#std.place`).
+/// - dx (none, length): Absolute horizontal offset for placing the note.
+/// - dy (none, length): Absolute vertical offset for placing the note.
+/// - anchor (dictionary): A dictionary defining how the note aligns to its anchor point (e.g., `(mark: horizon + right, body: horizon + left)`).
+/// - anchor-pin (none, str): A specific `#deixis-pin` name to anchor the inset note to.
+/// - layer (auto, str, dictionary): Rendering layer for the region mark and/or the body. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+///
+/// -> content
+#let deixis-inset-note(
+  /// Accepts up to two positional arguments: `[mark][body]`.
+  /// All named arguments are forwarded to ```ref #deixis-inset-note-body```.
+  /// -> arguments
+  ..args,
+  /// The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+  /// -> auto | str
+  mark-type: auto,
+  /// A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+  /// -> none | str | label
+  id: none,
+  /// The numbering style for the marker.
+  /// -> auto | str | function
+  numbering: auto,
+  /// A hardcoded marker override.
+  /// -> auto | content
+  marker: auto,
+  /// The specific block/minipage counter this note belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this note belongs to.
+  /// -> str
+  series: "default",
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// Mark marker placement.
+  ///
+  /// See @deixis-inline-mark.marker-position and @deixis-region-mark.marker-position.
+  ///
+  /// -> auto | alignment | dictionary
+  marker-position: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+  ///
+  /// See @deixis-inline-mark.inline-mode.
+  ///
+  /// -> auto | str
+  inline-mode: auto,
+  /// Array of pin names for the region mark.
+  ///
+  /// See @deixis-region-mark.pins.
+  ///
+  /// -> array
+  pins: (),
+  /// Internal padding for the region mark.
+  ///
+  /// See @deixis-region-mark.padding.
+  ///
+  /// -> auto | length | str | dictionary
+  padding: auto,
+  /// Shape drawing function for the region mark.
+  ///
+  /// See @deixis-region-mark.region-shape.
+  ///
+  /// -> auto | function
+  region-shape: auto,
+  /// If `true`, force the region mark into an inline box.
+  ///
+  /// See @deixis-region-mark.inline.
+  ///
+  /// -> bool
+  inline: false,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+  /// -> auto | str
+  link: auto,
+  /// An array of intermediate coordinate offsets to route the connector line through.
+  /// -> none | array
+  link-waypoints: none,
+  /// Defines the exact exit/entry ports for the connector line.
+  /// -> auto | array | dictionary
+  link-ports: auto,
+  /// The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+  /// -> auto | str
+  link-marks: auto,
+  /// The width of the inset note body.
+  /// -> auto | length | relative
+  width: auto,
+  /// A custom floating placement function (e.g., Typst's native `#std.place`).
+  ///
+  /// See @deixis-inset-note-body.placement.
+  ///
+  /// -> none | function
+  placement: none,
+  /// Absolute horizontal offset for placing the note.
+  ///
+  /// See @deixis-inset-note-body.dx.
+  ///
+  /// -> none | length
+  dx: none,
+  /// Absolute vertical offset for placing the note.
+  ///
+  /// See @deixis-inset-note-body.dy.
+  ///
+  /// -> none | length
+  dy: none,
+  /// A dictionary defining how the note aligns to its anchor point (e.g., `(mark: horizon + right, body: horizon + left)`).
+  ///
+  /// See @deixis-inset-note-body.anchor.
+  ///
+  /// -> dictionary
+  anchor: (mark: horizon + right, body: horizon + left),
+  /// A specific `#deixis-pin` name to anchor the inset note to.
+  ///
+  /// See @deixis-inset-note-body.anchor-pin.
+  ///
+  /// -> none | str
+  anchor-pin: none,
+  /// Rendering layer for the region mark and/or the body. Choices: `"flow"` | `"foreground"` | `"background"`.
+  ///
+  /// See @deixis-region-mark.layer and @deixis-inset-note-body.layer.
+  ///
+  /// ```tip
+  /// Since both @deixis-region-mark and @deixis-inset-note-body shares this parameter, you can pass `layer: (mark: "flow", body: "foreground")` to assign different layer to each component.
+  /// ```
+  ///
+  /// -> auto | str | dictionary
+  layer: auto,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+) = {
+  let pos = args.pos()
+  if pos.len() > 2 { panic("deixis: #deixis-inset-note accepts at most 2 positional arguments: [mark][body]") }
+  let mark-content = if pos.len() > 1 { pos.first() } else { none }
+  let note-body = if pos.len() > 0 { pos.last() } else { none }
+
+  let mark-type = _deixis-resolve-mark-type(mark-type, pins: pins)
+
+  if id != none {
+    return deixis-inset-note-body(
+      note-body,
+      id: id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      backlink: backlink,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      link: link,
+      link-waypoints: link-waypoints,
+      link-ports: link-ports,
+      link-marks: link-marks,
+      width: width,
+      placement: placement,
+      dx: dx,
+      dy: dy,
+      anchor: anchor,
+      anchor-pin: anchor-pin,
+      layer: layer,
+      render-single: render-single,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let render-mark(target-id) = {
+    if mark-type == "region" {
+      deixis-region-mark(
+        mark-content,
+        id: target-id,
+        pins: pins,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+        padding: padding,
+        region-shape: region-shape,
+        layer: layer,
+        inline: inline,
+      )
+    } else if mark-type == "phantom" {
+      deixis-phantom-mark(
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+      )
+    } else {
+      deixis-inline-mark(
+        mark-content,
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        inline-mode: inline-mode,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+      )
+    }
+  }
+
+  let render-body(target-id) = {
+    deixis-inset-note-body(
+      note-body,
+      id: target-id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      backlink: backlink,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      link: link,
+      link-waypoints: link-waypoints,
+      link-ports: link-ports,
+      link-marks: link-marks,
+      width: width,
+      placement: placement,
+      dx: dx,
+      dy: dy,
+      anchor: anchor,
+      anchor-pin: anchor-pin,
+      layer: layer,
+      render-single: render-single,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let m = render-mark(deixis-auto-id)
+  let b = render-body(deixis-auto-id)
+
+  let is-block-region = mark-type == "region" and inline == false
+  if is-block-region {
+    [#m#place(b)]
+  } else {
+    [#m#b]
+  }
+}
+
+// Inset note overlay
+#let _deixis-inset-notes-overlay(layer: "foreground") = {
+  let draw-bodies = context {
+    let notes = query(<deixis-inset-note>).filter(it => (
+      type(it.value) == dictionary and it.value.at("mark-lbl", default: none) != none
+    ))
+    let paths = ()
+    let current-page = here().page()
+    let all-pins = query(<deixis-pin>)
+
+    for n in notes {
+      let data = n.value
+      let n-layer = data.at("layer", default: "foreground")
+
+      let target_page = n.location().page()
+      if data.anchor-pin != none {
+        let pin-elems = all-pins.filter(x => x.value.name == data.anchor-pin)
+        if pin-elems.len() > 0 {
+          target_page = pin-elems.first().location().page()
+        }
+      }
+
+      if n-layer == layer and current-page == target_page {
+        let active-renderer = data.render-single
+        let rendered-content = active-renderer(data, inner-width: if data.width == auto { auto } else { 100% })
+        let dest-top-lbl = data.at("dest-top-lbl", default: none)
+
+        let final-rendered = block(width: data.width, {
+          if dest-top-lbl != none {
+            place(top + center, [#metadata(none)#dest-top-lbl])
+            place(bottom + center, [#metadata(none)#data.dest-bot-lbl])
+            place(horizon + left, [#metadata(none)#data.dest-left-lbl])
+            place(horizon + right, [#metadata(none)#data.dest-right-lbl])
+          }
+          rendered-content
+        })
+
+        if type(data.placement) == function {
+          paths.push(box(data.placement(final-rendered)))
+        } else if data.dx != none or data.dy != none {
+          paths.push(deixis-place-anchored(
+            final-rendered,
+            dx: if data.dx == none { 0pt } else { data.dx },
+            dy: if data.dy == none { 0pt } else { data.dy },
+            anchor: data.anchor,
+            internal-id: data.internal-id,
+            pin: data.anchor-pin,
+          ))
+        } else {
+          paths.push(deixis-place-anchored(
+            final-rendered,
+            dx: 0pt,
+            dy: 0pt,
+            anchor: data.anchor,
+            internal-id: data.internal-id,
+            pin: data.anchor-pin,
+          ))
+        }
+      }
+    }
+    paths.join()
+  }
+
+  let draw-links = context {
+    if layer != "foreground" { return none }
+
+    let notes = query(<deixis-inset-note>).filter(it => (
+      type(it.value) == dictionary and it.value.at("mark-lbl", default: none) != none
+    ))
+    let paths = ()
+    let sys = deixis-system.get()
+
+    for n in notes {
+      let data = n.value
+
+      let c-link = _deixis-resolve-typed-param(sys, data.at("link", default: auto), "link", "inset-note")
+      if c-link in (none, "none", false) { continue }
+
+      let c-link-stroke = data.at("link-stroke", default: _deixis-resolve-typed-param(
+        sys,
+        auto,
+        "stroke",
+        "inset-note",
+        component: "link",
+      ))
+      let c-link-radius = data.at("link-radius", default: _deixis-resolve-typed-param(
+        sys,
+        auto,
+        "radius",
+        "inset-note",
+        component: "link",
+      ))
+      let c-link-marks = _deixis-resolve-typed-param(
+        sys,
+        data.at("link-marks", default: auto),
+        "link-marks",
+        "inset-note",
+      )
+
+      let start-elems = query(selector(data.mark-lbl))
+      let d-top-elems = query(selector(data.at("dest-top-lbl", default: data.body-lbl)))
+
+      if start-elems.len() > 0 and d-top-elems.len() > 0 {
+        let current-page = here().page()
+        let S_page = start-elems.last().location().page()
+        let E_page = d-top-elems.last().location().page()
+
+        let region-elems = query(<deixis-region-mark>).filter(r => (
+          type(r.value) == dictionary
+            and r.value.at("internal-id", default: none) != none
+            and str(r.value.internal-id) == str(data.internal-id)
+        ))
+        let is-region = region-elems.len() > 0
+        let reg = if is-region { region-elems.first().value } else { none }
+        let all-pins = if is-region { query(<deixis-pin>) } else { () }
+
+        let r-pins = ()
+        if is-region {
+          for pin-name in reg.pins {
+            for p in all-pins.filter(x => x.value.name == pin-name) { r-pins.push(p) }
+          }
+          if r-pins.len() > 0 {
+            let sorted-pins = r-pins.sorted(key: p => (p.location().page(), p.location().position().y))
+            let first_region_page = sorted-pins.first().location().page()
+            let last_region_page = sorted-pins.last().location().page()
+
+            if E_page >= first_region_page and E_page <= last_region_page {
+              S_page = E_page
+            } else if E_page < first_region_page {
+              S_page = first_region_page
+            } else {
+              S_page = last_region_page
+            }
+          }
+        }
+
+        if current-page != S_page and current-page != E_page { continue }
+
+        let S = start-elems.last().location().position()
+        let D_top = d-top-elems.last().location().position()
+
+        let link-paths = _deixis-render-inset-link(
+          data,
+          current-page,
+          S_page,
+          E_page,
+          S,
+          D_top,
+          reg: reg,
+          r-pins: r-pins,
+          c-link: c-link,
+          c-link-stroke: c-link-stroke,
+          c-link-radius: c-link-radius,
+          c-link-marks: c-link-marks,
+        )
+
+        for el in link-paths { paths.push(el) }
+      }
+    }
+    paths.join()
+  }
+
+  [#draw-bodies#draw-links]
+}

--- a/packages/preview/deixis/0.1.1/src/layout.typ
+++ b/packages/preview/deixis/0.1.1/src/layout.typ
@@ -1,0 +1,1303 @@
+#import "states.typ": *
+#import "render.typ": *
+#import "routing.typ": *
+#import "utils.typ" as deixis-utils
+
+#let text-padding = (top: 0.9em, bottom: 0.2em, x: 0.1em)
+
+/// --------------------
+/// Group layout
+/// --------------------
+
+/// The common layout for grouped notes (footnotes and endnotes).
+/// - separator (auto, content): The separator override. If `auto`, uses the separator of the first note.
+/// - clearance (auto, length): The clearance override. If `auto`, uses the clearance of the first note.
+/// - gap (auto, length): The gap override. If `auto`, uses the local gap of each note.
+/// - render-group (auto, function): The group render function. If `auto`, uses the `render-group` of the first note.
+///
+/// -> content
+#let deixis-group-layout(
+  notes-data,
+  separator: auto,
+  clearance: auto,
+  gap: auto,
+  render-group: auto,
+) = {
+  if notes-data.len() == 0 { return }
+
+  let c-clearance = if clearance == auto { notes-data.first().at("clearance", default: 1em) } else { clearance }
+  let c-separator = if separator == auto { notes-data.first().at("separator", default: none) } else { separator }
+  let c-render-group = if render-group == auto {
+    notes-data.first().at("render-group", default: deixis-default-render-group)
+  } else { render-group }
+
+  let unique-series = ()
+  for data in notes-data {
+    let s = data.at("series", default: "default")
+    if s not in unique-series { unique-series.push(s) }
+  }
+
+  for (i, current-series) in unique-series.enumerate() {
+    let series-notes = notes-data.filter(n => n.at("series", default: "default") == current-series)
+
+    if i == 0 {
+      v(c-clearance, weak: true)
+      c-separator
+    } else {
+      v(c-clearance / 1.5, weak: true)
+    }
+
+    c-render-group(series-notes, gap: gap)
+  }
+}
+
+/// --------------------
+/// Margin layout
+/// --------------------
+
+#let _deixis-resolve-side(
+  natural-y,
+  l-current-bottom,
+  r-current-bottom,
+  bottom-bound,
+  l-space-abs,
+  r-space-abs,
+  min-margin-width,
+  preferred-side,
+  overflowed-l: false,
+  overflowed-r: false,
+  strategy: auto,
+) = {
+  if strategy not in ("strict", "nearest", auto) {
+    panic("_deixis-resolve-side: strategy must be 'strict', 'nearest', or auto.")
+  }
+  let actual-strategy = if strategy == auto { "nearest" } else { strategy }
+
+  let l-valid = l-space-abs >= min-margin-width
+  let r-valid = r-space-abs >= min-margin-width
+
+  if l-valid and r-valid {
+    let l-est = calc.max(natural-y, l-current-bottom)
+    let r-est = calc.max(natural-y, r-current-bottom)
+
+    let l-full = overflowed-l or (l-est >= bottom-bound - 1pt)
+    let r-full = overflowed-r or (r-est >= bottom-bound - 1pt)
+
+    if actual-strategy == "strict" {
+      let pref-full = if preferred-side == right { r-full } else { l-full }
+      let unpref-full = if preferred-side == right { l-full } else { r-full }
+
+      if not pref-full { return preferred-side } else if not unpref-full {
+        return if preferred-side == right { left } else { right }
+      } else {
+        if l-est < r-est { return left } else if r-est < l-est { return right } else { return preferred-side }
+      }
+    } else {
+      if l-est < r-est { return left } else if r-est < l-est { return right } else { return preferred-side }
+    }
+  }
+
+  if r-valid { return right }
+  if l-valid { return left }
+
+  if l-space-abs > r-space-abs + 1pt { return left }
+  if r-space-abs > l-space-abs + 1pt { return right }
+
+  return preferred-side
+}
+
+/// A lightweight margin layout engine that places each note exactly aligned with its marker.
+/// It intentionally ignores collisions, gaps, and spillovers.
+#let deixis-margin-note-exact-layout(
+  notes,
+  top-bound,
+  bottom-bound,
+  start-x,
+  text-width,
+  end-y,
+  left-space,
+  right-space,
+  current-page,
+  min-margin-width: 1in,
+  pushed-notes: (),
+  ..args,
+) = context {
+  let l-space-abs = deixis-utils.resolve-len(left-space)
+  let r-space-abs = deixis-utils.resolve-len(right-space)
+  let req-space = deixis-utils.resolve-len(min-margin-width)
+
+  let pref-dir = deixis-utils.text-direction(text.dir, text.lang)
+  let preferred-side = if pref-dir == rtl { left } else { right }
+
+  let resolve-rel-len(val, ref-len, def) = {
+    if val == auto { return def }
+    if type(val) == ratio { return (val / 100%) * ref-len }
+    if type(val) == relative { return deixis-utils.resolve-signed-len(val.length) + ((val.ratio / 100%) * ref-len) }
+    return deixis-utils.resolve-signed-len(val)
+  }
+
+  let formatted-notes = ()
+
+  for n in notes {
+    let note-data = n.note-data
+
+    let actual-side = note-data.side
+    if actual-side in ("inside", "outside") {
+      if note-data.at("target-id", default: "page") == "page" {
+        let c-page = if "current-page" in dictionary(sys) { current-page } else { current-block.page }
+        actual-side = if calc.odd(c-page) == (actual-side == "inside") { left } else { right }
+      } else {
+        let is-outside = (actual-side == "outside")
+        actual-side = if (pref-dir == rtl) == is-outside { left } else { right }
+      }
+    } else if actual-side == "left" { actual-side = left } else if actual-side == "right" { actual-side = right }
+
+    // min-margin-width safety catch
+    if actual-side != auto and note-data.at("mark-align-strictness", default: "none") != "strict" {
+      let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+      if margin-width < req-space {
+        let opposite-width = if actual-side == left { r-space-abs } else { l-space-abs }
+        if opposite-width > margin-width {
+          actual-side = if actual-side == left { right } else { left }
+        }
+      }
+    }
+
+    let c-mark-align = note-data.at("mark-align", default: "top")
+    let body-align = if type(c-mark-align) == dictionary and "body" in c-mark-align { c-mark-align.body } else if (
+      type(c-mark-align) in (str, alignment)
+    ) { c-mark-align } else { "top" }
+    let body-align-str = if type(body-align) == alignment { repr(body-align.y) } else { str(body-align) }
+
+    let dy-val = deixis-utils.resolve-signed-len(note-data.dy)
+    let natural-y = note-data.at("y", default: 0pt) + dy-val
+
+    if actual-side == auto {
+      actual-side = _deixis-resolve-side(
+        natural-y,
+        natural-y,
+        natural-y,
+        bottom-bound,
+        l-space-abs,
+        r-space-abs,
+        req-space,
+        preferred-side,
+        strategy: note-data.at("side-strategy", default: auto),
+      )
+    }
+
+    let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+    let n-width = calc.max(0pt, resolve-rel-len(note-data.width, margin-width, margin-width))
+    let dx-val = resolve-rel-len(note-data.dx, margin-width, (margin-width - n-width) / 2.0)
+
+    let pad-left = if actual-side == left { margin-width - n-width - dx-val } else { dx-val }
+    pad-left = calc.max(0pt, pad-left)
+
+    let attach-x = if actual-side == left { start-x - dx-val } else { start-x + text-width + dx-val }
+
+    let render-single = note-data.at("render-single", default: deixis-native-render-single)
+    let raw-rendered = render-single(note-data, inner-width: 100%, ..args.named())
+
+    let final-rendered = box(width: margin-width, align(left, pad(left: pad-left, block(width: n-width, raw-rendered))))
+    let h = measure(final-rendered).height
+
+    let shifted-y = natural-y
+    if body-align-str == "bottom" { shifted-y -= h } else if body-align-str == "horizon" { shifted-y -= h / 2 }
+
+    formatted-notes.push((
+      mark-page: n.mark-page,
+      mark-block: n.at("mark-block", default: 0),
+      block-idx: n.at("block-idx", default: 0),
+      mark-x: note-data.at("mark-x", default: 0pt),
+      mark-y: note-data.at("mark-y", default: 0pt),
+      marker-width: note-data.at("marker-width", default: 0pt),
+      marker-str: note-data.at("marker-str", default: none),
+      text-size: note-data.at("text-size", default: auto),
+      has-inline-box: note-data.at("has-inline-box", default: false),
+      mark-type: note-data.at("mark-type", default: "inline"),
+      reg: note-data.at("reg", default: none),
+      r-pins: note-data.at("r-pins", default: ()),
+      gap: 0pt,
+      side: actual-side,
+      link: note-data.at("link", default: "none"),
+      link-stroke: note-data.at("link-stroke", default: none),
+      link-radius: note-data.at("link-radius", default: 0pt),
+      link-marks: note-data.at("link-marks", default: "none"),
+      link-waypoints: note-data.at("link-waypoints", default: auto),
+      link-ports: note-data.at("link-ports", default: auto),
+      attach-x: attach-x,
+      y: shifted-y,
+      final-y: shifted-y,
+      h: h,
+      w: n-width,
+      rendered: final-rendered,
+      is-incoming: n.mark-page < current-page,
+      is-outgoing: false,
+    ))
+  }
+
+  let text-bounds = (left: start-x, right: start-x + text-width)
+
+  place(top + left, {
+    _deixis-render-margin-links(
+      formatted-notes,
+      current-page,
+      text-bounds,
+      top-bound,
+      bottom-bound,
+    )
+    for n in formatted-notes {
+      let margin-x = if n.side == left { start-x - l-space-abs } else { start-x + text-width }
+      place(dx: margin-x, dy: n.final-y, n.rendered)
+    }
+  })
+}
+
+#let _deixis-rubber-band(
+  note-list,
+  top-bound,
+  bottom-bound,
+) = {
+  if note-list.len() == 0 { return () }
+
+  let placed-y = ()
+  let current-bottom = top-bound
+  for (i, n) in note-list.enumerate() {
+    let gap = if i == 0 { 0pt } else { n.at("gap", default: 0pt) }
+    let target-y = calc.max(n.y, current-bottom + gap)
+    placed-y.push(target-y)
+    current-bottom = target-y + n.h
+  }
+
+  let final-y = ()
+  let next-allowed-bottom = bottom-bound
+  for i in range(note-list.len() - 1, -1, step: -1) {
+    let n = note-list.at(i)
+    let y = placed-y.at(i)
+    let n-mark-align-strict = n.at("mark-align-strictness", default: "none")
+
+    if y + n.h > next-allowed-bottom and n-mark-align-strict != "strict" {
+      y = next-allowed-bottom - n.h
+    }
+
+    if n-mark-align-strict == "loose" {
+      let min-y = calc.max(top-bound, n.mark-y - n.h)
+      if y < min-y { y = min-y }
+    }
+
+    final-y.insert(0, y)
+    let gap = if i == 0 { 0pt } else { n.at("gap", default: 0pt) }
+    next-allowed-bottom = y - gap
+  }
+
+  let resolved-y = ()
+  let cur-b = top-bound
+  for (i, n) in note-list.enumerate() {
+    let gap = if i == 0 { 0pt } else { n.at("gap", default: 0pt) }
+    let y = calc.max(final-y.at(i), cur-b + gap)
+    resolved-y.push(y)
+    cur-b = y + n.h
+  }
+
+  return resolved-y
+}
+
+/// A placement-based margin layout engine that uses the rubber band algorithm under the hood.
+#let deixis-margin-note-adaptive-layout(
+  notes,
+  top-bound,
+  bottom-bound,
+  start-x,
+  text-width,
+  end-y,
+  left-space,
+  right-space,
+  current-page,
+  min-margin-width: 1in,
+  pushed-notes: (),
+  ..args,
+) = context {
+  let l-space-abs = deixis-utils.resolve-len(left-space)
+  let r-space-abs = deixis-utils.resolve-len(right-space)
+  let req-space = deixis-utils.resolve-len(min-margin-width)
+
+  let left-notes = ()
+  let right-notes = ()
+  let pref-dir = deixis-utils.text-direction(text.dir, text.lang)
+  let preferred-side = if pref-dir == rtl { left } else { right }
+
+  let l-current-bottom = top-bound
+  let r-current-bottom = top-bound
+
+  let _resolve-rel-len(val, ref-len, def) = {
+    if val == auto { return def }
+    if type(val) == ratio { return (val / 100%) * ref-len }
+    if type(val) == relative { return deixis-utils.resolve-signed-len(val.length) + ((val.ratio / 100%) * ref-len) }
+    return deixis-utils.resolve-signed-len(val)
+  }
+
+  for n in notes {
+    let note-data = n.note-data
+
+    let n-gap = deixis-utils.resolve-len(note-data.at("gap", default: 0.5em))
+
+    let actual-side = note-data.side
+    if actual-side in ("inside", "outside") {
+      if note-data.at("target-id", default: "page") == "page" {
+        let c-page = if "current-page" in dictionary(sys) { current-page } else { current-block.page }
+        actual-side = if calc.odd(c-page) == (actual-side == "inside") { left } else { right }
+      } else {
+        let is-outside = (actual-side == "outside")
+        if pref-dir == rtl {
+          actual-side = if is-outside { left } else { right }
+        } else {
+          actual-side = if is-outside { right } else { left }
+        }
+      }
+    } else if actual-side == "left" { actual-side = left } else if actual-side == "right" { actual-side = right }
+
+    // min-margin-width safety catch
+    if actual-side != auto and note-data.at("mark-align-strictness", default: "none") != "strict" {
+      let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+      if margin-width < req-space {
+        let opposite-width = if actual-side == left { r-space-abs } else { l-space-abs }
+        if opposite-width > margin-width {
+          actual-side = if actual-side == left { right } else { left }
+        }
+      }
+    }
+
+    let c-mark-align = note-data.at("mark-align", default: "top")
+
+    let body-align = if type(c-mark-align) == dictionary and "body" in c-mark-align { c-mark-align.body } else if (
+      type(c-mark-align) in (str, alignment)
+    ) { c-mark-align } else { "top" }
+    let body-align-str = if type(body-align) == alignment { repr(body-align.y) } else { str(body-align) }
+
+    let dy-val = deixis-utils.resolve-signed-len(note-data.dy)
+    let natural-y = note-data.at("y", default: 0pt) + dy-val
+
+    if actual-side == auto {
+      actual-side = _deixis-resolve-side(
+        natural-y,
+        l-current-bottom,
+        r-current-bottom,
+        bottom-bound,
+        l-space-abs,
+        r-space-abs,
+        req-space,
+        preferred-side,
+        strategy: note-data.at("side-strategy", default: auto),
+      )
+    }
+
+    let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+    let n-width = calc.max(0pt, _resolve-rel-len(note-data.width, margin-width, margin-width))
+    let dx-val = _resolve-rel-len(note-data.dx, margin-width, (margin-width - n-width) / 2.0)
+
+    let pad-left = if actual-side == left { margin-width - n-width - dx-val } else { dx-val }
+
+    let attach-x = if actual-side == left {
+      start-x - dx-val
+    } else {
+      start-x + text-width + dx-val
+    }
+
+    let n-link = note-data.at("link", default: "none")
+    let n-link-stroke = note-data.at("link-stroke", default: none)
+    let n-link-radius = note-data.at("link-radius", default: 0pt)
+    let n-link-waypoints = note-data.at("link-waypoints", default: auto)
+    let n-link-ports = note-data.at("link-ports", default: auto)
+    let n-link-marks = note-data.at("link-marks", default: "none")
+
+    let render-single = note-data.at("render-single", default: deixis-native-render-single)
+
+    let raw-rendered = render-single(
+      note-data,
+      inner-width: 100%,
+      ..args.named(),
+    )
+
+    let final-rendered = box(width: margin-width, align(left, pad(left: pad-left, block(width: n-width, raw-rendered))))
+    let h = measure(final-rendered).height
+
+    if body-align-str == "bottom" { natural-y -= h } else if body-align-str == "horizon" { natural-y -= h / 2 }
+
+    let n-mark-align-strict = note-data.at("mark-align-strictness", default: "none")
+    let obj = (
+      mark-page: n.mark-page,
+      mark-block: n.at("mark-block", default: 0),
+      block-idx: n.at("block-idx", default: 0),
+      mark-x: note-data.at("mark-x", default: 0pt),
+      mark-y: note-data.at("mark-y", default: 0pt),
+      marker-width: note-data.at("marker-width", default: 0pt),
+      marker-str: note-data.at("marker-str", default: none),
+      text-size: note-data.at("text-size", default: auto),
+      has-inline-box: note-data.at("has-inline-box", default: false),
+      mark-type: note-data.at("mark-type", default: "inline"),
+      reg: note-data.at("reg", default: none),
+      r-pins: note-data.at("r-pins", default: ()),
+      gap: n-gap,
+      side: actual-side,
+      mark-align-strictness: n-mark-align-strict,
+      link: n-link,
+      link-stroke: n-link-stroke,
+      link-radius: n-link-radius,
+      link-marks: n-link-marks,
+      link-waypoints: n-link-waypoints,
+      link-ports: n-link-ports,
+      attach-x: attach-x,
+      y: natural-y,
+      h: h,
+      w: n-width,
+      rendered: final-rendered,
+    )
+
+    if actual-side == left {
+      let eff-gap = if left-notes.len() == 0 { 0pt } else { n-gap }
+      left-notes.push(obj)
+      l-current-bottom = calc.max(natural-y, l-current-bottom) + h + eff-gap
+    } else {
+      let eff-gap = if right-notes.len() == 0 { 0pt } else { n-gap }
+      right-notes.push(obj)
+      r-current-bottom = calc.max(natural-y, r-current-bottom) + h + eff-gap
+    }
+  }
+
+  let l-final = _deixis-rubber-band(
+    left-notes,
+    top-bound,
+    bottom-bound,
+  )
+  let r-final = _deixis-rubber-band(
+    right-notes,
+    top-bound,
+    bottom-bound,
+  )
+
+  let render-list(note-list, final-y, margin-x) = {
+    for i in range(note-list.len()) {
+      let n = note-list.at(i)
+      let y = final-y.at(i)
+      place(dx: margin-x, dy: y, n.rendered)
+    }
+  }
+
+  let text-bounds = (left: start-x, right: start-x + text-width)
+
+  let all-notes-here = ()
+  for i in range(left-notes.len()) {
+    let mut-n = left-notes.at(i)
+    mut-n.insert("final-y", l-final.at(i))
+    mut-n.insert("is-incoming", mut-n.mark-page < current-page)
+    mut-n.insert("is-outgoing", false)
+    all-notes-here.push(mut-n)
+  }
+  for i in range(right-notes.len()) {
+    let mut-n = right-notes.at(i)
+    mut-n.insert("final-y", r-final.at(i))
+    mut-n.insert("is-incoming", mut-n.mark-page < current-page)
+    mut-n.insert("is-outgoing", false)
+    all-notes-here.push(mut-n)
+  }
+
+  let formatted-pushed = pushed-notes.map(pn => {
+    let note-data = pn.note-data
+    (
+      mark-page: pn.mark-page,
+      mark-block: pn.at("mark-block", default: 0),
+      block-idx: pn.at("block-idx", default: 0),
+      mark-x: note-data.at("mark-x", default: 0pt),
+      mark-y: note-data.at("mark-y", default: 0pt),
+      marker-str: note-data.at("marker-str", default: none),
+      marker-width: note-data.at("marker-width", default: 0pt),
+      text-size: note-data.at("text-size", default: auto),
+      has-inline-box: note-data.at("has-inline-box", default: false),
+      mark-type: note-data.at("mark-type", default: "inline"),
+      reg: note-data.at("reg", default: none),
+      r-pins: note-data.at("r-pins", default: ()),
+      side: if note-data.at("side", default: right) in ("left", left) { left } else { right },
+      link: note-data.at("link", default: "none"),
+      link-stroke: note-data.at("link-stroke", default: none),
+      link-radius: note-data.at("link-radius", default: 0pt),
+      link-waypoints: note-data.at("link-waypoints", default: auto),
+      link-ports: note-data.at("link-ports", default: auto),
+      link-marks: note-data.at("link-marks", default: "none"),
+      attach-x: 0pt,
+      final-y: 0pt,
+      h: 0pt,
+      w: 0pt,
+      is-incoming: false,
+      is-outgoing: true,
+    )
+  })
+
+  place(top + left, {
+    _deixis-render-margin-links(
+      all-notes-here + formatted-pushed,
+      current-page,
+      text-bounds,
+      top-bound,
+      bottom-bound,
+    )
+    render-list(left-notes, l-final, start-x - l-space-abs)
+    render-list(right-notes, r-final, start-x + text-width)
+  })
+}
+
+/// A margin layout engine that stacks notes sequentially like a fluid column, ignoring strict mark alignment.
+#let deixis-margin-note-flow-layout(
+  notes,
+  top-bound,
+  bottom-bound,
+  start-x,
+  text-width,
+  end-y,
+  left-space,
+  right-space,
+  current-page,
+  min-margin-width: 1in,
+  pushed-notes: (),
+  ..args,
+) = context {
+  let l-space-abs = deixis-utils.resolve-len(left-space)
+  let r-space-abs = deixis-utils.resolve-len(right-space)
+  let req-space = deixis-utils.resolve-len(min-margin-width)
+
+  let left-notes = ()
+  let right-notes = ()
+  let pref-dir = deixis-utils.text-direction(text.dir, text.lang)
+  let preferred-side = if pref-dir == rtl { left } else { right }
+
+  let l-current-bottom = top-bound
+  let r-current-bottom = top-bound
+
+  let _resolve-rel-len(val, ref-len, def) = {
+    if val == auto { return def }
+    if type(val) == ratio { return (val / 100%) * ref-len }
+    if type(val) == relative { return deixis-utils.resolve-signed-len(val.length) + ((val.ratio / 100%) * ref-len) }
+    return deixis-utils.resolve-signed-len(val)
+  }
+
+  for n in notes {
+    let note-data = n.note-data
+
+    let n-gap = deixis-utils.resolve-len(note-data.at("gap", default: 0.5em))
+
+    let actual-side = note-data.side
+    if actual-side in ("inside", "outside") {
+      if note-data.at("target-id", default: "page") == "page" {
+        let c-page = if "current-page" in dictionary(sys) { current-page } else { current-block.page }
+        actual-side = if calc.odd(c-page) == (actual-side == "inside") { left } else { right }
+      } else {
+        let is-outside = (actual-side == "outside")
+        if pref-dir == rtl {
+          actual-side = if is-outside { left } else { right }
+        } else {
+          actual-side = if is-outside { right } else { left }
+        }
+      }
+    } else if actual-side == "left" { actual-side = left } else if actual-side == "right" { actual-side = right }
+
+    // min-margin-width safety catch
+    if actual-side != auto and note-data.at("mark-align-strictness", default: "none") != "strict" {
+      let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+      if margin-width < req-space {
+        let opposite-width = if actual-side == left { r-space-abs } else { l-space-abs }
+        if opposite-width > margin-width {
+          actual-side = if actual-side == left { right } else { left }
+        }
+      }
+    }
+
+    let c-mark-align = note-data.at("mark-align", default: "top")
+
+    let body-align = if type(c-mark-align) == dictionary and "body" in c-mark-align { c-mark-align.body } else if (
+      type(c-mark-align) in (str, alignment)
+    ) { c-mark-align } else { "top" }
+    let body-align-str = if type(body-align) == alignment { repr(body-align.y) } else { str(body-align) }
+
+    let dy-val = deixis-utils.resolve-signed-len(note-data.dy)
+    let natural-y = note-data.at("y", default: 0pt) + dy-val
+
+    if actual-side == auto {
+      actual-side = _deixis-resolve-side(
+        natural-y,
+        l-current-bottom,
+        r-current-bottom,
+        bottom-bound,
+        l-space-abs,
+        r-space-abs,
+        req-space,
+        preferred-side,
+        strategy: note-data.at("side-strategy", default: auto),
+      )
+    }
+
+    let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+    let n-width = calc.max(0pt, _resolve-rel-len(note-data.width, margin-width, margin-width))
+    let dx-val = _resolve-rel-len(note-data.dx, margin-width, (margin-width - n-width) / 2.0)
+
+    let pad-left = if actual-side == left { margin-width - n-width - dx-val } else { dx-val }
+
+    let attach-x = if actual-side == left {
+      start-x - dx-val
+    } else {
+      start-x + text-width + dx-val
+    }
+
+    let n-link = note-data.at("link", default: "none")
+    let n-link-stroke = note-data.at("link-stroke", default: none)
+    let n-link-radius = note-data.at("link-radius", default: 0pt)
+    let n-link-waypoints = note-data.at("link-waypoints", default: auto)
+    let n-link-ports = note-data.at("link-ports", default: auto)
+    let n-link-marks = note-data.at("link-marks", default: "none")
+
+    let render-single = note-data.at("render-single", default: deixis-native-render-single)
+
+    let raw-rendered = render-single(
+      note-data,
+      inner-width: 100%,
+      ..args.named(),
+    )
+
+    let final-rendered = box(width: margin-width, align(left, pad(left: pad-left, block(width: n-width, raw-rendered))))
+    let h = measure(final-rendered).height
+
+    if body-align-str == "bottom" { natural-y -= h } else if body-align-str == "horizon" { natural-y -= h / 2 }
+
+    let obj = (
+      mark-page: n.mark-page,
+      mark-block: n.at("mark-block", default: 0),
+      block-idx: n.at("block-idx", default: 0),
+      mark-x: note-data.at("mark-x", default: 0pt),
+      mark-y: note-data.at("mark-y", default: 0pt),
+      marker-width: note-data.at("marker-width", default: 0pt),
+      marker-str: note-data.at("marker-str", default: none),
+      text-size: note-data.at("text-size", default: auto),
+      has-inline-box: note-data.at("has-inline-box", default: false),
+      mark-type: note-data.at("mark-type", default: "inline"),
+      reg: note-data.at("reg", default: none),
+      r-pins: note-data.at("r-pins", default: ()),
+      gap: n-gap,
+      side: actual-side,
+      link: n-link,
+      link-stroke: n-link-stroke,
+      link-radius: n-link-radius,
+      link-marks: n-link-marks,
+      link-waypoints: n-link-waypoints,
+      link-ports: n-link-ports,
+      attach-x: attach-x,
+      y: natural-y,
+      h: h,
+      w: n-width,
+      rendered: final-rendered,
+    )
+
+    if actual-side == left {
+      let eff-gap = if left-notes.len() == 0 { 0pt } else { n-gap }
+      left-notes.push(obj)
+      l-current-bottom = calc.max(natural-y, l-current-bottom + eff-gap) + h
+    } else {
+      let eff-gap = if right-notes.len() == 0 { 0pt } else { n-gap }
+      right-notes.push(obj)
+      r-current-bottom = calc.max(natural-y, r-current-bottom + eff-gap) + h
+    }
+  }
+
+  let render-flow-container(note-list, margin-x, margin-width) = {
+    if note-list.len() == 0 { return (content: none, height: 0pt, final-y: ()) }
+
+    let fr-values = ()
+    let total-notes-height = 0pt
+    let current-y = top-bound
+
+    for (i, obj) in note-list.enumerate() {
+      let gap = if i == 0 { 0pt } else { obj.gap }
+      let target-y = calc.min(obj.y, end-y)
+
+      let min-y = current-y + gap
+      let extra-wanted = target-y - min-y
+      fr-values.push(calc.max(0pt, extra-wanted) / 1pt)
+
+      total-notes-height += gap + obj.h
+      current-y = calc.max(target-y, min-y) + obj.h
+    }
+
+    let end-dist = end-y - current-y
+    fr-values.push(calc.max(0pt, end-dist) / 1pt)
+
+    let total-fr = 0.0
+    for val in fr-values { total-fr += val }
+    if total-fr <= 1e-5 {
+      fr-values.last() = 1.0
+      total-fr = 1.0
+    }
+
+    let block-physical-height = end-y - top-bound
+    let container-height = calc.max(block-physical-height, total-notes-height)
+    let extra-space = calc.max(0pt, container-height - total-notes-height)
+
+    let final-y = ()
+    let exact-cur-y = top-bound
+    for (i, obj) in note-list.enumerate() {
+      let gap = if i == 0 { 0pt } else { obj.gap }
+      exact-cur-y += gap
+
+      let space = (fr-values.at(i) / total-fr) * extra-space
+      exact-cur-y += space
+      final-y.push(exact-cur-y)
+      exact-cur-y += note-list.at(i).h
+    }
+
+    let container-content = place(
+      dx: margin-x,
+      dy: top-bound,
+      block(width: margin-width, height: container-height, {
+        for (i, obj) in note-list.enumerate() {
+          let gap = if i == 0 { 0pt } else { obj.gap }
+
+          if i > 0 { v(gap) }
+          v(fr-values.at(i) * 1fr)
+          obj.rendered
+        }
+        v(fr-values.last() * 1fr)
+      }),
+    )
+
+    return (content: container-content, height: container-height, final-y: final-y)
+  }
+
+  let l-res = render-flow-container(
+    left-notes,
+    start-x - l-space-abs,
+    l-space-abs,
+  )
+  let r-res = render-flow-container(
+    right-notes,
+    start-x + text-width,
+    r-space-abs,
+  )
+
+  let text-bounds = (left: start-x, right: start-x + text-width)
+
+  let all-notes-here = ()
+  for i in range(left-notes.len()) {
+    let mut-n = left-notes.at(i)
+    mut-n.insert("final-y", l-res.final-y.at(i))
+    mut-n.insert("is-incoming", mut-n.mark-page < current-page)
+    mut-n.insert("is-outgoing", false)
+    all-notes-here.push(mut-n)
+  }
+  for i in range(right-notes.len()) {
+    let mut-n = right-notes.at(i)
+    mut-n.insert("final-y", r-res.final-y.at(i))
+    mut-n.insert("is-incoming", mut-n.mark-page < current-page)
+    mut-n.insert("is-outgoing", false)
+    all-notes-here.push(mut-n)
+  }
+
+  let formatted-pushed = pushed-notes.map(pn => {
+    let note-data = pn.note-data
+    (
+      mark-page: pn.mark-page,
+      mark-block: pn.at("mark-block", default: 0),
+      block-idx: pn.at("block-idx", default: 0),
+      mark-x: note-data.at("mark-x", default: 0pt),
+      mark-y: note-data.at("mark-y", default: 0pt),
+      marker-width: note-data.at("marker-width", default: 0pt),
+      marker-str: note-data.at("marker-str", default: none),
+      text-size: note-data.at("text-size", default: auto),
+      has-inline-box: note-data.at("has-inline-box", default: false),
+      mark-type: note-data.at("mark-type", default: "inline"),
+      reg: note-data.at("reg", default: none),
+      r-pins: note-data.at("r-pins", default: ()),
+      side: if note-data.at("side", default: right) in ("left", left) { left } else { right },
+      link: note-data.at("link", default: "none"),
+      link-stroke: note-data.at("link-stroke", default: none),
+      link-radius: note-data.at("link-radius", default: 0pt),
+      link-waypoints: note-data.at("link-waypoints", default: auto),
+      link-ports: note-data.at("link-ports", default: auto),
+      link-marks: note-data.at("link-marks", default: "none"),
+      attach-x: 0pt,
+      final-y: 0pt,
+      h: 0pt,
+      w: 0pt,
+      is-incoming: false,
+      is-outgoing: true,
+    )
+  })
+
+  let text-bounds = (left: start-x, right: start-x + text-width)
+
+  place(top + left, {
+    _deixis-render-margin-links(
+      all-notes-here + formatted-pushed,
+      current-page,
+      text-bounds,
+      top-bound,
+      bottom-bound,
+    )
+    l-res.content
+    r-res.content
+  })
+}
+
+#let _deixis-predict-cascade(
+  notes,
+  blocks-info,
+  pref-dir,
+  margin-layout,
+  min-margin-width: 1in,
+  cascade-breaker: true,
+  ..args,
+) = {
+  let block-buckets = ()
+  for i in range(blocks-info.len()) { block-buckets.push(()) }
+
+  let _resolve-rel-len(val, ref-len, def) = {
+    if val == auto { return def }
+    if type(val) == ratio { return (val / 100%) * ref-len }
+    if type(val) == relative { return deixis-utils.resolve-signed-len(val.length) + ((val.ratio / 100%) * ref-len) }
+    return deixis-utils.resolve-signed-len(val)
+  }
+
+  for n in notes {
+    let note-data = n.note-data
+    let mark-page = n.mark-page
+    let mark-x = n.mark-x
+    let mark-y = n.mark-y
+
+    // FIXME: hack for 2nd level notes and above
+    if note-data.at("depth", default: 0) >= 2 {
+      mark-x += note-data.at("marker-width", default: 0pt)
+    }
+
+    let n-gap = deixis-utils.resolve-len(note-data.at("gap", default: 0.5em))
+
+    let dy-abs = deixis-utils.resolve-signed-len(note-data.dy)
+    let natural-y = mark-y + dy-abs
+
+    let start-idx = 0
+    while start-idx < blocks-info.len() - 1 {
+      let cur-block = blocks-info.at(start-idx)
+      let next-block = blocks-info.at(start-idx + 1)
+
+      if (
+        mark-page > next-block.page
+          or (mark-page == next-block.page and (cur-block.page < next-block.page or natural-y >= next-block.top - 1pt))
+      ) {
+        start-idx += 1
+      } else { break }
+    }
+    let cur-block = blocks-info.at(start-idx)
+
+    let new-note-data = note-data
+    new-note-data.insert("mark-x", mark-x)
+    new-note-data.insert("mark-y", mark-y)
+    new-note-data.insert("x", mark-x)
+    new-note-data.insert("y", mark-y)
+    new-note-data.insert("reg", n.at("reg", default: none))
+    new-note-data.insert("r-pins", n.at("r-pins", default: ()))
+
+    if mark-page < cur-block.page or (mark-page == cur-block.page and natural-y < cur-block.top) {
+      new-note-data.insert("y", cur-block.top - dy-abs)
+    } else if mark-page > cur-block.page or (mark-page == cur-block.page and natural-y > cur-block.bottom) {
+      new-note-data.insert("y", cur-block.bottom - dy-abs)
+    }
+    block-buckets.at(start-idx).push((spoofed-data: new-note-data, mark-block: start-idx, mark-page: mark-page))
+  }
+
+  let final-results = ()
+  let overflow-queue = ()
+
+  for block-id in range(blocks-info.len()) {
+    let current-block = blocks-info.at(block-id)
+    let current-notes = overflow-queue + block-buckets.at(block-id)
+    overflow-queue = ()
+
+    if current-notes.len() == 0 { continue }
+
+    let first-note = current-notes.first().spoofed-data
+    let local-margin-layout = first-note.at("margin-layout", default: margin-layout)
+    let local-min-width = first-note.at("min-margin-width", default: min-margin-width)
+
+    let is-flow = local-margin-layout == "flow" or type(local-margin-layout) == function
+    let req-space = deixis-utils.resolve-len(local-min-width)
+
+    let l-space-abs = current-block.l-space
+    let r-space-abs = current-block.r-space
+    let l-current-bottom = current-block.top
+    let r-current-bottom = current-block.top
+
+    let l-notes = ()
+    let r-notes = ()
+
+    let pref-side = if pref-dir == rtl { left } else { right }
+    let overflowed-l = false
+    let overflowed-r = false
+
+    for n-obj in current-notes {
+      let note-data = n-obj.spoofed-data
+      let c-page = current-block.page
+      let dy-abs = deixis-utils.resolve-signed-len(note-data.dy)
+      let natural-y = note-data.at("y", default: 0pt) + dy-abs
+
+
+      let n-gap = deixis-utils.resolve-len(note-data.at("gap", default: 0.5em))
+
+      let actual-side = note-data.side
+      if actual-side in ("inside", "outside") {
+        if note-data.at("target-id", default: "page") == "page" {
+          let c-page = if "current-page" in dictionary(sys) { current-page } else { current-block.page }
+          actual-side = if calc.odd(c-page) == (actual-side == "inside") { left } else { right }
+        } else {
+          let is-outside = (actual-side == "outside")
+          if pref-dir == rtl {
+            actual-side = if is-outside { left } else { right }
+          } else {
+            actual-side = if is-outside { right } else { left }
+          }
+        }
+      } else if actual-side == "left" { actual-side = left } else if actual-side == "right" { actual-side = right }
+
+      // min-margin-width safety catch
+      if actual-side != auto and note-data.at("mark-align-strictness", default: "none") != "strict" {
+        let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+        if margin-width < req-space {
+          let opposite-width = if actual-side == left { r-space-abs } else { l-space-abs }
+          if opposite-width > margin-width {
+            actual-side = if actual-side == left { right } else { left }
+          }
+        }
+      }
+
+      if actual-side == auto {
+        actual-side = _deixis-resolve-side(
+          natural-y,
+          l-current-bottom,
+          r-current-bottom,
+          current-block.bottom,
+          l-space-abs,
+          r-space-abs,
+          req-space,
+          pref-side,
+          overflowed-l: overflowed-l,
+          overflowed-r: overflowed-r,
+          strategy: note-data.at("side-strategy", default: auto),
+        )
+      }
+
+      let margin-width = if actual-side == left { l-space-abs } else { r-space-abs }
+      let n-width = calc.max(0pt, _resolve-rel-len(note-data.width, margin-width, margin-width))
+      let dx-val = _resolve-rel-len(note-data.dx, margin-width, (margin-width - n-width) / 2.0)
+
+      let pad-left = if actual-side == left { margin-width - n-width - dx-val } else { dx-val }
+
+      let render-single = note-data.at("render-single", default: deixis-native-render-single)
+      let raw-rendered = render-single(note-data, inner-width: 100%, ..args.named())
+
+      let final-rendered = box(width: margin-width, align(left, pad(left: pad-left, block(
+        width: n-width,
+        raw-rendered,
+      ))))
+      let h = measure(final-rendered).height
+
+      let n-mark-align = note-data.at("mark-align", default: "top")
+      let n-mark-align-strict = note-data.at("mark-align-strictness", default: "none")
+
+      let body-align = if type(n-mark-align) == dictionary and "body" in n-mark-align { n-mark-align.body } else if (
+        type(n-mark-align) in (str, alignment)
+      ) { n-mark-align } else { "top" }
+      let body-align-str = if type(body-align) == alignment { repr(body-align.y) } else { str(body-align) }
+
+      let shifted-y = natural-y
+      if body-align-str == "bottom" { shifted-y -= h } else if body-align-str == "horizon" { shifted-y -= h / 2 }
+
+      let side-notes = if actual-side == left { l-notes } else { r-notes }
+      let test-notes = (
+        side-notes + ((mark-y: natural-y, y: shifted-y, h: h, gap: n-gap, mark-align-strictness: n-mark-align-strict),)
+      )
+      let physical-overflow = false
+
+      if is-flow {
+        let total-h = 0pt
+        for (i, n) in test-notes.enumerate() {
+          if i > 0 { total-h += n.gap }
+          total-h += n.h
+        }
+        if current-block.top + total-h > current-block.bottom + 0.1pt {
+          physical-overflow = true
+        }
+      } else {
+        let final-y-list = _deixis-rubber-band(
+          test-notes,
+          current-block.top,
+          current-block.bottom,
+        )
+
+        let final-bottom = if final-y-list.len() > 0 { final-y-list.last() + test-notes.last().h } else {
+          current-block.top
+        }
+
+        if final-bottom > current-block.bottom + 0.1pt {
+          physical-overflow = true
+        }
+      }
+
+      if cascade-breaker {
+        let block-avail-height = current-block.bottom - current-block.top
+        if physical-overflow and side-notes.len() == 0 and h > block-avail-height - 1pt {
+          physical-overflow = false
+        }
+      }
+
+      let n-spillover = note-data.at("spillover", default: true)
+      if physical-overflow and not n-spillover {
+        physical-overflow = false
+      }
+
+      let forced-overflow = false
+      if actual-side == left and overflowed-l { forced-overflow = true }
+      if actual-side == right and overflowed-r { forced-overflow = true }
+
+      if (forced-overflow or physical-overflow) and block-id < blocks-info.len() - 1 {
+        if actual-side == left { overflowed-l = true } else { overflowed-r = true }
+        let pushed-note-data = note-data
+        pushed-note-data.insert("y", blocks-info.at(block-id + 1).top - dy-abs)
+        overflow-queue.push((spoofed-data: pushed-note-data, mark-block: n-obj.mark-block, mark-page: n-obj.mark-page))
+      } else {
+        let accepted-note-data = note-data
+        accepted-note-data.insert("side", if actual-side == left { "left" } else { "right" })
+        final-results.push((
+          block-idx: block-id,
+          mark-block: n-obj.mark-block,
+          note-data: accepted-note-data,
+          mark-page: n-obj.mark-page,
+        ))
+
+        if actual-side == left {
+          let eff-gap = if l-notes.len() == 0 { 0pt } else { n-gap }
+          l-notes.push((mark-y: natural-y, y: shifted-y, h: h, gap: n-gap, mark-align-strictness: n-mark-align-strict))
+          l-current-bottom = calc.max(shifted-y, l-current-bottom + eff-gap) + h
+        } else {
+          let eff-gap = if r-notes.len() == 0 { 0pt } else { n-gap }
+          r-notes.push((mark-y: natural-y, y: shifted-y, h: h, gap: n-gap, mark-align-strictness: n-mark-align-strict))
+          r-current-bottom = calc.max(shifted-y, r-current-bottom + eff-gap) + h
+        }
+      }
+    }
+  }
+  return final-results
+}
+
+/// --------------------
+/// Other Utilities
+/// --------------------
+
+/// Places content relative to a specific anchor mark given its `internal-id` or a pin given its name.
+#let deixis-place-anchored(
+  body,
+  dx: 0pt,
+  dy: 0pt,
+  anchor: bottom + right,
+  internal-id: none,
+  pin: none,
+) = context {
+  let cur-pos = here().position()
+  let target-x = cur-pos.x
+  let target-y = cur-pos.y
+
+  let a-target = if type(anchor) == dictionary {
+    anchor.at("target", default: anchor.at("mark", default: bottom + right))
+  } else { anchor }
+  let a-body = if type(anchor) == dictionary { anchor.at("body", default: a-target) } else { anchor }
+
+  let in-left = a-target in (left, top + left, horizon + left, bottom + left)
+  let in-center = a-target in (center, top + center, horizon + center, bottom + center)
+  let in-top = a-target in (top, top + left, top + center, top + right)
+  let in-horizon = a-target in (horizon, horizon + left, horizon + center, horizon + right)
+
+  let b-right = a-body in (right, top + right, horizon + right, bottom + right)
+  let b-center = a-body in (center, top + center, horizon + center, bottom + center)
+  let b-bottom = a-body in (bottom, bottom + left, bottom + center, bottom + right)
+  let b-horizon = a-body in (horizon, horizon + left, horizon + center, horizon + right)
+
+  let r-pins = ()
+  let reg-val = none
+  let all-pins = query(<deixis-pin>)
+
+  if pin != none {
+    let pin-arr = if type(pin) == array { pin } else { (pin,) }
+    for pin-name in pin-arr {
+      for p in all-pins.filter(x => x.value.name == pin-name) { r-pins.push(p) }
+    }
+  } else if internal-id != none {
+    let region-elems = query(<deixis-region-mark>).filter(r => (
+      r.value.internal-id != none and str(r.value.internal-id) == str(internal-id)
+    ))
+    if region-elems.len() > 0 {
+      reg-val = region-elems.first().value
+      for pin-name in reg-val.pins {
+        for p in all-pins.filter(x => x.value.name == pin-name) { r-pins.push(p) }
+      }
+    }
+  }
+
+  if r-pins.len() > 0 {
+    let sorted-pins = r-pins.sorted(key: p => (p.location().page(), p.location().position().y))
+    let first-page = sorted-pins.first().location().page()
+    let last-page = sorted-pins.last().location().page()
+    let current-page = here().page()
+
+    let min-x = 1e10pt
+    let max-x = -1e10pt
+    let min-y = 1e10pt
+    let max-y = -1e10pt
+
+    for p in r-pins {
+      let px = p.location().position().x
+      let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+      let px-l = px - p-pad.left
+      let px-r = px + p-pad.right
+      if px-l < min-x { min-x = px-l }
+      if px-r > max-x { max-x = px-r }
+    }
+
+    let p-margins = deixis-utils.get-page-margins(current-page)
+    let page-h = deixis-utils.resolve-len(if type(page.height) == length { page.height } else {
+      deixis-utils.default-page-size.height
+    })
+    let top-bound = deixis-utils.resolve-len(p-margins.top)
+    let bottom-bound = page-h - deixis-utils.resolve-len(p-margins.bottom)
+
+    min-y = top-bound
+    max-y = bottom-bound
+
+    let page-pins = r-pins.filter(p => p.location().page() == current-page)
+    if page-pins.len() > 0 {
+      let local-min-y = 1e10pt
+      let local-max-y = -1e10pt
+      for p in page-pins {
+        let py = p.location().position().y
+        let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+        let py-t = py - p-pad.top
+        let py-b = py + p-pad.bottom
+        if py-t < local-min-y { local-min-y = py-t }
+        if py-b > local-max-y { local-max-y = py-b }
+      }
+      if current-page == first-page { min-y = local-min-y }
+      if current-page == last-page { max-y = local-max-y }
+    } else {
+      if last-page < current-page {
+        min-y = top-bound
+        max-y = top-bound
+      } else if first-page > current-page {
+        min-y = bottom-bound
+        max-y = bottom-bound
+      }
+    }
+
+    let reg-pad = if reg-val != none { deixis-utils.get-margins(reg-val.styles.at("padding", default: 0pt)) } else {
+      (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt)
+    }
+    min-x -= deixis-utils.resolve-len(reg-pad.left)
+    max-x += deixis-utils.resolve-len(reg-pad.right)
+
+    if current-page == first-page { min-y -= deixis-utils.resolve-len(reg-pad.top) }
+    if current-page == last-page { max-y += deixis-utils.resolve-len(reg-pad.bottom) }
+
+    target-x = max-x
+    if in-left { target-x = min-x } else if in-center { target-x = (min-x + max-x) / 2.0 }
+
+    target-y = max-y
+    if in-top { target-y = min-y } else if in-horizon { target-y = (min-y + max-y) / 2.0 }
+  } else if internal-id != none {
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let elems = query(selector(mark-lbl))
+    if elems.len() > 0 {
+      let el = elems.first()
+      let ex = el.location().position().x
+      let ey = el.location().position().y
+
+      let marker-width = 0pt
+      let marker-height = 11pt
+      let mm-elems = query(selector(metadata).and(selector(<deixis-inline-mark>).or(<deixis-phantom-mark>))).filter(
+        m => (
+          type(m.value) == dictionary
+            and m.value.at("internal-id", default: none) != none
+            and str(m.value.internal-id) == str(internal-id)
+        ),
+      )
+      if mm-elems.len() > 0 {
+        let mm-val = mm-elems.first().value
+        marker-width = mm-val.at("marker-width", default: 0pt)
+        let ts = mm-val.at("text-size", default: 11pt)
+        marker-height = if type(ts) == length { ts } else { 11pt }
+      }
+
+      let min-x = ex
+      let max-x = ex + marker-width
+      let min-y = ey - (marker-height * 0.8)
+      let max-y = ey + (marker-height * 0.2)
+
+      target-x = max-x
+      if in-left { target-x = min-x } else if in-center { target-x = (min-x + max-x) / 2.0 }
+
+      target-y = max-y
+      if in-top { target-y = min-y } else if in-horizon { target-y = (min-y + max-y) / 2.0 }
+    }
+  }
+
+  let offset-x = target-x - cur-pos.x + dx
+  let offset-y = target-y - cur-pos.y + dy
+
+  let size = measure(body)
+  if b-right { offset-x -= size.width } else if b-center { offset-x -= size.width / 2.0 }
+
+  if b-bottom { offset-y -= size.height } else if b-horizon { offset-y -= size.height / 2.0 }
+
+  place(box(place(top + left, dx: offset-x, dy: offset-y, body)))
+}
+
+/// Places content at a specific exact absolute coordinate on the page ignoring page margins.
+#let deixis-absolute-place(..args) = {
+  let pos-args = args.pos()
+  let align-val = none
+  let content = none
+
+  if pos-args.len() == 1 {
+    content = pos-args.first()
+  } else if pos-args.len() == 2 {
+    align-val = pos-args.first()
+    content = pos-args.last()
+  } else {
+    panic("deixis: deixis-absolute-place expects 1 or 2 positional arguments: [alignment], content.")
+  }
+
+  let dx = args.named().at("dx", default: 0pt)
+  let dy = args.named().at("dy", default: 0pt)
+
+  // double place trick to avoid infinite layout loop
+  place(top + left, context {
+    let page-pos = here().position()
+
+    let p-w = if type(page.width) == length { page.width } else { deixis-utils.default-page-size.width }
+    let p-h = if type(page.height) == length { page.height } else { deixis-utils.default-page-size.height }
+
+    place(
+      top + left,
+      dx: -page-pos.x,
+      dy: -page-pos.y,
+      box(
+        width: p-w,
+        height: p-h,
+        if align-val == none {
+          place(dx: dx, dy: dy, content)
+        } else {
+          place(align-val, dx: dx, dy: dy, content)
+        },
+      ),
+    )
+  })
+}

--- a/packages/preview/deixis/0.1.1/src/lib.typ
+++ b/packages/preview/deixis/0.1.1/src/lib.typ
@@ -1,0 +1,730 @@
+#import "core.typ": *
+#import "counter.typ": *
+#import "minipage.typ": *
+
+#import "inline-note.typ": *
+#import "region-note.typ": *
+#import "footnote.typ": *
+#import "endnote.typ": *
+#import "margin-note.typ": *
+#import "inset-note.typ": *
+
+#import "outline.typ": *
+#import "reference.typ": *
+
+/// Initializes the `deixis` state engine and layout overlays.
+///
+/// This function *must* wrap your document `#show: deixis-setup-notes.with(...)` before any other `deixis` functionality can be used.
+///
+/// ```warning
+/// `deixis` uses the page foreground and background to display some notes.
+/// Any attempt to modify the foreground or background after `#show: deixis-setup-notes` will completely overwrite the setup.
+/// Thus, you must always put `#set page(background: ..., foreground: ...)` before `#show: deixis-setup-notes`.
+/// ```
+///
+/// - body (content): The main document content to wrap.
+/// - foreground (none, content): Custom content to inject into the foreground overlay layer.
+/// - background (none, content): Custom content to inject into the background overlay layer.
+/// - override-page-footnotes (bool): If `true`, page-level footnotes will be rendered on the foreground.
+///
+/// -> content
+#let deixis-setup-notes(
+  /// The main document content to wrap.
+  /// -> content
+  body,
+  /// Custom content to inject into the foreground overlay layer.
+  /// -> none | content
+  foreground: none,
+  /// Custom content to inject into the background overlay layer.
+  /// -> none | content
+  background: none,
+  /// If `true`, page-level footnotes will be rendered on the foreground.
+  ///
+  /// ```info
+  /// Foreground overlay allows some behaviors like grouping footnotes by series or aligned marker.
+  /// ```
+  ///
+  /// -> bool
+  override-page-footnotes: true,
+) = context {
+  let native-bg = page.background
+  let native-fg = page.foreground
+
+  deixis-setup-state.update(true)
+
+  // override page footnotes
+  let fn-sep = if override-page-footnotes { none } else {
+    _deixis-resolve-typed-param(none, auto, "separator", "footnote")
+  }
+  let fn-clearance = _deixis-resolve-typed-param(none, auto, "clearance", "footnote")
+  let fn-gap = _deixis-resolve-typed-param(none, auto, "gap", "footnote")
+  let fn-indent = _deixis-resolve-typed-param(none, auto, "indent", "footnote")
+
+  show: it => if fn-sep != auto {
+    set footnote.entry(separator: fn-sep)
+    it
+  } else { it }
+  show: it => if fn-clearance != auto {
+    set footnote.entry(clearance: fn-clearance)
+    it
+  } else { it }
+  show: it => if fn-gap != auto {
+    set footnote.entry(gap: fn-gap)
+    it
+  } else { it }
+  show: it => if fn-indent != auto {
+    set footnote.entry(indent: fn-indent)
+    it
+  } else { it }
+
+  deixis-system.update(sys => {
+    let fg-layers = sys.at("fg-layers", default: (:))
+    let bg-layers = sys.at("bg-layers", default: (:))
+
+    // region-mark
+    bg-layers.insert("region-marks", place(top + left, context { _deixis-region-marks-overlay(layer: "background") }))
+    fg-layers.insert("region-marks", place(top + left, context { _deixis-region-marks-overlay(layer: "foreground") }))
+    // footnote
+    sys.insert("override-page-footnotes", override-page-footnotes)
+    if override-page-footnotes {
+      fg-layers.insert("footnotes", context { _deixis-page-footnotes-overlay() })
+    }
+    // inset-note
+    bg-layers.insert("inset-notes", place(top + left, context { _deixis-inset-notes-overlay(layer: "background") }))
+    fg-layers.insert("inset-notes", place(top + left, context { _deixis-inset-notes-overlay(layer: "foreground") }))
+    // margin-note
+    fg-layers.insert("margin-notes", place(top + left, context { _deixis-margin-notes-overlay() }))
+
+    if native-fg != none { fg-layers.insert("native-fg", native-fg) }
+    if native-bg != none { bg-layers.insert("native-bg", native-bg) }
+
+    if foreground not in (auto, none) { fg-layers.insert("user-fg", place(top + left, foreground)) }
+    if background not in (auto, none) { bg-layers.insert("user-bg", place(top + left, background)) }
+    sys.insert("fg-layers", fg-layers)
+    sys.insert("bg-layers", bg-layers)
+
+    return sys
+  })
+
+  set page(
+    background: context {
+      let layers = deixis-system.get().at("bg-layers", default: (:))
+      if "native-bg" in layers { layers.at("native-bg") }
+      if "user-bg" in layers { layers.at("user-bg") }
+
+      for (name, content) in layers {
+        if name != "user-bg" { content }
+      }
+    },
+    foreground: context {
+      let layers = deixis-system.get().at("fg-layers", default: (:))
+      for (name, content) in layers {
+        if name != "user-fg" { content }
+      }
+
+      if "user-fg" in layers { layers.at("user-fg") }
+      if "native-fg" in layers { layers.at("native-fg") }
+    },
+  )
+
+  show: deixis-show-refs
+  body
+}
+
+/// Dynamically updates the global `deixis` configuration mid-document.
+///
+/// This function acts like a standard Typst `#set` rule for the internal `deixis` state. It applies
+/// your new configuration to all subsequent notes within the current scope.
+///
+/// ```tip
+/// *Type-Specific Styling:* All parameters accept either a global value or a `dictionary` targeting specific note types
+/// (e.g., `stroke: (margin-note: red, inset-note: blue)`).
+/// The `dictionary` will be interpreted as scope specific and not a global value if it contains either note-scope keys or component-scope keys.
+/// - Note-scope keys: #(deixis-mark-types + deixis-note-types).
+/// - Component-scope keys: #(deixis-note-components).
+///   - `"nodes"` indicates both `"mark"` and `"body"` (excluding `"link"`).
+/// - Wildcard key: `"rest"` indicates anything else.
+/// ```
+///
+/// - numbering (auto, str, function, dictionary): The numbering style for markers.
+/// - marker-style (auto, function, dictionary): The styling function `(content) => content` for note markers.
+/// - body-style (auto, function, dictionary): The styling function `(content) => content` for note bodies.
+/// - backlink (auto, bool, str, dictionary): Enables or disables clickable backlinks from bodies to marks. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - marker-position (auto, alignment, dictionary): Mark marker placement.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+/// - stroke (auto, stroke, none, dictionary): The border stroke.
+/// - fill (auto, color, none, dictionary): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - link (auto, str, dictionary): The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+/// - link-marks (auto, str, dictionary): The connector arrowhead style. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+/// - separator (auto, content, none, dictionary): The separator line for note groups.
+/// - clearance (auto, length, dictionary): Vertical spacing before note groups.
+/// - gap (auto, length, dictionary): Vertical spacing between adjacent notes.
+/// - marker-gap (auto, length, dictionary): Horizontal spacing between the marker and the body text.
+/// - indent (auto, length, dictionary): The indentation applied to the note body.
+/// - margin-layout (auto, str): The layout engine for margin notes. Choices: `"adaptive"` | `"flow"` | `"exact"`.
+/// - min-margin-width (auto, length): Minimum margin width to put margin notes.
+/// - side-strategy (auto, str): Strategy to select side for margin note. Choices: `"nearest"` | `"strict"`.
+/// - mark-align (auto, alignment, dictionary): How margin notes align vertically relative to their marks.
+/// - mark-align-strictness (auto, str): How strictly to align margin notes to their marks. Choices: `"strict"` | `"loose"` | `"none"`.
+/// - spillover (auto, bool): Allow margin notes to spill over page boundaries.
+/// - region-shape (auto, function): Shape drawing function for region marks.
+/// - layer (auto, str): The rendering layer for region marks and inset notes. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - render-single (auto, function, dictionary): Note body rendering function.
+/// - render-group (auto, function, dictionary): Group rendering function for grouped notes (footnote and endnote).
+/// - container-func (auto, function, dictionary): Note body container function with signature `(content, ..args) => content`.
+///
+/// -> content
+#let deixis-set(
+  /// The numbering style for the marker.
+  ///
+  /// ```example
+  /// #deixis-set(numbering: "i")
+  /// #deixis-footnote[A note with roman numbering.]
+  /// ```
+  ///
+  /// -> auto | str | function | dictionary
+  numbering: auto,
+  /// The styling function `(content) => content` for note markers.
+  ///
+  /// ```example
+  /// #deixis-set(marker-style: (
+  ///   mark: it => text(super(it), fill: red),
+  ///   body: it => text([#it.], fill: blue, weight: "bold"))
+  /// )
+  /// #deixis-footnote[A note with custom mark marker style and body marker style.]
+  /// ```
+  ///
+  /// -> auto | function | dictionary
+  marker-style: auto,
+  /// The styling function `(content) => content` for note bodies.
+  ///
+  /// ```example
+  /// #deixis-set(body-style: it => text(it, fill: blue, weight: "semibold"))
+  /// #deixis-footnote[A note with custom body style.]
+  /// ```
+  ///
+  /// ```info
+  /// Setting `body-style` will override the default styling, i.e. `it => text(size: 0.85em, it)`.
+  /// Instead, applying custom styling directly to the body content does not.
+  /// ```
+  ///
+  /// ```example
+  /// #deixis-footnote[#text(fill: blue, weight: "semibold")[Another note with custom body style.]]
+  /// ```
+  ///
+  /// -> auto | function | dictionary
+  body-style: auto,
+  /// Enables or disables clickable backlinks from bodies to marks. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  ///
+  /// ```example
+  /// #deixis-set(backlink: true)
+  /// #deixis-footnote(label: <deixis-set.backlink>)[A note with backlink.]
+  /// #deixis-ref(<deixis-set.backlink>)
+  /// ```
+  ///
+  /// -> auto | bool | str | dictionary
+  backlink: auto,
+  /// Mark marker placement.
+  ///
+  /// See @deixis-inline-mark.marker-position and @deixis-region-mark.marker-position.
+  ///
+  /// -> auto | alignment | dictionary
+  marker-position: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+  ///
+  /// See @deixis-inline-mark.inline-mode.
+  ///
+  /// -> auto | str
+  inline-mode: auto,
+  /// The border stroke.
+  ///
+  /// ```example
+  /// #deixis-inset-note(
+  ///   stroke: (mark: red, body: blue),
+  ///   layer: "flow",
+  /// )[A note with red mark stroke.][And blue body stroke.]
+  /// ```
+  ///
+  /// -> auto | stroke | none | dictionary
+  stroke: auto,
+  /// The background fill color.
+  ///
+  /// ```example
+  /// #deixis-inset-note(
+  ///   stroke: none,
+  ///   fill: (mark: red, body: blue),
+  ///   layer: "flow",
+  /// )[A note with red mark fill.][And blue body fill.]
+  /// ```
+  ///
+  /// -> auto | color | none | dictionary
+  fill: auto,
+  /// The border radius.
+  ///
+  /// ```example
+  /// #deixis-inset-note(
+  ///   stroke: yellow,
+  ///   fill: yellow.transparentize(95%),
+  ///   radius: (mark: 0pt, body: 1em),
+  ///   layer: "flow",
+  /// )[A note with `0pt` mark radius.][And `1em` body radius.]
+  /// ```
+  ///
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+  ///
+  /// - `"none"`: The link is completely invisible.
+  /// - `"straight-line"`: A direct, shortest-path line from the start to the end point.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-inset-note(
+  ///   stroke: green,
+  ///   fill: green.transparentize(95%),
+  ///   link: "straight-line",
+  ///   dx: 4em, dy: 3em,
+  ///   layer: "flow",
+  /// )[Note mark.][Note body.]
+  /// ```
+  /// - `"right-angle"`: Routes the link orthogonally (moving only horizontally and vertically) and smooths the turns with rounded corners (fillets).
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-inset-note(
+  ///   stroke: green,
+  ///   fill: green.transparentize(95%),
+  ///   link: "right-angle",
+  ///   dx: 4em, dy: 3em,
+  ///   layer: "flow",
+  /// )[Note mark.][Note body.]
+  /// ```
+  /// - `"chamfer"`: Similar to `"right-angle"`, but cuts the corners with diagonal straight lines (bevels) instead of rounding them.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-inset-note(
+  ///   stroke: green,
+  ///   fill: green.transparentize(95%),
+  ///   link: "chamfer",
+  ///   dx: 4em, dy: 3em,
+  ///   layer: "flow",
+  /// )[Note mark.][Note body.]
+  /// ```
+  /// - `"curve"`: Draws a smooth *Weighted Bessel Spline*.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-inset-note(
+  ///   stroke: green,
+  ///   fill: green.transparentize(95%),
+  ///   link: "curve",
+  ///   dx: 4em, dy: 3em,
+  ///   layer: "flow",
+  /// )[Note mark.][Note body.]
+  /// ```
+  /// - `"ccr"`: Draws a *Centripetal Catmull-Rom* spline, which is more stable compared to other curves and less prone to unnatural loops or aggressive bulges.
+  /// - `"ucr"`: Draws a standard *Uniform Catmull-Rom* spline.
+  ///
+  /// ```tip
+  /// Link type can be changed dynamically mid-path by declaring them in the `link-waypoints` parameters of the note functions.
+  /// See @deixis-common-note-args.link-waypoints.
+  /// ```
+  ///
+  /// -> auto | str | dictionary
+  link: auto,
+  /// The connector arrowhead style. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-inset-note(
+  ///   stroke: green,
+  ///   fill: green.transparentize(95%),
+  ///   link: "straight-line",
+  ///   link-marks: "both",
+  ///   dx: 4em, dy: 3em,
+  ///   layer: "flow",
+  /// )[Note mark.][Note body.]
+  /// ```
+  ///
+  /// -> auto | str | dictionary
+  link-marks: auto,
+  /// The separator line for note groups.
+  ///
+  /// ```info
+  /// This only has effect on grouped notes (footnote and endnote).
+  /// ```
+  ///
+  /// ```example
+  /// #deixis-set(separator: line(length: 50%, stroke: (thickness: 0.5pt, dash: "dashed")))
+  /// #deixis-footnote[A footnote separated by a dashed line.]
+  /// ```
+  ///
+  /// See also #link("https://typst.app/docs/reference/model/footnote/#definitions-entry-separator")[std.footnote.entry.separator].
+  ///
+  /// -> auto | content | none | dictionary
+  separator: auto,
+  /// Vertical spacing before note groups.
+  ///
+  /// ```info
+  /// This only has effect on grouped notes (footnote and endnote).
+  /// ```
+  ///
+  /// ```example
+  /// #deixis-set(clearance: 3em)
+  /// #deixis-footnote[A note `3em`-spaced from the main content.]
+  /// ```
+  ///
+  /// See also #link("https://typst.app/docs/reference/model/footnote/#definitions-entry-clearance")[std.footnote.entry.clearance].
+  ///
+  /// -> auto | length | dictionary
+  clearance: auto,
+  /// Vertical spacing between adjacent notes.
+  ///
+  /// ```info
+  /// This only has effect on grouped notes (footnote and endnote) and margin note.
+  /// ```
+  ///
+  /// ```example
+  /// #deixis-set(gap: 1em)
+  /// #deixis-footnote[Note A.]
+  /// #deixis-footnote[Note B.]
+  /// ```
+  ///
+  /// See also #link("https://typst.app/docs/reference/model/footnote/#definitions-entry-gap")[std.footnote.entry.gap].
+  ///
+  /// -> auto | length | dictionary
+  gap: auto,
+  /// Horizontal spacing between the marker and the body text.
+  ///
+  /// ```example
+  /// #deixis-set(marker-gap: 1em)
+  /// #deixis-footnote[A note with `marker-gap=1em`.]
+  /// ```
+  ///
+  /// -> auto | length | dictionary
+  marker-gap: auto,
+  /// The indentation applied to the note body.
+  ///
+  /// ```example
+  /// #deixis-set(indent: 3em)
+  /// #deixis-footnote[A note with `indent=3em`.]
+  /// ```
+  ///
+  /// See also #link("https://typst.app/docs/reference/model/footnote/#definitions-entry-indent")[std.footnote.entry.indent].
+  ///
+  /// -> auto | length | dictionary
+  indent: auto,
+  /// The layout engine for margin notes. Choices: `"adaptive"` | `"flow"` | `"exact"`.
+  /// - `"adaptive"`: Apply a two-pass _rubber band algorithm_ to calculate the y-coordinates of all margin notes in the page; then use `#std.place` to put them into calculated positions.
+  /// - `"flow"`: Put margin notes in a block container with interleaved `#v(space)`, where `space` is provisional inter-note gap converted to `fraction`; and let the Typst engine calculates their final positions.
+  /// - `"exact"`: Put margin notes exactly where the marker is, ignore if they overlap or not.
+  ///
+  /// -> auto | str
+  margin-layout: auto,
+  /// Minimum margin width to put margin notes.
+  ///
+  /// ```example
+  /// //| margin: (left: 1.2in, right: 0.5in, y: 0.05in)
+  /// The margin of the minipage is set to `(left: 1.2in, right: 0.5in)`.
+  /// #deixis-set(min-margin-width: 1in)
+  /// #deixis-margin-note[This note prefers the left margin.]
+  /// ```
+  ///
+  /// -> auto | length
+  min-margin-width: auto,
+  /// Strategy to select side for margin note. Choices: `"nearest"` | `"strict"`.
+  ///
+  /// See @deixis-margin-note-body.side-strategy.
+  ///
+  /// -> auto | str
+  side-strategy: auto,
+  /// How margin notes align vertically relative to their marks.
+  ///
+  /// See @deixis-margin-note-body.mark-align.
+  ///
+  /// -> auto | alignment | dictionary
+  mark-align: auto,
+  /// How strictly to align margin notes to their marks. Choices: `"strict"` | `"loose"` | `"none"`.
+  ///
+  /// See @deixis-margin-note-body.mark-align-strictness.
+  ///
+  /// -> auto | str
+  mark-align-strictness: auto,
+  /// Allow margin notes to spill over page boundaries.
+  ///
+  /// See @deixis-margin-note-body.spillover.
+  ///
+  /// -> auto | bool
+  spillover: auto,
+  /// Shape drawing function for region marks.
+  ///
+  /// See @deixis-region-mark.region-shape.
+  ///
+  /// -> auto | function
+  region-shape: auto,
+  /// The rendering layer for region marks and inset notes. Choices: `"flow"` | `"foreground"` | `"background"`.
+  ///
+  /// See @deixis-region-mark.layer.
+  ///
+  /// -> auto | str
+  layer: auto,
+  /// Note body rendering function.
+  ///
+  /// `render-single` is used in combination with `render-group`. `deixis` provides a few basic render functions:
+  /// - `native`: _Almost_ pixel-identical to `std.footnote`.
+  /// ```example
+  /// #deixis-set(
+  ///   render-single: deixis-native-render-single,
+  ///   render-group: deixis-native-render-group,
+  /// )
+  /// #deixis-footnote[A normal note.]
+  /// #deixis-footnote(marker: [long marker])[A note with very long marker, and also a long body.]
+  /// ```
+  /// - `default`: Body markers are aligned, but the notes are still prose-printed.
+  /// ```example
+  /// #deixis-set(
+  ///   render-single: deixis-default-render-single,
+  ///   render-group: deixis-default-render-group,
+  /// )
+  /// #deixis-footnote[A normal note.]
+  /// #deixis-footnote(marker: [long marker])[A note with very long marker, and also a long body.]
+  /// ```
+  /// - `grid`: Body markers and body content are structured in a `grid`.
+  /// ```example
+  /// #deixis-set(
+  ///   render-group: deixis-grid-render-group,
+  /// )
+  /// #deixis-footnote[A normal note.]
+  /// #deixis-footnote(marker: [long marker])[A note with very long marker, and also a long body.]
+  /// ```
+  ///
+  /// ```tip
+  /// For full control, you can (and should) draft your own render function.
+  /// `deixis` provides some handy helper functions for this purpose.
+  /// See @deixis-generate-backlinks, @deixis-generate-body-meta, and @deixis-generate-body-marker.
+  /// ```
+  ///
+  /// ```example
+  /// #let custom-render-func(note-data, ..args) = {
+  ///   let backlink = note-data.backlink
+  ///   let body-marker = deixis-generate-body-marker(note-data + (body-marker-style: it => it))
+  ///   rect(
+  ///     ..note-data.styles,
+  ///     inset: (top: 10pt, rest: 5pt)
+  ///   )[
+  ///     #place(center + top, dy: -20pt, rect(
+  ///       stroke: note-data.styles.stroke,
+  ///       fill: white,
+  ///       radius: 1em,
+  ///       body-marker))
+  ///     #note-data.body
+  ///   ]
+  /// }
+  ///
+  /// #deixis-set(
+  ///   render-single: custom-render-func,
+  ///   render-group: deixis-native-render-group,
+  /// )
+  /// #deixis-footnote[A note with custom render function.]
+  /// ```
+  ///
+  /// -> auto | function | dictionary
+  render-single: auto,
+  /// Group rendering function for grouped notes (footnote and endnote).
+  ///
+  /// See @deixis-set.render-single.
+  ///
+  /// -> auto | function | dictionary
+  render-group: auto,
+  /// Note body container function with signature `(content, ..args) => content`.
+  ///
+  /// ```example
+  /// #import "@preview/colorful-boxes:1.4.3": stickybox
+  /// #deixis-set(container-func: (body, ..args) => stickybox(body))
+  /// #deixis-margin-note(target: "page")[Yes, we can also do that.]
+  /// ```
+  ///
+  /// ```tip
+  /// `container-func` is only a wrapper around the rendered body of each note and does not have access to the raw notes' data.
+  /// For more sophisticated control, you should use @deixis-set.render-single or @deixis-set.render-group.
+  /// ```
+  ///
+  /// -> auto | function | dictionary
+  container-func: auto,
+) = {
+  deixis-system.update(sys => {
+    // Pack only the explicitly provided updates
+    let updates = (:)
+    if numbering != auto { updates.insert("numbering", numbering) }
+    if marker-style != auto { updates.insert("marker-style", marker-style) }
+    if body-style != auto { updates.insert("body-style", body-style) }
+    if backlink != auto { updates.insert("backlink", backlink) }
+    if marker-position != auto { updates.insert("marker-position", marker-position) }
+    if inline-mode != auto { updates.insert("inline-mode", inline-mode) }
+    if stroke != auto { updates.insert("stroke", stroke) }
+    if fill != auto { updates.insert("fill", fill) }
+    if radius != auto { updates.insert("radius", radius) }
+    if link != auto { updates.insert("link", link) }
+    if link-marks != auto { updates.insert("link-marks", link-marks) }
+    if separator != auto { updates.insert("separator", separator) }
+    if clearance != auto { updates.insert("clearance", clearance) }
+    if gap != auto { updates.insert("gap", gap) }
+    if marker-gap != auto { updates.insert("marker-gap", marker-gap) }
+    if indent != auto { updates.insert("indent", indent) }
+    if margin-layout != auto { updates.insert("margin-layout", margin-layout) }
+    if spillover != auto { updates.insert("spillover", spillover) }
+    if mark-align != auto { updates.insert("mark-align", mark-align) }
+    if mark-align-strictness != auto { updates.insert("mark-align-strictness", mark-align-strictness) }
+    if min-margin-width != auto { updates.insert("min-margin-width", min-margin-width) }
+    if side-strategy != auto { updates.insert("side-strategy", side-strategy) }
+    if region-shape != auto { updates.insert("region-shape", region-shape) }
+    if layer != auto { updates.insert("layer", layer) }
+    if render-single != auto { updates.insert("render-single", render-single) }
+    if render-group != auto { updates.insert("render-group", render-group) }
+    if container-func != auto { updates.insert("container-func", container-func) }
+
+    if updates.len() == 0 { return sys }
+
+    let _deep-merge(old, new) = {
+      if type(old) == dictionary and type(new) == dictionary {
+        let old-has-note = old.keys().any(k => k in deixis-note-types)
+        let old-has-comp = old.keys().any(k => k in deixis-note-components)
+        let new-has-note = new.keys().any(k => k in deixis-note-types)
+        let new-has-comp = new.keys().any(k => k in deixis-note-components)
+
+        // If the new dictionary introduces a conflicting scope level
+        // override the old structure to prevent ambiguous nesting
+        if (old-has-note and new-has-comp) or (old-has-comp and new-has-note) {
+          return new
+        }
+
+        let res = old
+        for (k, v) in new {
+          res.insert(k, _deep-merge(old.at(k, default: auto), v))
+        }
+        return res
+      }
+      return new
+    }
+
+    if sys.stack.len() > 0 {
+      let last-idx = sys.stack.len() - 1
+      let current-level = sys.stack.at(last-idx)
+      for (k, v) in updates {
+        let old-val = current-level.at(k, default: auto)
+        current-level.insert(k, _deep-merge(old-val, v))
+      }
+      sys.stack.last() = current-level
+    } else {
+      for (k, v) in updates {
+        let old-val = sys.at(k, default: auto)
+        sys.insert(k, _deep-merge(old-val, v))
+      }
+    }
+
+    return sys
+  })
+}
+
+/// Fetches all rendered `deixis` notes that exist on or visually intersect the current page.
+///
+/// This is an useful introspection tool and can be used, for example, to set page headings based on what endnote is being displayed.
+///
+/// ```info
+/// Since it relies on spatial queries, it must be called within a `context` block.
+/// ```
+///
+/// ```example
+/// //| layout: "vertical"
+/// #let adaptive-header = context {
+///   let notes = deixis-page-notes(note-type: "endnote")
+///
+///   if notes.len() == 0 {
+///     align(center)[_My Book Title_]
+///   } else {
+///     let first-note = notes.first()
+///     let last-note = notes.last()
+///     // Helper to find the page number of the mark in the main text
+///     let _find-mark-page(lbl) = {
+///       let elems = query(selector(lbl))
+///       if elems.len() > 0 { elems.first().location().page() } else { 0 }
+///     }
+///     let p-start = _find-mark-page(first-note.mark-lbl)
+///     let p-end = _find-mark-page(last-note.mark-lbl)
+///     // pages
+///     let left-text = if p-start == p-end { [_Notes for page #p-start _] } else { [_Notes for pages #p-start -- #p-end _] }
+///     // note numbers
+///     let right-text = if notes.len() == 1 { [_Note #first-note.marker-str _] } else { [_Notes #first-note.marker-str -- #last-note.marker-str _] }
+///     grid(
+///       columns: (1fr, 1fr),
+///       align(left)[#left-text],
+///       align(right)[#right-text]
+///     )
+///   }
+/// }
+///
+/// #adaptive-header
+/// // Real usage: (cannot be used in example environment)
+/// // #set page(header: adaptive-header)
+///
+/// We can do that, Rik
+/// #deixis-endnote[Test note 1 #lorem(10)]
+/// #deixis-endnote[Test note 2 #lorem(10)]
+/// #deixis-endnote[Test note 3 #lorem(10)].
+///
+/// #deixis-print-endnotes()
+/// ```
+///
+/// - note-type (auto, str, array): Filter the results to a specific note type (e.g., `"margin-note"`) or an array of types. If `auto`, returns all intersecting notes.
+///
+/// -> array
+#let deixis-page-notes(
+  note-type: auto,
+) = {
+  let p = here().page()
+
+  let starts = query(<deixis-rendered-start>).filter(e => e.location().page() == p).map(e => e.value)
+  let ends = query(<deixis-rendered-end>).filter(e => e.location().page() == p).map(e => e.value)
+
+  let combined = starts + ends
+
+  if combined.len() == 0 {
+    let prevs = query(selector(<deixis-rendered-start>).before(here()))
+    let nexts = query(selector(<deixis-rendered-end>).after(here()))
+    if prevs.len() > 0 and nexts.len() > 0 {
+      let last-prev = prevs.last().value
+      let first-next = nexts.first().value
+
+      let k-prev = str(last-prev.at("body-lbl", default: "prev"))
+      let k-next = str(first-next.at("body-lbl", default: "next"))
+
+      if k-prev == k-next {
+        combined.push(last-prev)
+      }
+    }
+  }
+
+  if note-type != auto {
+    combined = combined.filter(val => val.at("body-type", default: none) == note-type)
+  }
+
+  let active-notes = ()
+  let seen-ids = ()
+
+  for val in combined {
+    let count = val.at("count", default: none)
+    if count == none {
+      continue
+    }
+    let k = str(val.at("internal-id", default: count))
+    if k not in seen-ids {
+      seen-ids.push(k)
+
+      let resolved-num = _deixis-query-marker-str(val)
+      let final-val = val
+      final-val.insert("marker-str", resolved-num)
+
+      active-notes.push(final-val)
+    }
+  }
+
+  active-notes.sorted(key: n => n.count)
+}

--- a/packages/preview/deixis/0.1.1/src/margin-note.typ
+++ b/packages/preview/deixis/0.1.1/src/margin-note.typ
@@ -1,0 +1,1130 @@
+#import "core.typ": *
+#import "inline-note.typ": *
+#import "region-note.typ": *
+
+/// A standalone body content of a margin note.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// The old manor was a labyrinth of
+/// #deixis-inline-mark(id: <crepuscular>)[crepuscular]
+/// corridors, where the shadows seemed to stretch and breathe with the setting sun.
+///
+/// #deixis-margin-note-body(id: <crepuscular>)[Relating to or resembling twilight.]
+/// ```
+///
+/// - body (content): The actual text or content of the note.
+/// - id (none, str, label): A unique identifier linking this body to its corresponding mark.
+/// - target (auto, int, label, str): The specific block/minipage render context this note belongs to.
+/// - series (auto, str): The counter series this note belongs to.
+/// - label (none, label): An optional `label` to attach to the rendered body.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - link (auto, str): The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+/// - link-waypoints (none, auto, array): An array of intermediate coordinate offsets to route the connector line through.
+/// - link-ports (auto, array, dictionary): Defines the exact exit/entry ports on the mark and body for the connector line.
+/// - link-marks (auto, str): The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+/// - width (auto, length, relative): The width of the margin note body. Defaults to `90%` of the margin width.
+/// - dx (auto, length): Horizontal offset adjustment for the body.
+/// - dy (length): Vertical offset adjustment for the body. Defaults to `0pt`.
+/// - side (auto, alignment): Which margin to place the note in (`left` or `right`). If `auto`, uses the side nearest the mark.
+/// - side-strategy (auto, str): Strategy to select side for margin note. Choices: `"nearest"` | `"strict"`.
+/// - mark-align (auto, alignment, dictionary): How the note aligns vertically relative to its mark.
+/// - mark-align-strictness (auto, str): How strictly the engine attempts to keep the note exactly aligned with its mark. Choices: `"strict"` | `"loose"` | `"none"`.
+/// - spillover (auto, bool): Allow this note to spill over page boundary.
+/// - anchor-pin (none, str): A specific `#deixis-pin` name to anchor the body to, instead of the default layout logic.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+/// - ..args (arguments): Only accepts named arguments, which are forwarded to `container-func`.
+///
+/// -> content
+#let deixis-margin-note-body(
+  /// The actual text or content of the note.
+  /// -> content
+  body,
+  /// A unique identifier linking this body to its corresponding mark.
+  /// -> none | str | label
+  id: none,
+  /// The specific block/minipage render context this note belongs to.
+  /// -> auto | int | label | str
+  target: auto,
+  /// The counter series this note belongs to.
+  /// -> auto | str
+  series: auto,
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(link: "right-angle")[A linked note.]
+  /// ```
+  ///
+  /// -> auto | str
+  link: auto,
+  /// An array of intermediate coordinate offsets to route the connector line through.
+  /// -> none | auto | array
+  link-waypoints: auto,
+  /// Defines the exact exit/entry ports on the mark and body for the connector line.
+  /// -> auto | array | dictionary
+  link-ports: auto,
+  /// The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+  /// -> auto | str
+  link-marks: auto,
+  /// The width of the margin note body. Defaults to `90%` of the margin width.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #lorem(3)
+  /// #deixis-margin-note(width: 50%)[A narrow 50% note.]
+  /// ```
+  ///
+  /// -> auto | length | relative
+  width: 90%,
+  /// Horizontal offset adjustment for the body.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(dx: -30pt)[A horizontally shifted note.]
+  /// ```
+  ///
+  /// -> auto | length
+  dx: auto,
+  /// Vertical offset adjustment for the body.
+  ///
+  /// ```info
+  /// `dy` is applied pre-layout, meaning that the final coordinates of the note can change after the rubber band pass.
+  /// ```
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(dy: -50pt)[A vertically shifted note.]
+  /// ```
+  ///
+  /// -> length
+  dy: 0pt,
+  /// Which margin to place the note in (`left` or `right`). If `auto`, uses the side nearest the mark.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(side: left)[This is a left side note.]
+  /// #deixis-margin-note(side: right)[This is a right side note.]
+  /// ```
+  ///
+  /// -> auto | alignment
+  side: auto,
+  /// Strategy to select side for margin note. Choices: `"nearest"` | `"strict"`.
+  ///
+  /// - With `side-strategy: "nearest"`, notes will prefer the side that minimizes the vertical distance from the mark to the body.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(side-strategy: "nearest")[Note A body.]
+  /// #deixis-margin-note(side-strategy: "nearest")[Note B body.]
+  /// ```
+  ///
+  /// - With `side-strategy: "strict"`, notes will prefer the more visually favorable side until it is overflow.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(side-strategy: "strict")[Note A body.]
+  /// #deixis-margin-note(side-strategy: "strict")[Note B body.]
+  /// ```
+  ///
+  /// -> auto | str
+  side-strategy: auto,
+  /// How the note aligns vertically relative to its mark.
+  /// - It can be an `alignment` or an equivalent `str`.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #lorem(8)
+  /// #deixis-margin-note(
+  ///   mark-align: bottom,
+  ///   link: "right-angle",
+  ///   stroke: red,
+  ///   container-func: deixis-rect-container)[Top-aligned note body]
+  /// ```
+  /// - Or a component-scope `dictionary`, only useful with `mark-type: "region"`.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(
+  ///   mark-type: "region",
+  ///   padding: "text",
+  ///   mark-align: (mark: horizon, body: horizon),
+  ///   link: "right-angle",
+  ///   stroke: red,
+  ///   container-func: deixis-rect-container)[#lorem(8)][Horizon-aligned note body.]
+  /// ```
+  ///
+  /// -> auto | alignment | dictionary
+  mark-align: auto,
+  /// How strictly the engine attempts to keep the note exactly aligned with its mark. Choices: `"strict"` | `"loose"` | `"none"`.
+  /// -> auto | str
+  mark-align-strictness: auto,
+  /// Allow this note to spill over page boundary.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(spillover: false)[This is a very long note. #lorem(120)]
+  /// #deixis-margin-note(spillover: false)[This is another extremely long note. #lorem(120)]
+  /// #deixis-margin-note(spillover: true)[This is a spilled note.]
+  /// ```
+  ///
+  /// -> auto | bool
+  spillover: auto,
+  /// A specific `#deixis-pin` name to anchor the body to, instead of the default layout logic.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-margin-note(
+  ///   anchor-pin: "pin0")[A note anchored to a pin.]
+  /// #lorem(20)
+  /// #deixis-pin("pin0")
+  /// ```
+  ///
+  /// -> none | str
+  anchor-pin: none,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+  /// Only accepts named arguments, which are forwarded to `container-func`.
+  /// -> arguments
+  ..args,
+) = {
+  if args.pos().len() > 0 { panic("deixis: #deixis-margin-note-body accepts at most 1 positional argument [body].") }
+  let container-args = (stroke: stroke, fill: fill, radius: radius) + args.named()
+
+  let series = if series == auto { "default" } else { series }
+
+  let render-celibate(sys, celibate-id) = {
+    let body = deixis-utils._deixis-trim-content(body)
+    let resolved = _deixis-resolve-target(sys, target)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "margin-note", ..container-args)
+
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "margin-note")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "margin-note")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "margin-note")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "margin-note")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "margin-note")
+
+    let c-margin-layout = _deixis-resolve-typed-param(sys, auto, "margin-layout", "margin-note")
+    let c-min-margin-width = _deixis-resolve-typed-param(sys, auto, "min-margin-width", "margin-note")
+    let c-mark-align = _deixis-resolve-typed-param(sys, mark-align, "mark-align", "margin-note")
+    let c-mark-align-strictness = _deixis-resolve-typed-param(
+      sys,
+      mark-align-strictness,
+      "mark-align-strictness",
+      "margin-note",
+    )
+    let c-side-strategy = _deixis-resolve-typed-param(sys, side-strategy, "side-strategy", "margin-note")
+    let c-spillover = _deixis-resolve-typed-param(sys, spillover, "spillover", "margin-note")
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "margin-note")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "margin-note")
+
+    let note-data = (
+      (
+        internal-id: celibate-id,
+        target-id: resolved.render-id,
+        inst-id: resolved.inst-id,
+        series: series,
+        count: none,
+        marker-str: none,
+        body: body,
+        mark-lbl: none,
+        body-lbl: none,
+        label: label,
+        mark-marker-style: auto,
+        body-marker-style: auto,
+        body-style: c-body-style,
+        backlink: c-backlink,
+        indent: c-indent,
+        gap: c-gap,
+        marker-gap: c-marker-gap,
+        styles: b-styles,
+        render-single: active-renderer,
+        container-func: active-container,
+      )
+        + (
+          width: width,
+          dx: dx,
+          dy: dy,
+          margin-layout: c-margin-layout,
+          min-margin-width: c-min-margin-width,
+          side: side,
+          side-strategy: c-side-strategy,
+          mark-align: c-mark-align,
+          mark-align-strictness: c-mark-align-strictness,
+          spillover: c-spillover,
+          anchor-pin: anchor-pin,
+          depth: sys.stack.len(),
+          has-inline-box: false,
+          mark-type: none,
+          text-size: text.size,
+          marker-width: 0pt,
+        )
+    )
+
+    [#metadata(note-data)<deixis-margin-note>]
+  }
+
+  if id == none {
+    return [
+      #std.counter("deixis-celibate-note").step()
+      #context {
+        _deixis-check-setup-state()
+        render-celibate(deixis-system.get(), "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      }
+    ]
+  }
+
+  let state-updater = deixis-system.update(sys => {
+    let current-target-uid = if id == deixis-auto-id {
+      sys.at("last-auto-uid", default: none)
+    } else {
+      sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+
+    if current-target-uid == none { return sys }
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-label-index = sys.at("label-index", default: (:))
+
+    let payload = new-notes.at(current-target-uid)
+    payload.insert("body-type", "margin-note")
+    payload.insert("body", body)
+    new-notes.insert(current-target-uid, payload)
+
+    if label != none {
+      let lbl-str = if type(label) == str { label } else { str(label) }
+      if lbl-str in new-label-index and new-label-index.at(lbl-str) != current-target-uid {
+        panic("deixis: Duplicate note label detected: '" + lbl-str + "'.")
+      }
+      new-label-index.insert(lbl-str, current-target-uid)
+    }
+
+    return (..sys, notes: new-notes, label-index: new-label-index)
+  })
+
+  state-updater
+  context {
+    _deixis-check-setup-state()
+    let body = deixis-utils._deixis-trim-content(body)
+
+    let sys = deixis-system.get()
+    let final-sys = deixis-system.final()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else {
+      final-sys.at("id-index", default: (:)).at(str(id), default: none)
+    }
+    let reg = if target-uid != none { final-sys.at("notes", default: (:)).at(target-uid, default: none) } else { none }
+
+    if reg == none {
+      return [
+        #std.counter("deixis-celibate-note").step()
+        #render-celibate(sys, "celibate-" + str(std.counter("deixis-celibate-note").get().first()))
+      ]
+    }
+
+    let internal-id = reg.internal-id
+    let resolved = _deixis-resolve-target(sys, if target == auto { reg.at("target-id", default: 0) } else { target })
+    let depth = sys.stack.len()
+
+    let series = reg.at("series", default: series)
+    let count = reg.count
+    let marker-str = _deixis-query-marker-str(reg)
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let saved-styles = reg.at("styles", default: (:))
+    let merged-styles = _deixis-merge-styles(saved-styles, container-args)
+
+    let b-styles = _deixis-resolve-body-styles(sys, "margin-note", ..merged-styles)
+    let l-styles = _deixis-resolve-link-styles(
+      sys,
+      "margin-note",
+      stroke: merged-styles.at("stroke", default: auto),
+      radius: merged-styles.at("radius", default: auto),
+    )
+
+    let mark-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "margin-note",
+      component: "mark",
+    )
+    let body-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "margin-note",
+      component: "body",
+    )
+    let c-body-style = _deixis-resolve-typed-param(sys, auto, "body-style", "margin-note")
+    let c-backlink = _deixis-resolve-typed-param(sys, backlink, "backlink", "margin-note")
+
+    let c-indent = _deixis-resolve-typed-param(sys, auto, "indent", "margin-note")
+    let c-gap = _deixis-resolve-typed-param(sys, auto, "gap", "margin-note")
+    let c-marker-gap = _deixis-resolve-typed-param(sys, auto, "marker-gap", "margin-note")
+
+    let c-margin-layout = _deixis-resolve-typed-param(sys, auto, "margin-layout", "margin-note")
+    let c-min-margin-width = _deixis-resolve-typed-param(sys, auto, "min-margin-width", "margin-note")
+    let c-side-strategy = _deixis-resolve-typed-param(sys, side-strategy, "side-strategy", "margin-note")
+    let c-mark-align = _deixis-resolve-typed-param(sys, mark-align, "mark-align", "margin-note")
+    let c-mark-align-strictness = _deixis-resolve-typed-param(
+      sys,
+      mark-align-strictness,
+      "mark-align-strictness",
+      "margin-note",
+    )
+    let c-spillover = _deixis-resolve-typed-param(sys, spillover, "spillover", "margin-note")
+
+    let c-link = _deixis-resolve-typed-param(sys, link, "link", "margin-note")
+    let c-link-ports = deixis-utils._deixis-normalize-ports(link-ports)
+    let c-link-marks = _deixis-resolve-typed-param(sys, link-marks, "link-marks", "margin-note")
+    if reg.at("mark-type", default: "inline") == "phantom" {
+      if link == auto { c-link = "none" }
+    }
+
+    let active-renderer = _deixis-resolve-typed-param(sys, render-single, "render-single", "margin-note")
+    let active-container = _deixis-resolve-typed-param(sys, container-func, "container-func", "margin-note")
+
+    let has-inline-box = if reg.at("mark-type", default: "inline") == "inline" {
+      reg.at("inline-mode", default: auto) == "box" and reg.at("has-mark-body", default: false)
+    } else { false }
+
+    let note-data = (
+      (
+        internal-id: internal-id,
+        target-id: resolved.render-id,
+        inst-id: resolved.inst-id,
+        series: series,
+        count: count,
+        marker-str: marker-str,
+        body: body,
+        mark-lbl: mark-lbl,
+        body-lbl: body-lbl,
+        label: label,
+        mark-marker-style: mark-marker-style,
+        body-marker-style: body-marker-style,
+        body-style: c-body-style,
+        backlink: c-backlink,
+        indent: c-indent,
+        gap: c-gap,
+        marker-gap: c-marker-gap,
+        styles: b-styles,
+        render-single: active-renderer,
+        container-func: active-container,
+      )
+        + (
+          width: width,
+          dx: dx,
+          dy: dy,
+          margin-layout: c-margin-layout,
+          min-margin-width: c-min-margin-width,
+          side: side,
+          side-strategy: c-side-strategy,
+          mark-align: c-mark-align,
+          mark-align-strictness: c-mark-align-strictness,
+          spillover: c-spillover,
+          link: c-link,
+          link-stroke: l-styles.stroke,
+          link-radius: l-styles.radius,
+          link-waypoints: link-waypoints,
+          link-ports: c-link-ports,
+          link-marks: c-link-marks,
+          anchor-pin: anchor-pin,
+          depth: depth,
+          has-inline-box: has-inline-box,
+          mark-type: reg.at("mark-type", default: "inline"),
+          text-size: text.size,
+          marker-width: if marker-str != none { measure(mark-marker-style(marker-str)).width } else { 0pt },
+        )
+    )
+
+    [#metadata(note-data)<deixis-margin-note>]
+  }
+}
+
+/// A wrapper for generating margin notes.
+///
+/// This function creates a mark in the text and delegates the body to ```ref #deixis-margin-note-body```.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// The traveler felt a sudden sense of
+/// #deixis-margin-note[fernweh][A deep, aching longing for far-off places; literally _farsickness_.]
+/// as he watched the ships disappear beyond the horizon, bound for lands he had never seen.
+/// ```
+///
+/// - ..args (arguments): Accepts up to two positional arguments: `[mark][body]`. All named arguments are forwarded to ```ref #deixis-margin-note-body```.
+/// - mark-type (auto, str): The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+/// - id (none, str, label): A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+/// - numbering (auto, str, function): The numbering style for the marker.
+/// - marker (auto, content): A hardcoded marker override.
+/// - target (int, label, str): The specific block/minipage counter this note belongs to.
+/// - series (str): The counter series this note belongs to. Defaults to `"default"`.
+/// - label (none, label): An optional `label` to attach to the rendered body block.
+/// - marker-style (auto, function): A custom styling function for the marker.
+/// - marker-position (auto, alignment, dictionary): Mark marker placement.
+/// - stroke (auto, stroke, none): The border stroke.
+/// - fill (auto, color, none): The background fill color.
+/// - radius (auto, length, dictionary): The border radius.
+/// - inline-mode (auto, str): The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+/// - pins (array): Array of pin names for the region mark.
+/// - padding (auto, length, str, dictionary): Internal padding for the region mark.
+/// - region-shape (auto, function): Shape drawing function for the region mark.
+/// - layer (auto, str): Rendering layer for the region mark. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - inline (bool): If `true`, force the region mark into an inline box.
+/// - backlink (auto, bool, str): Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+/// - link (auto, str): The type of connector line, Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+/// - link-waypoints (none, auto, array): An array of intermediate coordinate offsets to route the connector line through.
+/// - link-ports (auto, array, dictionary): Defines the exact exit/entry ports on the mark and body for the connector line.
+/// - link-marks (auto, str): The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+/// - width (auto, length, relative): The width of the margin note body. Defaults to `90%` of the margin width.
+/// - dx (auto, length): Horizontal offset adjustment for the body.
+/// - dy (length): Vertical offset adjustment for the body. Defaults to `0pt`.
+/// - side (auto, alignment): Which margin to place the note in (`left` or `right`). If `auto`, uses the side nearest the mark.
+/// - side-strategy (auto, str): Strategy to select side for margin note. Choices: `"nearest"` | `"strict"`.
+/// - mark-align (auto, alignment, dictionary): How the note aligns vertically relative to its mark.
+/// - mark-align-strictness (auto, str): How strictly the engine attempts to keep the note exactly aligned with its mark. Choices: `"strict"` | `"loose"` | `"none"`.
+/// - spillover (auto, bool): Allow this note to spill over page boundary.
+/// - anchor-pin (none, str): A specific `#deixis-pin` name to anchor the body to, instead of the default layout logic.
+/// - render-single (auto, function): A custom render function for the inner layout of the body.
+/// - container-func (auto, function): A custom container wrapper for the body block.
+///
+/// -> content
+#let deixis-margin-note(
+  /// Accepts up to two positional arguments: `[mark][body]`.
+  /// All named arguments are forwarded to ```ref #deixis-margin-note-body```.
+  /// -> arguments
+  ..args,
+  /// The type of mark to render in the text. Choices: `"inline"` | `"region"` | `"phantom"`.
+  /// -> auto | str
+  mark-type: auto,
+  /// A unique identifier linking an existing mark to the body internally. If `none`, a mark will be created.
+  /// -> none | str | label
+  id: none,
+  /// The numbering style for the marker.
+  /// -> auto | str | function
+  numbering: auto,
+  /// A hardcoded marker override.
+  /// -> auto | content
+  marker: auto,
+  /// The specific block/minipage counter this note belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this note belongs to.
+  /// -> str
+  series: "default",
+  /// An optional `label` to attach to the rendered body block.
+  /// -> none | label
+  label: none,
+  /// A custom styling function for the marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Mark marker placement.
+  ///
+  /// See @deixis-inline-mark.marker-position and @deixis-region-mark.marker-position.
+  ///
+  /// -> auto | alignment | dictionary
+  marker-position: auto,
+  /// The border stroke.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The visual decoration applied to the marked inline text. Choices: `"highlight"` | `"box"` | `"parentheses"` | `"underline"` | `"text-fill"` | `"none"`.
+  ///
+  /// See @deixis-inline-mark.inline-mode.
+  ///
+  /// -> auto | str
+  inline-mode: auto,
+  /// Array of pin names for the region mark.
+  ///
+  /// See @deixis-region-mark.pins.
+  ///
+  /// -> array
+  pins: (),
+  /// Internal padding for the region mark.
+  ///
+  /// See @deixis-region-mark.padding.
+  ///
+  /// -> auto | length | str | dictionary
+  padding: auto,
+  /// Shape drawing function for the region mark.
+  ///
+  /// See @deixis-region-mark.region-shape.
+  ///
+  /// -> auto | function
+  region-shape: auto,
+  /// Rendering layer for the region mark. Choices: `"flow"` | `"foreground"` | `"background"`.
+  ///
+  /// See @deixis-region-mark.layer.
+  ///
+  /// -> auto | str
+  layer: auto,
+  /// If `true`, force the region mark into an inline box.
+  ///
+  /// See @deixis-region-mark.inline.
+  ///
+  /// -> bool
+  inline: false,
+  /// Whether to generate a clickable backlink returning the reader to the mark. Choices: `bool` | `"always"` | `"none"` | `"never"` | `"multiple"`.
+  /// -> auto | bool | str
+  backlink: auto,
+  /// The type of connector line. Choices: `"none"` | `"straight-line"` | `"right-angle"` | `"chamfer"` | `"curve"` | `"ucr"` | `"ccr"`.
+  ///
+  /// See @deixis-margin-note-body.link.
+  ///
+  /// -> auto | str
+  link: auto,
+  /// An array of intermediate coordinate offsets to route the connector line through.
+  /// -> none | auto | array
+  link-waypoints: auto,
+  /// Defines the exact exit/entry ports on the mark and body for the connector line.
+  /// -> auto | array | dictionary
+  link-ports: auto,
+  /// The arrowhead style for the connector line. Choices: `"none"` | `"mark"` | `"body"` | `"both"`.
+  /// -> auto | str
+  link-marks: auto,
+  /// The width of the margin note body.
+  ///
+  /// See @deixis-margin-note-body.width.
+  ///
+  /// -> auto | length | relative
+  width: 90%,
+  /// Horizontal offset adjustment for the body.
+  ///
+  /// See @deixis-margin-note-body.dx.
+  ///
+  /// -> auto | length
+  dx: auto,
+  /// Vertical offset adjustment for the body.
+  ///
+  /// See @deixis-margin-note-body.dy.
+  ///
+  /// -> length
+  dy: 0pt,
+  /// Which margin to place the note in (`left` or `right`).
+  ///
+  /// See @deixis-margin-note-body.side.
+  ///
+  /// -> auto | alignment
+  side: auto,
+  /// Strategy to select side for margin note. Choices: `"nearest"` | `"strict"`.
+  ///
+  /// See @deixis-margin-note-body.side-strategy.
+  ///
+  /// -> auto | str
+  side-strategy: auto,
+  /// How the note aligns vertically relative to its mark.
+  ///
+  /// See @deixis-margin-note-body.mark-align.
+  ///
+  /// -> auto | alignment | dictionary
+  mark-align: auto,
+  /// How strictly the engine attempts to keep the note exactly aligned with its mark. Choices: `"strict"` | `"loose"` | `"none"`.
+  ///
+  /// See @deixis-margin-note-body.mark-align-strictness.
+  ///
+  /// -> auto | str
+  mark-align-strictness: auto,
+  /// Allow this note to spill over page boundary.
+  ///
+  /// See @deixis-margin-note-body.spillover.
+  ///
+  /// -> auto | bool
+  spillover: auto,
+  /// A specific `#deixis-pin` name to anchor the body to, instead of the default layout logic.
+  ///
+  /// See @deixis-margin-note-body.anchor-pin.
+  ///
+  /// -> none | str
+  anchor-pin: none,
+  /// A custom render function for the inner layout of the body.
+  /// -> auto | function
+  render-single: auto,
+  /// A custom container wrapper for the body block.
+  /// -> auto | function
+  container-func: auto,
+) = {
+  let pos = args.pos()
+  if pos.len() > 2 { panic("deixis: #deixis-margin-note accepts at most 2 positional arguments: [mark][body]") }
+  let mark-content = if pos.len() > 1 { pos.first() } else { none }
+  let body = if pos.len() > 0 { pos.last() } else { none }
+
+  let mark-type = _deixis-resolve-mark-type(mark-type, pins: pins)
+
+  if id != none {
+    return deixis-margin-note-body(
+      body,
+      id: id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      backlink: backlink,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      link: link,
+      link-marks: link-marks,
+      link-waypoints: link-waypoints,
+      link-ports: link-ports,
+      width: width,
+      dx: dx,
+      dy: dy,
+      side: side,
+      side-strategy: side-strategy,
+      mark-align: mark-align,
+      mark-align-strictness: mark-align-strictness,
+      spillover: spillover,
+      anchor-pin: anchor-pin,
+      render-single: render-single,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let render-mark(target-id) = {
+    if mark-type == "region" {
+      deixis-region-mark(
+        mark-content,
+        id: target-id,
+        pins: pins,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+        padding: padding,
+        region-shape: region-shape,
+        layer: layer,
+        inline: inline,
+      )
+    } else if mark-type == "phantom" {
+      deixis-phantom-mark(
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+      )
+    } else {
+      deixis-inline-mark(
+        mark-content,
+        id: target-id,
+        numbering: numbering,
+        marker: marker,
+        target: target,
+        series: series,
+        marker-style: marker-style,
+        marker-position: marker-position,
+        inline-mode: inline-mode,
+        stroke: stroke,
+        fill: fill,
+        radius: radius,
+      )
+    }
+  }
+
+  let render-body(target-id) = {
+    deixis-margin-note-body(
+      body,
+      id: target-id,
+      target: target,
+      label: label,
+      marker-style: marker-style,
+      backlink: backlink,
+      stroke: stroke,
+      fill: fill,
+      radius: radius,
+      link: link,
+      link-marks: link-marks,
+      link-waypoints: link-waypoints,
+      link-ports: link-ports,
+      width: width,
+      dx: dx,
+      dy: dy,
+      side: side,
+      side-strategy: side-strategy,
+      mark-align: mark-align,
+      mark-align-strictness: mark-align-strictness,
+      spillover: spillover,
+      anchor-pin: anchor-pin,
+      render-single: render-single,
+      container-func: container-func,
+      ..args.named(),
+    )
+  }
+
+  let m = render-mark(deixis-auto-id)
+  let b = render-body(deixis-auto-id)
+
+  let is-block-region = mark-type == "region" and inline == false
+  if is-block-region {
+    [#m#place(b)]
+  } else {
+    [#m#b]
+  }
+}
+
+// Margin note overlay
+#let _deixis-margin-notes-overlay() = context {
+  let current-page = here().page()
+  let total-pages = counter(page).final().first()
+
+  let notes = query(<deixis-margin-note>)
+  if notes.len() == 0 { return }
+
+  let sys = deixis-system.get()
+  let all-pins = query(<deixis-pin>)
+  let processed-notes = ()
+
+  // pre-processor
+  for n in notes {
+    let note-data = n.value
+
+    let is-celibate = note-data.at("mark-lbl", default: none) == none
+
+    let mark-page = n.location().page()
+    let mark-x = n.location().position().x
+    let mark-y = n.location().position().y
+    let marker-width = note-data.at("marker-width", default: 0pt)
+
+    let is-region = false
+    let reg = none
+    let r-pins = ()
+
+    let anchor-pin = note-data.at("anchor-pin", default: none)
+
+    if not is-celibate {
+      let internal-id = str(note-data.mark-lbl).replace("deixis-mark-", "")
+
+      let region-elems = query(<deixis-region-mark>).filter(r => (
+        r.value.internal-id != none and str(r.value.internal-id) == internal-id
+      ))
+      is-region = region-elems.len() > 0
+      reg = if is-region { region-elems.first().value } else { none }
+
+      if is-region {
+        for pin-name in reg.pins {
+          for p in all-pins.filter(x => x.value.name == pin-name) { r-pins.push(p) }
+        }
+      } else {
+        // Pre-calculate marker width for inline/phantom marks
+        let mm-elems = query(selector(metadata).and(selector(<deixis-inline-mark>).or(<deixis-phantom-mark>))).filter(
+          m => (
+            type(m.value) == dictionary
+              and m.value.at("internal-id", default: none) != none
+              and str(m.value.internal-id) == str(internal-id)
+          ),
+        )
+        if mm-elems.len() > 0 {
+          marker-width = mm-elems.first().value.at("marker-width", default: 0pt)
+        }
+      }
+    }
+
+    if type(anchor-pin) == str {
+      let spec-pins = all-pins.filter(p => p.value.name == anchor-pin)
+      if spec-pins.len() > 0 {
+        let p = spec-pins.first()
+        mark-page = p.location().page()
+        mark-x = p.location().position().x
+        mark-y = p.location().position().y
+      }
+    } else if not is-celibate {
+      if is-region and r-pins.len() > 0 {
+        // Region bbox align
+        let sorted-pins = r-pins.sorted(key: p => (p.location().page(), p.location().position().y))
+        let c-align = note-data.at("mark-align", default: "top")
+
+        let align-str = if type(c-align) == dictionary { repr(c-align.mark) } else { repr(c-align) }
+
+        if "bottom" in align-str {
+          let target-pin = sorted-pins.last()
+          mark-page = target-pin.location().page()
+          mark-x = target-pin.location().position().x
+          mark-y = target-pin.location().position().y
+        } else if "horizon" in align-str {
+          let p-first = sorted-pins.first()
+          let p-last = sorted-pins.last()
+
+          mark-page = p-first.location().page()
+          mark-x = p-first.location().position().x
+
+          if p-first.location().page() == p-last.location().page() {
+            mark-y = (p-first.location().position().y + p-last.location().position().y) / 2
+          } else {
+            mark-y = p-first.location().position().y
+          }
+        } else {
+          let target-pin = sorted-pins.first()
+          mark-page = target-pin.location().page()
+          mark-x = target-pin.location().position().x
+          mark-y = target-pin.location().position().y
+        }
+      } else {
+        // Inline & Phantom mark align
+        let text-elems = query(selector(note-data.mark-lbl))
+        if text-elems.len() > 0 {
+          let tel = text-elems.first()
+          mark-page = tel.location().page()
+          mark-x = tel.location().position().x
+          mark-y = tel.location().position().y
+
+          // FIXME: hack for 2nd level notes and above
+          if note-data.at("depth", default: 0) >= 2 {
+            mark-x -= marker-width
+          }
+        }
+      }
+    }
+
+    processed-notes.push((
+      note-data: note-data,
+      mark-page: mark-page,
+      mark-x: mark-x,
+      mark-y: mark-y,
+      marker-width: marker-width,
+      mark-type: note-data.at("mark-type", default: "inline"),
+      reg: reg,
+      r-pins: r-pins,
+    ))
+  }
+
+  let sys = deixis-system.get()
+
+  let c-margin-layout = _deixis-resolve-typed-param(sys, auto, "margin-layout", "margin-note")
+  let c-min-margin-width = _deixis-resolve-typed-param(sys, auto, "min-margin-width", "margin-note")
+
+  let p-margins = deixis-utils.get-page-margins(current-page)
+  let r-len(val, def) = if val == auto { def } else { val }
+  let page-w = r-len(page.width, deixis-utils.default-page-size.width)
+  let page-h = r-len(page.height, deixis-utils.default-page-size.height)
+
+  let top-bound = deixis-utils.resolve-len(p-margins.top)
+  let bottom-bound = deixis-utils.resolve-len(page-h) - deixis-utils.resolve-len(p-margins.bottom)
+  let l-space-abs = deixis-utils.resolve-len(p-margins.left)
+  let r-space-abs = deixis-utils.resolve-len(p-margins.right)
+
+  let start-x = l-space-abs
+  let width-val = deixis-utils.resolve-len(page-w) - l-space-abs - r-space-abs
+
+  // calculate stranded notes
+  let all-block-notes = processed-notes.filter(n => n.note-data.target-id != "page")
+  let stranded-notes = all-block-notes.filter(n => n.mark-page == current-page)
+  let stranded-pushed = ()
+
+  for n in stranded-notes {
+    let rid = n.note-data.target-id
+    let starts = query(<deixis-block-start>).filter(x => x.value.at("render-id", default: none) == rid)
+    if starts.len() > 0 and starts.first().location().page() > current-page {
+      let new-note-data = n.note-data
+      new-note-data.insert("mark-x", n.mark-x)
+      new-note-data.insert("mark-y", n.mark-y)
+      new-note-data.insert("marker-width", n.marker-width)
+      stranded-pushed.push((note-data: new-note-data, mark-page: current-page, mark-block: 0, block-idx: 1))
+    }
+  }
+
+  // page level
+  let all-page-notes = processed-notes.filter(n => n.note-data.target-id == "page")
+
+  if all-page-notes.len() > 0 or stranded-pushed.len() > 0 {
+    let active-notes = ()
+    let pushed-notes = stranded-pushed
+
+    if all-page-notes.len() > 0 {
+      let pages-info = ()
+      for p in range(1, total-pages + 1) {
+        let p-m = deixis-utils.get-page-margins(p)
+        pages-info.push((
+          idx: p - 1,
+          page: p,
+          top: deixis-utils.resolve-len(p-m.top),
+          bottom: deixis-utils.resolve-len(r-len(page.height, deixis-utils.default-page-size.height))
+            - deixis-utils.resolve-len(p-m.bottom),
+          l-space: deixis-utils.resolve-len(p-m.left),
+          r-space: deixis-utils.resolve-len(p-m.right),
+        ))
+      }
+
+      let predicted-notes = _deixis-predict-cascade(
+        all-page-notes,
+        pages-info,
+        deixis-utils.text-direction(text.dir, text.lang),
+        c-margin-layout,
+        min-margin-width: c-min-margin-width,
+        cascade-breaker: true,
+      )
+
+      active-notes = predicted-notes.filter(x => x.block-idx == current-page - 1)
+      pushed-notes += predicted-notes.filter(x => x.mark-page == current-page and x.block-idx > current-page - 1)
+    }
+
+    if active-notes.len() > 0 or pushed-notes.len() > 0 {
+      // Default to global stack
+      let page-layout = c-margin-layout
+      let page-min-width = c-min-margin-width
+
+      if active-notes.len() > 0 {
+        let first-note = active-notes.first().note-data
+        page-layout = first-note.at("margin-layout", default: c-margin-layout)
+        page-min-width = first-note.at("min-margin-width", default: c-min-margin-width)
+      }
+
+      let layout-func = if type(page-layout) == function {
+        page-layout
+      } else if page-layout == "flow" {
+        deixis-margin-note-flow-layout
+      } else if page-layout == "exact" {
+        deixis-margin-note-exact-layout
+      } else if page-layout == "adaptive" {
+        deixis-margin-note-adaptive-layout
+      } else {
+        panic("deixis: margin-layout='" + repr(page-layout) + "' not supported.")
+      }
+
+      layout-func(
+        active-notes,
+        top-bound,
+        bottom-bound,
+        start-x,
+        width-val,
+        bottom-bound,
+        l-space-abs,
+        r-space-abs,
+        current-page,
+        min-margin-width: page-min-width,
+        pushed-notes: pushed-notes,
+      )
+    }
+  }
+
+  // block level
+  let all-block-notes = processed-notes.filter(n => n.note-data.target-id != "page")
+  if all-block-notes.len() > 0 {
+    let starts-dict = (:)
+    for s in query(<deixis-block-start>) { starts-dict.insert(s.value.id, s) }
+    let ends-dict = (:)
+    for e in query(<deixis-block-end>) { ends-dict.insert(e.value.id, e) }
+    let rights-dict = (:)
+    for r in query(<deixis-block-right>) { rights-dict.insert(r.value.id, r) }
+
+    let target-groups = (:)
+    for (id, s) in starts-dict {
+      let rid = s.value.at("render-id", default: none)
+      if rid != none {
+        if rid not in target-groups { target-groups.insert(rid, ()) }
+        target-groups
+          .at(rid)
+          .push((id: id, start: s, end: ends-dict.at(id, default: none), right: rights-dict.at(id, default: none)))
+      }
+    }
+
+    for (rid, blocks) in target-groups {
+      let notes = all-block-notes.filter(n => n.note-data.target-id == rid)
+      if notes.len() == 0 { continue }
+      let sorted-blocks = blocks.sorted(key: b => (b.start.location().page(), b.start.location().position().y))
+
+      let first-note-data = notes.first().note-data
+      let b-margin-layout = first-note-data.at("margin-layout", default: c-margin-layout)
+      let b-min-margin-width = first-note-data.at("min-margin-width", default: c-min-margin-width)
+
+      let blocks-info = ()
+      let valid = true
+      for (i, b) in sorted-blocks.enumerate() {
+        if b.end == none or b.right == none {
+          valid = false
+          break
+        }
+        blocks-info.push((
+          idx: i,
+          page: b.start.location().page(),
+          top: b.start.location().position().y,
+          bottom: b.end.location().position().y,
+          l-space: b.start.value.l-space,
+          r-space: b.start.value.r-space,
+        ))
+      }
+      if not valid { continue }
+
+      let predicted-notes = _deixis-predict-cascade(
+        notes,
+        blocks-info,
+        deixis-utils.text-direction(text.dir, text.lang),
+        b-margin-layout,
+        min-margin-width: b-min-margin-width,
+        cascade-breaker: false,
+      )
+
+      for (i, b-info) in blocks-info.enumerate() {
+        if b-info.page != current-page { continue }
+        let b = sorted-blocks.at(i)
+        let active-notes = predicted-notes.filter(x => x.block-idx == i)
+        let pushed-notes = predicted-notes.filter(x => (
+          x.mark-block == i and blocks-info.at(x.block-idx).page > current-page
+        ))
+
+        if active-notes.len() > 0 or pushed-notes.len() > 0 {
+          let layout-func = if type(b-margin-layout) == function { b-margin-layout } else if b-margin-layout == "flow" {
+            deixis-margin-note-flow-layout
+          } else { deixis-margin-note-adaptive-layout }
+          layout-func(
+            active-notes,
+            b.start.location().position().y,
+            b.end.location().position().y,
+            b.start.location().position().x,
+            b.right.location().position().x - b.start.location().position().x,
+            b.end.location().position().y,
+            b-info.l-space,
+            b-info.r-space,
+            current-page,
+            min-margin-width: b-min-margin-width,
+            pushed-notes: pushed-notes,
+          )
+        }
+      }
+    }
+  }
+}
+
+/// A ```ref #deixis-margin-note-body``` with default `side: "outside", mark-align-strictness: "loose"`.
+#let deixis-sidenote-body = deixis-margin-note-body.with(side: "outside", mark-align-strictness: "loose")
+
+/// A ```ref #deixis-margin-note``` with default `side: "outside", mark-align-strictness: "loose"`.
+#let deixis-sidenote = deixis-margin-note.with(side: "outside", mark-align-strictness: "loose")

--- a/packages/preview/deixis/0.1.1/src/minipage.typ
+++ b/packages/preview/deixis/0.1.1/src/minipage.typ
@@ -1,0 +1,327 @@
+#import "core.typ": *
+
+/// Creates an isolated, self-contained layout environment for notes.
+///
+/// A minipage acts as a sub-document. Any notes declared inside it (like margin notes or footnotes)
+/// are strictly bound to its physical boundaries, and its note counters operate independently of the
+/// main document flow. This is essential for creating complex layouts like infoboxes, sidebars, or
+/// custom chapter summaries without breaking global note numbering.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// #deixis-footnote[This is a page footnote.]
+/// #deixis-block(inset: 5pt, fill: gray.lighten(90%))[
+///   Inside a `#deixis-block`, notes have its own counter system and layout behaviors.
+///   #deixis-footnote[This is a block-level footnote.]
+/// ]
+/// ```
+///
+/// ````experiment
+/// You can nest `#deixis-block`, infinitely, but it will be hyper fragile.
+///
+/// ```example
+/// //| sandbox-mode: "page"
+/// #deixis-block(inset: 5pt, fill: red.lighten(90%))[
+///   #deixis-footnote[Level 1.]
+///   #deixis-block(inset: 5pt, fill: orange.lighten(90%))[
+///     #deixis-footnote[Level 2.]
+///     #deixis-block(inset: 5pt, fill: yellow.lighten(90%))[
+///       #deixis-footnote[Level 3.]
+///       #deixis-block(inset: 5pt, fill: green.lighten(90%))[
+///         You are wandering into the unknown#deixis-footnote[Level 4.].
+///       ]
+///     ]
+///   ]
+/// ]
+/// ```
+/// ````
+///
+/// - id (auto, str): A unique identifier for this layout context. If `auto`, the engine generates one automatically.
+/// - thread (none, str): Allows multiple separate minipages to share the same continuous note counter. Pass a matching string to link them into the same "thread".
+/// - sync-counters-with (auto, int, label, str): Synchronize internal counters with another `#deixis-block` or the global document counters rather than starting from 1.
+/// - width (auto, length, relative): See #link("https://typst.app/docs/reference/layout/block/#parameters-width")[`std.block.width`].
+/// - height (auto, length, relative): See #link("https://typst.app/docs/reference/layout/block/#parameters-height")[`std.block.height`].
+/// - breakable (auto, bool): See #link("https://typst.app/docs/reference/layout/block/#parameters-breakable")[`std.block.breakable`].
+/// - fill (auto, color, none): See #link("https://typst.app/docs/reference/layout/block/#parameters-fill")[`std.block.fill`].
+/// - stroke (auto, stroke, none): See #link("https://typst.app/docs/reference/layout/block/#parameters-stroke")[`std.block.stroke`].
+/// - radius (auto, length, dictionary): See #link("https://typst.app/docs/reference/layout/block/#parameters-radius")[`std.block.radius`].
+/// - inset (auto, length, dictionary): See #link("https://typst.app/docs/reference/layout/block/#parameters-inset")[`std.block.inset`].
+/// - outset (auto, length, dictionary): See #link("https://typst.app/docs/reference/layout/block/#parameters-outset")[`std.block.outset`].
+/// - spacing (auto, length): See #link("https://typst.app/docs/reference/layout/block/#parameters-spacing")[`std.block.spacing`].
+/// - above (auto, length): See #link("https://typst.app/docs/reference/layout/block/#parameters-above")[`std.block.above`].
+/// - below (auto, length): See #link("https://typst.app/docs/reference/layout/block/#parameters-below")[`std.block.below`].
+/// - clip (auto, bool): See #link("https://typst.app/docs/reference/layout/block/#parameters-clip")[`std.block.clip`].
+/// - sticky (auto, bool): See #link("https://typst.app/docs/reference/layout/block/#parameters-sticky")[`std.block.sticky`].
+/// - ..args (arguments): Accepts at most 1 positional argument: `[body]`, the content of the minipage.
+///
+/// -> content
+#let deixis-block(
+  /// A unique identifier for this layout context. If `auto`, the engine generates one automatically.
+  /// -> auto | str
+  id: auto,
+  /// Allows multiple separate minipages to share the same continuous note counter. Pass a matching string to link them into the same "thread".
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-block(thread: "green", inset: 5pt, fill: green.lighten(90%))[
+  ///   #deixis-footnote[This block belongs to the `"green"` thread.]
+  /// ]
+  ///
+  /// #deixis-block(inset: 5pt, fill: red.lighten(90%))[
+  ///   #deixis-footnote[This block does not, hence, its notes count from 1.]
+  /// ]
+  ///
+  /// #deixis-block(thread: "green", inset: 5pt, fill: green.lighten(90%))[
+  ///   #deixis-footnote[This block also belongs to the `"green"` thread.]
+  /// ]
+  /// ```
+  ///
+  /// ````tip
+  /// `thread` cannot be used to sync counters with the `"page"`.
+  /// For that purpose, use @deixis-block.sync-counters-with.
+  /// ```experiment
+  /// `thread` and `sync-counters-with` can be used together, at your own risk.
+  /// ```
+  /// ````
+  ///
+  /// -> none | str
+  thread: none,
+  /// Synchronize internal counters with another `#deixis-block` or the global document counters rather than starting from 1.
+  /// - Accepts `int` for going up in the stack level, and `"page"` for the document global.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-block(sync-counters-with: "page", inset: 5pt, fill: red.lighten(90%))[
+  ///   #deixis-footnote[This block shares its counters with the document.]
+  /// ]
+  ///
+  /// #deixis-block(sync-counters-with: -1, inset: 5pt, fill: orange.lighten(90%))[
+  ///   #deixis-footnote[Same for this block.]
+  /// ]
+  /// ```
+  /// - Also accepts `label` or `str` for targetting another `#deixis-block`.
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// #deixis-block(id: <blue-block>, inset: 5pt, fill: blue.lighten(90%))[
+  ///   #deixis-footnote[This block is given an `id: <blue-block>`.]
+  /// ]
+  ///
+  /// #deixis-block(sync-counters-with: <blue-block>, inset: 5pt, fill: teal.lighten(90%))[
+  ///   #deixis-footnote[This block shares its counters with `<blue-block>`.]
+  /// ]
+  /// ```
+  ///
+  /// ```tip
+  /// To sync counters of multiple blocks, it is more convenient to use @deixis-block.thread.
+  /// ```
+  ///
+  /// -> auto | int | label | str
+  sync-counters-with: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-width")[`std.block.width`].
+  /// -> auto | length | relative
+  width: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-height")[`std.block.height`].
+  /// -> auto | length | relative
+  height: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-breakable")[`std.block.breakable`].
+  /// -> auto | bool
+  breakable: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-fill")[`std.block.fill`].
+  /// -> auto | color | none
+  fill: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-stroke")[`std.block.stroke`].
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-radius")[`std.block.radius`].
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-inset")[`std.block.inset`].
+  ///
+  /// ```info
+  /// The left and right inset of a `#deixis-block` is where block-level @deixis-margin-note-body are rendered.
+  /// ```
+  ///
+  /// -> auto | length | dictionary
+  inset: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-outset")[`std.block.outset`].
+  /// -> auto | length | dictionary
+  outset: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-spacing")[`std.block.spacing`].
+  /// -> auto | length
+  spacing: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-above")[`std.block.above`].
+  /// -> auto | length
+  above: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-below")[`std.block.below`].
+  /// -> auto | length
+  below: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-clip")[`std.block.clip`].
+  /// -> auto | bool
+  clip: auto,
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-sticky")[`std.block.sticky`].
+  /// -> auto | bool
+  sticky: auto,
+  /// Accepts at most 1 positional argument: `[body]`, the content of the minipage.
+  /// See #link("https://typst.app/docs/reference/layout/block/#parameters-body")[`std.block.body`].
+  /// -> arguments
+  ..args,
+) = {
+  if args.named().len() > 0 {
+    panic("deixis: Unknown named argument(s) " + repr(args.named().keys()) + " passed to #deixis-block.")
+  }
+  if args.pos().len() > 1 {
+    panic("deixis: #deixis-block accepts at most 1 positional argument (the body).")
+  }
+
+  context _deixis-check-setup-state()
+  std.counter("deixis-block-inst").step()
+
+  context {
+    let body = args.pos().at(0, default: [])
+
+    let c-val = std.counter("deixis-block-inst").get().first()
+    let inst-id = if id != auto { str(id) } else { str(c-val) }
+    let sys = deixis-system.get()
+
+    let actual-render-id = if thread != none { "thread-" + thread } else { inst-id }
+    let actual-count-id = if sync-counters-with != auto {
+      _deixis-resolve-target(sys, sync-counters-with).count-id
+    } else if (
+      thread != none
+    ) { "thread-" + thread } else { actual-render-id }
+
+    let m-inset = deixis-utils.get-margins(if inset != auto { inset } else { 0pt })
+    let l-space = deixis-utils.resolve-len(m-inset.left)
+    let r-space = deixis-utils.resolve-len(m-inset.right)
+
+    let safe-block-args = (:)
+    if width != auto { safe-block-args.insert("width", width) }
+    if height != auto { safe-block-args.insert("height", height) }
+    if breakable != auto { safe-block-args.insert("breakable", breakable) }
+    if fill != auto { safe-block-args.insert("fill", fill) }
+    if stroke != auto { safe-block-args.insert("stroke", stroke) }
+    if radius != auto { safe-block-args.insert("radius", radius) }
+    if outset != auto { safe-block-args.insert("outset", outset) }
+    if spacing != auto { safe-block-args.insert("spacing", spacing) }
+    if above != auto { safe-block-args.insert("above", above) }
+    if below != auto { safe-block-args.insert("below", below) }
+    if clip != auto { safe-block-args.insert("clip", clip) }
+    if sticky != auto { safe-block-args.insert("sticky", sticky) }
+
+    block(inset: m-inset, ..safe-block-args, {
+      deixis-system.update(sys => {
+        sys.stack.push((
+          inst-id: inst-id,
+          render-id: actual-render-id,
+          count-id: actual-count-id,
+          left-space: l-space,
+          right-space: r-space,
+        ))
+        if id != auto { sys.blocks.insert(str(id), sys.stack.last()) }
+        return sys
+      })
+
+      block(width: 100%, height: 0pt, above: 0pt, below: 0pt, {
+        box(width: 0pt, height: 0pt)[#metadata((
+          id: inst-id,
+          render-id: actual-render-id,
+          thread: thread,
+          l-space: l-space,
+          r-space: r-space,
+        ))<deixis-block-start>]
+        place(top + right, box(width: 0pt, height: 0pt)[#metadata((id: inst-id))<deixis-block-right>])
+      })
+
+      body
+
+      context {
+        let block-fn-data = query(<deixis-footnote>)
+          .filter(x => x.value.inst-id == inst-id and x.value.target-id == actual-render-id)
+          .map(x => x.value)
+        if block-fn-data.len() > 0 {
+          if height != auto {
+            colbreak()
+            v(1e-10fr)
+          }
+
+          deixis-group-layout(block-fn-data)
+        }
+      }
+
+      block(width: 100%, height: 0pt, above: 0pt, below: 0pt)[#box(width: 0pt, height: 0pt)[#metadata((
+        id: inst-id,
+        render-id: actual-render-id,
+        thread: thread,
+      ))<deixis-block-end>]]
+      deixis-system.update(sys => {
+        let popped = sys.stack.pop()
+        return sys
+      })
+    })
+  }
+}
+
+/// Creates an isolated layout environment for notes, utilizing `margin` instead of `inset`/`outset`.
+///
+/// This is just a convenience wrapper around `#deixis-block`.
+/// It forward calls to `#deixis-block` with `inset: margin` and `outset: 0pt` by default.
+///
+/// See `#deixis-block` for details about parameters.
+///
+/// - id (auto, str): A unique identifier for this layout context. If `auto`, the engine generates one automatically.
+/// - thread (none, str): Allows multiple separate minipages to share the same continuous note counter. Pass a matching string to link them into the same "thread".
+/// - sync-counters-with (auto, int, label, str): Synchronize internal counters with another `#deixis-block` or the global document counters rather than starting from 1.
+/// - width (auto, length, relative): See #link("https://typst.app/docs/reference/layout/block/#parameters-width")[`std.block.width`].
+/// - height (auto, length, relative): See #link("https://typst.app/docs/reference/layout/block/#parameters-height")[`std.block.height`].
+/// - breakable (auto, bool): See #link("https://typst.app/docs/reference/layout/block/#parameters-breakable")[`std.block.breakable`].
+/// - fill (auto, color, none): See #link("https://typst.app/docs/reference/layout/block/#parameters-fill")[`std.block.fill`].
+/// - stroke (auto, stroke, none): See #link("https://typst.app/docs/reference/layout/block/#parameters-stroke")[`std.block.stroke`].
+/// - radius (auto, length, dictionary): See #link("https://typst.app/docs/reference/layout/block/#parameters-radius")[`std.block.radius`].
+/// - margin (auto, length, dictionary): See ```ref #deixis-block.inset```.
+/// - spacing (auto, length): See #link("https://typst.app/docs/reference/layout/block/#parameters-spacing")[`std.block.spacing`].
+/// - above (auto, length): See #link("https://typst.app/docs/reference/layout/block/#parameters-above")[`std.block.above`].
+/// - below (auto, length): See #link("https://typst.app/docs/reference/layout/block/#parameters-below")[`std.block.below`].
+/// - clip (auto, bool): See #link("https://typst.app/docs/reference/layout/block/#parameters-clip")[`std.block.clip`].
+/// - sticky (auto, bool): See #link("https://typst.app/docs/reference/layout/block/#parameters-sticky")[`std.block.sticky`].
+/// - ..args (arguments): Accepts at most 1 positional argument: `[body]`, the content of the minipage.
+///
+/// -> content
+#let deixis-minipage(
+  id: auto,
+  thread: none,
+  sync-counters-with: auto,
+  width: auto,
+  height: auto,
+  breakable: auto,
+  fill: auto,
+  stroke: auto,
+  radius: auto,
+  /// External margin pushing the block outward from surrounding content.
+  /// -> auto | length | dictionary
+  margin: auto,
+  spacing: auto,
+  above: auto,
+  below: auto,
+  clip: auto,
+  sticky: auto,
+  ..args,
+) = {
+  deixis-block(
+    id: id,
+    thread: thread,
+    sync-counters-with: sync-counters-with,
+    width: width,
+    height: height,
+    breakable: breakable,
+    fill: fill,
+    stroke: stroke,
+    radius: radius,
+    inset: margin,
+    outset: 0pt,
+    spacing: spacing,
+    above: above,
+    below: below,
+    clip: clip,
+    sticky: sticky,
+    ..args,
+  )
+}

--- a/packages/preview/deixis/0.1.1/src/outline.typ
+++ b/packages/preview/deixis/0.1.1/src/outline.typ
@@ -1,0 +1,394 @@
+#import "core.typ": *
+
+/// A dynamically styled outline (Table of Contents) for your annotations.
+///
+/// The outline extracts the content from note bodies and clips it to a single line.
+/// Each entry features a dynamic visual badge that inherits
+/// the styling of the specific note it represents.
+/// They act as clickable hyperlinks, returning the reader to the mark's location.
+///
+/// ```example
+/// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: red)[This is a note!]
+///
+/// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: green)[This is another note!]
+///
+/// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: blue)[This is yet another note!]
+/// // `target: 0` restricts the search to notes inside this example block.
+/// #deixis-note-outline(target: 0)
+/// ```
+///
+/// - title (content, none): The heading content to display above the outline. Set to `none` to disable the heading.
+/// - heading-level (int): The heading level for the outline's main title. Any dynamically generated group sub-headings will be rendered at `heading-level + 1`.
+/// - target (auto, label, str, int): Filters the outline to notes belonging to a specific target block or minipage.
+/// - threat (auto, label, str): Filters the outline to only show notes belonging to a specific thread of minipages.
+/// - include-types (auto, array): A list of note types to explicitly include (e.g., `("margin-note", "endnote")`). If `auto`, includes all types.
+/// - exclude-types (array): A list of note types to explicitly exclude.
+/// - series (auto, str, array): Filters the outline to notes belonging to a specific series or array of series.
+/// - include-celibates (bool, str): Determines if decoupled, standalone marks or bodies should be included. Choices: `bool` | `"both"` | `"none"` | `"mark"` | `"body"`.
+/// - after (none, location, label, str): Only includes notes that appear *after* this location, label, or `<deixis-pin>` name.
+/// - before (none, location, label, str): Only includes notes that appear *before* this location, label, or `<deixis-pin>` name.
+/// - group-by (none, str, function): Categorizes the notes under sub-headings. Accepts `"type"` (e.g., "Margin Notes"), `"series"`, or a custom `function(note) => string`.
+/// - fill (none, content): Fills the space between the excerpt and the page number. Commonly set to `repeat[.]` for standard TOC styling.
+/// - gap (auto, length): The vertical spacing between individual note rows in the outline.
+///
+/// -> content
+#let deixis-note-outline(
+  /// The heading content to display above the outline. Set to `none` to disable the heading.
+  ///
+  /// ```example
+  /// #deixis-note-outline(target: 0, title: [Liste des Notes])
+  /// ```
+  ///
+  /// -> content | none
+  title: [List of Notes],
+  /// The heading level for the outline's main title. Any dynamically generated group sub-headings will be rendered at `heading-level + 1`.
+  ///
+  /// ```example
+  /// #deixis-note-outline(target: 0, heading-level: 3)
+  /// ```
+  ///
+  /// -> int
+  heading-level: 1,
+  /// Filters the outline to notes belonging to a specific target block or minipage.
+  /// -> auto | label | str | int
+  target: auto,
+  /// Filters the outline to only show notes belonging to a specific thread of minipages.
+  /// -> auto | str
+  thread: auto,
+  /// A list of note types to explicitly include (e.g., `("margin-note", "endnote")`). If `auto`, includes all types.
+  /// -> auto | array
+  include-types: auto,
+  /// A list of note types to explicitly exclude.
+  /// -> array
+  exclude-types: (),
+  /// Filters the outline to notes belonging to a specific series or array of series.
+  /// -> auto | str | array
+  series: auto,
+  /// Determines if decoupled, standalone marks or bodies should be included. Choices: `bool` | `"both"` | `"none"` | `"mark"` | `"body"`.
+  /// -> bool | str
+  include-celibates: false,
+  /// Only includes notes that appear *after* this location, label, or `<deixis-pin>` name.
+  /// -> none | location | label | str
+  after: none,
+  /// Only includes notes that appear *before* this location, label, or `<deixis-pin>` name.
+  /// -> none | location | label | str
+  before: none,
+  /// Categorizes the notes under sub-headings. Accepts `"type"`, `"series"`, or a custom `function(note) => string`.
+  ///
+  /// ```example
+  /// //| margin: (right: 0.6in, rest: 0.05in)
+  /// #deixis-footnote(stroke: red)[This is a footnote!]
+  /// #deixis-margin-note(stroke: green)[This is a margin note!]
+  /// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: blue)[This is an inset note!]
+  ///
+  /// #deixis-note-outline(target: 0, group-by: "type")
+  /// ```
+  ///
+  /// -> none | str | function
+  group-by: none,
+  /// Fills the space between the excerpt and the page number. Commonly set to `repeat[.]` for standard TOC styling.
+  ///
+  /// ```example
+  /// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: red)[This is a note!]
+  ///
+  /// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: green)[This is another note!]
+  ///
+  /// #deixis-inset-note(dx: 10pt, dy: 0pt, stroke: blue)[This is yet another note!]
+  ///
+  /// #deixis-note-outline(target: 0, fill: repeat[.])
+  /// ```
+  ///
+  /// -> none | content
+  fill: none,
+  /// The vertical spacing between individual note rows in the outline.
+  /// -> auto | length
+  gap: auto,
+) = context {
+  _deixis-check-setup-state()
+  let active-sys = deixis-system.get()
+
+  let resolve-bound(b-val, b-name) = {
+    if b-val == none { return none }
+    if type(b-val) == location { return b-val }
+    if type(b-val) == str {
+      let pins = query(<deixis-pin>).filter(p => p.value.at("name", default: "") == b-val)
+      if pins.len() == 0 { panic("deixis: Could not find pin named '" + b-val + "'.") }
+      return pins.first().location()
+    } else {
+      let elems = query(b-val)
+      if elems.len() == 0 { panic("deixis: Could not find target matching '" + repr(b-val) + "'.") }
+      return elems.first().location()
+    }
+  }
+
+  let loc-after = resolve-bound(after, "after")
+  let loc-before = resolve-bound(before, "before")
+
+  let is-in-bounds(loc) = {
+    if loc == none { return false }
+    if loc-after != none {
+      if loc.page() < loc-after.page() { return false }
+      if loc.page() == loc-after.page() and loc.position().y < loc-after.position().y { return false }
+    }
+    if loc-before != none {
+      if loc.page() > loc-before.page() { return false }
+      if loc.page() == loc-before.page() and loc.position().y > loc-before.position().y { return false }
+    }
+    return true
+  }
+
+  let extract-id(val) = {
+    if type(val) != dictionary { return none }
+
+    let raw-id = val.at("internal-id", default: none)
+
+    if raw-id == none {
+      let b-lbl = val.at("body-lbl", default: none)
+      if b-lbl == none and "note-data" in val { b-lbl = val.note-data.at("body-lbl", default: none) }
+      if b-lbl != none and str(b-lbl).starts-with("deixis-body-") { raw-id = str(b-lbl).replace("deixis-body-", "") }
+    }
+
+    if raw-id == none {
+      let m-lbl = val.at("mark-lbl", default: none)
+      if m-lbl == none and "note-data" in val { m-lbl = val.note-data.at("mark-lbl", default: none) }
+      if m-lbl != none and str(m-lbl).starts-with("deixis-mark-") { raw-id = str(m-lbl).replace("deixis-mark-", "") }
+    }
+
+    if raw-id != none {
+      let sid = str(raw-id)
+      if sid.starts-with("celibate-") { return none }
+      return sid
+    }
+    return none
+  }
+
+  let extract-field(val, key, default-val) = {
+    if key in val { return val.at(key) }
+    if "note-data" in val and key in val.note-data { return val.note-data.at(key) }
+    return default-val
+  }
+
+  let m-tag-map = (
+    (<deixis-inline-mark>, "inline-mark"),
+    (<deixis-region-mark>, "region-mark"),
+    (<deixis-phantom-mark>, "phantom-mark"),
+  )
+  let b-tag-map = (
+    (<deixis-inline-note>, "inline-note"),
+    (<deixis-footnote>, "footnote"),
+    (<deixis-endnote>, "endnote"),
+    (<deixis-margin-note>, "margin-note"),
+    (<deixis-inset-note>, "inset-note"),
+  )
+
+  // collect metadata
+  let combined = (:)
+  let raw-celibates = ()
+
+  for (tag, type-str) in m-tag-map {
+    for m in query(selector(tag)) {
+      let val = m.value
+      let i-id = extract-id(val)
+      if i-id == none {
+        raw-celibates.push((loc: m.location(), mark-meta: val, body-meta: none, m-type: type-str, b-type: none))
+      } else {
+        let entry = combined.at(i-id, default: (
+          loc: m.location(),
+          mark-meta: none,
+          body-meta: none,
+          m-type: none,
+          b-type: none,
+        ))
+        entry.mark-meta = val
+        entry.m-type = type-str
+        entry.loc = m.location() // Mark loc takes priority
+        combined.insert(i-id, entry)
+      }
+    }
+  }
+
+  for (tag, type-str) in b-tag-map {
+    for b in query(selector(tag)) {
+      let val = b.value
+      let i-id = extract-id(val)
+      if i-id == none {
+        raw-celibates.push((loc: b.location(), mark-meta: none, body-meta: val, m-type: none, b-type: type-str))
+      } else {
+        let entry = combined.at(i-id, default: (
+          loc: b.location(),
+          mark-meta: none,
+          body-meta: none,
+          m-type: none,
+          b-type: none,
+        ))
+        entry.body-meta = val
+        entry.b-type = type-str
+        if entry.mark-meta == none { entry.loc = b.location() } // Fallback to body loc
+        combined.insert(i-id, entry)
+      }
+    }
+  }
+
+  let c-inc-marks = (
+    include-celibates == true
+      or include-celibates == "both"
+      or include-celibates in ("mark", "marks")
+      or (type(include-celibates) == array and ("mark" in include-celibates or "marks" in include-celibates))
+  )
+
+  let c-inc-bodies = (
+    include-celibates == true
+      or include-celibates == "both"
+      or include-celibates in ("body", "bodies")
+      or (type(include-celibates) == array and ("body" in include-celibates or "bodies" in include-celibates))
+  )
+
+  let all-raw = combined.values() + raw-celibates
+  let valid-notes = ()
+
+  for n in all-raw {
+    let is-celibate-mark = n.body-meta == none and n.mark-meta != none
+    let is-celibate-body = n.mark-meta == none and n.body-meta != none
+
+    if is-celibate-mark and not c-inc-marks { continue }
+    if is-celibate-body and not c-inc-bodies { continue }
+
+    if not is-in-bounds(n.loc) { continue }
+
+    let actual-type = if n.b-type != none { n.b-type } else { n.m-type }
+    if include-types != auto and actual-type not in include-types { continue }
+    if actual-type in exclude-types { continue }
+
+    let meta-to-use = if n.body-meta != none { n.body-meta } else { n.mark-meta }
+
+    let c-series = extract-field(meta-to-use, "series", "default")
+    if series != auto {
+      if type(series) == array and c-series not in series { continue }
+      if type(series) == str and c-series != series { continue }
+    }
+
+    let note-target-id = extract-field(meta-to-use, "target-id", "page")
+    if thread != auto {
+      if note-target-id != ("thread-" + str(thread)) { continue }
+    } else if target != auto {
+      let resolved-outline-target = _deixis-resolve-target(active-sys, target)
+      if note-target-id != resolved-outline-target.render-id { continue }
+    }
+
+    let num = extract-field(meta-to-use, "marker-str", none)
+    if num == none and n.mark-meta != none { num = extract-field(n.mark-meta, "marker-str", none) }
+
+    let m-lbl = extract-field(meta-to-use, "mark-lbl", none)
+    let b-lbl = extract-field(meta-to-use, "body-lbl", none)
+    let target-dest = if m-lbl != none {
+      m-lbl
+    } else if b-lbl != none {
+      b-lbl
+    } else {
+      n.loc
+    }
+
+    let styles = extract-field(meta-to-use, "styles", (:))
+    let s-obj = if styles.at("stroke", default: auto) != none { styles.at("stroke", default: 0.5pt + luma(200)) } else {
+      none
+    }
+    let f-obj = if styles.at("fill", default: auto) != auto { styles.fill } else { none }
+    let r-obj = if styles.at("radius", default: auto) != auto { styles.radius } else { 2pt }
+
+    let badge = if num != none and num != "" {
+      box(
+        fill: f-obj,
+        stroke: s-obj,
+        radius: r-obj,
+        inset: (x: 0.3em, y: 0.2em),
+        outset: (y: 0.1em),
+        baseline: 15%,
+        clip: true,
+        text(size: 0.8em, weight: "bold", num),
+      )
+    } else {
+      box(fill: f-obj, stroke: s-obj, radius: r-obj, width: 0.8em, height: 0.8em, baseline: 10%)
+    }
+
+    valid-notes.push((
+      loc: n.loc,
+      dest: target-dest,
+      body: extract-field(meta-to-use, "body", none),
+      badge: badge,
+      type: actual-type,
+      series: c-series,
+    ))
+  }
+
+  // group and render
+  let grouped = (:)
+  let pretty-types = (
+    "inline-mark": "Inline Marks",
+    "phantom-mark": "Phantom Marks",
+    "region-mark": "Region Marks",
+    "inline-note": "Inline Notes",
+    "footnote": "Footnotes",
+    "endnote": "Endnotes",
+    "margin-note": "Margin Notes",
+    "inset-note": "Inset Notes",
+  )
+
+  for note in valid-notes.sorted(key: n => n.loc.page()) {
+    let key = "Notes"
+    if type(group-by) == str {
+      if group-by == "type" {
+        key = pretty-types.at(note.type, default: note.type)
+      } else if group-by == "series" { key = note.series }
+    } else if type(group-by) == function {
+      key = group-by(note)
+    }
+    let arr = grouped.at(str(key), default: ())
+    arr.push(note)
+    grouped.insert(str(key), arr)
+  }
+
+  if title != none { heading(level: heading-level, title) }
+
+  let c-gap = if gap == auto { 0.6em } else { gap }
+  for (g-key, g-notes) in grouped {
+    if grouped.keys().len() > 1 and group-by != none {
+      heading(level: heading-level + 1, g-key)
+    }
+
+    let outline-items = ()
+    for note in g-notes {
+      let c-body = if note.body != none {
+        note.body
+      } else {
+        text(fill: luma(150), style: "italic", size: 0.9em)[No body text]
+      }
+
+      let content-and-page = grid(
+        columns: (1fr, auto),
+        column-gutter: 0.5em,
+        align: (left + top, right + bottom),
+        {
+          set text(size: 0.95em)
+          set par(justify: false)
+
+          if fill != none {
+            [#c-body #box(width: 1fr, fill)]
+          } else {
+            [#c-body #h(1fr)]
+          }
+        },
+        text(size: 0.95em)[#note.loc.page()],
+      )
+
+      outline-items.push(link(note.dest, note.badge))
+      outline-items.push(link(note.dest, content-and-page))
+    }
+    grid(
+      columns: (auto, 1fr),
+      column-gutter: 0.75em,
+      row-gutter: c-gap,
+      align: (center + top, left + top),
+      ..outline-items
+    )
+  }
+}

--- a/packages/preview/deixis/0.1.1/src/pin.typ
+++ b/packages/preview/deixis/0.1.1/src/pin.typ
@@ -1,0 +1,293 @@
+#import "core.typ": *
+
+/// The default prefix used in ```ref #deixis-attach.prefix``` when `prefix: auto`.
+/// Defaults to `"deixispin"` and can be set using ```ref #deixis-set-pin-pattern```.
+///
+/// ```warning
+/// While counter-intuitive, prefix should not contain special characters like `".~!@#$%^&*()-_"`, if you want it to works on `raw` code.
+/// ```
+///
+/// -> str
+#let deixis-pin-prefix-state = state("deixis-pin-prefix", "deixispin")
+
+/// The default postfix used in ```ref #deixis-attach.postfix``` when `postfix: auto`.
+/// Defaults to `""` (empty string) and can be set using ```ref #deixis-set-pin-pattern```.
+///
+/// ````warning
+/// Similar to ```ref #deixis-pin-prefix-state```, postfix should not contain special characters like `".~!@#$%^&*()-_"`.
+/// ````
+///
+/// -> str
+#let deixis-pin-postfix-state = state("deixis-pin-postfix", "")
+
+/// Sets the global prefix and postfix used by ```ref #deixis-attach``` regex engine.
+///
+/// - prefix (str): The string prefix to use for regex matching.
+/// - postfix (str): The string postfix to use for regex matching.
+#let deixis-set-pin-pattern(
+  /// The string prefix to use for regex matching.
+  /// -> str
+  prefix: auto,
+  /// The string postfix to use for regex matching.
+  /// -> str
+  postfix: auto,
+) = {
+  if prefix != auto {
+    deixis-pin-prefix-state.update(prefix)
+  }
+  if postfix != auto {
+    deixis-pin-postfix-state.update(postfix)
+  }
+}
+
+/// Manually drops an invisible, named geometric anchor (a `"pin"`) into the document flow.
+///
+/// Pins are the coordinate anchors that ```ref #deixis-region-mark``` uses to draw its highlights.
+/// They can also be used as anchor coordinates for ```ref #deixis-inset-note-body``` and ```ref #deixis-margin-note-body```.
+///
+/// - name (str): The unique identifier for this pin.
+/// - padding (str, length, dictionary): The mathematical padding around the pin. Using `"text"` automatically calculates the height of the current font size.
+/// - extra-data (dictionary): Additional metadata to attach to the pin payload.
+///
+/// -> content
+#let deixis-pin(
+  /// The unique identifier for this pin.
+  /// -> str
+  name,
+  /// The mathematical padding around the pin.
+  /// - Accepts `length` or `dictionary`.
+  /// ```example
+  /// #place(center + horizon, deixis-pin("test-padding", padding: 5pt))
+  /// #deixis-region-mark(pins: ("test-padding",))
+  /// ```
+  /// - If `"text"`, the height of the current font size is calculated.
+  /// ```example
+  /// The library was filled with the #deixis-pin("susurrus-l", padding: "text")susurrus#deixis-pin("susurrus-r", padding: "text") of turning pages.
+  /// #deixis-region-mark(pins: ("susurrus-l", "susurrus-r"))
+  /// ```
+  ///
+  /// -> str | length | dictionary
+  padding: "text",
+  /// Additional metadata to attach to the pin payload.
+  /// -> dictionary
+  extra-data: (:),
+) = context {
+  let actual-padding = if padding == "text" {
+    text-padding
+  } else {
+    padding
+  }
+
+  let pad = deixis-utils.get-margins(actual-padding)
+  let abs-pad = (
+    left: deixis-utils.resolve-len(pad.left),
+    right: deixis-utils.resolve-len(pad.right),
+    top: deixis-utils.resolve-len(pad.top),
+    bottom: deixis-utils.resolve-len(pad.bottom),
+  )
+
+  box[#metadata((
+    name: name,
+    padding: abs-pad,
+    ..extra-data,
+  ))<deixis-pin>]
+}
+
+/// A wrapper that attaches pins to a block of content.
+///
+/// This function does two things:
+/// 1. It scans the `body` text for your pin prefix (e.g., `deixispinTop`) and converts them into physical inline pins.
+/// 2. It can place absolute overlay pins relative to the bounding box of the `body` (e.g., placing a pin exactly at `dx: 100%, dy: 100%`).
+///
+/// - body (content): The content block to wrap and scan.
+/// - pins (dictionary): A dictionary mapping pin names to overlay coordinates and padding. Example: `("my-pin": (dx: 100%, dy: 50%, padding: 2pt))`.
+/// - prefix (auto, str, none): The regex prefix to search for. If `auto`, it uses the global state. Set to `none` to disable regex scanning.
+/// - padding (auto, str, length, dictionary): Padding for pins replaced with `prefix`. It has no effect on pins defined with `pins`.
+/// - inline (bool): If `true`, the wrapper uses an inline `box` instead of a `block`.
+///
+/// -> content
+#let deixis-attach(
+  /// The content block to wrap and scan.
+  /// -> content
+  body,
+  /// A dictionary mapping pin names to overlay coordinates and padding. Example: `("my-pin": (dx: 100%, dy: 50%, padding: 2pt))`.
+  ///
+  /// ```example
+  /// #deixis-attach(
+  ///   pins: (
+  ///     cat-tl: (dx: 40%, dy: 35%, padding: (left: -5pt, top: -5pt)),
+  ///     cat-br: (dx: 60%, dy: 60%, padding: (right: 5pt, bottom: 5pt)),
+  /// ))[
+  ///   #image("../assets/loading-cat.jpg")
+  /// ]
+  /// #deixis-region-mark(
+  ///   pins: ("cat-tl", "cat-br"),
+  ///   stroke: red + 2pt,
+  /// )
+  /// ```
+  ///
+  /// -> dictionary
+  pins: (:),
+  /// The regex prefix to search for. If `auto`, it uses the global state. Set to `none` to disable regex scanning.
+  ///
+  /// ```info
+  /// Pins attached with regex scan will have `padding: "text"` by default. Use @deixis-attach.padding for customization.
+  /// ```
+  ///
+  /// ````example
+  /// Usage:
+  /// #deixis-attach(prefix: "mypin")[
+  ///   ```typst
+  ///   mypincode1#deixis-attachmypincode2(postfix: "deixis")[
+  ///     deixispinp1deixisThis line will be pinned.deixispinp2deixis
+  ///   ]
+  ///   // Now one can use pins "p1" and "p2"
+  ///   ```
+  /// ]
+  /// #deixis-region-mark(pins: ("code1", "code2"), fill: red.transparentize(95%))
+  /// ````
+  ///
+  /// ```tip
+  /// Oftentimes, if `prefix` alone is not enough, you can also define a `postfix`.
+  ///
+  /// The name of the pin attached with regex scan should also not contain any special character, depending on the `raw` language.
+  /// ```
+  ///
+  /// -> auto | str | none
+  prefix: auto,
+  /// The regex postfix to search for. If `auto`, it uses the global state.
+  ///
+  /// ````example
+  /// Python hello world program:
+  /// #deixis-attach(
+  ///   prefix: "mypin",
+  ///   postfix: "mypin")[
+  ///   ```python
+  ///   mypincode3mypinprintmypincode4mypin("Hello world!")
+  ///   ```
+  /// ]
+  /// #deixis-region-mark(pins: ("code3", "code4"), fill: red.transparentize(95%))
+  /// ````
+  ///
+  /// -> auto | str | none
+  postfix: auto,
+  /// Padding for pins replaced with @deixis-attach.prefix. It has no effect on pins defined with @deixis-attach.pins.
+  ///
+  /// ```example
+  /// Pythagorean theorem:
+  ///
+  /// #align(center)[
+  /// #deixis-attach(
+  ///   prefix: "mypin",
+  ///   padding: (  // dict of pin names
+  ///     eq1: (top: 1.2em, bottom: 0.5em, left: 1em),
+  ///     eq2: (top: 1.2em, bottom: 0.5em, right: 1em),
+  ///   ),
+  /// )[
+  ///   mypineq1$a^2 + b^2 = c^2$mypineq2
+  /// ]
+  /// ]
+  /// #deixis-region-mark(pins: ("eq1", "eq2"), stroke: orange, fill: orange.transparentize(95%))
+  /// ```
+  ///
+  /// -> auto | str | length | dictionary
+  padding: auto,
+  /// If `true`, the wrapper uses an inline `box` instead of a `block`.
+  ///
+  /// ```example
+  /// #lorem(7)
+  /// #deixis-attach(
+  ///   pins: (tl1: (dx: 0%, dy: 0%), br1: (dx: 100%, dy: 100%)),
+  ///   inline: false)[
+  ///   Block-level attached content.
+  /// ]
+  /// #deixis-region-mark(pins: ("tl1", "br1"), stroke: teal)
+  ///
+  /// #lorem(7)
+  /// #deixis-attach(
+  ///   pins: (tl2: (dx: 0%, dy: 0%), br2: (dx: 100%, dy: 100%)),
+  ///   inline: true)[
+  ///   Inline attached content.
+  /// ]
+  /// #deixis-region-mark(pins: ("tl2", "br2"), stroke: green)
+  /// ```
+  ///
+  /// -> bool
+  inline: false,
+) = context {
+  _deixis-check-setup-state()
+
+  let prefix = if prefix == auto { deixis-pin-prefix-state.get() } else { prefix }
+  let postfix = if postfix == auto { deixis-pin-postfix-state.get() } else { postfix }
+
+  let valid-prefix = prefix != none and type(prefix) == str and prefix.len() > 0
+  let valid-postfix = postfix != none and type(postfix) == str and postfix.len() > 0
+
+  let pattern-str = ""
+  if valid-postfix {
+    pattern-str = prefix + "([a-zA-Z0-9_-]+?)" + postfix
+  } else {
+    pattern-str = prefix + "([a-zA-Z0-9_-]+)"
+  }
+  // ------------------------------
+
+  let pin-pattern = if valid-prefix { regex(pattern-str) }
+
+  let dimension-dict-padding = (
+    type(padding) == dictionary and padding.keys().any(k => k in ("left", "right", "top", "bottom", "x", "y", "rest"))
+  )
+  if dimension-dict-padding and not padding.keys().all(k => k in ("left", "right", "top", "bottom", "x", "y", "rest")) {
+    panic("deixis: #deixis-attach padding keys must be either dimensions or pin names. Mixxing them is not allowed.")
+  }
+
+  let pin-replacer = it => if valid-prefix {
+    // Safely extract Capture Group 1 (the pin name) directly from the regex match!
+    let m = it.text.match(pin-pattern)
+    let pin-name = m.captures.at(0)
+
+    let pin-padding = if padding == auto {
+      "text"
+    } else if type(padding) == dictionary {
+      if dimension-dict-padding {
+        padding
+      } else {
+        if pin-name == "rest" {
+          panic(
+            "deixis: #deixis-attach reserves 'rest' as a special keyword for pin-scoped padding dictionary. Rename your pin.",
+          )
+        }
+        padding.at(pin-name, default: padding.at("rest", default: 0pt))
+      }
+    } else {
+      padding
+    }
+    deixis-pin(pin-name, padding: pin-padding, extra-data: (type: "inline-regex"))
+  } else { it }
+
+  show pin-pattern: pin-replacer
+  show raw: it => if valid-prefix {
+    show pin-pattern: pin-replacer
+    it
+  } else { it }
+
+  if pins.len() > 0 {
+    let container = if inline { box } else { block }
+    container(width: auto, height: auto, {
+      for (pin-name, pin-args) in pins {
+        let dx = if "dx" in pin-args { pin-args.dx } else { pin-args.at(0, default: 0pt) }
+        let dy = if "dy" in pin-args { pin-args.dy } else { pin-args.at(1, default: 0pt) }
+        let padding = if "padding" in pin-args { pin-args.padding } else { 0pt }
+        let extra-data = if "extra-data" in pin-args { pin-args.extra-data } else { (:) }
+
+        place(top + left, dx: dx, dy: dy, deixis-pin(
+          pin-name,
+          padding: padding,
+          extra-data: (type: "overlay", dx: dx, dy: dy) + extra-data,
+        ))
+      }
+      body
+    })
+  } else {
+    body
+  }
+}

--- a/packages/preview/deixis/0.1.1/src/reference.typ
+++ b/packages/preview/deixis/0.1.1/src/reference.typ
@@ -1,0 +1,266 @@
+#import "core.typ": *
+
+/// A styled, clickable cross-reference to a specific note.
+///
+/// - ..targets (arguments): The positional target label (e.g., `<my-note>`) to reference.
+/// - supplement (auto, content, none): The prefix to display before the number (e.g., `[Note]`). Set to `none` for just the number.
+/// - marker-style (auto, function): A custom styling function `(string) => content` for the reference number. If `auto`, it inherits the note's original marker style.
+/// - celibate-marker (str): The marker displayed for celibate notes.
+///
+/// -> content
+#let deixis-ref(
+  /// The positional target `label` (e.g., `<my-note>`) to reference.
+  ///
+  /// ```example
+  /// //| sandbox-mode: "page"
+  /// Let's create some test notes
+  /// #deixis-margin-note(label: <note-a>)[Test note A.]
+  /// #deixis-margin-note(label: <note-b>)[Test note B.]
+  /// #deixis-margin-note(label: <note-c>)[Test note C.]
+  ///
+  /// Single reference: #deixis-ref(<note-a>)
+  /// ```
+  ///
+  /// - Multiple consecutive references will be collapsed automatically.
+  /// ```example
+  /// Multiple reference: #deixis-ref(<note-a>, <note-b>, <note-c>)
+  /// ```
+  ///
+  /// - The last positional argument, if of type `content` or `str`, will be interpreted as @deixis-ref.supplement.
+  /// ```example
+  /// #deixis-ref(<note-b>)[Comment]
+  /// ```
+  ///
+  /// -> arguments
+  ..targets,
+  /// The prefix to display before the number (e.g., `[Note]`). Set to `none` for just the number.
+  ///
+  /// ```example
+  /// #deixis-ref(<note-c>, supplement: [Todo])
+  /// ```
+  ///
+  /// -> auto | content | none
+  supplement: auto,
+  /// A custom styling function `(string) => content` for the reference number. If `auto`, it inherits the note's original marker style.
+  /// -> auto | function
+  marker-style: auto,
+  /// The marker displayed for celibate notes.
+  /// -> str
+  celibate-marker: "?",
+) = {
+  let named = targets.named()
+  let fallback = named.remove("_fallback", default: auto)
+  if named.len() > 0 {
+    panic("deixis: Unknown named argument(s) " + repr(targets.named().keys()) + " passed to #deixis-ref.")
+  }
+  let targets = targets.pos()
+  if targets.len() == 0 { return none }
+
+  let supplement = supplement
+  if type(targets.last()) in (content, str) {
+    if supplement != auto {
+      panic("deixis: #deixis-ref only accepts supplement as named or the last positional argument.")
+    }
+    supplement = targets.remove(-1)
+  }
+  if targets.any(it => type(it) != label) {
+    panic("deixis: #deixis-ref only accepts one last positional content argument as supplement.")
+  }
+
+  let meta-tags = targets
+    .map(target => {
+      [#metadata((target: str(target)))<deixis-ref-marker>]
+    })
+    .join()
+
+  let content = context {
+    let sys = deixis-system.final()
+    let notes = sys.at("notes", default: (:))
+    let id-idx = sys.at("id-index", default: (:))
+    let lbl-idx = sys.at("label-index", default: (:))
+
+    let resolve-payload(t) = {
+      // check registry
+      if t in lbl-idx { return notes.at(lbl-idx.at(t)) }
+      if t in id-idx { return notes.at(id-idx.at(t)) }
+      let raw-internal = t.replace("deixis-body-", "").replace("deixis-mark-", "")
+      if raw-internal in notes { return notes.at(raw-internal) }
+
+      // query metadata for celibate notes
+      let queried = query(std.label(t))
+      if queried.len() > 0 {
+        let el = queried.first()
+        if el.func() == metadata {
+          if type(el.value) == dictionary {
+            return el.value
+          } else {
+            // Failsafe in case the metadata payload was stripped
+            return (marker-str: none, is-celibate: true)
+          }
+        }
+      }
+
+      return none
+    }
+
+    // Single-target resolution for the `show ref:` rule fallback
+    if targets.len() == 1 {
+      let t-str = str(targets.first())
+      let is-deixis = false
+
+      if resolve-payload(t-str) != none {
+        is-deixis = true
+      }
+
+      if not is-deixis {
+        return if fallback != auto { fallback } else { ref(targets.first()) }
+      }
+    }
+
+    let results = ()
+
+    for target in targets {
+      let t-lbl = if type(target) == str { std.label(target) } else { target }
+      let t-str = str(t-lbl)
+
+      let data = resolve-payload(t-str)
+      if data == none { data = (:) }
+
+      let internal-id = data.at("internal-id", default: none)
+      let marker-str = none
+
+      if internal-id != none {
+        let marks = query(selector(<deixis-inline-mark>).or(<deixis-phantom-mark>).or(<deixis-region-mark>))
+
+        let match = marks.find(m => (
+          type(m.value) == dictionary
+            and m.value.at("internal-id", default: none) != none
+            and str(m.value.internal-id) == str(internal-id)
+        ))
+
+        if match != none {
+          marker-str = match.value.at("marker-str", default: none)
+        }
+      }
+
+      if marker-str == none {
+        marker-str = _deixis-evaluate-marker-str(data)
+      }
+
+      if marker-str == none { marker-str = celibate-marker }
+
+      let m-style = auto
+      if marker-style != auto {
+        m-style = marker-style
+      } else {
+        let mark-type = data.at("mark-type", default: "inline")
+        let raw-m-style = data.at("marker-style", default: auto)
+        m-style = _deixis-resolve-typed-param(
+          sys,
+          raw-m-style,
+          "marker-style",
+          mark-type,
+          component: "mark",
+        )
+      }
+
+      let int-val = none
+      if type(marker-str) == str and marker-str.match(regex("^\d+$")) != none {
+        int-val = int(marker-str)
+      } else if type(marker-str) == int {
+        int-val = marker-str
+        marker-str = str(marker-str)
+      }
+
+      results.push((lbl: t-lbl, marker-str: marker-str, int-val: int-val, m-style: m-style))
+    }
+
+    let valid-styles = results.filter(r => r.m-style != auto)
+    let master-style = if valid-styles.len() > 0 { valid-styles.first().m-style } else {
+      let raw-m-style = _deixis-resolve-typed-param(sys, auto, "marker-style", "rest", component: "mark")
+      if raw-m-style != auto { raw-m-style } else { it => super(it) }
+    }
+
+    results = results.map(r => {
+      if r.m-style == auto { r.insert("m-style", master-style) }
+      r
+    })
+
+    let format-num(res, is-first) = {
+      let num = (res.m-style)(res.marker-str)
+      if is-first and supplement not in (auto, none) {
+        [#supplement~#num]
+      } else {
+        num
+      }
+    }
+
+    // collapsing
+    let all-ints = results.all(r => r.int-val != none)
+    let formatted-content = ()
+
+    if not all-ints {
+      for (i, res) in results.enumerate() {
+        formatted-content.push(std.link(res.lbl, format-num(res, i == 0)))
+        if i < results.len() - 1 { formatted-content.push(master-style([, ])) }
+      }
+    } else {
+      let sorted = results.sorted(key: r => r.int-val)
+      let runs = ()
+      let current-run = (sorted.first(),)
+
+      for i in range(1, sorted.len()) {
+        let prev = sorted.at(i - 1)
+        let curr = sorted.at(i)
+        if curr.int-val == prev.int-val + 1 {
+          current-run.push(curr)
+        } else {
+          runs.push(current-run)
+          current-run = (curr,)
+        }
+      }
+      runs.push(current-run)
+
+      for (i, run) in runs.enumerate() {
+        let is-first = (i == 0) // Only prepend supplement to the very first item
+
+        if run.len() == 1 {
+          let r0 = run.first()
+          formatted-content.push(std.link(r0.lbl, format-num(r0, is-first)))
+        } else if run.len() == 2 {
+          let r0 = run.first()
+          let r1 = run.last()
+          formatted-content.push(std.link(r0.lbl, format-num(r0, is-first)))
+          formatted-content.push(master-style([, ]))
+          formatted-content.push(std.link(r1.lbl, (r1.m-style)(r1.marker-str)))
+        } else {
+          let r0 = run.first()
+          let r1 = run.last()
+          formatted-content.push(std.link(r0.lbl, format-num(r0, is-first)))
+          formatted-content.push(master-style([–]))
+          formatted-content.push(std.link(r1.lbl, (r1.m-style)(r1.marker-str)))
+        }
+        if i < runs.len() - 1 { formatted-content.push(master-style([, ])) }
+      }
+    }
+
+    formatted-content.join()
+  }
+
+  [#meta-tags#content]
+}
+
+/// A show rule to automatically convert `@note-label` to `#deixis-ref(<note-label>)`.
+///
+/// ```example
+/// #show: deixis-show-refs
+/// ```
+///
+/// - body (content): The content of the document.
+///
+/// -> content
+#let deixis-show-refs(body) = {
+  show ref: it => deixis-ref(it.target, supplement: it.supplement, _fallback: it)
+
+  body
+}

--- a/packages/preview/deixis/0.1.1/src/region-note.typ
+++ b/packages/preview/deixis/0.1.1/src/region-note.typ
@@ -1,0 +1,719 @@
+#import "core.typ": *
+#import "pin.typ": *
+
+// Shared Region Rendering Engine
+#let _deixis-render-region-shape(
+  sys,
+  reg,
+  all-pins,
+  current-page,
+  base-pos: none,
+  draw-shape: true,
+  draw-marker: true,
+) = {
+  let active-pins = ()
+  for pin-name in reg.pins {
+    let matches = all-pins.filter(p => p.value.name == pin-name)
+    for m in matches { active-pins.push(m) }
+  }
+
+  if active-pins.len() == 0 { return none }
+
+  let sorted-pins = active-pins.sorted(key: p => (p.location().page(), p.location().position().y))
+  let first-page = sorted-pins.first().location().page()
+  let last-page = sorted-pins.last().location().page()
+
+  if current-page < first-page or current-page > last-page { return none }
+
+  let min-x = 1e10pt
+  let max-x = -1e10pt
+
+  for p in active-pins {
+    let px = deixis-utils.resolve-signed-len(p.location().position().x)
+    let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+    let px-l = px - deixis-utils.resolve-signed-len(p-pad.left)
+    let px-r = px + deixis-utils.resolve-signed-len(p-pad.right)
+    if px-l < min-x { min-x = px-l }
+    if px-r > max-x { max-x = px-r }
+  }
+
+  let p-margins = deixis-utils.get-page-margins(current-page)
+  let page-h = deixis-utils.resolve-len(if type(page.height) == length { page.height } else {
+    deixis-utils.default-page-size.height
+  })
+  let text-top = deixis-utils.resolve-len(p-margins.top)
+  let text-bottom = page-h - deixis-utils.resolve-len(p-margins.bottom)
+
+  let min-y = text-top
+  let max-y = text-bottom
+
+  let page-pins = active-pins.filter(p => p.location().page() == current-page)
+
+  if page-pins.len() > 0 {
+    let local-min-y = 1e10pt
+    let local-max-y = -1e10pt
+    for p in page-pins {
+      let py = deixis-utils.resolve-signed-len(p.location().position().y)
+      let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+      let py-t = py - deixis-utils.resolve-signed-len(p-pad.top)
+      let py-b = py + deixis-utils.resolve-signed-len(p-pad.bottom)
+      if py-t < local-min-y { local-min-y = py-t }
+      if py-b > local-max-y { local-max-y = py-b }
+    }
+    if current-page == first-page { min-y = local-min-y }
+    if current-page == last-page { max-y = local-max-y }
+  }
+
+  let reg-pad = deixis-utils.get-margins(reg.styles.at("padding", default: 0pt))
+  min-x -= deixis-utils.resolve-signed-len(reg-pad.left)
+  max-x += deixis-utils.resolve-signed-len(reg-pad.right)
+
+  if current-page == first-page { min-y -= deixis-utils.resolve-signed-len(reg-pad.top) }
+  if current-page == last-page { max-y += deixis-utils.resolve-signed-len(reg-pad.bottom) }
+
+  let box-w = max-x - min-x
+  let box-h = max-y - min-y
+
+  // Cross-page style adjustments
+  let c-styles = reg.styles
+  if first-page != last-page {
+    let c-rad = deixis-utils.get-radius(reg.styles.at("radius", default: 0pt))
+    let c-stroke = deixis-utils.get-stroke(reg.styles.at("stroke", default: none))
+
+    if current-page == first-page {
+      c-rad.bottom-left = 0pt
+      c-rad.bottom-right = 0pt
+      if c-stroke != none { c-stroke.bottom = none }
+    } else if current-page == last-page {
+      c-rad.top-left = 0pt
+      c-rad.top-right = 0pt
+      if c-stroke != none { c-stroke.top = none }
+    } else {
+      c-rad = (top-left: 0pt, top-right: 0pt, bottom-left: 0pt, bottom-right: 0pt)
+      if c-stroke != none {
+        c-stroke.top = none
+        c-stroke.bottom = none
+      }
+    }
+    c-styles.radius = c-rad
+    c-styles.stroke = c-stroke
+  }
+
+  let active-shape-func = reg.at("shape-func", default: deixis-rect-region)
+  let highlight-box = active-shape-func(width: box-w, height: box-h, ..c-styles)
+
+  let body-exists = if reg.body-lbl != none { query(selector(reg.body-lbl)).len() > 0 } else { false }
+
+  let anchor = if current-page == first-page and reg.mark-lbl != none {
+    [#metadata(none)#reg.mark-lbl]
+  } else { none }
+
+  let mark-marker-style = _deixis-resolve-typed-param(
+    sys,
+    reg.at("marker-style", default: auto),
+    "marker-style",
+    "region-mark",
+    component: "mark",
+  )
+
+  let marker = if reg.marker-str == none {
+    anchor
+  } else if body-exists {
+    [#anchor#std.link(reg.body-lbl)[#mark-marker-style(reg.marker-str)]]
+  } else {
+    [#anchor#mark-marker-style(reg.marker-str)]
+  }
+
+  let c-mark-pos = reg.styles.at("marker-position", default: top + right)
+  let pos-dict = if type(c-mark-pos) == dictionary { c-mark-pos } else { (align: c-mark-pos, dx: 0pt, dy: 0pt) }
+
+  let m-align = pos-dict.at("align", default: top + left)
+
+  let resolve-relative(val, base-len) = {
+    if type(val) == length { return val }
+    if type(val) == ratio { return val * base-len }
+    if type(val) == relative { return val.length + (val.ratio * base-len) }
+    return 0pt
+  }
+
+  let m-dx = resolve-relative(pos-dict.at("dx", default: 0pt), box-w)
+  let m-dy = resolve-relative(pos-dict.at("dy", default: 0pt), box-h)
+
+  // Coordinate Relativity
+  let offset-x = min-x
+  let offset-y = min-y
+  if base-pos != none {
+    offset-x -= deixis-utils.resolve-signed-len(base-pos.x)
+    offset-y -= deixis-utils.resolve-signed-len(base-pos.y)
+  }
+
+  place(top + left, dx: offset-x, dy: offset-y, box(width: box-w, height: box-h, {
+    if draw-shape { highlight-box }
+
+    if draw-marker and marker != none {
+      let m-size = measure(marker)
+      let m-str = repr(m-align)
+
+      let align-x = if "left" in m-str { -1 } else if "right" in m-str { 1 } else { 0 }
+      let align-y = if "top" in m-str { -1 } else if "bottom" in m-str { 1 } else { 0 }
+
+      let out-dx = (m-size.width / 2.0) * align-x + m-dx
+      let out-dy = (m-size.height / 2.0) * align-y + m-dy
+
+      place(m-align, dx: out-dx, dy: out-dy, marker)
+    }
+  }))
+}
+
+/// A visual enclose mark of a specific region in the document.
+///
+/// Region marks are highly versatile. They can dynamically wrap a continuous block of text provided as a
+/// positional argument, or they can asynchronously draw a shape spanning between pre-defined `#deixis-pin` coordinates.
+/// They natively support crossing page boundaries when using the background or foreground layers.
+///
+/// ```example
+/// Inline marks cannot highlight equations or `raw`:
+///
+/// #deixis-inline-mark[*Sigmoid:* $f(x) = frac(1, 1 + e^(-x))$ or `torch.sigmoid`.]
+///
+/// This is where region marks shine:
+///
+/// #deixis-region-mark(inline: true)[*ReLU:* $f(x) = max(0, x)$ or `torch.relu`]
+/// ```
+///
+/// ```example
+/// #let highlight-cell = deixis-region-mark.with(stroke: blue, fill: blue.transparentize(95%))
+///
+/// #set text(0.8em)
+/// #table(
+///   columns: (auto, 1fr, auto, 1fr),
+///   align: center + horizon,
+///   fill: (x, y) => if y == 0 { gray.lighten(80%) },
+///
+///   table.header([*Function*], [*Equation*], [*Output\ Range*], [*Common\ Usecase*]),
+///   [*Sigmoid*], [$1 / (1 + e^(-x))$], [$(0, 1)$], [Binary classifier],
+///   [*Tanh*], [$(e^x - e^(-x)) / (e^x + e^(-x))$], [$(-1, 1)$], [RNNs],
+///   [*ReLU*], [$max(0, x)$], [$[0, inf)$], [CNNs],
+///   [*GELU*], highlight-cell(padding: 4pt)[$x Phi(x)$], [$approx [-0.17, inf)$], [*Transformers*],
+/// )
+/// ```
+///
+/// - ..args (arguments): Accepts at most 1 positional argument: `[body]`.
+/// - id (none, str, label): The unique identifier linking this region to its data/body state.
+/// - pins (array): An array of pin names (e.g., `("pinA", "pinB")`). If provided, the note draws between these pins instead of wrapping a positional body. Cannot be used simultaneously with a positional body argument.
+/// - numbering (auto, str, function): The numbering style for the region's marker.
+/// - marker (auto, content): A hardcoded marker to use instead of the automatic counter.
+/// - target (int, label, str): The specific block/minipage counter context this mark belongs to.
+/// - series (str): The counter series this mark belongs to.
+/// - marker-style (auto, function): A custom styling function `(string) => content` for the generated marker.
+/// - marker-position (auto, alignment, dictionary): Where to place the marker relative to the bounding box.
+/// - stroke (auto, stroke, none): The border stroke of the region highlight.
+/// - fill (auto, color, none): The background fill color of the region highlight.
+/// - radius (auto, length, dictionary): The border radius of the region shape. Automatically adjusts when breaking across pages.
+/// - padding (auto, length, str): The padding between the highlighted text and the border. Using `"text"` aligns to font metrics.
+/// - region-shape (auto, function): Shape drawing function.
+/// - layer (auto, str): The rendering layer context. Choices: `"flow"` | `"foreground"` | `"background"`.
+/// - inline (bool): If `true`, the region wraps the text in an inline `box` instead of a standard `block`.
+///
+/// -> content
+#let deixis-region-mark(
+  /// Accepts at most 1 positional argument: `[body]`.
+  /// -> arguments
+  ..args,
+  /// The unique identifier linking this region to its data/body state.
+  /// -> none | str | label
+  id: none,
+  /// An array of pin names (e.g., `("pinA", "pinB")`). If provided, the note draws between these pins instead of wrapping a positional body. Cannot be used simultaneously with a positional body argument.
+  ///
+  /// See @deixis-pin and @deixis-attach.
+  ///
+  /// -> array
+  pins: (),
+  /// The numbering style for the region's marker.
+  /// -> auto | str | function
+  numbering: auto,
+  /// A hardcoded marker to use instead of the automatic counter.
+  /// -> auto | content
+  marker: auto,
+  /// The specific block/minipage counter context this mark belongs to.
+  /// -> int | label | str
+  target: 0,
+  /// The counter series this mark belongs to.
+  /// -> str
+  series: "default",
+  /// A custom styling function `(string) => content` for the generated marker.
+  /// -> auto | function
+  marker-style: auto,
+  /// Where to place the marker relative to the bounding box.
+  /// - If `alignment`, align to one of the 9 locations.
+  /// ```example
+  /// #deixis-region-mark(
+  ///   id: <celibate-region1>,
+  ///   marker-position: top + center)[#lorem(10)]
+  /// ```
+  /// - If `dictionary` of `length` or `relative`, place the mark at `(dx, dy)` relative to the top left corner of the region. `relative` is understood as to the dimensions of the region.
+  /// ```example
+  /// #deixis-region-mark(
+  ///   id: <celibate-region2>,
+  ///   marker-position: (dx: 100% + 5pt, dy: 5pt))[#lorem(10)]
+  /// ```
+  ///
+  /// -> auto | alignment | dictionary
+  marker-position: auto,
+  /// The border stroke of the region highlight.
+  /// -> auto | stroke | none
+  stroke: auto,
+  /// The background fill color of the region highlight.
+  /// -> auto | color | none
+  fill: auto,
+  /// The border radius of the region shape. Automatically adjusts when breaking across pages.
+  /// -> auto | length | dictionary
+  radius: auto,
+  /// The padding between the highlighted text and the border. Using `"text"` aligns to font metrics.
+  /// -> auto | length | str
+  padding: auto,
+  /// Shape drawing function.
+  ///
+  /// ```example
+  /// *Kepler’s First Law of Planetary Motion* states that every planet’s orbit is an ellipse:
+  /// #align(
+  ///   center,
+  ///   deixis-region-mark(padding: (x: 8pt, y: 8pt), region-shape: deixis-ellipse-region)[$r = frac(1 - e^2, 1 + e cos(theta))$]
+  /// )
+  /// ```
+  ///
+  /// -> auto | function
+  region-shape: auto,
+  /// The rendering layer context. Choices: `"flow"` | `"foreground"` | `"background"`.
+  /// - With `"foreground"` layer, the region is rendered in the foreground of the page, and may occlude the highlighted content.
+  /// - With `"background"` layer, the region will be rendered in the background of the page, and might be occluded by other contents.
+  /// ```example
+  /// // pins already placed in manual.typ
+  /// This example draws the #box(width: 0.6em, height: 0.6em, stroke: yellow) yellow region around this documentation chapter.
+  /// #deixis-region-mark(
+  ///   pins: ("region-mark-chapter-start", "region-mark-chapter-end"),
+  ///   padding: (x: 5pt, top: -5pt, bottom: 5pt),
+  ///   stroke: yellow + 2pt,
+  ///   fill: yellow.transparentize(98%),
+  ///   radius: 10pt,
+  ///   layer: "background",
+  /// )
+  /// ```
+  /// - With `"flow"` layer, the placement of the region is synchronuous.
+  /// ```example
+  /// #deixis-region-mark(
+  ///   pins: ("test-layer3", "test-layer4"),
+  ///   stroke: none,
+  ///   fill: purple.transparentize(25%),
+  ///   layer: "flow",
+  /// )  // below the highlighted text
+  ///
+  /// #quote(attribution: [Messmer the Impaler], block: true)[*#deixis-pin("test-layer1")Mongrel#deixis-pin("test-layer2") #deixis-pin("test-layer3")intruder#deixis-pin("test-layer4").*]
+  ///
+  /// #deixis-region-mark(
+  ///   pins: ("test-layer1", "test-layer2"),
+  ///   stroke: none,
+  ///   fill: red.transparentize(25%),
+  ///   layer: "flow",
+  /// )  // above the highlighted text
+  /// ```
+  ///
+  /// ```tip
+  /// - Use `"flow"` for highlighting images, diagrams, ...
+  ///   Be aware that it will trigger a `#parbreak`.
+  ///
+  /// - Use `"background"` for highlighting texts, equations, ... _if they are not in a non-transparent container_.
+  ///
+  /// - Use `"foreground"` or `"background"` where the region can span across multiple pages.
+  /// ```
+  ///
+  /// -> auto | str
+  layer: auto,
+  /// If `true`, the region wraps the text in an inline `box` instead of a standard `block`.
+  /// -> bool
+  inline: false,
+) = {
+  let named = args.named()
+  if named.len() > 0 {
+    panic(
+      "deixis: Unknown named argument(s) "
+        + repr(named.keys())
+        + ". Styling arguments are not allowed in mark-only note functions.",
+    )
+  }
+
+  let styles = (stroke: stroke, fill: fill, radius: radius)
+
+  let pos = args.pos()
+  if pos.len() > 1 { panic("#deixis-region-mark accepts at most 1 positional argument [body].") }
+
+  let body = if pos.len() == 1 { deixis-utils._deixis-trim-content(pos.first()) } else { none }
+  let has-body = body != none
+  let has-pins = type(pins) == array and pins.len() > 0
+
+  if has-pins == has-body {
+    panic("#deixis-region-mark requires either 'pins' or a positional body, but not both.")
+  }
+
+  let padding = if padding == auto {
+    if inline and has-body { "text" } else { 0pt }
+  } else { padding }
+
+  if id == none {
+    return [
+      #std.counter("deixis-anon-region").step()
+      #context {
+        let sys = deixis-system.get()
+        let m-styles = _deixis-resolve-mark-styles(
+          sys,
+          "region-mark",
+          marker-position: marker-position,
+          stroke: stroke,
+          fill: fill,
+          radius: radius,
+        )
+        let c-shape = _deixis-resolve-typed-param(sys, region-shape, "region-shape", "region-mark")
+        let c-layer = _deixis-resolve-typed-param(sys, layer, "layer", "region-mark", component: "mark")
+
+        let c-pins = pins
+        let rendered-body = none
+        let c-padding = if padding == "text" { text-padding } else { padding }
+
+        if has-body {
+          let internal-id = std.counter("deixis-anon-region").get().first()
+          let auto-prefix = "deixis-reg-anon-" + str(internal-id)
+
+          let pin-tl = auto-prefix + "-tl"
+          let pin-br = auto-prefix + "-br"
+          c-pins = (pin-tl, pin-br)
+
+          if inline {
+            rendered-body = [#deixis-pin(pin-tl, padding: padding)#body#deixis-pin(pin-br, padding: padding)]
+          } else {
+            let attach-pins = (:)
+            attach-pins.insert(pin-tl, (
+              dx: 0%,
+              dy: 0%,
+              padding: if padding == "text" {
+                (top: text-padding.top - measure([T]).height, bottom: text-padding.bottom, x: text-padding.x)
+              } else { padding },
+            ))
+            attach-pins.insert(pin-br, (
+              dx: 100%,
+              dy: 100%,
+              padding: if padding == "text" { text-padding } else { padding },
+            ))
+
+            rendered-body = deixis-attach(body, pins: attach-pins)
+          }
+          c-padding = 0pt
+        }
+
+        let is-multipage = false
+        let all-pins = query(<deixis-pin>)
+        let active-pins = ()
+        for pin-name in c-pins {
+          for m in all-pins.filter(p => p.value.name == pin-name) { active-pins.push(m) }
+        }
+
+        if active-pins.len() > 0 {
+          let sorted = active-pins.sorted(key: p => p.location().page())
+          if sorted.first().location().page() != sorted.last().location().page() {
+            is-multipage = true
+          }
+        }
+
+        if c-layer == "flow" and is-multipage {
+          panic(
+            "deixis: cannot render multi-page region with 'flow' layer, please switch to asynchronuous layers: 'foreground' or 'background'.",
+          )
+        }
+
+        let meta-payload = (
+          internal-id: none,
+          mark-lbl: none,
+          body-lbl: none,
+          marker-str: none,
+          marker-style: auto,
+          pins: c-pins,
+          shape-func: c-shape,
+          layer: c-layer,
+          styles: m-styles + (padding: c-padding),
+        )
+
+        let rendered-region = none
+        if c-layer == "flow" {
+          let drawing-context = context {
+            let all-pins = query(<deixis-pin>)
+            _deixis-render-region-shape(
+              deixis-system.get(),
+              meta-payload,
+              all-pins,
+              here().page(),
+              base-pos: here().position(),
+            )
+          }
+          if inline {
+            rendered-region = box(width: 0pt, height: 0pt, drawing-context)
+          } else {
+            rendered-region = place(drawing-context)
+          }
+        }
+
+        let mark-body = if inline {
+          [#rendered-region#rendered-body]
+        } else {
+          [#rendered-body#rendered-region]
+        }
+        [#mark-body#metadata(meta-payload)<deixis-region-mark>]
+      }
+    ]
+  }
+
+  _deixis-validate-target(target)
+
+  deixis-system.update(sys => {
+    if id != none and str(id) in sys.at("id-index", default: (:)) { return sys }
+
+    let new-note-uid = sys.at("note-uid", default: 0) + 1
+    let uid-str = str(new-note-uid)
+
+    let resolved = _deixis-resolve-target(sys, target)
+    let full-c-id = resolved.count-id + ":" + series
+
+    let new-counters = sys.counters
+    let current-count = new-counters.at(full-c-id, default: 0) + 1
+    new-counters.insert(full-c-id, current-count)
+
+    let new-blocks = sys.blocks
+    if resolved.render-id != "page" and type(target) in (str, label) and str(target) not in new-blocks {
+      new-blocks.insert(str(target), (
+        render-id: resolved.render-id,
+        count-id: resolved.count-id,
+        inst-id: resolved.inst-id,
+      ))
+    }
+
+    let c-numbering = _deixis-resolve-typed-param(sys, numbering, "numbering", "region-mark")
+    let m-styles = _deixis-resolve-mark-styles(sys, "region-mark", marker-position: marker-position)
+
+    let payload = (
+      internal-id: new-note-uid,
+      target-id: resolved.render-id,
+      inst-id: resolved.inst-id,
+      series: series,
+      count: current-count,
+      numbering: c-numbering,
+      marker: marker,
+      mark-type: "region",
+      marker-style: marker-style,
+      marker-position: m-styles.marker-position,
+      styles: styles,
+      has-mark-body: has-body,
+    )
+
+    let new-notes = sys.at("notes", default: (:))
+    let new-id-index = sys.at("id-index", default: (:))
+
+    new-notes.insert(uid-str, payload)
+
+    if id == deixis-auto-id {
+      sys.insert("last-auto-uid", uid-str)
+    } else if id != none {
+      let id-str = str(id)
+      if id-str in new-id-index and not id-str.starts-with("deixis-auto-") {
+        panic("deixis: Duplicate note ID detected: '" + id-str + "'.\nNote IDs must be unique across the document.")
+      }
+      new-id-index.insert(id-str, uid-str)
+    }
+
+    return (
+      ..sys,
+      note-uid: new-note-uid,
+      blocks: new-blocks,
+      counters: new-counters,
+      notes: new-notes,
+      id-index: new-id-index,
+    )
+  })
+
+  context {
+    let sys = deixis-system.get()
+
+    let target-uid = if id == deixis-auto-id { sys.at("last-auto-uid", default: none) } else if id != none {
+      sys.id-index.at(str(id), default: none)
+    } else { none }
+    let reg = if target-uid != none { sys.notes.at(target-uid, default: none) } else { none }
+
+    let saved-styles = if reg != none { reg.at("styles", default: (:)) } else { styles }
+    let c-styles = _deixis-merge-styles(saved-styles, styles, allowed-keys: ("stroke", "fill", "radius"))
+
+    let m-styles = _deixis-resolve-mark-styles(
+      sys,
+      "region-mark",
+      marker-position: marker-position,
+      ..c-styles,
+    )
+
+    let c-shape = _deixis-resolve-typed-param(sys, region-shape, "region-shape", "region-mark")
+    let c-layer = _deixis-resolve-typed-param(sys, layer, "layer", "region-mark", component: "mark")
+
+    let c-pins = pins
+    let rendered-body = none
+    let c-padding = if padding == "text" { text-padding } else { padding }
+
+    let internal-id = if reg != none { reg.internal-id } else { "temp-pass-1" }
+
+    if has-body {
+      let auto-prefix = "deixis-reg-" + str(internal-id)
+      let pin-tl = auto-prefix + "-tl"
+      let pin-br = auto-prefix + "-br"
+      c-pins = (pin-tl, pin-br)
+
+      if inline {
+        rendered-body = [#deixis-pin(pin-tl, padding: padding)#body#deixis-pin(pin-br, padding: padding)]
+      } else {
+        let attach-pins = (:)
+        attach-pins.insert(pin-tl, (
+          dx: 0%,
+          dy: 0%,
+          padding: if padding == "text" {
+            (top: text-padding.top - measure([T]).height, bottom: text-padding.bottom, x: text-padding.x)
+          } else { padding },
+        ))
+        attach-pins.insert(pin-br, (
+          dx: 100%,
+          dy: 100%,
+          padding: if padding == "text" { text-padding } else { padding },
+        ))
+
+        rendered-body = deixis-attach(body, pins: attach-pins)
+      }
+      c-padding = 0pt
+    }
+
+    let is-multipage = false
+    let all-pins = query(<deixis-pin>)
+    let active-pins = ()
+    for pin-name in c-pins {
+      for m in all-pins.filter(p => p.value.name == pin-name) { active-pins.push(m) }
+    }
+
+    if active-pins.len() > 0 {
+      let sorted = active-pins.sorted(key: p => p.location().page())
+      if sorted.first().location().page() != sorted.last().location().page() {
+        is-multipage = true
+      }
+    }
+
+    if c-layer == "flow" and is-multipage {
+      panic(
+        "deixis: cannot render multi-page region with 'flow' layer, please switch to asynchronuous layers: 'foreground' or 'background'.",
+      )
+    }
+
+    if reg == none {
+      let meta-payload = (
+        internal-id: none,
+        mark-lbl: none,
+        body-lbl: none,
+        marker-str: none,
+        marker-style: auto,
+        pins: c-pins,
+        shape-func: c-shape,
+        layer: c-layer,
+        styles: m-styles + (padding: c-padding),
+      )
+      return [#rendered-body#metadata(meta-payload)<deixis-region-mark>#anchor]
+    }
+
+    let count = reg.count
+    let c-numbering = reg.at("numbering", default: "1")
+    let c-marker = reg.at("marker", default: auto)
+
+    let marker-str = if c-marker != auto {
+      c-marker
+    } else if c-numbering != none {
+      std.numbering(c-numbering, count)
+    } else {
+      none
+    }
+
+    let mark-lbl = std.label("deixis-mark-" + str(internal-id))
+    let body-lbl = std.label("deixis-body-" + str(internal-id))
+
+    let mark-marker-style = _deixis-resolve-typed-param(
+      sys,
+      marker-style,
+      "marker-style",
+      "region-mark",
+      component: "mark",
+    )
+
+    let meta-payload = (
+      internal-id: internal-id,
+      mark-lbl: mark-lbl,
+      body-lbl: body-lbl,
+      marker-str: marker-str,
+      marker-style: mark-marker-style,
+      pins: c-pins,
+      shape-func: c-shape,
+      layer: c-layer,
+      styles: m-styles + (padding: c-padding),
+    )
+
+    let rendered-region = none
+    if c-layer == "flow" {
+      let drawing-context = context {
+        let all-pins = query(<deixis-pin>)
+        _deixis-render-region-shape(
+          deixis-system.get(),
+          meta-payload,
+          all-pins,
+          here().page(),
+          base-pos: here().position(),
+        )
+      }
+      if inline {
+        rendered-region = box(width: 0pt, height: 0pt, drawing-context)
+      } else {
+        rendered-region = place(drawing-context)
+      }
+    }
+
+    let mark-body = if inline {
+      [#rendered-region#rendered-body]
+    } else {
+      [#rendered-body#rendered-region]
+    }
+    [#mark-body#metadata(meta-payload)<deixis-region-mark>]
+  }
+}
+
+#let _deixis-region-marks-overlay(layer: "foreground") = context {
+  let regions = query(<deixis-region-mark>).map(x => x.value)
+  let all-pins = query(<deixis-pin>)
+  let current-page = here().page()
+  let sys = deixis-system.get()
+
+  for reg in regions {
+    let note-layer = reg.at("layer", default: "foreground")
+
+    if note-layer == "flow" { continue }
+
+    let draw-shape = note-layer == layer
+    let draw-marker = layer == "foreground"
+
+    if not draw-shape and not draw-marker { continue }
+
+    _deixis-render-region-shape(
+      sys,
+      reg,
+      all-pins,
+      current-page,
+      base-pos: none,
+      draw-shape: draw-shape,
+      draw-marker: draw-marker,
+    )
+  }
+}

--- a/packages/preview/deixis/0.1.1/src/render.typ
+++ b/packages/preview/deixis/0.1.1/src/render.typ
@@ -1,0 +1,418 @@
+#import "states.typ": deixis-system
+
+// A default style that resembles that of native `std.footnote`.
+#let deixis-default-footnote-style(it) = {
+  set text(size: 0.85em)
+  it
+}
+
+/// --------------------
+/// Containers
+/// --------------------
+
+/// A simple container that renders the note body as a plain block.
+/// - body (content): The rendered note content.
+/// - ..args (arguments): Ignored formatting arguments.
+///
+/// -> content
+#let deixis-plain-container(body, ..args) = body
+
+/// An alias of the standard Typst `#std.rect`.
+/// - body (content): The rendered note content.
+/// - ..args (arguments): Forwarded to `rect`.
+#let deixis-rect-container = rect
+
+/// A simple alert (admonition) container.
+/// - body (content): The rendered note content.
+/// - ..args (arguments): Formatting arguments.
+///
+/// -> content
+#let deixis-alert-container(body, ..args) = {
+  let stroke = args.at("stroke", default: none)
+  if stroke != none {
+    let s-obj = std.stroke(stroke)
+    stroke = std.stroke(
+      cap: s-obj.cap,
+      dash: s-obj.dash,
+      join: s-obj.join,
+      miter-limit: s-obj.miter-limit,
+      paint: s-obj.paint,
+      thickness: 2 * s-obj.thickness,
+    )
+  }
+  rect(
+    width: 100%,
+    fill: args.at("fill", default: none),
+    stroke: (left: stroke),
+    inset: args.at("inset", default: 5pt),
+    outset: args.at("outset", default: 0pt),
+    body,
+  )
+}
+
+/// --------------------
+/// Region Shapes
+/// --------------------
+
+/// A rectangular region mark.
+///
+/// -> content
+#let deixis-rect-region(..args) = {
+  rect(
+    width: args.at("width"),
+    height: args.at("height"),
+    fill: args.at("fill", default: none),
+    stroke: args.at("stroke", default: none),
+    radius: args.at("radius", default: 0pt),
+  )
+}
+
+/// A rectangular region mark without stroke.
+///
+/// -> content
+#let deixis-highlight-rect-region(..args) = {
+  rect(
+    width: args.at("width"),
+    height: args.at("height"),
+    fill: args.at("fill", default: none),
+    radius: args.at("radius", default: 0pt),
+  )
+}
+
+/// An elliptical region mark.
+///
+/// -> content
+#let deixis-ellipse-region(..args) = {
+  ellipse(
+    width: args.at("width"),
+    height: args.at("height"),
+    fill: args.at("fill", default: none),
+    stroke: args.at("stroke", default: none),
+  )
+}
+
+/// An elliptical region mark without stroke.
+///
+/// -> content
+#let deixis-highlight-ellipse-region(..args) = {
+  ellipse(
+    width: args.at("width"),
+    height: args.at("height"),
+    fill: args.at("fill", default: none),
+  )
+}
+
+/// --------------------
+/// Render
+/// --------------------
+
+#let _deixis-should-render-backlinks(data) = {
+  let b = data.at("backlink", default: false)
+  if b == auto { b = false }
+
+  if b in (false, "none", "never") { return false }
+  if b in (true, "always") { return true }
+  if b == "multiple" {
+    if data.at("mark-lbl", default: none) == none { return false }
+
+    let label = data.at("label", default: none)
+    if label == none { return false }
+
+    return query(<deixis-ref-marker>).filter(m => m.value.target == str(label)).len() > 0
+  }
+  return true
+}
+
+/// Returns the backlink buttons linking to the mark and anywhere the body is referenced.
+/// - data (dictionary): Note data.
+///
+/// -> content
+#let deixis-generate-backlinks(data) = {
+  let base-lbl = data.at("mark-lbl", default: none)
+  let backlink-hook = emoji.arrow.l.hook
+
+  let internal-id = data.at("internal-id", default: none)
+  if internal-id == none { return [] }
+
+  let aliases = ()
+  if data.at("body-lbl", default: none) != none { aliases.push(str(data.body-lbl)) }
+  if data.at("mark-lbl", default: none) != none { aliases.push(str(data.mark-lbl)) }
+  if data.at("label", default: none) != none { aliases.push(str(data.label)) }
+
+  let sys = deixis-system.final()
+  let id-idx = sys.at("id-index", default: (:))
+  let lbl-idx = sys.at("label-index", default: (:))
+
+  let is-celibate = str(internal-id).starts-with("celibate-")
+
+  if not is-celibate {
+    for (k, v) in id-idx {
+      if str(v) == str(internal-id) { aliases.push(k) }
+    }
+    for (k, v) in lbl-idx {
+      if str(v) == str(internal-id) { aliases.push(k) }
+    }
+  }
+
+  let extra-refs = query(<deixis-ref-marker>).filter(m => m.value.target in aliases)
+
+  if base-lbl == none and extra-refs.len() == 0 {
+    return []
+  }
+
+  let links = ()
+  let counter = 1
+
+  // mark link
+  if base-lbl != none {
+    if extra-refs.len() == 0 {
+      return [#h(0.05em)#std.link(base-lbl)[#backlink-hook]]
+    } else {
+      links.push(std.link(base-lbl)[#backlink-hook#super(str(counter))])
+      counter += 1
+    }
+  }
+
+  // reference links
+  for m in extra-refs {
+    if base-lbl == none and extra-refs.len() == 1 {
+      links.push(std.link(m.location())[#backlink-hook])
+    } else {
+      links.push(std.link(m.location())[#backlink-hook#super(str(counter))])
+      counter += 1
+    }
+  }
+
+  [#h(0.05em)#links.join(" ")]
+}
+
+/// Returns the invisible metadata allowing other components to link to the note body, usually put before the body marker.
+/// - data (dictionary): Note data.
+///
+/// -> content
+#let deixis-generate-body-meta(data) = {
+  let disable-links = data.at("disable-links", default: false)
+  let body-lbl = if not disable-links { data.at("body-lbl", default: none) } else { none }
+
+  let meta = metadata(data)
+  let custom-lbl = data.at("label", default: none)
+  let c-lbl = if not disable-links and custom-lbl != none {
+    if type(custom-lbl) == str { std.label(custom-lbl) } else { custom-lbl }
+  } else { none }
+
+  let ref-meta = if c-lbl != none { [#metadata(meta.value)#c-lbl] } else { none }
+
+  return [#meta#body-lbl#ref-meta]
+}
+
+/// Returns the visual marker for the note body, attaching metadata from ```ref #deixis-generate-body-meta```.
+/// - data (dictionary): Note data.
+///
+/// -> content
+#let deixis-generate-body-marker(data) = {
+  let body-marker-style = data.at("body-marker-style", default: it => super(it))
+
+  let meta = deixis-generate-body-meta(data)
+  let body-marker = if data.marker-str == none {
+    meta
+  } else if data.at("mark-lbl", default: none) == none {
+    [#meta#body-marker-style(data.marker-str)]
+  } else {
+    [#meta#std.link(data.mark-lbl, body-marker-style(data.marker-str))]
+  }
+  return body-marker
+}
+
+/// --------------------
+/// Render Single
+/// --------------------
+
+/// A rendering function that formats the note body closely matching Typst's native footnote style.
+///
+/// -> content
+#let deixis-native-render-single(data, inner-width: auto, ..args) = {
+  let body-style = data.at("body-style", default: it => it)
+
+  let body-marker = deixis-generate-body-marker(data)
+
+  let active-body = data.body
+  let note-cap-ht = measure(body-style("T")).height
+
+  if _deixis-should-render-backlinks(data) {
+    let formatted-backlink = box(height: note-cap-ht, align(top, super(deixis-generate-backlinks(data))))
+    active-body = [#active-body#formatted-backlink]
+  }
+
+  let formatted-marker = box(height: note-cap-ht, align(top, body-marker))
+  let container = data.at("container-func", default: deixis-plain-container)
+
+  let m-indent = data.at("indent", default: 0pt)
+  let marker-gap = data.at("marker-gap", default: 0.05em)
+  let inner-space = if data.marker-str != none and data.marker-str != "" { h(marker-gap) } else { none }
+
+  let final-note = body-style(block(width: inner-width, above: 0pt, below: 0pt, {
+    set par(leading: 0.65em)
+    [#h(m-indent)#formatted-marker#inner-space#active-body]
+  }))
+
+  container(final-note, ..data.at("styles", default: (:)))
+}
+
+/// The default rendering function, formatting the note body with the marker aligned to the side.
+///
+/// -> content
+#let deixis-default-render-single(
+  data,
+  inner-width: auto,
+  max-marker-width: auto,
+  max-marker-gap: auto,
+  ..args,
+) = {
+  let body-style = data.at("body-style", default: it => it)
+
+  let indent = data.at("indent", default: 0pt)
+  let marker-gap = data.at("marker-gap", default: 0.05em)
+
+  let body-marker = deixis-generate-body-marker(data)
+
+  let note-cap-ht = measure(body-style("T")).height
+
+  let l-w = if max-marker-width != auto { max-marker-width } else {
+    measure(body-style([#h(indent)#body-marker])).width
+  }
+  let formatted-marker = box(width: l-w, height: note-cap-ht, align(bottom + right, body-marker))
+
+  let g-w = if max-marker-gap != auto { max-marker-gap } else {
+    if data.marker-str != none and data.marker-str != "" { measure(body-style([#h(marker-gap)])).width } else { 0pt }
+  }
+
+  let final-body = if g-w > 0pt { [#h(g-w)#data.body] } else { data.body }
+
+  if _deixis-should-render-backlinks(data) {
+    let formatted-backlink = box(height: note-cap-ht, align(top, super(deixis-generate-backlinks(data))))
+    final-body = [#final-body#formatted-backlink]
+  }
+
+  let container = data.at("container-func", default: deixis-plain-container)
+
+  let final-note = body-style(block(width: inner-width, above: 0pt, below: 0pt, {
+    set par(leading: 0.65em)
+    [#formatted-marker#final-body]
+  }))
+
+  container(final-note, ..data.at("styles", default: (:)))
+}
+
+/// --------------------
+/// Render Group
+/// --------------------
+
+/// Render a group of notes by vertical stacking, similar to Typst's native footnote stacking.
+///
+/// -> content
+#let deixis-native-render-group(notes-data, gap: auto, ..args) = {
+  for (i, data) in notes-data.enumerate() {
+    let local-gap = data.at("gap", default: 0.5em)
+    let active-single = data.at("render-single", default: deixis-native-render-single)
+
+    v(if gap == auto { local-gap } else { gap }, weak: true)
+
+    active-single(data)
+  }
+}
+
+/// Render a group of notes by vertical stacking while aligning body markers.
+/// Should be used in combination with ```ref #deixis-default-render-single```.
+///
+/// -> content
+#let deixis-default-render-group(notes-data, gap: auto, ..args) = {
+  let max-marker-width = 0pt
+  let max-marker-gap = 0pt
+
+  for data in notes-data {
+    let body-marker-style = data.at("body-marker-style", default: it => super(it))
+    let body-style = data.at("body-style", default: it => it)
+
+    let indent = data.at("indent", default: 0pt)
+    let marker-gap = data.at("marker-gap", default: 0.05em)
+
+    let body-marker = if data.marker-str == none {
+      []
+    } else {
+      [#body-marker-style(data.marker-str)]
+    }
+
+    let w = measure(body-style([#h(indent)#body-marker])).width
+    if w > max-marker-width { max-marker-width = w }
+
+    let g-width = if data.marker-str != none and data.marker-str != "" {
+      measure(body-style([#h(marker-gap)])).width
+    } else { 0pt }
+    if g-width > max-marker-gap { max-marker-gap = g-width }
+  }
+
+  for (i, data) in notes-data.enumerate() {
+    let local-gap = data.at("gap", default: 0.5em)
+    let active-single = data.at("render-single", default: deixis-default-render-single)
+
+    v(if gap == auto { local-gap } else { gap }, weak: true)
+
+    active-single(data, max-marker-width: max-marker-width, max-marker-gap: max-marker-gap)
+  }
+}
+
+/// Render a group of notes by putting them into a `grid` layout.
+///
+/// ```info
+/// Unlike other group renderers, this function does not forward call to individual `render-single` of each note.
+/// ```
+///
+/// -> content
+#let deixis-grid-render-group(notes-data, gap: auto, ..args) = {
+  let gap = if gap == auto { notes-data.first().at("gap", default: 0.5em) } else { gap }
+
+  let max-gap-w = 0pt
+  for data in notes-data {
+    let body-style = data.at("body-style", default: it => it)
+    let marker-gap = data.at("marker-gap", default: 0.75em)
+
+    let g-width = if data.marker-str != none and data.marker-str != "" {
+      measure(body-style([#h(marker-gap)])).width
+    } else { 0pt }
+
+    if g-width > max-gap-w { max-gap-w = g-width }
+  }
+
+  let grid-cells = ()
+
+  for data in notes-data {
+    let body-style = data.at("body-style", default: it => it)
+
+    let m-indent = data.at("indent", default: 0pt)
+
+    let body-marker = deixis-generate-body-marker(data)
+
+    let note-cap-ht = measure(body-style("T")).height
+
+    let backlink-content = if _deixis-should-render-backlinks(data) {
+      box(height: note-cap-ht, align(top, super(deixis-generate-backlinks(data))))
+    } else { none }
+
+    let formatted-marker = box(height: note-cap-ht, align(top + right, body-marker))
+
+    grid-cells.push(
+      body-style([#h(m-indent)#formatted-marker]),
+    )
+
+    grid-cells.push(
+      body-style([#data.body#backlink-content]),
+    )
+  }
+
+  grid(
+    columns: (auto, 1fr),
+    column-gutter: max-gap-w,
+    row-gutter: gap,
+    ..grid-cells
+  )
+}

--- a/packages/preview/deixis/0.1.1/src/routing.typ
+++ b/packages/preview/deixis/0.1.1/src/routing.typ
@@ -1,0 +1,1579 @@
+#import "utils.typ" as deixis-utils
+
+#let deixis-waypoint-split = "split"
+#let deixis-link-types = ("none", "straight-line", "right-angle", "chamfer", "curve", "ccr", "ucr")
+
+// Draw the rectangle around mark marker.
+#let _deixis-draw-marker-highlight(
+  mark-x,
+  mark-y,
+  marker-width,
+  marker-str,
+  stroke: 0.5pt + luma(200),
+  text-size: auto,
+  has-inline-box: false,
+  mark-type: "inline",
+) = {
+  let t-val = deixis-utils.resolve-len(if text-size != auto and type(text-size) == length { text-size } else { 11pt })
+  let box-y = mark-y - (t-val * 0.8)
+  let box-x = mark-x - 1.5pt
+  let actual-box-h = t-val * 0.85
+
+  if not has-inline-box {
+    if marker-str == none {
+      // do nothing
+    } else if mark-type == "phantom" or marker-str == "" {
+      return place(dx: mark-x, dy: box-y, line(start: (0pt, 0pt), end: (0pt, actual-box-h), stroke: stroke))
+    } else if mark-type == "inline" {
+      return place(dx: box-x, dy: box-y, box(
+        width: marker-width + 3pt,
+        height: actual-box-h,
+        stroke: stroke,
+        radius: 1pt,
+      ))
+    }
+  }
+  return none
+}
+
+// Draw an arrowhead.
+#let _deixis-draw-arrowhead(p1, p2, stroke: luma(0)) = {
+  let dx = (deixis-utils.resolve-signed-len(p2.at(0)) - deixis-utils.resolve-signed-len(p1.at(0))) / 1pt
+  let dy = (deixis-utils.resolve-signed-len(p2.at(1)) - deixis-utils.resolve-signed-len(p1.at(1))) / 1pt
+
+  let angle = calc.atan2(dx, dy)
+
+  let s-obj = std.stroke(stroke)
+  let abs-thick = if s-obj.thickness == auto { 1.0 } else { deixis-utils.resolve-len(s-obj.thickness) / 1pt }
+
+  let arrow-length = calc.max(4.0, abs-thick * 4.0)
+  let arrow-half-width = calc.max(2.5, abs-thick * 2.5)
+  let inset-depth = arrow-length * 0.4
+
+  let tip = p2
+
+  let p-back = (
+    p2.at(0) - arrow-length * calc.cos(angle) * 1pt,
+    p2.at(1) - arrow-length * calc.sin(angle) * 1pt,
+  )
+
+  let p-inset = (
+    p2.at(0) - (arrow-length - inset-depth) * calc.cos(angle) * 1pt,
+    p2.at(1) - (arrow-length - inset-depth) * calc.sin(angle) * 1pt,
+  )
+
+  let p-left = (
+    p-back.at(0) - arrow-half-width * calc.sin(angle) * 1pt,
+    p-back.at(1) + arrow-half-width * calc.cos(angle) * 1pt,
+  )
+
+  let p-right = (
+    p-back.at(0) + arrow-half-width * calc.sin(angle) * 1pt,
+    p-back.at(1) - arrow-half-width * calc.cos(angle) * 1pt,
+  )
+
+  place(top + left, curve(
+    fill: s-obj.paint,
+    stroke: none,
+    curve.move(tip),
+    curve.line(p-left),
+    curve.line(p-inset),
+    curve.line(p-right),
+    curve.close(),
+  ))
+}
+
+// Corners for right-angle and chamfer links.
+#let _deixis-orthogonal-cmds(vertices, radius: 0pt, corner-style: "fillet") = {
+  let cmds = ()
+  if vertices.len() < 2 { return cmds }
+
+  let abs-radius = deixis-utils.resolve-len(if radius == auto { 0pt } else { radius })
+
+  // deduplicate consecutive identical points
+  let clean-pts = ()
+  for p in vertices {
+    if clean-pts.len() == 0 or clean-pts.last() != p { clean-pts.push(p) }
+  }
+  if clean-pts.len() < 2 { return cmds }
+
+  for i in range(1, clean-pts.len() - 1) {
+    let p-prev = clean-pts.at(i - 1)
+    let p-curr = clean-pts.at(i)
+    let p-next = clean-pts.at(i + 1)
+
+    let dx-in = p-prev.at(0) - p-curr.at(0)
+    let dy-in = p-prev.at(1) - p-curr.at(1)
+    let len-in = calc.sqrt((dx-in / 1pt) * (dx-in / 1pt) + (dy-in / 1pt) * (dy-in / 1pt)) * 1pt
+
+    let dx-out = p-next.at(0) - p-curr.at(0)
+    let dy-out = p-next.at(1) - p-curr.at(1)
+    let len-out = calc.sqrt((dx-out / 1pt) * (dx-out / 1pt) + (dy-out / 1pt) * (dy-out / 1pt)) * 1pt
+
+    // shrink the radius/chamfer cut if the line segment is extremely short
+    let r = calc.min(abs-radius, len-in / 2.0, len-out / 2.0)
+
+    if r <= 0.05pt or len-in == 0pt or len-out == 0pt {
+      cmds.push(curve.line(p-curr))
+    } else {
+      let p-in = (
+        p-curr.at(0) + (dx-in / len-in) * r,
+        p-curr.at(1) + (dy-in / len-in) * r,
+      )
+      let p-out = (
+        p-curr.at(0) + (dx-out / len-out) * r,
+        p-curr.at(1) + (dy-out / len-out) * r,
+      )
+
+      cmds.push(curve.line(p-in))
+
+      if corner-style == "chamfer" {
+        cmds.push(curve.line(p-out))
+      } else {
+        cmds.push(curve.quad(p-curr, p-out))
+      }
+    }
+  }
+  cmds.push(curve.line(clean-pts.last()))
+  return cmds
+}
+
+// Resolves the optimal geometric connection between a set of source and destination ports based on Manhattan or Euclidean distance.
+#let _deixis-resolve-best-ports(source-ports, dest-ports, metric: "euclidean") = {
+  let best-S = none
+  let best-D = none
+  let min-cost = 0pt
+
+  for S in source-ports {
+    for D in dest-ports {
+      let sx = deixis-utils.resolve-signed-len(S.x)
+      let sy = deixis-utils.resolve-signed-len(S.y)
+      let dx = deixis-utils.resolve-signed-len(D.x)
+      let dy = deixis-utils.resolve-signed-len(D.y)
+
+      let diff-x = dx - sx
+      let diff-y = dy - sy
+
+      let abs-dx = if diff-x < 0pt { -diff-x } else { diff-x }
+      let abs-dy = if diff-y < 0pt { -diff-y } else { diff-y }
+
+      let dist = if metric == "euclidean" {
+        let diff-x-num = deixis-utils.to-float(diff-x)
+        let diff-y-num = deixis-utils.to-float(diff-y)
+        calc.sqrt(diff-x-num * diff-x-num + diff-y-num * diff-y-num) * 1pt
+      } else {
+        abs-dx + abs-dy
+      }
+      let penalty = 0pt
+
+      if D.id == "top" and sy > dy { penalty += 1e10pt }
+      if D.id == "bottom" and sy < dy { penalty += 1e10pt }
+      if D.id == "left" and sx > dx { penalty += 1e10pt }
+      if D.id == "right" and sx < dx { penalty += 1e10pt }
+
+      if S.id == "top" and dy > sy { penalty += 1e10pt }
+      if S.id == "bottom" and dy < sy { penalty += 1e10pt }
+      if S.id == "left" and dx > sx { penalty += 1e10pt }
+      if S.id == "right" and dx < sx { penalty += 1e10pt }
+
+      let cost = dist + penalty
+
+      if best-S == none or cost < min-cost {
+        min-cost = cost
+        best-S = S
+        best-D = D
+      }
+    }
+  }
+  return (best-S, best-D)
+}
+
+// Translates user-provided relative waypoints into absolute page coordinates.
+#let _deixis-resolve-waypoints(waypoints, start-x, start-y, m-box, b-box) = {
+  if waypoints in (none, auto) { return () }
+  let wps = if type(waypoints) == array { waypoints } else { (waypoints,) }
+
+  let resolved = ()
+
+  let current-x = start-x
+  let current-y = start-y
+
+  let get-anchor(spec) = {
+    if type(spec) != str { return none }
+
+    let is-m = spec.starts-with("mark") or spec in ("source", "start")
+    let is-b = spec.starts-with("body") or spec in ("target", "end")
+    if not is-m and not is-b { return none }
+
+    let box = if is-m { m-box } else { b-box }
+    let res-x = box.center-x
+    let res-y = box.center-y
+
+    if "left" in spec { res-x = box.left } else if "right" in spec { res-x = box.right }
+
+    if "top" in spec { res-y = box.top } else if "bottom" in spec { res-y = box.bottom }
+
+    return (res-x, res-y)
+  }
+
+  let resolve-coord(spec, cur, is-x) = {
+    // 1. Check if it's an anchor string
+    let anchor = get-anchor(spec)
+    if anchor != none { return if is-x { anchor.at(0) } else { anchor.at(1) } }
+
+    // 2. Otherwise, resolve relative/ratio logic from the center
+    let s = if is-x { m-box.center-x } else { m-box.center-y }
+    let e = if is-x { b-box.center-x } else { b-box.center-y }
+
+    let val = 0pt
+    if type(spec) == ratio {
+      let r-val = float(repr(spec).replace("%", "")) / 100.0
+      val = (e - s) * r-val
+    } else if type(spec) == relative {
+      let r-val = float(repr(spec.ratio).replace("%", "")) / 100.0
+      val = deixis-utils.resolve-signed-len(spec.length) + (e - s) * r-val
+    } else {
+      val = deixis-utils.resolve-signed-len(spec)
+    }
+    return cur + val
+  }
+
+  for wp in wps {
+    if (
+      wp == deixis-waypoint-split
+        or wp in deixis-link-types
+        or (type(wp) == array and wp.len() > 0 and wp.at(0) == deixis-waypoint-split)
+    ) {
+      resolved.push(wp)
+      continue
+    }
+
+    let norm-wp = wp
+    let anchor = get-anchor(wp)
+    if anchor != none {
+      norm-wp = (wp, wp) // Both X and Y evaluate to the same anchor object
+    } else if type(wp) != array {
+      norm-wp = (wp, 0pt)
+    }
+
+    let x-spec = if type(norm-wp) == array and norm-wp.len() > 0 { norm-wp.at(0) } else { 0pt }
+    let y-spec = if type(norm-wp) == array and norm-wp.len() > 1 { norm-wp.at(1) } else { 0pt }
+
+    // sanity check
+    let valid-x = type(x-spec) in (length, ratio, relative) or get-anchor(x-spec) != none
+    let valid-y = type(y-spec) in (length, ratio, relative) or get-anchor(y-spec) != none
+    if not valid-x or not valid-y {
+      panic(
+        "deixis: Invalid waypoint coordinate. Must be a length, ratio, relative, link type, or an anchor string. Got: "
+          + repr(norm-wp),
+      )
+    }
+
+    let next-x = resolve-coord(x-spec, current-x, true)
+    let next-y = resolve-coord(y-spec, current-y, false)
+
+    resolved.push((next-x, next-y))
+    current-x = next-x
+    current-y = next-y
+  }
+  return resolved
+}
+
+#let _deixis-render-waypoint-path(
+  S-x,
+  S-y,
+  E-x,
+  E-y,
+  waypoints: (),
+  link-type: "straight-line",
+  link-stroke: luma(0),
+  link-radius: 0pt,
+  link-marks: "none",
+  source-dir: "vertical",
+  target-dir: "horizontal",
+) = {
+  let end-rel = (E-x - S-x, E-y - S-y)
+
+  let clean-wps = ()
+  let cur-pt = (0pt, 0pt)
+  for wp in waypoints {
+    if type(wp) == str {
+      clean-wps.push(wp)
+      continue
+    }
+
+    let dx = wp.at(0) - cur-pt.at(0)
+    let dy = wp.at(1) - cur-pt.at(1)
+    let dist-sq = (dx / 1pt) * (dx / 1pt) + (dy / 1pt) * (dy / 1pt)
+
+    let edx = wp.at(0) - end-rel.at(0)
+    let edy = wp.at(1) - end-rel.at(1)
+    let edist-sq = (edx / 1pt) * (edx / 1pt) + (edy / 1pt) * (edy / 1pt)
+
+    if dist-sq > 0.01 and edist-sq > 0.01 {
+      clean-wps.push(wp)
+      cur-pt = wp
+    }
+  }
+
+  // calculate the exact pullback distance to hide the flat line cap
+  let s-obj = std.stroke(link-stroke)
+  let abs-thick = if s-obj.thickness == auto { 1.0 } else { deixis-utils.resolve-len(s-obj.thickness) / 1pt }
+  let arrow-length = calc.max(4.0, abs-thick * 4.0)
+  let inset-depth = arrow-length * 0.4
+
+  // pull back into the arrow's inset notch
+  let pullback = calc.max(0.0, (arrow-length - inset-depth) - 0.2) * 1pt
+
+  let coord-wps = clean-wps.filter(x => type(x) == array)
+
+  let pt-first-dir = if coord-wps.len() > 0 { coord-wps.first() } else { end-rel }
+  let pt-last-dir = if coord-wps.len() > 0 { coord-wps.last() } else { (0pt, 0pt) }
+
+  let get-start-pullback() = {
+    let eff-s-dir = if source-dir == "none" { "vertical" } else { source-dir }
+    let dx = pt-first-dir.at(0)
+    let dy = pt-first-dir.at(1)
+
+    if link-type in ("straight-line", "none", none) {
+      let len = calc.max(1e-5pt, calc.sqrt((dx / 1pt) * (dx / 1pt) + (dy / 1pt) * (dy / 1pt)) * 1pt)
+      return ((dx / len) * pullback, (dy / len) * pullback)
+    } else {
+      // orthogonal/curve links always depart strictly horizontally or vertically
+      let sign-x = if dx >= 0pt { 1 } else { -1 }
+      let sign-y = if dy >= 0pt { 1 } else { -1 }
+      return if eff-s-dir == "horizontal" { (pullback * sign-x, 0pt) } else { (0pt, pullback * sign-y) }
+    }
+  }
+
+  let get-end-pullback() = {
+    let eff-t-dir = if target-dir == "none" { "horizontal" } else { target-dir }
+    let dx = end-rel.at(0) - pt-last-dir.at(0)
+    let dy = end-rel.at(1) - pt-last-dir.at(1)
+
+    if link-type in ("straight-line", "none", none) {
+      let len = calc.max(1e-5pt, calc.sqrt((dx / 1pt) * (dx / 1pt) + (dy / 1pt) * (dy / 1pt)) * 1pt)
+      return ((dx / len) * pullback, (dy / len) * pullback)
+    } else {
+      // prthogonal/curve links always arrive strictly horizontally or vertically
+      let sign-x = if dx >= 0pt { 1 } else { -1 }
+      let sign-y = if dy >= 0pt { 1 } else { -1 }
+      return if eff-t-dir == "horizontal" { (pullback * sign-x, 0pt) } else { (0pt, pullback * sign-y) }
+    }
+  }
+
+  let start-pb = get-start-pullback()
+  let end-pb = get-end-pullback()
+
+  // shortened coordinates
+  let path-start = if link-marks in ("mark", "start", "both") {
+    (start-pb.at(0), start-pb.at(1))
+  } else { (0pt, 0pt) }
+
+  let path-end = if link-marks in ("body", "end", "both") {
+    (end-rel.at(0) - end-pb.at(0), end-rel.at(1) - end-pb.at(1))
+  } else { end-rel }
+
+  // chunking
+  let raw-points = ()
+  let raw-types = ()
+  let cur-type = link-type
+
+  for wp in clean-wps {
+    if type(wp) == str {
+      cur-type = wp
+    } else {
+      raw-points.push(wp)
+      raw-types.push(cur-type)
+    }
+  }
+  raw-points.push(path-end)
+  raw-types.push(cur-type)
+
+  let chunks = ()
+  let chunk-start = path-start
+  let current-chunk-wps = ()
+  let current-chunk-type = raw-types.first()
+
+  for i in range(raw-points.len()) {
+    let pt = raw-points.at(i)
+    let typ = raw-types.at(i)
+
+    if typ == current-chunk-type {
+      current-chunk-wps.push(pt)
+    } else {
+      let chunk-end = current-chunk-wps.last()
+      let inner-wps = current-chunk-wps.slice(0, -1)
+      chunks.push((start: chunk-start, end: chunk-end, wps: inner-wps, type: current-chunk-type))
+      chunk-start = chunk-end
+      current-chunk-type = typ
+      current-chunk-wps = (pt,)
+    }
+  }
+  let chunk-end = current-chunk-wps.last()
+  let inner-wps = current-chunk-wps.slice(0, -1)
+  chunks.push((start: chunk-start, end: chunk-end, wps: inner-wps, type: current-chunk-type))
+
+  let cmds = (curve.move((path-start)),)
+  let global-t-start = (0pt, 0pt)
+  let global-t-end = (0pt, 0pt)
+
+  // render each chunk independently
+  for (i, chunk) in chunks.enumerate() {
+    let C-start = chunk.start
+    let C-end = chunk.end
+    let wps = chunk.wps
+    let l-type = chunk.type
+
+    let c-s-dir = if i == 0 { source-dir } else { "none" }
+    let c-t-dir = if i == chunks.len() - 1 { target-dir } else { "none" }
+
+    let t-start = (0pt, 0pt)
+    let t-end = (0pt, 0pt)
+
+    if l-type in ("none", none) {
+      t-start = if wps.len() > 0 { wps.first() } else { C-end }
+      t-end = if wps.len() > 0 { wps.last() } else { C-start }
+      cmds.push(curve.move(C-end))
+    } else if l-type == "straight-line" {
+      t-start = if wps.len() > 0 { wps.first() } else { C-end }
+      t-end = if wps.len() > 0 { wps.last() } else { C-start }
+      for wp in wps { cmds.push(curve.line(wp)) }
+      cmds.push(curve.line(C-end))
+    } else if l-type in ("right-angle", "chamfer") {
+      let pts = (C-start,)
+      let eff-s-dir = if c-s-dir == "none" { "vertical" } else { c-s-dir }
+      let eff-t-dir = if c-t-dir == "none" { "horizontal" } else { c-t-dir }
+
+      if wps.len() == 0 {
+        let is-same-dir = (eff-s-dir == eff-t-dir)
+
+        if not is-same-dir {
+          if eff-s-dir == "vertical" {
+            pts.push((C-start.at(0), C-end.at(1)))
+            t-start = (C-start.at(0), C-end.at(1))
+            t-end = if C-end.at(0) != C-start.at(0) { (C-start.at(0), C-end.at(1)) } else { C-start }
+          } else {
+            pts.push((C-end.at(0), C-start.at(1)))
+            t-start = (C-end.at(0), C-start.at(1))
+            t-end = if C-end.at(1) != C-start.at(1) { (C-end.at(0), C-start.at(1)) } else { C-start }
+          }
+        } else {
+          if eff-s-dir == "vertical" {
+            if C-end.at(0) == C-start.at(0) {
+              t-start = C-end
+              t-end = C-start
+            } else {
+              let mid-y = C-start.at(1) + (C-end.at(1) - C-start.at(1)) / 2.0
+              pts.push((C-start.at(0), mid-y))
+              pts.push((C-end.at(0), mid-y))
+              t-start = (C-start.at(0), mid-y)
+              t-end = (C-end.at(0), mid-y)
+            }
+          } else {
+            if C-end.at(1) == C-start.at(1) {
+              t-start = C-end
+              t-end = C-start
+            } else {
+              let mid-x = C-start.at(0) + (C-end.at(0) - C-start.at(0)) / 2.0
+              pts.push((mid-x, C-start.at(1)))
+              pts.push((mid-x, C-end.at(1)))
+              t-start = (mid-x, C-start.at(1))
+              t-end = (mid-x, C-end.at(1))
+            }
+          }
+        }
+        pts.push(C-end)
+      } else {
+        let current-pt = C-start
+        for wp in wps {
+          if current-pt == C-start {
+            if eff-s-dir == "vertical" {
+              t-start = (C-start.at(0), wp.at(1))
+              pts.push(t-start)
+            } else {
+              t-start = (wp.at(0), C-start.at(1))
+              pts.push(t-start)
+            }
+          } else {
+            pts.push((current-pt.at(0), wp.at(1)))
+          }
+          pts.push(wp)
+          current-pt = wp
+        }
+        if eff-t-dir == "horizontal" {
+          pts.push((current-pt.at(0), C-end.at(1)))
+          t-end = if current-pt.at(0) != C-end.at(0) { (current-pt.at(0), C-end.at(1)) } else { current-pt }
+        } else {
+          pts.push((C-end.at(0), current-pt.at(1)))
+          t-end = if current-pt.at(1) != C-end.at(1) { (C-end.at(0), current-pt.at(1)) } else { current-pt }
+        }
+        pts.push(C-end)
+      }
+
+      let stroke-obj = std.stroke(link-stroke)
+      let thick = deixis-utils.resolve-len(if stroke-obj.thickness == auto { 1pt } else { stroke-obj.thickness })
+      let c-rad = if link-radius == auto { calc.max(3pt, thick * 4) } else { deixis-utils.resolve-len(link-radius) }
+
+      let c-style = if l-type == "chamfer" { "chamfer" } else { "fillet" }
+      let r-cmds = _deixis-orthogonal-cmds(pts, radius: c-rad, corner-style: c-style)
+
+      for c in r-cmds { cmds.push(c) }
+    } else if l-type in ("curve", "ccr", "ucr") {
+      let dx = C-end.at(0) - C-start.at(0)
+      let dy = C-end.at(1) - C-start.at(1)
+      let eff-s-dir = if c-s-dir == "none" { "vertical" } else { c-s-dir }
+      let eff-t-dir = if c-t-dir == "none" { "horizontal" } else { c-t-dir }
+
+      if wps.len() == 0 {
+        t-start = if eff-s-dir == "horizontal" { (C-start.at(0) + dx * 0.5, C-start.at(1)) } else {
+          (C-start.at(0), C-start.at(1) + dy * 0.5)
+        }
+        t-end = if eff-t-dir == "horizontal" { (C-start.at(0) + dx * 0.5, C-end.at(1)) } else {
+          (C-end.at(0), C-start.at(1) + dy * 0.5)
+        }
+        cmds.push(curve.cubic(t-start, t-end, C-end))
+      } else {
+        let pts = (C-start,) + wps + (C-end,)
+
+        let add(p1, p2) = (p1.at(0) + p2.at(0), p1.at(1) + p2.at(1))
+        let sub(p1, p2) = (p1.at(0) - p2.at(0), p1.at(1) - p2.at(1))
+        let scale(p, s) = (p.at(0) * s, p.at(1) * s)
+
+        let get-pt(idx) = {
+          if idx < 0 {
+            let p0 = pts.at(0)
+            let p1 = pts.at(1)
+            (p0.at(0) * 2 - p1.at(0), p0.at(1) * 2 - p1.at(1))
+          } else if idx >= pts.len() {
+            let pL = pts.last()
+            let pP = pts.at(pts.len() - 2)
+            (pL.at(0) * 2 - pP.at(0), pL.at(1) * 2 - pP.at(1))
+          } else { pts.at(idx) }
+        }
+
+        for j in range(pts.len() - 1) {
+          let p-prev = get-pt(j - 1)
+          let p-curr = get-pt(j)
+          let p-next = get-pt(j + 1)
+          let p-next2 = get-pt(j + 2)
+
+          let c1 = (0pt, 0pt)
+          let c2 = (0pt, 0pt)
+
+          if l-type == "curve" {
+            // Weighted Bessel Spline
+            let tension = 0.25
+            let d-curr-x = p-next.at(0) - p-curr.at(0)
+            let d-curr-y = p-next.at(1) - p-curr.at(1)
+            let len-curr = calc.sqrt((d-curr-x / 1pt) * (d-curr-x / 1pt) + (d-curr-y / 1pt) * (d-curr-y / 1pt))
+
+            let get-dir(pa, pb) = {
+              let dx = (pb.at(0) - pa.at(0)) / 1pt
+              let dy = (pb.at(1) - pa.at(1)) / 1pt
+              let l = calc.max(1e-5, calc.sqrt(dx * dx + dy * dy))
+              (dx / l, dy / l)
+            }
+
+            let t1-x = 0
+            let t1-y = 0
+            if j == 0 {
+              if eff-s-dir == "vertical" { t1-y = if d-curr-y > 0pt { 1 } else { -1 } } else {
+                t1-x = if d-curr-x > 0pt { 1 } else { -1 }
+              }
+            } else {
+              let dir-in = get-dir(p-prev, p-curr)
+              let dir-out = get-dir(p-curr, p-next)
+              t1-x = dir-in.at(0) + dir-out.at(0)
+              t1-y = dir-in.at(1) + dir-out.at(1)
+            }
+            let t1-len = calc.max(1e-5, calc.sqrt(t1-x * t1-x + t1-y * t1-y))
+            let cp-dist1 = len-curr * tension
+            c1 = (
+              p-curr.at(0) + deixis-utils.to-length(t1-x / t1-len) * cp-dist1,
+              p-curr.at(1) + deixis-utils.to-length(t1-y / t1-len) * cp-dist1,
+            )
+
+            let t2-x = 0
+            let t2-y = 0
+            if j == pts.len() - 2 {
+              if eff-t-dir == "vertical" { t2-y = if d-curr-y > 0pt { 1 } else { -1 } } else {
+                t2-x = if d-curr-x > 0pt { 1 } else { -1 }
+              }
+            } else {
+              let dir-in = get-dir(p-curr, p-next)
+              let dir-out = get-dir(p-next, p-next2)
+              t2-x = dir-in.at(0) + dir-out.at(0)
+              t2-y = dir-in.at(1) + dir-out.at(1)
+            }
+            let t2-len = calc.max(1e-5, calc.sqrt(t2-x * t2-x + t2-y * t2-y))
+            let cp-dist2 = len-curr * tension
+            c2 = (
+              p-next.at(0) - deixis-utils.to-length(t2-x / t2-len) * cp-dist2,
+              p-next.at(1) - deixis-utils.to-length(t2-y / t2-len) * cp-dist2,
+            )
+          } else if l-type == "ccr" {
+            // Centripetal Catmull-Rom
+            let get-dist(pa, pb) = calc.sqrt(
+              calc.pow((pa.at(0) - pb.at(0)) / 1pt, 2) + calc.pow((pa.at(1) - pb.at(1)) / 1pt, 2),
+            )
+
+            let d1 = calc.sqrt(get-dist(p-prev, p-curr)) + 1e-5
+            let d2 = calc.sqrt(get-dist(p-curr, p-next)) + 1e-5
+            let d3 = calc.sqrt(get-dist(p-next, p-next2)) + 1e-5
+
+            let d1-sq = d1 * d1
+            let d2-sq = d2 * d2
+            let d3-sq = d3 * d3
+
+            let off1-x = (
+              (d1-sq * (p-next.at(0) - p-curr.at(0)) + d2-sq * (p-curr.at(0) - p-prev.at(0))) / (3.0 * d1 * (d1 + d2))
+            )
+            let off1-y = (
+              (d1-sq * (p-next.at(1) - p-curr.at(1)) + d2-sq * (p-curr.at(1) - p-prev.at(1))) / (3.0 * d1 * (d1 + d2))
+            )
+
+            let off2-x = (
+              (d2-sq * (p-next2.at(0) - p-next.at(0)) + d3-sq * (p-next.at(0) - p-curr.at(0))) / (3.0 * d3 * (d2 + d3))
+            )
+            let off2-y = (
+              (d2-sq * (p-next2.at(1) - p-next.at(1)) + d3-sq * (p-next.at(1) - p-curr.at(1))) / (3.0 * d3 * (d2 + d3))
+            )
+
+            c1 = (p-curr.at(0) + off1-x, p-curr.at(1) + off1-y)
+            c2 = (p-next.at(0) - off2-x, p-next.at(1) - off2-y)
+          } else {
+            // Uniform Catmull-Rom
+            let get-tan(idx) = scale(sub(get-pt(idx + 1), get-pt(idx - 1)), 1.0 / 6.0)
+            c1 = add(p-curr, get-tan(j))
+            c2 = sub(p-next, get-tan(j + 1))
+          }
+
+          if j == 0 { t-start = c1 }
+          if j == pts.len() - 2 { t-end = c2 }
+          cmds.push(curve.cubic(c1, c2, p-next))
+        }
+      }
+    }
+
+    if i == 0 { global-t-start = t-start }
+    if i == chunks.len() - 1 { global-t-end = t-end }
+  }
+
+  let elements = ()
+
+  elements.push(place(top + left, dx: S-x, dy: S-y, curve(stroke: link-stroke, ..cmds)))
+
+  let abs-t-start = (S-x + global-t-start.at(0), S-y + global-t-start.at(1))
+  let abs-t-end = (S-x + global-t-end.at(0), S-y + global-t-end.at(1))
+
+  if link-marks in ("mark", "start", "both") {
+    elements.push(_deixis-draw-arrowhead(abs-t-start, (S-x, S-y), stroke: link-stroke))
+  }
+  if link-marks in ("body", "end", "both") {
+    elements.push(_deixis-draw-arrowhead(abs-t-end, (E-x, E-y), stroke: link-stroke))
+  }
+
+  return elements
+}
+
+#let _deixis-draw-direct-link(
+  S-x,
+  S-y,
+  E-x,
+  E-y,
+  waypoints: (),
+  link-type: "straight-line",
+  link-stroke: luma(0),
+  link-radius: 0pt,
+  link-marks: "none",
+  source-dir: "vertical",
+  target-dir: "horizontal",
+  is-incoming: false,
+  is-outgoing: false,
+  extra-data: (:),
+) = {
+  let actual-mark = link-marks
+  if is-incoming {
+    if actual-mark == "both" { actual-mark = "end" } else if actual-mark == "start" { actual-mark = "none" }
+  } else if is-outgoing {
+    if actual-mark == "both" { actual-mark = "start" } else if actual-mark == "end" { actual-mark = "none" }
+  }
+
+  let elements = ()
+
+  let c-content = if type(link-type) == function {
+    let func-args = (
+      S-x: S-x,
+      S-y: S-y,
+      E-x: E-x,
+      E-y: E-y,
+      waypoints: waypoints,
+      stroke: link-stroke,
+      radius: link-radius,
+      mark: actual-mark,
+      is-incoming: is-incoming,
+      is-outgoing: is-outgoing,
+    )
+    for (k, v) in extra-data { func-args.insert(k, v) }
+    (place(top + left, dx: S-x, dy: S-y, link-type(func-args)),)
+  } else {
+    _deixis-render-waypoint-path(
+      S-x,
+      S-y,
+      E-x,
+      E-y,
+      waypoints: waypoints,
+      link-type: link-type,
+      link-stroke: link-stroke,
+      link-radius: link-radius,
+      link-marks: actual-mark,
+      source-dir: source-dir,
+      target-dir: target-dir,
+    )
+  }
+
+  for el in c-content { elements.push(el) }
+
+  // draw spill marks
+  if is-incoming or is-outgoing {
+    let c-obj = std.stroke(link-stroke)
+    let c-paint = if c-obj.paint == auto { black } else { c-obj.paint }
+    let c-rad = if c-obj.thickness == auto { 1.5pt } else { 1.5 * c-obj.thickness }
+    let spill-mark = circle(radius: c-rad, fill: c-paint, stroke: none)
+
+    if is-outgoing {
+      elements.push(place(top + left, dx: E-x - c-rad, dy: E-y - c-rad, spill-mark))
+    } else if is-incoming {
+      elements.push(place(top + left, dx: S-x - c-rad, dy: S-y - c-rad, spill-mark))
+    }
+  }
+
+  return elements
+}
+
+// The routing engine for rendering connector lines between marks and bodies.
+#let _deixis-route-link(
+  data,
+  internal-id,
+  current-page,
+  S-page,
+  E-page,
+  S-candidates,
+  D-candidates,
+  c-link: auto,
+  c-link-stroke: auto,
+  c-link-radius: auto,
+  c-link-marks: auto,
+  split-default: "source",
+  turn-x: auto,
+  synthetic-waypoints: auto,
+  is-margin: false,
+  extra-data: (:),
+) = {
+  let paths = ()
+  let is-cross-page = (S-page != E-page)
+  let is-outgoing = (is-cross-page and current-page == S-page)
+  let is-incoming = (is-cross-page and current-page == E-page)
+
+  // user link-ports
+  let S-candidates = S-candidates
+  let D-candidates = D-candidates
+  let c-ports = data.at("link-ports", default: auto)
+  if type(c-ports) == dictionary {
+    if "mark" in c-ports {
+      let f-S = S-candidates.filter(p => p.id == c-ports.mark)
+      if f-S.len() > 0 { S-candidates = f-S }
+    }
+    if "body" in c-ports {
+      let f-D = D-candidates.filter(p => p.id == c-ports.body)
+      if f-D.len() > 0 { D-candidates = f-D }
+    }
+  }
+
+  let m-cx = S-candidates.first().x
+  let m-y = S-candidates.first().y
+  let D-top-x = D-candidates.first().x
+  let D-top-y = D-candidates.first().y
+
+  let extract-box(candidates) = {
+    let xs = candidates.map(c => c.x)
+    let ys = candidates.map(c => c.y)
+    let min-x = calc.min(..xs)
+    let max-x = calc.max(..xs)
+    let min-y = calc.min(..ys)
+    let max-y = calc.max(..ys)
+    return (
+      left: min-x,
+      right: max-x,
+      top: min-y,
+      bottom: max-y,
+      center-x: (min-x + max-x) / 2.0,
+      center-y: (min-y + max-y) / 2.0,
+    )
+  }
+  let m-box = extract-box(S-candidates)
+  let b-box = extract-box(D-candidates)
+
+  let raw-waypoints = data.at("link-waypoints", default: auto)
+  if raw-waypoints == auto {
+    raw-waypoints = if synthetic-waypoints != auto { synthetic-waypoints } else { none }
+  }
+  let raw-wps = if type(raw-waypoints) == array {
+    raw-waypoints
+  } else if raw-waypoints != none {
+    (raw-waypoints,)
+  } else {
+    ()
+  }
+
+  let split-item = raw-wps.find(x => (
+    x == deixis-waypoint-split or (type(x) == array and x.len() > 0 and x.at(0) == deixis-waypoint-split)
+  ))
+
+  let explicit-config = if type(split-item) == array and split-item.len() > 1 { split-item.at(1) } else { auto }
+  let split-idx = raw-wps.position(x => x == split-item)
+
+  // spill mark coordinates
+  let current-x = if split-default == "source" { m-box.center-x } else {
+    if turn-x != auto { turn-x } else { b-box.center-x }
+  }
+
+  if split-idx != none and split-idx > 0 {
+    let pre-wps = raw-wps.slice(0, split-idx)
+    let dry-run = _deixis-resolve-waypoints(pre-wps, m-box.center-x, m-box.center-y, m-box, b-box)
+    let valid-wps = dry-run.filter(x => type(x) == array)
+    if valid-wps.len() > 0 { current-x = valid-wps.last().at(0) }
+  }
+
+  let split-x = current-x
+
+  if explicit-config != auto {
+    if explicit-config == "average" {
+      split-x = (m-box.center-x + if turn-x != auto { turn-x } else { b-box.center-x }) / 2.0
+    } else if (
+      type(explicit-config) == str
+        and (
+          "mark" in explicit-config or "body" in explicit-config or explicit-config in ("source", "target")
+        )
+    ) {
+      let is-m = explicit-config.starts-with("mark") or explicit-config == "source"
+      let box = if is-m { m-box } else { b-box }
+
+      split-x = if explicit-config == "target" and turn-x != auto { turn-x } else { box.center-x }
+      if "left" in explicit-config { split-x = box.left } else if "right" in explicit-config { split-x = box.right }
+    } else {
+      split-x = current-x + deixis-utils.resolve-signed-len(explicit-config)
+    }
+  } else {
+    if split-idx != none and split-idx > 0 {
+      let pre-wps = raw-wps.slice(0, split-idx)
+      let dry-run = _deixis-resolve-waypoints(pre-wps, m-box.center-x, m-box.center-y, m-box, b-box)
+      let valid-wps = dry-run.filter(x => type(x) == array)
+
+      if valid-wps.len() > 0 {
+        split-x = valid-wps.last().at(0)
+      } else {
+        split-x = if split-default == "source" { m-box.center-x } else {
+          if turn-x != auto { turn-x } else { b-box.center-x }
+        }
+      }
+    } else {
+      split-x = if split-default == "source" { m-box.center-x } else {
+        if turn-x != auto { turn-x } else { b-box.center-x }
+      }
+    }
+  }
+
+  let goes-forward = S-page < E-page
+  let p-margins = deixis-utils.get-page-margins(current-page)
+  let page-h = if type(page.height) == length { page.height } else { deixis-utils.default-page-size.height }
+  let top-bound = deixis-utils.resolve-len(p-margins.top)
+  let bottom-bound = deixis-utils.resolve-len(page-h) - deixis-utils.resolve-len(p-margins.bottom)
+
+  let virtual-y-in = if goes-forward { top-bound } else { bottom-bound }
+  let virtual-y-out = if goes-forward { bottom-bound } else { top-bound }
+  if goes-forward {
+    virtual-y-out = calc.max(virtual-y-out, m-box.bottom)
+    virtual-y-in = calc.min(virtual-y-in, b-box.top)
+  } else {
+    virtual-y-out = calc.min(virtual-y-out, m-box.top)
+    virtual-y-in = calc.max(virtual-y-in, b-box.bottom)
+  }
+
+  let virtual-id-in = if goes-forward { "top" } else { "bottom" }
+  let virtual-id-out = if goes-forward { "bottom" } else { "top" }
+
+  if is-margin {
+    virtual-y-in = calc.min(top-bound, b-box.top)
+    virtual-y-out = calc.max(bottom-bound, m-box.bottom)
+    virtual-id-in = "top"
+    virtual-id-out = "bottom"
+  }
+
+  let active-raw-wps = raw-wps
+  let wps-start-x = m-cx
+  let wps-start-y = m-y
+
+  if split-idx != none {
+    if is-outgoing { active-raw-wps = raw-wps.slice(0, split-idx) } else if is-incoming {
+      active-raw-wps = raw-wps.slice(split-idx + 1)
+      wps-start-x = split-x
+      wps-start-y = virtual-y-in
+    } else { active-raw-wps = raw-wps.slice(0, split-idx) + raw-wps.slice(split-idx + 1) }
+  } else if is-outgoing or is-incoming {
+    if is-outgoing { active-raw-wps = raw-wps } else if is-incoming {
+      active-raw-wps = ()
+      wps-start-x = split-x
+      wps-start-y = virtual-y-in
+    }
+  }
+
+  let resolved-wps = _deixis-resolve-waypoints(active-raw-wps, wps-start-x, wps-start-y, m-box, b-box)
+
+  let safe-wps = resolved-wps.filter(x => type(x) == str or (type(x) == array and x.len() >= 2))
+  let coord-wps = safe-wps.filter(x => type(x) == array)
+
+  let S-anchor-x = S-candidates.first().x
+  let S-anchor-y = S-candidates.first().y
+  let E-anchor-x = D-top-x
+  let E-anchor-y = D-top-y
+  let source-dir = "vertical"
+  let target-dir = "vertical"
+
+  if is-outgoing {
+    let virtual-D-ports = ((x: split-x, y: virtual-y-out, dir: "vertical", id: virtual-id-out),)
+    if coord-wps.len() > 0 {
+      virtual-D-ports = ((x: coord-wps.first().at(0), y: coord-wps.first().at(1), dir: "none", id: "none"),)
+    }
+
+    let (best-S, best-D) = _deixis-resolve-best-ports(S-candidates, virtual-D-ports)
+    S-anchor-x = best-S.x
+    S-anchor-y = best-S.y
+    source-dir = best-S.dir
+    E-anchor-x = split-x
+    E-anchor-y = virtual-y-out
+    target-dir = virtual-id-out
+  } else if is-incoming {
+    let virtual-S-ports = ((x: split-x, y: virtual-y-in, dir: "vertical", id: virtual-id-in),)
+    if coord-wps.len() > 0 {
+      virtual-S-ports = ((x: coord-wps.last().at(0), y: coord-wps.last().at(1), dir: "none", id: "none"),)
+    }
+
+    let (best-S, best-D) = _deixis-resolve-best-ports(virtual-S-ports, D-candidates)
+    S-anchor-x = split-x
+    S-anchor-y = virtual-y-in
+    source-dir = virtual-id-in
+    E-anchor-x = best-D.x
+    E-anchor-y = best-D.y
+    target-dir = best-D.dir
+  } else {
+    let virtual-S-ports = S-candidates
+    let virtual-D-ports = D-candidates
+
+    if coord-wps.len() > 0 {
+      let first-wp = (x: coord-wps.first().at(0), y: coord-wps.first().at(1))
+      virtual-D-ports = ((x: first-wp.x, y: first-wp.y, dir: "none", id: "none"),)
+    }
+
+    let (best-S, temp-D) = _deixis-resolve-best-ports(S-candidates, virtual-D-ports)
+
+    if coord-wps.len() > 0 {
+      let last-wp = (x: coord-wps.last().at(0), y: coord-wps.last().at(1))
+      virtual-S-ports = ((x: last-wp.x, y: last-wp.y, dir: "none", id: "none"),)
+    }
+
+    let (temp-S, best-D) = _deixis-resolve-best-ports(virtual-S-ports, D-candidates)
+
+    S-anchor-x = best-S.x
+    S-anchor-y = best-S.y
+    source-dir = best-S.dir
+    E-anchor-x = best-D.x
+    E-anchor-y = best-D.y
+    target-dir = best-D.dir
+  }
+
+  let final-wps = safe-wps.map(wp => if type(wp) == str { wp } else { (wp.at(0) - S-anchor-x, wp.at(1) - S-anchor-y) })
+
+  let call-extra = (dx: E-anchor-x - S-anchor-x, dy: E-anchor-y - S-anchor-y)
+  for (k, v) in extra-data { call-extra.insert(k, v) }
+
+  let direct-links = _deixis-draw-direct-link(
+    S-anchor-x,
+    S-anchor-y,
+    E-anchor-x,
+    E-anchor-y,
+    waypoints: final-wps,
+    link-type: c-link,
+    link-stroke: c-link-stroke,
+    link-radius: c-link-radius,
+    link-marks: c-link-marks,
+    source-dir: source-dir,
+    target-dir: target-dir,
+    is-incoming: is-incoming,
+    is-outgoing: is-outgoing,
+    extra-data: call-extra,
+  )
+
+  for el in direct-links { paths.push(el) }
+  return paths
+}
+
+/// --------------------
+/// Margin link
+/// --------------------
+
+#let _deixis-render-margin-links(
+  all-notes,
+  current-page,
+  text-bounds,
+  top-bound,
+  bottom-bound,
+) = {
+  let paths = ()
+
+  let font-asc = deixis-utils.resolve-len(0.9em)
+  let font-desc = deixis-utils.resolve-len(0.1em)
+  let box-h = deixis-utils.resolve-len(0.8em)
+  let box-y-offset = 0pt
+  let actual-box-h = box-h + 2pt
+
+  let track-drops = (:)
+  let track-verticals = (:)
+
+  let left-body-notes = all-notes.filter(n => n.side in (left, "left") and not n.at("is-outgoing", default: false))
+  let min-gap-l = 20.0
+  if left-body-notes.len() > 0 {
+    min-gap-l = calc.min(..left-body-notes.map(n => {
+      let nx = n.at("attach-x", default: 0pt)
+      return calc.max(0.0, (text-bounds.left - nx) / 1pt)
+    }))
+  }
+  let max-v-lines-l = calc.max(1, calc.floor((min-gap-l - 4.0) / 2.5))
+
+  let right-body-notes = all-notes.filter(n => n.side not in (left, "left") and not n.at("is-outgoing", default: false))
+  let min-gap-r = 20.0
+  if right-body-notes.len() > 0 {
+    min-gap-r = calc.min(..right-body-notes.map(n => {
+      let nx = n.at("attach-x", default: 0pt)
+      return calc.max(0.0, (nx - text-bounds.right) / 1pt)
+    }))
+  }
+  let max-v-lines-r = calc.max(1, calc.floor((min-gap-r - 4.0) / 2.5))
+
+  for n in all-notes.sorted(key: x => x.at("mark-x", default: 0pt)) {
+    let is-incoming = n.at("is-incoming", default: false)
+    let is-outgoing = n.at("is-outgoing", default: false)
+
+    if not is-incoming and n.at("mark-page", default: current-page) != current-page { continue }
+
+    let link = n.at("link", default: "none")
+    if link in (none, false, "none") { continue }
+
+    let link-stroke = n.at("link-stroke", default: none)
+    let link-radius = n.at("link-radius", default: 0pt)
+    let link-marks = n.at("link-marks", default: "none")
+    let link-waypoints = n.at("link-waypoints", default: auto)
+
+    let actual-mark = link-marks
+    if is-incoming {
+      if actual-mark == "both" { actual-mark = "end" } else if actual-mark == "start" { actual-mark = "none" }
+    } else if is-outgoing {
+      if actual-mark == "both" { actual-mark = "start" } else if actual-mark == "end" { actual-mark = "none" }
+    }
+
+    let is-left = n.side in (left, "left")
+    let bound-x = if is-left { text-bounds.left } else { text-bounds.right }
+
+    let marker-width = n.at("marker-width", default: 0pt)
+    let mark-x = n.at("mark-x", default: 0pt)
+    let mark-y = n.at("mark-y", default: 0pt)
+    let mark-center-x = mark-x + (marker-width / 2)
+
+    let text-size = n.at("text-size", default: auto)
+    let t-val = deixis-utils.resolve-len(if text-size != auto and type(text-size) == length { text-size } else { 11pt })
+
+    let has-inline-box = n.at("has-inline-box", default: false)
+
+    let box-top = mark-y - (t-val * if has-inline-box { 0.9 } else { 0.8 })
+    let box-bottom = mark-y + (t-val * if has-inline-box { 0.2 } else { 0.05 })
+
+    let box-y = mark-y - (t-val * 0.8)
+    let box-x = mark-x - 1.5pt
+    let actual-box-h = t-val * 0.85
+
+    let n-top = n.at("final-y", default: 0pt)
+    let n-h = n.at("h", default: 0pt)
+    let n-w = n.at("w", default: 0pt)
+    let n-bottom = n-top + n-h
+    let n-x = n.at("attach-x", default: 0pt)
+
+    let safe-pad = calc.min(4.0, (n-h / 1pt) / 2.0)
+    let clamp-min = (n-top + (safe-pad * 1pt)) / 1pt
+    let clamp-max = (n-bottom - (safe-pad * 1pt)) / 1pt
+
+    clamp-max = calc.max(clamp-min, clamp-max)
+
+    let safe-wps = if link-waypoints != none and type(link-waypoints) == array {
+      link-waypoints.filter(x => type(x) == array and x.len() >= 2)
+    } else { () }
+
+    let m-y-attach = 0pt
+    let n-attach-y = 0pt
+    let ideal-y = calc.clamp(mark-y / 1pt, clamp-min, clamp-max) * 1pt
+
+    if is-incoming {
+      n-attach-y = clamp-min * 1pt
+      m-y-attach = top-bound
+    } else if is-outgoing {
+      m-y-attach = box-bottom
+      n-attach-y = bottom-bound
+    } else {
+      let resolve-peek-y(y-spec, base-y, target-abs-y) = {
+        if type(y-spec) == length { return base-y + y-spec }
+        if type(y-spec) == relative { return base-y + y-spec.length }
+        if type(y-spec) == ratio { return base-y } // Ignored for pre-flight
+        if type(y-spec) == str {
+          if "body" in y-spec or "target" in y-spec or "end" in y-spec { return target-abs-y }
+          if "mark" in y-spec or "source" in y-spec or "start" in y-spec { return base-y }
+        }
+        return base-y
+      }
+
+      let goes-up = ideal-y < mark-y
+      if safe-wps.len() > 0 {
+        let first-y = safe-wps.first().at(1)
+        if type(first-y) == length { goes-up = first-y < 0pt } else if type(first-y) == relative {
+          goes-up = first-y.length < 0pt
+        }
+      }
+
+      m-y-attach = if goes-up { box-top } else { box-bottom }
+
+      let last-source-y = m-y-attach
+      if safe-wps.len() > 0 {
+        last-source-y = resolve-peek-y(safe-wps.last().at(1), m-y-attach, ideal-y)
+      }
+
+      n-attach-y = calc.clamp(last-source-y / 1pt, clamp-min, clamp-max) * 1pt
+    }
+
+    // --- HORIZONTAL ANTI-OVERLAP ---
+
+    let route-down = false
+    if is-outgoing {
+      route-down = true
+    } else if is-incoming {
+      route-down = false
+    } else {
+      route-down = (m-y-attach > mark-y)
+    }
+
+    let dir-str = if route-down { "d" } else { "u" }
+    let line-key = str(calc.round(mark-y / 1pt)) + "-" + dir-str
+    let h-count = track-drops.at(line-key, default: 0)
+    track-drops.insert(line-key, h-count + 1)
+
+    let h-cycle = calc.rem(h-count, 4)
+    let step-size = t-val * 0.04
+    let drop-mag = 0pt
+
+    let base-drop = t-val * 0.05
+    let max-drop = t-val * 0.25
+    drop-mag = base-drop + (h-cycle * step-size)
+    drop-mag = calc.min(drop-mag / 1pt, max-drop / 1pt) * 1pt
+
+    let drop-y = m-y-attach + (if route-down { drop-mag } else { -drop-mag })
+
+    // --- VERTICAL ANTI-OVERLAP ---
+    let side-key = if is-left { "l" } else { "r" }
+    let v-count = track-verticals.at(side-key, default: 0)
+    track-verticals.insert(side-key, v-count + 1)
+
+    let max-v = if is-left { max-v-lines-l } else { max-v-lines-r }
+    let v-cycle = calc.rem(v-count, max-v)
+    let turn-shift = 2.0 + (v-cycle * 2.5)
+
+    let turn-x = if is-left {
+      bound-x - turn-shift * 1pt
+    } else {
+      bound-x + turn-shift * 1pt
+    }
+
+    // draw rectangles
+    let highlight = _deixis-draw-marker-highlight(
+      mark-x,
+      mark-y,
+      marker-width,
+      n.marker-str,
+      stroke: link-stroke,
+      text-size: t-val,
+      has-inline-box: has-inline-box,
+      mark-type: n.at("mark-type", default: "inline"),
+    )
+
+    if not is-incoming and highlight != none { paths.push(highlight) }
+
+    // anchors & synthetic waypoints
+    let mark-type = n.at("mark-type", default: "inline")
+    let S-candidates = ()
+    let synth-wps = ()
+
+    let c-ports = n.at("link-ports", default: auto)
+    let override-mark = if type(c-ports) == dictionary and "mark" in c-ports { c-ports.mark } else { auto }
+
+    if mark-type == "region" and n.r-pins.len() > 0 {
+      let r-pins = n.r-pins
+      let reg = n.reg
+      let min-x = 1e10pt
+      let max-x = -1e10pt
+      let min-y = 1e10pt
+      let max-y = -1e10pt
+      let page-pins = r-pins.filter(p => p.location().page() == current-page)
+
+      if page-pins.len() > 0 {
+        for p in page-pins {
+          let px = deixis-utils.resolve-signed-len(p.location().position().x)
+          let py = deixis-utils.resolve-signed-len(p.location().position().y)
+          let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+
+          let px-l = px - deixis-utils.resolve-signed-len(p-pad.left)
+          let px-r = px + deixis-utils.resolve-signed-len(p-pad.right)
+          let py-t = py - deixis-utils.resolve-signed-len(p-pad.top)
+          let py-b = py + deixis-utils.resolve-signed-len(p-pad.bottom)
+
+          if px-l < min-x { min-x = px-l }
+          if px-r > max-x { max-x = px-r }
+          if py-t < min-y { min-y = py-t }
+          if py-b > max-y { max-y = py-b }
+        }
+      } else {
+        min-x = mark-center-x
+        max-x = mark-center-x
+        min-y = m-y-attach
+        max-y = m-y-attach
+      }
+
+      let reg-pad = deixis-utils.get-margins(reg.styles.at("padding", default: 0pt))
+      min-x -= deixis-utils.resolve-signed-len(reg-pad.left)
+      max-x += deixis-utils.resolve-signed-len(reg-pad.right)
+      min-y -= deixis-utils.resolve-signed-len(reg-pad.top)
+      max-y += deixis-utils.resolve-signed-len(reg-pad.bottom)
+
+      let sliding-y = calc.clamp(n-attach-y / 1pt, min-y / 1pt, max-y / 1pt) * 1pt
+      if sliding-y < min-y { sliding-y = (min-y + max-y) / 2.0 }
+
+      let r-cx = (min-x + max-x) / 2.0
+      let r-cy = (min-y + max-y) / 2.0
+
+      // user-provided ports
+      if override-mark == "top" {
+        S-candidates = ((x: r-cx, y: min-y, dir: "vertical", id: "top"),)
+      } else if override-mark == "bottom" {
+        S-candidates = ((x: r-cx, y: max-y, dir: "vertical", id: "bottom"),)
+      } else if override-mark == "left" {
+        S-candidates = ((x: min-x, y: r-cy, dir: "horizontal", id: "left"),)
+      } else if override-mark == "right" {
+        S-candidates = ((x: max-x, y: r-cy, dir: "horizontal", id: "right"),)
+      } else {
+        // Fallback to distance-minimizing sliding port
+        let out-x = if is-left { min-x } else { max-x }
+        let out-id = if is-left { "left" } else { "right" }
+        S-candidates = ((x: out-x, y: sliding-y, dir: "horizontal", id: out-id),)
+      }
+
+      let S-pt = S-candidates.first()
+      let out-x = S-pt.x
+      let out-y = S-pt.y
+
+      // prevent backwards folding if user forces a port that points across the text bounds
+      if S-pt.id == "left" and min-x < turn-x {
+        turn-x = min-x - turn-shift * 1pt
+      } else if S-pt.id == "right" and max-x > turn-x {
+        turn-x = max-x + turn-shift * 1pt
+      }
+
+      if link-waypoints == auto and link in ("straight-line", "right-angle", "chamfer", "curve", "ccr", "ucr") {
+        if S-pt.dir == "vertical" {
+          // if port is top/bottom, it must exit vertically into the drop channel first
+          if is-outgoing {
+            synth-wps = (
+              (0pt, drop-y - out-y),
+              (turn-x - out-x, 0pt),
+              (0pt, bottom-bound - drop-y),
+              deixis-waypoint-split,
+            )
+          } else if is-incoming {
+            synth-wps = (deixis-waypoint-split, (0pt, n-attach-y - top-bound))
+          } else {
+            synth-wps = ((0pt, drop-y - out-y), (turn-x - out-x, 0pt), (0pt, n-attach-y - drop-y))
+          }
+        } else {
+          // horizontal exit
+          synth-wps = (
+            (turn-x - out-x, 0pt),
+            (0pt, n-attach-y - out-y),
+          )
+        }
+      } else {
+        if is-outgoing or is-incoming { synth-wps = (deixis-waypoint-split,) }
+      }
+    } else {
+      // inline & phantom mark
+      let use-bottom = if override-mark == "bottom" { true } else if override-mark == "top" { false } else {
+        route-down
+      }
+      let out-id = if use-bottom { "bottom" } else { "top" }
+      let out-y = if use-bottom { box-bottom } else { box-top }
+
+      S-candidates = (
+        (x: mark-center-x, y: out-y, dir: "vertical", id: out-id),
+      )
+
+      if link-waypoints == auto and link in ("straight-line", "right-angle", "chamfer", "curve", "ccr", "ucr") {
+        if is-outgoing {
+          synth-wps = (
+            (0pt, drop-y - out-y),
+            (turn-x - mark-center-x, 0pt),
+            (0pt, bottom-bound - drop-y),
+            deixis-waypoint-split,
+          )
+        } else if is-incoming {
+          synth-wps = (deixis-waypoint-split, (0pt, n-attach-y - top-bound))
+        } else {
+          synth-wps = ((0pt, drop-y - out-y), (turn-x - mark-center-x, 0pt), (0pt, n-attach-y - drop-y))
+        }
+      } else {
+        if is-outgoing or is-incoming { synth-wps = (deixis-waypoint-split,) }
+      }
+    }
+
+    let D-candidates = (
+      (x: n-x, y: n-attach-y, dir: "horizontal", id: if is-left { "right" } else { "left" }),
+    )
+
+    let S-page = current-page
+    let E-page = current-page
+    if is-outgoing { E-page = current-page + 1 } else if is-incoming { S-page = current-page - 1 }
+
+    let extra = (
+      bound-dx: bound-x - mark-center-x,
+      turn-dx: turn-x - mark-center-x,
+      drop-y: drop-y - m-y-attach,
+      side: n.side,
+    )
+
+    let link-paths = _deixis-route-link(
+      n,
+      n.at("id", default: "margin"),
+      current-page,
+      S-page,
+      E-page,
+      S-candidates,
+      D-candidates,
+      c-link: link,
+      c-link-stroke: link-stroke,
+      c-link-radius: link-radius,
+      c-link-marks: actual-mark,
+      split-default: "target",
+      turn-x: turn-x,
+      synthetic-waypoints: synth-wps,
+      is-margin: true,
+      extra-data: extra,
+    )
+
+    for el in link-paths { paths.push(el) }
+  }
+  return paths.join()
+}
+
+/// --------------------
+/// Inset link
+/// --------------------
+
+#let _deixis-render-inset-link(
+  data,
+  current-page,
+  S-page,
+  E-page,
+  S,
+  D-top,
+  reg: none,
+  r-pins: (),
+  c-link: auto,
+  c-link-stroke: auto,
+  c-link-radius: auto,
+  c-link-marks: auto,
+) = {
+  let internal-id = data.internal-id
+  let mark-type = data.at("mark-type", default: "inline")
+
+  let paths = ()
+  let is-cross-page = (S-page != E-page)
+  let is-outgoing = (is-cross-page and current-page == S-page)
+  let is-incoming = (is-cross-page and current-page == E-page)
+
+  let source-candidates = ()
+  let m-cx = S.x
+  let mark-y = S.y
+
+  // cross-page bounding boxes
+  if mark-type == "region" and r-pins.len() > 0 {
+    let sorted-pins = r-pins.sorted(key: p => (p.location().page(), p.location().position().y))
+    let first-region-page = sorted-pins.first().location().page()
+    let last-region-page = sorted-pins.last().location().page()
+
+    let min-x = 1e10pt
+    let max-x = -1e10pt
+    for p in r-pins {
+      let px = deixis-utils.resolve-signed-len(p.location().position().x)
+      let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+      let px-l = px - deixis-utils.resolve-signed-len(p-pad.left)
+      let px-r = px + deixis-utils.resolve-signed-len(p-pad.right)
+      if px-l < min-x { min-x = px-l }
+      if px-r > max-x { max-x = px-r }
+    }
+
+    let p-margins = deixis-utils.get-page-margins(S-page)
+    let page-h = deixis-utils.resolve-len(if type(page.height) == length { page.height } else {
+      deixis-utils.default-page-size.height
+    })
+    let min-y = deixis-utils.resolve-len(p-margins.top)
+    let max-y = page-h - deixis-utils.resolve-len(p-margins.bottom)
+
+    let page-pins = r-pins.filter(p => p.location().page() == S-page)
+    if page-pins.len() > 0 {
+      let local-min-y = 1e10pt
+      let local-max-y = -1e10pt
+      for p in page-pins {
+        let py = deixis-utils.resolve-signed-len(p.location().position().y)
+        let p-pad = p.value.at("padding", default: (left: 0pt, right: 0pt, top: 0pt, bottom: 0pt))
+        let py-t = py - deixis-utils.resolve-signed-len(p-pad.top)
+        let py-b = py + deixis-utils.resolve-signed-len(p-pad.bottom)
+        if py-t < local-min-y { local-min-y = py-t }
+        if py-b > local-max-y { local-max-y = py-b }
+      }
+      if S-page == first-region-page { min-y = local-min-y }
+      if S-page == last-region-page { max-y = local-max-y }
+    }
+
+    let reg-pad = deixis-utils.get-margins(reg.styles.at("padding", default: 0pt))
+    min-x -= deixis-utils.resolve-signed-len(reg-pad.left)
+    max-x += deixis-utils.resolve-signed-len(reg-pad.right)
+    if S-page == first-region-page { min-y -= deixis-utils.resolve-signed-len(reg-pad.top) }
+    if S-page == last-region-page { max-y += deixis-utils.resolve-signed-len(reg-pad.bottom) }
+
+    m-cx = (min-x + max-x) / 2.0
+    mark-y = min-y
+
+    source-candidates = (
+      (x: m-cx, y: min-y, dir: "vertical", id: "top"),
+      (x: m-cx, y: max-y, dir: "vertical", id: "bottom"),
+      (x: min-x, y: (min-y + max-y) / 2.0, dir: "horizontal", id: "left"),
+      (x: max-x, y: (min-y + max-y) / 2.0, dir: "horizontal", id: "right"),
+    )
+  }
+
+  // inline marker fallback
+  if source-candidates.len() == 0 {
+    let mm-elems = query(selector(metadata).and(selector(<deixis-inline-mark>).or(<deixis-phantom-mark>))).filter(m => (
+      type(m.value) == dictionary
+        and m.value.at("internal-id", default: none) != none
+        and str(m.value.internal-id) == str(internal-id)
+    ))
+
+    let marker-width = data.at("marker-width", default: 0pt)
+    let text-size = data.at("text-size", default: 11pt)
+
+    if mm-elems.len() > 0 {
+      let mm-val = mm-elems.first().value
+      marker-width = mm-val.at("marker-width", default: marker-width)
+      text-size = mm-val.at("text-size", default: text-size)
+    }
+
+    let t-val = if type(text-size) == length { text-size } else { 11pt }
+    let has-inline-box = data.at("has-inline-box", default: false)
+
+    let mark-x = S.x
+    mark-y = S.y
+    m-cx = S.x + (marker-width / 2)
+
+    if not is-incoming and mark-type != "region" {
+      let highlight = _deixis-draw-marker-highlight(
+        mark-x,
+        mark-y,
+        marker-width,
+        data.marker-str,
+        stroke: c-link-stroke,
+        text-size: t-val,
+        has-inline-box: has-inline-box,
+        mark-type: mark-type,
+      )
+      if highlight != none { paths.push(highlight) }
+    }
+
+    let box-top = mark-y - (t-val * if has-inline-box { 0.9 } else { 0.8 })
+    let box-bottom = mark-y + (t-val * if has-inline-box { 0.2 } else { 0.05 })
+    let box-horizon = mark-y - (t-val * 0.3)
+
+    source-candidates = (
+      (x: m-cx, y: box-top, dir: "vertical", id: "top"),
+      (x: m-cx, y: box-bottom, dir: "vertical", id: "bottom"),
+    )
+    if data.at("marker-width", default: 0pt) == 0pt {
+      source-candidates.push(
+        (x: mark-x + marker-width + 1.5pt, y: box-horizon, dir: "horizontal", id: "right"),
+      )
+      source-candidates.push(
+        (x: mark-x - 1.5pt, y: box-horizon, dir: "horizontal", id: "left"),
+      )
+    } else if data.at("marker-position", default: none) in (right, "right") {
+      source-candidates.push(
+        (x: mark-x + marker-width + 1.5pt, y: box-horizon, dir: "horizontal", id: "right"),
+      )
+    } else if data.at("marker-position", default: none) in (left, "left") {
+      source-candidates.push(
+        (x: mark-x - 1.5pt, y: box-horizon, dir: "horizontal", id: "left"),
+      )
+    }
+  }
+
+  let d-bot-elems = query(selector(data.at("dest-bot-lbl", default: data.body-lbl)))
+  let d-left-elems = query(selector(data.at("dest-left-lbl", default: data.body-lbl)))
+  let d-right-elems = query(selector(data.at("dest-right-lbl", default: data.body-lbl)))
+
+  let D-bot = if d-bot-elems.len() > 0 { d-bot-elems.last().location().position() } else { D-top }
+  let D-left = if d-left-elems.len() > 0 { d-left-elems.last().location().position() } else { D-top }
+  let D-right = if d-right-elems.len() > 0 { d-right-elems.last().location().position() } else { D-top }
+
+  let dest-candidates = (
+    (x: D-top.x, y: D-top.y, dir: "vertical", id: "top"),
+    (x: D-bot.x, y: D-bot.y, dir: "vertical", id: "bottom"),
+    (x: D-left.x, y: D-left.y, dir: "horizontal", id: "left"),
+    (x: D-right.x, y: D-right.y, dir: "horizontal", id: "right"),
+  )
+
+  let routed-links = _deixis-route-link(
+    data,
+    internal-id,
+    current-page,
+    S-page,
+    E-page,
+    source-candidates,
+    dest-candidates,
+    c-link: c-link,
+    c-link-stroke: c-link-stroke,
+    c-link-radius: c-link-radius,
+    c-link-marks: c-link-marks,
+    split-default: "source",
+    is-margin: false,
+  )
+
+  if type(routed-links) == array {
+    paths += routed-links
+  } else if routed-links != none {
+    paths.push(routed-links)
+  }
+
+  return paths
+}

--- a/packages/preview/deixis/0.1.1/src/states.typ
+++ b/packages/preview/deixis/0.1.1/src/states.typ
@@ -1,0 +1,11 @@
+#let deixis-system = std.state("deixis-system", (
+  note-uid: 0,
+  stack: (),
+  blocks: (:),
+  counters: (:),
+  notes: (:), // str(internal-id) -> note-data
+  id-index: (:), // str(id) -> str(internal-id)
+  label-index: (:), // str(label) -> str(internal-id)
+))
+#let deixis-setup-state = std.state("deixis-setup-state", false)
+#let deixis-auto-id = "deixis-auto"

--- a/packages/preview/deixis/0.1.1/src/utils.typ
+++ b/packages/preview/deixis/0.1.1/src/utils.typ
@@ -1,0 +1,195 @@
+// A4 paper size
+#let default-page-size = (
+  width: 21.0cm,
+  height: 29.7cm,
+)
+
+#let resolve-len(val) = {
+  if val == auto or type(val) == fraction or val == none or type(val) == ratio {
+    0pt
+  } else {
+    measure(line(length: val)).width
+  }
+}
+
+#let resolve-signed-len(val) = measure(box(width: val + 1e10pt)).width - 1e10pt
+
+#let to-length(val) = if type(val) == length { val } else { val * 1pt }
+
+#let to-float(val) = if type(val) == length { val / 1pt } else { val }
+
+#let get-page-margins(page-num) = {
+  let m = page.margin
+
+  let p-w = if type(page.width) == length { page.width } else { default-page-size.width }
+  let p-h = if type(page.height) == length { page.height } else { default-page-size.height }
+
+  let auto-x = p-w * (2.5 / (default-page-size.width / 1cm))
+  let auto-y = p-h * (2.5 / (default-page-size.height / 1cm))
+
+  if m == auto { return (left: auto-x, right: auto-x, top: auto-y, bottom: auto-y) }
+
+  if type(m) != dictionary { return (left: m, right: m, top: m, bottom: m) }
+
+  let get(key, def) = if key in m and m.at(key) != auto { m.at(key) } else { def }
+
+  let rest-x = get("rest", auto-x)
+  let rest-y = get("rest", auto-y)
+
+  let x = get("x", rest-x)
+  let y = get("y", rest-y)
+
+  let l-margin = get("left", x)
+  let r-margin = get("right", x)
+  let t-margin = get("top", y)
+  let b-margin = get("bottom", y)
+
+  if "inside" in m or "outside" in m {
+    let inside = get("inside", x)
+    let outside = get("outside", x)
+
+    if calc.odd(page-num) {
+      l-margin = inside
+      r-margin = outside
+    } else {
+      l-margin = outside
+      r-margin = inside
+    }
+  }
+
+  return (left: l-margin, right: r-margin, top: t-margin, bottom: b-margin)
+}
+
+#let get-margins(m, default: 0pt) = {
+  let default-m = default
+
+  if m == auto { return (left: default-m, right: default-m, top: default-m, bottom: default-m) }
+  if type(m) != dictionary { return (left: m, right: m, top: m, bottom: m) }
+
+  let r-auto(val, def) = if val == auto { def } else { val }
+
+  let rest = r-auto(m.at("rest", default: default-m), default-m)
+  let x = r-auto(m.at("x", default: rest), rest)
+  let y = r-auto(m.at("y", default: rest), rest)
+
+  let l-margin = r-auto(m.at("left", default: x), x)
+  let r-margin = r-auto(m.at("right", default: x), x)
+  let t-margin = r-auto(m.at("top", default: y), y)
+  let b-margin = r-auto(m.at("bottom", default: y), y)
+
+  return (left: l-margin, right: r-margin, top: t-margin, bottom: b-margin)
+}
+
+#let get-radius(r) = {
+  if type(r) == dictionary {
+    return (
+      top-left: r.at("top-left", default: 0pt),
+      top-right: r.at("top-right", default: 0pt),
+      bottom-left: r.at("bottom-left", default: 0pt),
+      bottom-right: r.at("bottom-right", default: 0pt),
+    )
+  } else {
+    let abs-r = if r == auto { 0pt } else { r }
+    return (top-left: abs-r, top-right: abs-r, bottom-left: abs-r, bottom-right: abs-r)
+  }
+}
+
+#let get-stroke(s) = {
+  if s in (none, auto) { return none }
+  if type(s) == dictionary and ("top" in s or "bottom" in s or "left" in s or "right" in s) {
+    return (
+      top: s.at("top", default: none),
+      bottom: s.at("bottom", default: none),
+      left: s.at("left", default: none),
+      right: s.at("right", default: none),
+    )
+  }
+  return (top: s, bottom: s, left: s, right: s)
+}
+
+#let _deixis-normalize-ports(val) = {
+  if val in (auto, none) { return auto }
+
+  let valid-ports = ("top", "bottom", "left", "right")
+
+  let parse-port(p) = {
+    let s = if type(p) == alignment { repr(p) } else if type(p) == str { p } else { none }
+    if s not in valid-ports {
+      panic(
+        "deixis: Invalid port '"
+          + repr(p)
+          + "'. Allowed ports are: top, bottom, left, right (or their string equivalents).",
+      )
+    }
+    return s
+  }
+
+  if type(val) in (str, alignment) {
+    let s = parse-port(val)
+    return (mark: s, body: s)
+  } else if type(val) == dictionary {
+    let res = (:)
+    for (k, v) in val {
+      if k not in ("mark", "body") {
+        panic("deixis: Invalid key '" + k + "' in link-ports. Allowed keys are 'mark' and 'body'.")
+      }
+      res.insert(k, parse-port(v))
+    }
+    return res
+  } else {
+    panic("deixis: link-ports must be an alignment, string, or dictionary. Got: " + type(val))
+  }
+}
+
+#let _deixis-trim-content(c) = {
+  if type(c) != content { return c }
+  if c.func() != [].func() { return c } // Ensure it is a sequence
+
+  let space-func = [ ].func()
+  let children = c.children
+
+  // strip leading spaces
+  let start-idx = 0
+  while start-idx < children.len() {
+    if children.at(start-idx).func() == space-func {
+      start-idx += 1
+    } else {
+      break
+    }
+  }
+
+  // strip trailing spaces
+  let end-idx = children.len()
+  while end-idx > start-idx {
+    let func = children.at(end-idx - 1).func()
+    if func == space-func or func == parbreak {
+      end-idx -= 1
+    } else {
+      break
+    }
+  }
+
+  if start-idx >= end-idx { return [] }
+  return children.slice(start-idx, end-idx).join()
+}
+
+#let text-direction(dir, lang) = if dir == auto {
+  if (
+    lang
+      in (
+        "ar",
+        "dv",
+        "fa",
+        "he",
+        "ks",
+        "pa",
+        "ps",
+        "sd",
+        "ug",
+        "ur",
+        "yi",
+      )
+  ) { rtl } else { ltr }
+} else {
+  dir
+}

--- a/packages/preview/deixis/0.1.1/typst.toml
+++ b/packages/preview/deixis/0.1.1/typst.toml
@@ -1,0 +1,14 @@
+[package]
+name = "deixis"
+version = "0.1.1"
+entrypoint = "src/lib.typ"
+authors = [
+  "Hoang-Nhat Tran <hnhat.tran@gmail.com>"
+]
+license = "MIT"
+description = "Typeset decoupled notes, connectors, and spatial highlights."
+repository = "https://github.com/inspiros/typst-deixis"
+keywords = ["layout", "positioning", "mark", "inline-mark", "region-mark", "note", "inline-note", "footnote", "endnote", "margin-note", "sidenote", "inset-note", "pin", "arrow", "draw"]
+categories = ["layout", "utility"]
+compiler = "0.14.0"
+exclude = ["CHANGELOG.md"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

**Description:**
- Added a geometric path pullback calculation for routed links when `link-marks` is enabled, ensuring thick lines stay hidden inside the arrowheads.
- Improved the `#deixis-note-outline` rendering engine. It now allows multi-line note bodies to wrap naturally without clipping, and aligns page numbers to the bottom.
- Fixed a panic caused by backlinks on celibate (mark-only) endnotes.
- Fixed an issue where multi-page region marks would calculate incorrect vertical boundaries on non-A4 paper sizes by dynamically resolving Typst's native `auto` margins.
- Add a showcase and link to source code on all example images when clicked. 
