### PR TITLE
calepin:0.0.1

### DIFF
--- a/packages/preview/calepin/0.0.1/LICENSE
+++ b/packages/preview/calepin/0.0.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vincent Arel-Bundock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/calepin/0.0.1/README.md
+++ b/packages/preview/calepin/0.0.1/README.md
@@ -1,0 +1,31 @@
+# Calepin
+
+Website: <https://vincentarelbundock.github.io/calepin>
+
+Computational notebooks mix narrative text with executable code. Figures, tables, and numbers are computed when the document is rendered, rather than pasted in by hand. This helps analysts write reproducible reports in the tradition of literate programming.
+
+Calepin brings computational notebooks to Typst. It lets you write prose, code chunks, inline computations, figures, tables, and computed values in a single `.typ` source file, then render the document to PDF, HTML, or other Typst-supported formats. Calepin supports Python, R, shell commands, many languages through Jupyter kernels, and diagram tools such as Mermaid, Graphviz, TikZ, and D2.
+
+Typst intentionally sandboxes package and document code. That sandboxing is an important safety feature, but it also means Typst packages cannot run Python, R, shell commands, or other external programs by themselves. Calepin therefore requires an external command-line tool, `calepin`, to execute code chunks through external commands and render their results.
+
+Without this package, a `.typ` file containing `calepin.chunk()` or `calepin.inline()` calls would be difficult to compile with plain `typst`, because those calls normally depend on Calepin's generated runtime. This package provides a stable Typst import so computational notebooks can be compiled with either `typst` or `calepin` without an import error.
+
+When the external Calepin tool is not available and the document is compiled directly with `typst`, code is printed nicely and left unevaluated. The output document also includes a visible warning explaining that chunks were not executed and linking to the Calepin documentation.
+
+Use this package in Typst sources as:
+
+```typst
+#import "@preview/calepin:0.0.1" as calepin
+```
+
+To suppress the visible warning when compiling directly with `typst`, set:
+
+```typst
+#calepin.setup(fallback-warning: false)
+```
+
+To execute chunks and render results, compile with the Calepin CLI:
+
+```sh
+calepin compile paper.typ
+```

--- a/packages/preview/calepin/0.0.1/lib.typ
+++ b/packages/preview/calepin/0.0.1/lib.typ
@@ -1,0 +1,50 @@
+#let _warning-shown = state("calepin-shim-warning-shown", false)
+#let _warning-enabled = state("calepin-shim-warning-enabled", true)
+
+#let _warning() = context {
+  if _warning-enabled.get() and not _warning-shown.get() {
+    _warning-shown.update(true)
+    block(
+      width: 100%,
+      fill: rgb("#fff8d9"),
+      stroke: 0.5pt + rgb("#d8b94e"),
+      radius: 2pt,
+      inset: (x: 0.65em, y: 0.45em),
+    )[
+      #strong[Calepin warning:] This document was compiled directly with Typst.
+      Code chunks are shown unevaluated. Use `calepin compile <file.typ>` to
+      execute chunks and render results. See
+      #link("https://vincentarelbundock.github.io/calepin")[vincentarelbundock.github.io/calepin].
+    ]
+  }
+}
+
+#let setup(..args) = {
+  let opts = args.named()
+  _warning-enabled.update(_ => opts.at("fallback-warning", default: true))
+}
+
+#let _body-from-args(args, name) = {
+  let positional = args.pos()
+  if positional.len() >= 2 and type(positional.at(0)) == str {
+    positional.at(1)
+  } else if positional.len() >= 1 {
+    positional.at(0)
+  } else {
+    panic("calepin." + name + ": missing code block")
+  }
+}
+
+#let chunk(..args) = [
+  #_warning()
+  #_body-from-args(args, "chunk")
+]
+
+#let inline(..args) = [
+  #_warning()
+  #_body-from-args(args, "inline")
+]
+
+#let chunk-from-raw-plain(engine, it) = it
+
+#let require() = none

--- a/packages/preview/calepin/0.0.1/tests/direct-typst.typ
+++ b/packages/preview/calepin/0.0.1/tests/direct-typst.typ
@@ -1,0 +1,7 @@
+#import "@preview/calepin:0.0.1" as calepin
+
+#calepin.chunk("python")[
+```python
+print(42)
+```
+]

--- a/packages/preview/calepin/0.0.1/typst.toml
+++ b/packages/preview/calepin/0.0.1/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "calepin"
+version = "0.0.1"
+entrypoint = "lib.typ"
+authors = ["Vincent Arel-Bundock"]
+license = "MIT"
+description = "Write computational notebooks with executable code chunks."
+repository = "https://github.com/vincentarelbundock/calepin"
+homepage = "https://vincentarelbundock.github.io/calepin"
+keywords = ["notebook", "literate-programming", "reproducible", "code-execution", "python", "r"]
+categories = ["integration", "scripting"]
+compiler = "0.13.0"


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

Description:

> Computational notebooks mix narrative text with executable code. Figures, tables, and numbers are computed when the document is rendered, rather than pasted in by hand. This helps analysts write reproducible reports in the tradition of literate programming.
> 
> Calepin brings computational notebooks to Typst. It lets you write prose, code chunks, inline computations, figures, tables, and computed values in a single `.typ` source file, then render the document to PDF, HTML, or other Typst-supported formats. Calepin supports Python, R, shell commands, many languages through Jupyter kernels, and diagram tools such as Mermaid, Graphviz, TikZ, and D2.
> 
> Typst intentionally sandboxes package and document code. That sandboxing is an important safety feature, but it also means Typst packages cannot run Python, R, shell commands, or other external programs by themselves. Calepin therefore requires an external command-line tool, `calepin`, to execute code chunks through external commands and render their results.
> 
> Without this package, a `.typ` file containing `calepin.chunk()` or `calepin.inline()` calls would be difficult to compile with plain `typst`, because those calls normally depend on Calepin's generated runtime. This package provides a stable Typst import so computational notebooks can be compiled with either `typst` or `calepin` without an import error.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
  - Explanation: "Calepin" means "notebook" in French. This is a package for Computational notebooks in Typst. It is not related to any canonical Typst word or brand.
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

<!--
The following box only needs to be checked for **template** submissions. If you're submitting a package that isn't a template, you can delete the following section. See the guidelines section about licenses in the README for more details.
-->
- [ ] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use.
