### PR TITLE
to-stuff:1.0.0

### DIFF
--- a/packages/preview/to-stuff/1.0.0/LICENSE.md
+++ b/packages/preview/to-stuff/1.0.0/LICENSE.md
@@ -1,0 +1,10 @@
+Copyright 2026 Nik Mennega
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/packages/preview/to-stuff/1.0.0/README.md
+++ b/packages/preview/to-stuff/1.0.0/README.md
@@ -1,0 +1,1357 @@
+# To-Stuff
+
+To-Stuff is a collection of [Typst](https://typst.app/) functions for converting string values to native types. This is most useful when loading layout data from an external configuration source, such as a YAML file.
+
+- Avoids any use of [`eval()`][typst_eval].
+- All conversion functions optionally accept a default value to return on failure.
+- Where no default value is specified, a failed conversion panics with a sensible error message.
+
+
+## How to use
+
+Import the package into the current scope, optionally renamed using the `as` keyword:
+
+```typ
+#import "@preview/to-stuff:1.0.0"
+// Bindings available as to-stuff.alignment(), to-stuff.angle(), etc.
+
+// …or…
+
+#import "@preview/to-stuff:1.0.0" as to
+// Bindings available as to.alignment(), to.angle(), etc.
+```
+
+The package’s `let` bindings have the same names as their return types, and rely on Typst’s `import` syntax to scope safely. It is not recommended to load the individual bindings into the current scope, as that may cause [collisions with the types themselves][typst_shadow].
+
+```typ
+#assert(type(42pt) == length) // Expected behaviour
+
+#import "@preview/to-stuff:1.0.0": * // NOT RECOMMENDED
+
+#assert(type(42pt) != length) // To-Stuff bindings collide with standard types
+#assert(type(42pt) == std.length) // Workaround
+```
+
+
+## Localisation
+
+All conversions involving numeric values assume the number strings to be in a format understood by Typst code; specifically:
+
+- All numeric digits must be ASCII characters 0-9 and/or A-F (case non-sensitive).
+- Decimal separators must be a full stop/period; commas, apostrophes, etc. are not supported.
+- Thousands separators are not supported.
+
+
+## General Purpose Function
+
+### `stuff`
+
+Attempts to convert a value to the most appropriate data type, based on brute-force process of elimination. If no valid conversion can be found, the original value is returned unaltered.
+
+Unlike the [direct conversion functions](#direct-conversion-functions), this function does not panic in the event of a failed conversion, and does not accept a default value.
+
+```typ
+#stuff(
+	value, // any
+	recursive: false, // bool
+	arguments-collapse: false, // bool
+	numbers-as: auto, // type
+	none-from: (), // array
+) -> any
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `array` or `dictionary` or `arguments` or [others](#direct-conversion-functions) (positional, required)
+
+The value that should be converted to a native data type.
+
+- A string with the value `"auto"` is converted to `auto`.
+- A string representation of a native data type that is recognised by a [direct conversion function](#direct-conversion-functions) is converted accordingly.
+- A `dictionary` that conforms to a valid [`alignment`](#alignment), [`relative`](#relative) or [`stroke`](#stroke) is converted.
+- An `array` that conforms to a valid [`version`](#version) is converted.
+- Any other value is returned unchanged.
+
+#### `recursive`
+
+`bool`
+
+Whether to recurse through the items of `arguments` and `array` values, and of `dictionary` values that could not otherwise be converted.
+
+Note that recursing an `array` means that it will not be converted to a single `version`, even if otherwise suitable; `version`-like strings will still be converted as expected.
+
+Default: `false`
+
+#### `arguments-collapse`
+
+`bool`
+
+Whether to return an `arguments` value as an `array` or `dictionary`, where possible.
+
+Has no effect when `recursive` is not `true`.
+
+- A setting of `true` returns an `arguments` value with no named arguments as an `array`, or an `arguments` value with no positional arguments as a `dictionary`. An `arguments` value with both named and positional arguments will always be returned as an `arguments`.
+- A setting of `false` returns an `arguments` value as an `arguments`, regardless of its lack of named or positional arguments.
+
+Default: `false`
+
+#### `numbers-as`
+
+`type`
+
+The standard type to which to attempt to convert basic numbers.
+
+- A setting of [`std.int`](#int) converts `decimal`s, `float`s and eligible strings to `int` types.
+- A setting of [`std.float`](#float) converts `int`s, `decimal`s and eligible strings to `float` types.
+- A setting of [`std.decimal`](#decimal) converts `int`s and eligible strings to `decimal` types, but [ignores `float`s][typst_decimal].
+- A setting of [`std.version`](#version) converts `int`s and eligible strings to `version` types, but ignores `float`s and `decimal`s.
+- A setting of `auto` applies the [`number`](#number) direct conversion function, which if successful returns either an `int` or a `float` as appropriate.
+
+Default: `auto`
+
+#### `none-from`
+
+`array`
+
+Specify strings to convert to `none`. Case non-sensitive.
+
+Default: `()`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.stuff("auto")
+// -> auto
+
+#let b = to.stuff("true")
+// -> true
+
+#let c = to.stuff("top + right")
+// -> right + top
+
+#let d = to.stuff((x: "right", y: "top"))
+// -> right + top
+
+#let e = to.stuff("45deg")
+// -> 45deg
+
+#let f = to.stuff("rgb(255, 65, 54)")
+// -> rgb("#ff4136")
+
+#let g = to.stuff("rtl")
+// -> rtl
+
+#let h = to.stuff("25e-1")
+// -> 2.5
+
+#let i = to.stuff("2.5fr")
+// -> 2.5fr
+
+#let j = to.stuff("0x2a")
+// -> 42
+
+#let k = to.stuff("45pt")
+// -> 45pt
+
+#let l = to.stuff("45%")
+// -> 45%
+
+#let m = to.stuff("45pt + 3%")
+// -> 3% + 45pt
+
+#let n = to.stuff((ratio: "3%", length: "45pt"))
+// -> 3% + 45pt
+
+#let o = to.stuff("2pt + red + densely-dashed")
+// -> (paint: rgb("#ff4136"), thickness: 2pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let p = to.stuff((paint: red, thickness: 2pt, dash: "densely-dashed"))
+// -> (paint: rgb("#ff4136"), thickness: 2pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let q = to.stuff(recursive: true, (
+	mixed: ("A", "2", "33.3%", "auto", "5pt", "horizon + center"),
+	origin: (x: "center", y: "horizon"),
+	line: (thickness: "0.5pt", paint: "blue", dash: "dotted"),
+))
+/* -> (
+	mixed: ("A", 2, 33.3%, auto, 5pt, center + horizon),
+	origin: center + horizon,
+	line: (paint: rgb("#0074d9"), thickness: 0.5pt, dash: (array: ("dot", 2pt), phase: 0pt)),
+) */
+
+#let r = to.stuff(recursive: true, arguments-collapse: false, arguments(paint: "black", thickness:
+"0.9pt"))
+// -> arguments(paint: luma(0%), thickness: 0.9pt)
+
+#let s = to.stuff(recursive: true, arguments-collapse: true, arguments(paint: "black", thickness:
+"0.9pt"))
+// -> 0.9pt + luma(0%)
+
+#let t = to.stuff(numbers-as: decimal, "2.5")
+// -> decimal("2.5")
+
+#let u = to.stuff(numbers-as: float, "2.5")
+// -> 2.5
+
+#let v = to.stuff(numbers-as: int, "2.5")
+// -> 2
+
+#let w = to.stuff("")
+// -> ""
+```
+</details>
+
+
+## Direct Conversion Functions
+
+### `alignment`
+
+Attempts to convert a value to an `alignment`.
+
+```typ
+#alignment(
+	value, // str | alignment | dictionary
+	default: auto, // auto | none | alignment
+) -> none | alignment
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `alignment` or `dictionary` (positional, required)
+
+The value that should be converted to an `alignment`.
+
+- An `alignment` is returned unchanged.
+- A string representation of any of the eight `alignment` values is converted to that value.
+	- The string must not contain any scoping prefix, e.g. `alignment.…`, or the conversion will fail.
+- A string consisting of two `alignment` representations joined by a plus sign is converted to the corresponding 2D alignment.
+	- The two alignments must be on different axes, or the conversion will fail.
+- A `dictionary` containing one or more of the keys `x` and `y`, and no other keys, is converted.
+	- The value of `x`, if present, must be either a horizontal `alignment` or a value that would convert to one.
+	- The value of `y`, if present, must be either a vertical `alignment` or a value that would convert to one.
+
+#### `default`
+
+`auto` or `none` or `alignment`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.alignment("top + right")
+// -> right + top
+
+#let b = to.alignment(top + right)
+// -> right + top
+
+#let c = to.alignment((x: "right", y: "top"))
+// -> right + top
+
+#let d = to.alignment("turnwise")
+// panics with: "could not convert to alignment: \"turnwise\""
+
+#let e = to.alignment("top + bottom")
+// panics with: "cannot add two vertical alignments: \"top + bottom\""
+
+#let f = to.alignment(default: top + right, "top + bottom")
+// -> right + top
+
+#let g = to.alignment(default: none, "top + bottom")
+// -> none
+```
+</details>
+
+
+### `angle`
+
+Attempts to convert a value to an `angle`.
+
+```typ
+#angle(
+	value, // str | angle
+	default: auto, // auto | none | angle
+) -> none | angle
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `angle` (positional, required)
+
+The value that should be converted to an `angle`.
+
+- An `angle` is returned unchanged.
+- A string representation of a number followed by the letters `deg` or `rad` is converted.
+	- The number may be positive or negative, and may contain decimal places and/or an exponent.
+
+#### `default`
+
+`auto` or `none` or `angle`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.angle("45deg")
+// -> 45deg
+
+#let b = to.angle(45deg)
+// -> 45deg
+
+#let c = to.angle("42")
+// panics with: "could not convert to angle: \"42\""
+
+#let d = to.angle(default: 45deg, "42")
+// -> 45deg
+
+#let e = to.angle(default: none, "42")
+// -> none
+```
+</details>
+
+
+### `bool`
+
+Attempts to convert a value to a `bool`.
+
+```typ
+#bool(
+	value, // str | bool
+	default: auto, // auto | none | bool
+) -> none | bool
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `bool` (positional, required)
+
+The value that should be converted to a `bool`.
+
+- A `bool` is returned unchanged.
+- A string value of `"true"` is converted to `true`. Case non-sensitive.
+- A string value of `"false"` is converted to `false`. Case non-sensitive.
+
+
+#### `default`
+
+`auto` or `none` or `bool`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.bool("true")
+// -> true
+
+#let b = to.bool(true)
+// -> true
+
+#let c = to.bool("auto")
+// panics with: "could not convert to boolean: \"auto\""
+
+#let d = to.bool(default: true, "auto")
+// -> true
+
+#let e = to.bool(default: none, "auto")
+// -> none
+```
+</details>
+
+
+### `color`
+
+Attempts to convert a value to a `color`.
+
+```typ
+#color(
+	value, // str | color
+	default: auto, // auto | none | color
+) -> none | color
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `color` (positional, required)
+
+The value that should be converted to a `color`.
+
+- A `color` is returned unchanged.
+- A string representation of a predefined color value is converted to that built-in color.
+- A string representation of a hash symbol followed by a 6- or 8-digit hexadecimal code is converted to the corresponding RGB or RGBA value.
+- A string representation of a color space function followed by parentheses and arguments is converted.
+	- The string must not contain any scoping prefix, e.g. `color.…`, or the conversion will fail. This includes the `hsl`, `hsv`, and `linear-rgb` functions.
+
+#### `default`
+
+`auto` or `none` or `color`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.color("red")
+// -> rgb("#ff4136")
+
+#let b = to.color(red)
+// -> rgb("#ff4136")
+
+#let c = to.color("#FF4136FF")
+// -> rgb("#ff4136")
+
+#let d = to.color("rgb(255, 65, 54)")
+// -> rgb("#ff4136")
+
+#let e = to.color("hsv(135deg,75%,127,100)")
+// -> color.hsv(135deg, 75%, 49.8%, 39.22%)
+
+#let f = to.color("indigo")
+// panics with: "could not convert to color: \"indigo\""
+
+#let g = to.color(default: red, "indigo")
+// -> rgb("#ff4136")
+
+#let h = to.color(default: none, "indigo")
+// -> none
+```
+</details>
+
+
+### `decimal`
+
+Attempts to convert a value to a `decimal`.
+
+While the standard [`decimal` constructor][typst_decimal] throws an error on failure, this function [panics][typst_panic] instead, which may be suppressed if desired via the `default` argument.
+
+```typ
+#decimal(
+	value, // str | int | decimal
+	default: auto, // auto | none | int | decimal
+) -> none | decimal
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `int` or `decimal` (positional, required)
+
+The value that should be converted to a `decimal`.
+
+- A `decimal` is returned unchanged.
+- An `int` is converted.
+- A string representation of a number is converted.
+	- The number may be positive or negative, and may contain decimal places, but not an exponent.
+	- Hexadecimal numbers, prefixed with `0x`, are permitted.
+	- Octal numbers, prefixed with `0o`, are permitted.
+	- Binary numbers, prefixed with `0b`, are permitted.
+
+#### `default`
+
+`auto` or `none` or `int` or `decimal`
+
+What to return if `value` could not be converted; `int` defaults are converted to `decimal`. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.decimal("42")
+// -> decimal("42")
+
+#let b = to.decimal(42)
+// -> decimal("42")
+
+#let c = to.decimal("0x2a")
+// -> decimal("42")
+
+#let d = to.decimal(0x2a)
+// -> decimal("42")
+
+#let e = to.decimal("2.5")
+// -> decimal("2.5")
+
+#let f = to.decimal(2.5)
+// panics with: "could not convert to decimal: 2.5"
+
+#let h = to.decimal("25e-1")
+// panics with: "could not convert to decimal: \"25e-1\""
+
+#let h = to.decimal(default: 42, "25e-1")
+// -> decimal("42")
+
+#let i = to.decimal(default: none, "25e-1")
+// -> none
+```
+</details>
+
+
+### `direction`
+
+Attempts to convert a value to a `direction`.
+
+```typ
+#direction(
+	value, // str | direction
+	default: auto, // auto | none | direction
+) -> none | direction
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `direction` (positional, required)
+
+The value that should be converted to a `direction`.
+
+- A `direction` is returned unchanged.
+- A string representation of any of the four `direction` values is converted to that value.
+	- The string must not contain any scoping prefix, e.g. `direction.…`, or the conversion will fail.
+
+
+#### `default`
+
+`auto` or `none` or `direction`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.direction("rtl")
+// -> rtl
+
+#let b = to.direction(rtl)
+// -> rtl
+
+#let c = to.direction("btf")
+// panics with: "could not convert to direction: \"btf\""
+
+#let d = to.direction(default: rtl, "btf")
+// -> rtl
+
+#let e = to.direction(default: none, "btf")
+// -> none
+```
+</details>
+
+
+### `float`
+
+Attempts to convert a value to a `float`.
+
+While the standard [`float` constructor][typst_float] throws an error on failure, this function [panics][typst_panic] instead, which may be suppressed if desired via the `default` argument.
+
+```typ
+#float(
+	value, // str | int | float | decimal
+	default: auto, // auto | none | int | float | decimal
+) -> none | float
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `int` or `float` or `decimal` (positional, required)
+
+The value that should be converted to a `float`.
+
+- A `float` is returned unchanged.
+- A `decimal` or `int` is converted.
+- A string representation of a number is converted.
+	- The number may be positive or negative, and may contain decimal places and/or an exponent.
+	- Hexadecimal numbers, prefixed with `0x`, are permitted.
+	- Octal numbers, prefixed with `0o`, are permitted.
+	- Binary numbers, prefixed with `0b`, are permitted.
+
+#### `default`
+
+`auto` or `none` or `int` or `float` or `decimal`
+
+What to return if `value` could not be converted; `decimal` and `int` defaults are converted to `float`. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.float("42")
+// -> 42.0
+
+#let b = to.float(42)
+// -> 42.0
+
+#let c = to.float("2.5")
+// -> 2.5
+
+#let d = to.float(2.5)
+// -> 2.5
+
+#let e = to.float(25e-1)
+// -> 2.5
+
+#let f = to.float("25e-1")
+// -> 2.5
+
+#let g = to.float("0x2a")
+// -> 42.0
+
+#let h = to.float(0x2a)
+// -> 42.0
+
+#let i = to.float("42%")
+// panics with: "could not convert to float: \"42%\""
+
+#let j = to.float(default: 42, "42%")
+// -> 42.0
+
+#let k = to.float(default: none, "42%")
+// -> none
+```
+</details>
+
+
+### `fraction`
+
+Attempts to convert a value to a `fraction`.
+
+```typ
+#fraction(
+	value, // str | fraction
+	default: auto, // auto | none | fraction
+) -> none | fraction
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `fraction` (positional, required)
+
+The value that should be converted to a `fraction`.
+
+- A `fraction` is returned unchanged.
+- A string representation of a number followed by the letters `fr` is converted.
+	- The number may be positive or negative, and may contain decimal places and/or an exponent.
+
+#### `default`
+
+`auto` or `none` or `fraction`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.fraction("2.5fr")
+// -> 2.5fr
+
+#let b = to.fraction(2.5fr)
+// -> 2.5fr
+
+#let c = to.fraction("42")
+// panics with: "could not convert to fraction: \"42\""
+
+#let d = to.fraction(default: 2.5fr, "42")
+// -> 2.5fr
+
+#let e = to.fraction(default: none, "42")
+// -> none
+```
+</details>
+
+
+### `int`
+
+Attempts to convert a value to an `int`.
+
+While the standard [`int` constructor][typst_int] throws an error on failure, this function [panics][typst_panic] instead, which may be suppressed if desired via the `default` argument.
+
+This function can also parse correctly-prefixed strings in hexadecimal, octal and binary.
+
+```typ
+#int(
+	value, // str | int | float | decimal
+	default: auto, // auto | none | int
+) -> none | int
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `int` or `float` or `decimal` (positional, required)
+
+The value that should be converted to an `int`.
+
+- An `int` is returned unchanged.
+- A `decimal` or `float` is rounded towards zero and converted.
+- A string representation of a number is converted.
+	- The number may be positive or negative, and may contain decimal places and/or an exponent.
+	- Hexadecimal numbers, prefixed with `0x`, are permitted.
+	- Octal numbers, prefixed with `0o`, are permitted.
+	- Binary numbers, prefixed with `0b`, are permitted.
+
+#### `default`
+
+`auto` or `none` or `int`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.int("42")
+// -> 42
+
+#let b = to.int(42)
+// -> 42
+
+#let c = to.int("2.5")
+// -> 2
+
+#let d = to.int(2.5)
+// -> 2
+
+#let e = to.int(25e-1)
+// -> 2
+
+#let f = to.int("25e-1")
+// -> 2
+
+#let g = to.int("0x2a")
+// -> 42
+
+#let h = to.int(0x2a)
+// -> 42
+
+#let i = to.int("42%")
+// panics with: "could not convert to int: \"42%\""
+
+#let j = to.int(default: 42, "42%")
+// -> 42
+
+#let k = to.int(default: none, "42%")
+// -> none
+```
+</details>
+
+
+### `length`
+
+Attempts to convert a value to a `length`.
+
+```typ
+#length(
+	value, // str | length
+	default: auto, // auto | none | length
+) -> none | length
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `length` (positional, required)
+
+The value that should be converted to a `length`.
+
+- A `length` is returned unchanged.
+- A string representation of a number followed by the letters `pt`, `mm`, `cm`, `in`, or `em`, is converted.
+	- The number may be positive or negative, and may contain decimal places and/or an exponent.
+
+#### `default`
+
+`auto` or `none` or `length`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.length("45pt")
+// -> 45pt
+
+#let b = to.length(45pt)
+// -> 45pt
+
+#let c = to.length("42")
+// panics with: "could not convert to length: \"42\""
+
+#let d = to.length(default: 45pt, "42")
+// -> 45pt
+
+#let e = to.length(default: none, "42")
+// -> none
+```
+</details>
+
+
+### `number`
+
+Attempts to convert a value to an `int` or a `float` as appropriate.
+
+
+```typ
+#number(
+	value, // str | int | float | decimal
+	default: auto, // auto | none | int | float | decimal
+) -> none | int | float | decimal
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `int` or `float` or `decimal` (positional, required)
+
+The value that should be converted to a `float` or `int`.
+
+- A `decimal`, `float` or `int` is returned unchanged.
+- A string representation of a number is converted.
+	- The number may be positive or negative.
+	- A number that contains decimal places and/or an exponent, is converted to a `float`.
+	- Hexadecimal numbers, prefixed with `0x`, are converted to an `int`.
+	- Octal numbers, prefixed with `0o`, are converted to an `int`.
+	- Binary numbers, prefixed with `0b`, are converted to an `int`.
+
+#### `default`
+
+`auto` or `none` or `int` or `float` or `decimal`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.number("42")
+// -> 42
+
+#let b = to.number(42)
+// -> 42
+
+#let c = to.number("2.5")
+// -> 2.5
+
+#let d = to.number(2.5)
+// -> 2.5
+
+#let e = to.number(25e-1)
+// -> 2.5
+
+#let f = to.number("25e-1")
+// -> 2.5
+
+#let g = to.number("0x2a")
+// -> 42
+
+#let h = to.number(0x2a)
+// -> 42
+
+#let i = to.number("42%")
+// panics with: "could not convert to int or float: \"45%\""
+
+#let j = to.number(default: 42, "42%")
+// -> 42
+
+#let k = to.number(default: none, "42%")
+// -> none
+```
+</details>
+
+
+### `ratio`
+
+Attempts to convert a value to a `ratio`.
+
+```typ
+#ratio(
+	value, // str | ratio
+	default: auto, // auto | none | ratio
+) -> none | ratio
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `ratio` (positional, required)
+
+The value that should be converted to a `ratio`.
+
+- A `ratio` is returned unchanged.
+- A string representation of a number followed by a percent sign is converted.
+	- The number may be positive or negative, and may contain decimal places and/or an exponent.
+
+#### `default`
+
+`auto` or `none` or `ratio`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.ratio("45%")
+// -> 45%
+
+#let b = to.ratio(45%)
+// -> 45%
+
+#let c = to.ratio("42")
+// panics with: "could not convert to ratio: \"42\""
+
+#let d = to.ratio(default: 45%, "42")
+// -> 45%
+
+#let e = to.ratio(default: none, "42")
+// -> none
+```
+</details>
+
+
+### `relative`
+
+Attempts to convert a value to a `relative`.
+
+```typ
+#relative(
+	value, // str | relative | ratio | length | dictionary
+	default: auto, // auto | none | relative | ratio | length
+) -> none | relative
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `relative` or `ratio` or `length` or `dictionary` (positional, required)
+
+The value that should be converted to a `relative`.
+
+- A `relative` is returned unchanged.
+- A `ratio` is returned as a `relative` with a `length` of `0pt`.
+- A `length` is returned as a `relative` with a `ratio` of `0%`.
+- A string representation of a `ratio` (see [above](#ratio)) is converted.
+- A string representation of a `length` (see [above](#length)) is converted.
+- A string consisting of multiple `ratio`s and `length`s joined by plus signs or minus signs is converted to a single `relative` length.
+	- All `length`-like substrings are added.
+	- All `ratio`-like substrings are added.
+- A `dictionary` containing one or more of the keys `ratio` and `length`, and no other keys, is converted.
+	- The value of `ratio`, if present, must be either a `ratio` or a value that would convert to one.
+	- The value of `length`, if present, must be either a `length` or a value that would convert to one.
+
+#### `default`
+
+`auto` or `none` or `relative` or `ratio` or `length`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.relative("45pt + 3%")
+// -> 3% + 45pt
+
+#let b = to.relative(45pt + 3%)
+// -> 3% + 45pt
+
+#let c = to.relative((ratio: "3%", length: "45pt"))
+// -> 3% + 45pt
+
+#let d = to.relative("42")
+// panics with: "could not convert to relative: \"42\""
+
+#let e = to.relative(default: 45pt + 3%, "42")
+// -> 3% + 45pt
+
+#let f = to.relative(default: none, "42")
+// -> none
+```
+</details>
+
+
+### `stroke`
+
+Attempts to convert a value to a `stroke`.
+
+```typ
+#stroke(
+	value, // str | stroke | color | length | array | dictionary
+	default: auto, // auto | none | stroke | color | length
+) -> none | stroke
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `stroke` or `color` or `length` or `array` or `dictionary` (positional, required)
+
+The value that should be converted to a `stroke`.
+
+- A `stroke`, `color` or `length` is returned unchanged.
+- A string representation of a `color` (see [above](#color)) is converted.
+- A string representation of a `length` (see [above](#length)) is converted.
+- A valid [dash pattern][typst_dash] is converted.
+- A string representation of one or more valid `color`s, `length`s and/or predefined dash patterns joined by plus signs is converted.
+	- All `color`-like substrings are combined via `color.mix()`.
+	- All `length`-like substrings added.
+- A `dictionary` that would otherwise be accepted as a valid `stroke` is converted.
+
+#### `default`
+
+`auto` or `none` or `stroke` or `color` or `length`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.stroke("red")
+// -> rgb("#ff4136")
+
+#let b = to.stroke(45pt)
+// -> 45pt
+
+#let c = to.stroke("densely-dashed")
+// -> (dash: (array(3pt, 2pt), phase: 0pt))
+
+#let d = to.stroke((3pt, 2pt))
+// -> (dash: (array(3pt, 2pt), phase: 0pt))
+
+#let e = to.stroke((paint: red, thickness: 2pt, dash: "densely-dashed"))
+// -> (paint: rgb("#ff4136"), thickness: 2pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let f = to.stroke("2pt + red + densely-dashed + silver + 5pt")
+// -> (paint: oklab(77.85%, 0.1, 0.054), thickness: 7pt, dash: (array: (3pt, 2pt), phase: 0pt))
+
+#let g = to.stroke("deep-dish")
+// panics with: "could not convert to stroke: \"deep-dish\""
+
+#let h = to.stroke(default: red + 45pt, "deep-dish")
+// -> 45pt + rgb("#ff4136")
+
+#let i = to.stroke(default: none, "deep-dish")
+// -> none
+```
+</details>
+
+
+### `version`
+
+Attempts to convert a value to a `version`.
+
+```typ
+#version(
+	value, // str | version | int | array
+	default: auto, // auto | none | version
+) -> none | version
+```
+
+<details>
+	<summary>View arguments</summary>
+
+#### `value`
+
+`str` or `version` or `int` or `array` (positional, required)
+
+The value that should be converted to a `version`.
+
+- A `version` is returned unchanged.
+- An `int` is converted.
+- A string representation of positive integers separated by periods is converted.
+- An array of any combination of the above is flattened and converted.
+
+#### `default`
+
+`auto` or `none` or `version`
+
+What to return if `value` could not be converted. If `auto`, failed conversions cause a [panic][typst_panic].
+
+Default: `auto`
+</details>
+
+<details>
+	<summary>View examples</summary>
+
+```typ
+#import "@preview/to-stuff:1.0.0" as to
+
+#let a = to.version("42")
+// -> version(42)
+
+#let b = to.version(42)
+// -> version(42)
+
+#let c = to.version("2.5")
+// -> version(2, 5)
+
+#let d = to.version(2.5)
+// -> panics with: "expected integer, array or version, found float 2.5"
+
+#let e = to.version("2.5.1")
+// -> version(2, 5, 1)
+
+#let f = to.version((2, 5, 1))
+// -> version(2, 5, 1)
+
+#let g = to.version((2, -5, 1))
+// -> panics with "number must be greater than zero: -5"
+
+#let h = to.version((2, (5, 1)))
+// -> version(2, 5, 1)
+
+#let i = to.version((2, std.version(5, 1)))
+// -> version(2, 5, 1)
+
+#let j = `to.version("42%")`
+// -> panics with: "could not convert to version: \"42%\""
+
+#let k = to.version(default: sys.version, "42%")
+// -> version(0, 14, 2)
+
+#let l = to.version(default: none, "42%")
+// -> none
+```
+</details>
+
+
+[typst_eval]: https://typst.app/docs/reference/foundations/eval/
+[typst_panic]: https://typst.app/docs/reference/foundations/panic/
+[typst_decimal]: https://typst.app/docs/reference/foundations/decimal/#constructor
+[typst_float]: https://typst.app/docs/reference/foundations/float/#constructor
+[typst_int]: https://typst.app/docs/reference/foundations/int/#constructor
+[typst_dash]: https://typst.app/docs/reference/visualize/stroke/#constructor-dash
+[typst_shadow]: https://typst.app/docs/reference/foundations/std/#using-shadowed-definitions
+
+
+## Changelog
+
+### 1.0.0 - 2026-06-08
+
+#### Changed
+
+- **Breaking:** less strict, more natural handling of integers and floats.
+	- Integer and float conversions may accept integers, floats or decimals.
+	- Float and generic number conversions may default to an integer, float, or decimal.
+	- Integer conversions may only default to an integer (or `none`).
+
+#### Added
+
+- New general-purpose function `stuff` to guess most appropriate conversion.
+- Expose new conversions:
+	- bool
+	- decimal
+	- version
+
+#### Removed
+
+- **Breaking:** remove deprecated `quiet` argument from all direct conversion functions.
+- **Breaking:** remove deprecated `scalar` function alias.
+
+### 0.5.1 - 2026-01-16
+
+#### Changed
+
+- Invalid `default` and `quiet` values throw failed assertions instead of panicking.
+
+#### Fixed
+
+- Reject empty dictionaries when converting:
+	- alignment
+	- relative
+	- stroke
+
+### 0.5.0 - 2025-12-20
+
+#### Changed
+
+- Rename scalar to number.
+- Deprecate scalar (retained as alias of number for backward compatibility).
+
+#### Added
+
+- Add `default` argument to every conversion ([#2][issue_002]).
+- Deprecate the `quiet` argument (equivalent to `default: none`).
+
+#### Fixed
+
+- Additional validation restraints for color constructors ([#1][issue_001]).
+
+### 0.4.0 - 2025-12-06
+
+#### Changed
+
+- Remove reliance on `eval()` from:
+	- color
+- All use of `eval()` now entirely eliminated.
+
+#### Added
+
+- Expose new conversions:
+	- float
+	- int
+	- scalar (returns either float or int as appropriate)
+
+#### Fixed
+
+- Color conversion via constructor now checks validity of all arguments.
+- Stroke miter-limit now treated as scalar.
+
+### 0.3.1 - 2025-10-30
+
+#### Added
+
+- Dictionary conversion to stroke now checks validity of cap, join and miter-limit.
+
+### 0.3.0 - 2025-10-19
+
+#### Changed
+
+- Improve conversion logic and error checking for stroke.
+
+### 0.2.1 - 2025-10-10
+
+#### Changed
+
+- Remove reliance on `eval()` from:
+	- alignment
+
+### 0.2.0 - 2025-10-08
+
+#### Changed
+
+- Remove reliance on `eval()` from:
+	- angle
+	- fraction
+	- length
+	- ratio
+	- relative
+
+#### Added
+
+- Allow exponential notation in numeric conversions.
+
+### 0.1.0 - 2025-09-30
+
+_Initial release._
+
+
+[issue_001]:https://codeberg.org/boondoc/typst-to-stuff/issues/1
+[issue_002]:https://codeberg.org/boondoc/typst-to-stuff/issues/2
+

--- a/packages/preview/to-stuff/1.0.0/exports.typ
+++ b/packages/preview/to-stuff/1.0.0/exports.typ
@@ -1,0 +1,13 @@
+
+#import	"/internals/numbers.typ"	:   decimal, float, int, number
+#import	"/internals/units.typ"		:   angle, fraction, length, ratio
+#import	"/internals/alignment.typ"	:   alignment
+#import	"/internals/bool.typ"		:   bool
+#import	"/internals/color.typ"		:   color
+#import	"/internals/direction.typ"	:   direction
+#import	"/internals/relative.typ"	:   relative
+#import	"/internals/stroke.typ"		:   stroke
+#import	"/internals/version.typ"	:   version
+
+#import	"/internals/stuff.typ"		:   stuff
+

--- a/packages/preview/to-stuff/1.0.0/internals/alignment.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/alignment.typ
@@ -1,0 +1,101 @@
+
+#import	"/internals/utils.typ"		:   *
+
+#let	alignment(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.alignment,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+	if type(value) == dictionary and value.len() > 0 {
+		let	original			=   repr(value)
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			x				:  "horizontal",
+			y				:  "vertical",
+		)
+
+		if keys_this.all(x => x in keys_valid.keys()) {
+			for (field, axis) in keys_valid {
+				if field in value {
+					value.insert(field, alignment(default : none, value.at(field)))
+
+					if none == value.at(field) or value.at(field).axis() != axis {
+						return mild-panic(
+							default				:   default,
+							types				:   types,
+							"could not convert “{field}” component to {axis} alignment: "
+								.replace("{axis}",	axis)
+								.replace("{field}",	field)
+								+ original,
+						)
+					}
+				}
+			}
+
+			return value.values().sum()
+		}
+
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   keys_this,
+				valid				:   keys_valid.keys(),
+				repr(value),
+			),
+		)
+	}
+
+
+	let	panic-message			=  "could not convert to alignment: " + repr(value)
+
+	if type(value) != std.str {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	let	value				=   value.trim()
+	let	constants			=   list-predefined(std.alignment)
+
+	if value in constants {
+		return constants.at(value)
+	}
+
+
+	let	parts				=   value.split("+").map(std.str.trim)
+
+	if not parts.all(x => x in constants) {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+	let	axes				=   parts.map(x => constants.at(x).axis())
+
+	if axes.at(0) == axes.at(1) {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			"cannot add two {axis} alignments: "
+				.replace("{axis}", axes.at(0))
+				+ repr(value),
+		)
+	}
+
+
+	return parts.map(alignment).sum()
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/bool.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/bool.typ
@@ -1,0 +1,33 @@
+
+#import	"/internals/utils.typ"		:   *
+
+#let	bool(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.bool,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	constants			= (
+		"false"				:   false,
+		"true"				:   true,
+	)
+
+	if type(value) == std.str and lower(value.trim()) in constants {
+		return constants.at(lower(value.trim()))
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to boolean: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/color.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/color.typ
@@ -1,0 +1,216 @@
+
+#import	"/internals/numbers.typ"	:   int, number
+#import	"/internals/units.typ"		:   angle, ratio
+#import	"/internals/utils.typ"		:   *
+
+
+#let	color(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.color,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	panic-message			=  "could not convert to color: " + repr(value)
+
+	if type(value) != std.str {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	let	value				=   value.trim()
+	let	constants			=   list-predefined(std.color)
+	let	constructors			= (
+		rgb				: (
+			constructor			:  std.color.rgb,
+			args				: (
+				red				: (optional: false,	types: (ratio, int)),
+				green				: (optional: false,	types: (ratio, int)),
+				blue				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		linear-rgb			: (
+			constructor			:  std.color.linear-rgb,
+			args				: (
+				red				: (optional: false,	types: (ratio, int)),
+				green				: (optional: false,	types: (ratio, int)),
+				blue				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		luma				: (
+			constructor			:  std.color.luma,
+			args				: (
+				lightness			: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+		cmyk				: (
+			constructor			:  std.color.cmyk,
+			args				: (
+				cyan				: (optional: false,	types: (ratio,)),
+				magenta				: (optional: false,	types: (ratio,)),
+				yellow				: (optional: false,	types: (ratio,)),
+				black				: (optional: false,	types: (ratio,)),
+			),
+		),
+		hsl				: (
+			constructor			:  std.color.hsl,
+			args				: (
+				hue				: (optional: false,	types: (angle,)),
+				saturation			: (optional: false,	types: (ratio, int)),
+				lightness			: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		hsv				: (
+			constructor			:  std.color.hsv,
+			args				: (
+				hue				: (optional: false,	types: (angle,)),
+				saturation			: (optional: false,	types: (ratio, int)),
+				value				: (optional: false,	types: (ratio, int)),
+				alpha				: (optional: true,	types: (ratio, int)),
+			),
+		),
+		oklab				: (
+			constructor			:  std.color.oklab,
+			args				: (
+				lightness			: (optional: false,	types: (ratio,)),
+				A				: (optional: false,	types: (ratio, number),	clamp: false),
+				B				: (optional: false,	types: (ratio, number),	clamp: false),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+		oklch				: (
+			constructor			:  std.color.oklch,
+			args				: (
+				lightness			: (optional: false,	types: (ratio,)),
+				chroma				: (optional: false,	types: (ratio, number), clamp: false),
+				hue				: (optional: false,	types: (angle,)),
+				alpha				: (optional: true,	types: (ratio,)),
+			),
+		),
+	)
+
+	let	clamps				= (
+		int 				: (
+			fails				:   x => 0 > x or x > 255,
+			error				:  "component must be between 0 and 255",
+		),
+		ratio				: (
+			fails				:   x => 0% > x or x > 100%,
+			error				:  "component must be between 0% and 100%",
+		),
+	)
+
+
+	if value in constants {
+		return constants.at(value)
+	}
+
+	if value.contains(regex("^#?([[:xdigit:]]{3,4}|[[:xdigit:]]{6}|[[:xdigit:]]{8})$")) {
+		return std.color.rgb(value)
+	}
+
+
+	let	rx-funcs			=   regex( "^(" + constructors.keys().join("|") + ")\(([^)]*)\)$")
+
+	if value.contains(rx-funcs) {
+		let	(func, args)			=   value.match(rx-funcs).captures
+
+		if func not in constructors {
+			return mild-panic(
+				default				:   default,
+				types				:   types,
+				panic-message,
+			)
+		}
+
+		let	allowed				=   constructors.at(func).args.pairs()
+		let	required			=   allowed.filter(x => not x.last().optional)
+		let	args				=   args
+			.split(",")
+			.map(str.trim)
+			.filter(x => "" != x)
+			.enumerate()
+			.map(((offset, arg)) => {
+				if offset >= allowed.len() {
+					return ("panic", "unexpected argument " + repr(arg))
+				}
+
+				let	(name, rules)			=   allowed.at(offset)
+
+				for	parse in rules.types {
+					let	clamp				=   clamps.at(
+						default				: (:),
+						repr(parse),
+					)
+					let	parsed				=   parse(
+						default				:   none,
+						arg,
+					)
+
+					if none == parsed {
+						continue;
+					}
+
+
+					if repr(parse) in clamps and rules.at(
+						default				:   true,
+						"clamp",
+					) and clamp.at("fails")(parsed) {
+						return ("panic", (name, clamp.error).join(" "))
+					}
+
+					return (name, parsed)
+				}
+
+				return ("panic", (
+					name,
+					"component expected",
+					rules.types.map(repr).join(
+						last				:  ", or ",
+						", ",
+					).replace("number", "float"),
+				).join(" "))
+			})
+			.to-dict()
+
+		if "panic" in args {
+			return mild-panic(
+				default				:   default,
+				types				:   types,
+				panic-message + "; " + args.panic,
+			)
+		}
+
+		if args.len() < required.len() {
+			return mild-panic(
+				default				:   default,
+				types				:   types,
+				panic-message + "; missing " + required.at(args.len()).first() + " component",
+			)
+		}
+
+		return	constructors.at(func).at("constructor")(..args.values())
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		panic-message,
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/direction.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/direction.typ
@@ -1,0 +1,30 @@
+
+#import	"/internals/utils.typ"		:   *
+
+#let	direction(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.direction,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	constants			=   list-predefined(std.direction)
+
+	if type(value) == std.str and value.trim() in constants {
+		return constants.at(value.trim())
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to direction: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/numbers.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/numbers.typ
@@ -1,0 +1,259 @@
+
+#import	"/internals/utils.typ"		:   mild-panic, neg
+
+#let	rx-catchall			=  "(([-+\s]*)([[:digit:].]+(e[+-]?[[:digit:]]+)?))"
+#let	rx-decimals			=  "(([-+\s]*)([[:digit:].]+))"
+#let	rx-quantity			=  "(([-+\s]*)([[:digit:]]*\.?[[:digit:]]+(e[+-]?[[:digit:]]+)?))"
+#let	rx-prefixed			=  "(([-+\s]*)0([xob])(\S+))"
+
+#let	int_from_base(value, base)	= {
+	let	digits				=  "0123456789abcdefghijklmnopqrstuvwxyz"
+	let	max				=   digits.len()
+
+	assert.eq(
+		message				:  "Base must be between 2 and {max}: {base}"
+							.replace("{max}",	std.str(max))
+							.replace("{base}",	std.str(base)),
+		base,
+		calc.clamp(base, 2, max),
+	)
+
+	let	v				=   lower(value)
+	let	d				=   digits.slice(0, base)
+
+	if none != v.match(regex("([^" + d + "]+)")) {
+		let	base				=   std.str(base)
+		let	debug				= (
+			"16"				:  "hexadecimal",
+			 "8"				:  "octal",
+			 "2"				:  "binary",
+		).at(
+			default				:  "base-" + base,
+			base,
+		)
+
+		let	xob				= (
+			"16"				:  "0x",
+			 "8"				:  "0o",
+			 "2"				:  "0b",
+		).at(
+			default				:  "",
+			base
+		)
+
+		return	"invalid {base} number: {value}"
+				.replace("{value}",	repr(xob + value))
+				.replace("{base}",	debug)
+	}
+
+	return	 v
+		.rev()
+		.clusters()
+		.enumerate()
+		.map(((x, c)) => d.position(c) * calc.pow(base, x))
+		.sum()
+}
+
+#let	xob(
+	default				:   auto,
+	types				:  ( ),
+	value,
+) = {
+	let	(_, signs, xob, num)		=   value.matches(regex("^" + rx-prefixed + "$")).first().captures
+
+	let	v				=   int_from_base(num, (
+			x				:   16,
+			o				:    8,
+			b				:    2,
+		)
+		.at(xob))
+
+	if type(v) == std.str {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			v,
+		)
+	}
+
+	v * neg(signs)
+}
+
+
+#let	number(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.int,
+		std.float,
+		std.decimal,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	if type(value) == std.str {
+		let	value				=   value.trim()
+
+		if value.contains(regex("^" + rx-prefixed + "$")) {
+			return xob(
+				default				:   default,
+				types				:   types,
+				value,
+			)
+		}
+
+		let	rx				=   regex("^" + rx-catchall + "$")
+
+		// Regex is a little inadequate, so some extra constraints are needed here
+		if value != "." and value.contains(rx) and value.matches(".").len() <= 1 {
+			let	(_, signs, num, _)		=   value.matches(rx).first().captures
+
+			if "." in value or "e" in value {
+				return std.float(num) * neg(signs)
+			} else {
+				return std.int(num) * neg(signs)
+			}
+		}
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to int or float: " + repr(value),
+	)
+}
+
+
+#let	int(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.int,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+	// Non-integer inputs are fine but default MUST be an integer
+	if type(value) in (std.float, std.decimal) {
+		return std.int(value)
+	}
+
+
+	if type(value) == std.str {
+		let	num				=   number(
+			default				:   none,
+			value,
+		)
+
+		if none != num {
+			return std.int(num)
+		}
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to int: " + repr(value),
+	)
+}
+
+
+#let	float(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.int,
+		std.float,
+		std.decimal,
+	)
+
+	if type(value) in types {
+		return std.float(value)
+	}
+
+
+	if type(value) == std.str {
+		let	num				=   number(
+			default				:   none,
+			value,
+		)
+
+		if none != num {
+			return std.float(num)
+		}
+	}
+
+
+	if type(default) in types {
+		default				=   std.float(default)
+	}
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to float: " + repr(value),
+	)
+}
+
+
+#let	decimal(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.int,
+		std.decimal,
+	)
+
+	if type(value) in types {
+		return std.decimal(value)
+	}
+
+
+	if type(value) == std.str {
+		let	value				=   value.trim()
+
+		if value.contains(regex("^" + rx-prefixed + "$")) {
+			let	num				=   xob(
+				default				:   default,
+				types				:   types,
+				value,
+			)
+
+			if none != num {
+				return std.decimal(num)
+			}
+		}
+
+		let	rx				=   regex("^" + rx-decimals + "$")
+
+		// Regex is a little inadequate, so some extra constraints are needed here
+		if value != "." and value.contains(rx) and value.matches(".").len() <= 1 {
+			let	(_, signs, num)			=   value.matches(rx).first().captures
+
+			return std.decimal(num) * neg(signs)
+		}
+	}
+
+
+	if type(default) in types {
+		default				=   std.decimal(default)
+	}
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to decimal: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/relative.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/relative.typ
@@ -1,0 +1,100 @@
+
+#import	"/internals/numbers.typ"	:   rx-quantity
+#import	"/internals/units.typ"		:   length, ratio
+#import	"/internals/utils.typ"		:   *
+
+#let	relative(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.relative,
+		std.ratio,
+		std.length,
+	)
+
+	if type(value) in types {
+		return value + 0pt + 0%
+	}
+
+
+	if type(default) in types {
+		default				+=   0pt + 0%
+	}
+
+	if type(value) == dictionary and value.len() > 0 {
+		let	original			=   repr(value)
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			ratio				:   ratio,
+			length				:   length,
+		)
+
+		if keys_this.all(x => x in keys_valid.keys()) {
+			for (field, func) in keys_valid {
+				if field in value {
+					value.insert(field, func(default : none, value.at(field)))
+
+					if none == value.at(field) {
+						return mild-panic(
+							default				:   default,
+							types				:   types,
+							"could not convert “{field}” component to {field}: "
+								.replace("{field}", field)
+								+ original,
+						)
+					}
+				}
+			}
+
+			return value.values().sum()
+		}
+
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   keys_this,
+				valid				:   keys_valid.keys(),
+				repr(value),
+			),
+		)
+	}
+
+
+	let	rx				=  "^(" + rx-quantity + "(pt|mm|cm|in|em|%))"
+
+	if type(value) == std.str and value.trim().contains(regex(rx + "+$")) {
+		let	value				=   value.trim()
+		let	parts				= (
+			ratio				:   0%,
+			length				:   0pt,
+		)
+
+		while value.len() > 0 {
+			let	match				=   value.match(regex(rx))
+
+			if none == match {
+				break
+			}
+
+			if match.captures.at(5) == "%" {
+				parts.ratio			+=   ratio(default : 0%, match.text)
+			} else {
+				parts.length			+=   length(default : 0pt, match.text)
+			}
+
+			value				=   value.slice(match.end)
+		}
+
+		return relative(parts)
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to relative: " + repr(value),
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/stroke.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/stroke.typ
@@ -1,0 +1,421 @@
+
+#import	"/internals/numbers.typ"	:   number
+#import	"/internals/units.typ"		:   length
+#import	"/internals/color.typ"		:   color
+#import	"/internals/utils.typ"		:   *
+
+#let	valid-preset(
+	valid				: ( ),
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	if value.trim() in valid {
+		return value.trim()
+	}
+
+	let	expectations			=   valid.join(
+		last				:  "”, or “",
+		"”, “",
+	)
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"expected “{expected}”, found {value}"
+			.replace("{expected}", expectations)
+			.replace("{value}", repr(value)),
+	)
+}
+
+
+#let	stroke-cap-preset(
+	default				:   auto,
+	types				: ( ),
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"butt",
+		"round",
+		"square",
+	),
+	default				:   default,
+	types				:   types,
+	value,
+)
+
+#let	stroke-join-preset(
+	default				:   auto,
+	types				: ( ),
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"miter",
+		"round",
+		"bevel",
+	),
+	default				:   default,
+	types				:   types,
+	value,
+)
+
+#let	stroke-dash-preset(
+	default				:   auto,
+	types				: ( ),
+	value,
+) = valid-preset(
+	valid				: ( // Built-in constants
+		"solid",
+		"dotted",
+		"densely-dotted",
+		"loosely-dotted",
+		"dashed",
+		"densely-dashed",
+		"loosely-dashed",
+		"dash-dotted",
+		"densely-dash-dotted",
+		"loosely-dash-dotted",
+	),
+	default				:   default,
+	types				:   types,
+	value,
+)
+
+#let	stroke-dash-array(
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	let	dash				=   value.map(x => {
+		if x == "dot" {
+			return x
+		}
+
+		length(default : none, x)
+	})
+
+	if dash.all(x => none != x) {
+		return dash
+	}
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"expected array of “dot” or length, found " + debug-value(value),
+	)
+}
+
+#let	stroke-dash-dict(
+	strict				:   true,
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	let	dash				= (
+		array				: ( ),
+		phase				:   0pt,
+	)
+
+	let	test				=   x => x in dash.keys()
+	let	maybe				=   value.keys().any(test)
+	let	valid				=   value.keys().all(test)
+
+	if not strict and not maybe { // Not attempting to be a dash: let it through
+		return none
+	}
+
+	if (strict or maybe) and not valid {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   value.keys(),
+				valid				:   dash.keys(),
+				repr(value),
+			),
+		)
+	}
+
+	if "array" in value {
+		dash.array			=   dash.array + stroke-dash-array(value.array)
+	}
+
+	if "phase" in value {
+		dash.phase			=   dash.phase + length(value.phase)
+	}
+
+	dash
+}
+
+#let	stroke(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.stroke,
+		std.color,
+		std.length,
+	)
+
+	if type(value) in types {
+		return std.stroke(value)
+	}
+
+
+	if type(default) in types {
+		default				=   std.stroke(default)
+	}
+
+	// An array of lengths is assumed to be the dash
+	if type(value) == array {
+		let	dash				=   stroke-dash-array(
+			default				:   default,
+			types				:   types,
+			value,
+		)
+
+		if type(dash) == array {
+			return std.stroke(dash : dash)
+		}
+
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			dash,
+		)
+	}
+
+	if type(value) == dictionary and value.len() > 0 {
+		let	keys_this			=   value.keys()
+		let	keys_valid			= (
+			"paint",
+			"thickness",
+			"dash",
+			"cap",
+			"join",
+			"miter-limit",
+		)
+
+		// A dictionary containing valid pattern parameters for keys could be the dash
+		let	dash				=   stroke-dash-dict(
+			strict				:   false,
+			default				:   default,
+			types				:   types,
+			value,
+		)
+
+		if none != dash {
+			if type(dash) == std.str {
+				panic(dash)
+			}
+
+			if type(dash) == dictionary {
+				return std.stroke(
+					dash				:   dash,
+				)
+			}
+		}
+
+		// Any other dictionary must be a whole stroke
+		if keys_this.all(x => x in keys_valid) {
+			if "paint" in value {
+				value.paint			=   color(
+					default				:   default,
+					value.paint,
+				)
+
+				if none == value.paint { // Implies default:none
+					return none
+				}
+			}
+
+			if "thickness" in value {
+				value.thickness			=   length(
+					default				:   default,
+					value.thickness,
+				)
+
+				if none == value.thickness { // Implies default:none
+					return none
+				}
+			}
+
+			if "dash" in value {
+				let	funcs				= (
+					array				:   stroke-dash-array,
+					dictionary			:   stroke-dash-dict,
+					str				:   stroke-dash-preset,
+				)
+
+				if repr(type(value.dash)) in funcs {
+					let	key				=   repr(type(value.dash))
+					let	dash				=   funcs.at(key)(
+						default				:   default,
+						types				:   types,
+						value.dash,
+					)
+
+					if none == dash { // Implies default:none
+						return none
+					}
+
+					if key != "str" and type(dash) == std.str {
+						panic(dash)
+					}
+
+					if key == "str" and dash != value.dash.trim() {
+						panic(dash)
+					}
+
+					value.dash			=   dash
+				}
+			}
+
+			if "cap" in value {
+				let	cap				=   stroke-cap-preset(
+					default				:   default,
+					types				:   types,
+					value.cap,
+				)
+
+				if none == cap { // Implies default:none
+					return none
+				}
+
+				if cap != value.cap.trim() {
+					panic(cap)
+				}
+
+				value.cap			=   cap
+			}
+
+			if "join" in value {
+				let	join				=   stroke-join-preset(
+					default				:   default,
+					types				:   types,
+					value.join,
+				)
+
+				if none == join { // Implies default:none
+					return none
+				}
+
+				if join != value.join.trim() {
+					panic(join)
+				}
+
+				value.join			=   join
+			}
+
+			if "miter-limit" in value {
+				value.miter-limit		=   number(
+					default				:   default,
+					value.miter-limit,
+				)
+
+				if none == value.miter-limit { // Implies default:none
+					return none
+				}
+			}
+
+			return std.stroke(value)
+		}
+
+
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			message-unexpected-keys(
+				found				:   keys_this,
+				valid				:   keys_valid,
+				repr(value),
+			),
+		)
+	}
+
+
+	let	panic-message			=  "could not convert to stroke: " + repr(value)
+
+	// We’ve covered full stroke definitions, as well as individual paint, thickness and dash values;
+	// an individual cap, join or miter-limit value isn’t really worth worrying about. That leaves
+	// string depictions of compound paint+length+dash declarations.
+	if type(value) != std.str {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	// Splitting on `+` and evaluating components separately catches more edge cases than one big regex,
+	// e.g. a non-ridiculous regex would probably pass `invalid + 3pt`, which would be an error.
+	// Allowing addition of multiple paints/thicknesses is a little cheeky; we can’t easily do subtraction
+	// since splitting on `-` breaks dash pattern strings.
+	let	o				= (:)
+
+	for	c in value.split("+").map(std.str.trim).filter(x => x != "") {
+		let	d				=   stroke-dash-preset(
+			default				:   none,
+			types				:  (std.str,),
+			c,
+		)
+		if none != d {
+			if "dash" in o {
+				return mild-panic(
+					default				:   default,
+					types				:   types,
+					"cannot add two stroke arrays: " + repr(value),
+				)
+			}
+
+			o.insert("dash", d)
+			continue
+		}
+
+		let	k				=   color(default : none, c)
+		if none != k {
+			o.insert(
+				"paint",
+				if "paint" in o {
+					std.color.mix(o.paint, k)
+				} else {
+					k
+				},
+			)
+			continue
+		}
+
+		let	t				=   length(default : none, c)
+		if none != t {
+			o.insert(
+				"thickness",
+				t + o.at(
+					default				:   0pt,
+					"thickness",
+				),
+			)
+			continue
+		}
+
+		// Value cannot be processed
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			panic-message,
+		)
+	}
+
+
+	if o.keys().len() > 0 {
+		return std.stroke(o)
+	}
+
+
+	return mild-panic(
+		default				:   default,
+		types				:   types,
+		panic-message,
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/stuff.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/stuff.typ
@@ -1,0 +1,178 @@
+
+#import	"/internals/numbers.typ"	as  n
+#import	"/internals/units.typ"		as  u
+#import	"/internals/alignment.typ"	as  a
+#import	"/internals/bool.typ"		as  b
+#import	"/internals/color.typ"		as  c
+#import	"/internals/direction.typ"	as  d
+#import	"/internals/relative.typ"	as  r
+#import	"/internals/stroke.typ"		as  s
+#import	"/internals/version.typ"	as  v
+#import	"/internals/utils.typ"		:   debug-value
+
+
+#let	stuff(
+	recursive			:   false,
+	arguments-collapse		:   false,
+	numbers-as			:   auto,
+	none-from			: ( ),
+	value,
+) = {
+	let	number-types			= (
+		int				:   n.int,
+		float				:   n.float,
+		decimal				:   n.decimal,
+		version				:   v.version,
+	)
+
+	assert.eq(
+		message				:  "to-stuff: “recursive” argument expected boolean, found {value}"
+							.replace("{value}", debug-value(recursive)),
+		type(recursive),
+		std.bool,
+	)
+
+	assert.eq(
+		message				:  "to-stuff: “arguments-collapse” argument expected boolean, found {value}"
+							.replace("{value}", debug-value(arguments-collapse)),
+		type(arguments-collapse),
+		std.bool,
+	)
+
+	assert(
+		message				:  "to-stuff: “numbers-as” argument expected {types}, or auto, found {value}"
+							.replace("{types}", number-types.keys().map(x => "std." + x).join(", "))
+							.replace("{value}", debug-value(numbers-as)),
+		auto == numbers-as or repr(numbers-as) in number-types,
+	)
+
+	assert.eq(
+		message				:  "to-stuff: “none-from” argument expected array of strings, found {value}"
+							.replace("{value}", debug-value(none-from)),
+		type(none-from),
+		array,
+	)
+
+	for test in none-from {
+		assert.eq(
+			message				:  "to-stuff: “none-from” values expected strings, found {val}"
+								.replace("{val}", debug-value(test)),
+			type(test),
+			std.str,
+		)
+	}
+
+
+	let	defaults			= (
+		default				:   none,
+	)
+
+	let	args				= (
+		recursive			:   recursive,
+		arguments-collapse		:   arguments-collapse,
+		numbers-as			:   numbers-as,
+		none-from			:   none-from,
+	)
+
+	if type(value) == arguments and recursive {
+		if arguments-collapse {
+			if 0 == value.named().len() {
+				return stuff(..args, value.pos())
+			}
+
+			if 0 == value.pos().len() {
+				return stuff(..args, value.named())
+			}
+		}
+
+
+		// Directly processing value.named() as a unit runs the risk of mistaking it for
+		// a valid dictionary conversion target (e.g. strokes) when we have not explicitly
+		// enabled argument-collapsing.
+		let	dict				= (:)
+
+		for (k, v) in value.named() {
+			dict.insert(k, stuff(..args, v))
+		}
+
+		return arguments(
+			..stuff(..args, value.pos()),
+			..dict,
+		)
+	}
+
+
+	if type(value) == array {
+		// Prioritise recursing into arrays over assuming they’re versions
+		if recursive {
+			return value.map(stuff.with(..args))
+		}
+
+		let	native				=   v.version(..defaults, value)
+		if none != native {
+			return native
+		}
+	}
+
+
+	if type(value) == dictionary {
+		// Prioritise assuming dictionaries are type structures over recursing into them
+		for func in(
+			a.alignment,
+			r.relative,
+			s.stroke,
+		) {
+			let	native				=   func(..defaults, value)
+			if none != native {
+				return native
+			}
+		}
+
+		if recursive {
+			return value.keys().zip(stuff(..args, value.values())).to-dict()
+		}
+	}
+
+
+	if type(value) == std.str {
+		let	trimmed				=   value.trim()
+
+		if trimmed == "auto" {
+			return auto
+		}
+
+		for from in none-from.map(lower) {
+			if lower(trimmed) == from {
+				return none
+			}
+		}
+	}
+
+
+	for func in (
+		b.bool,
+		a.alignment,
+		d.direction,
+		number-types.at(
+			default				:   n.number,
+			repr(numbers-as),
+		),
+		v.version,
+		u.angle,
+		u.fraction,
+		u.length,
+		u.ratio,
+		r.relative,
+		c.color,
+		s.stroke,
+	) {
+		let	native				=   func(..defaults, value)
+		if none != native {
+			return native
+		}
+	}
+
+
+	value
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/units.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/units.typ
@@ -1,0 +1,89 @@
+
+#import	"/internals/numbers.typ"	:   rx-quantity
+#import	"/internals/utils.typ"		:   mild-panic, neg
+
+#let	units(
+	units				: (:),
+	default				:   auto,
+	types				: ( ),
+	value,
+) = {
+	if type(value) in types {
+		return value
+	}
+
+
+	let	rx				=   regex("^" + rx-quantity + "(" + units.keys().join("|") + ")$")
+
+	if type(value) == std.str and value.trim().contains(rx) {
+		let	(_, signs, num, _, unit)	=   value.trim().matches(rx).first().captures
+
+		return std.float(num) * units.at(unit) * neg(signs)
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		"could not convert to " + repr(types.first()) + ": " + repr(value),
+	)
+}
+
+
+#let	length(
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"pt"				:   1pt,
+		"mm"				:   1mm,
+		"cm"				:   1cm,
+		"in"				:   1in,
+		"em"				:   1em,
+	),
+	default				:   default,
+	types				:  (std.length,),
+	value,
+)
+
+
+#let	fraction(
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"fr"				:   1fr,
+	),
+	default				:   default,
+	types				:  (std.fraction,),
+	value,
+)
+
+
+#let	ratio(
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"%"				:   1%,
+	),
+	default				:   default,
+	types				:  (std.ratio,),
+	value,
+)
+
+
+#let	angle(
+	default				:   auto,
+	value,
+) = units(
+	units				: (
+		"deg"				:   1deg,
+		"rad"				:   1rad,
+	),
+	default				:   default,
+	types				:  (std.angle,),
+	value,
+)
+
+

--- a/packages/preview/to-stuff/1.0.0/internals/utils.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/utils.typ
@@ -1,0 +1,70 @@
+
+#let	neg(signs)			=   signs.split("").filter(x => x == "-").map(x => -1).product(default : 1)
+
+#let	list-predefined(type)		=   dictionary(std).pairs().filter(
+						x => std.type(x.last()) == type
+					).to-dict()
+
+#let	message-unexpected-keys(
+	found				: ( ),
+	valid				: ( ),
+	value,
+) = {
+	return "unexpected key/s “" + found.filter(x => x not in valid).join(
+		last				:  "”, and “",
+		"”, “",
+	) + "”; valid keys are “" + valid.join(
+		last				:  "”, and “",
+		"”, “",
+	) + "” in " + value
+}
+
+#let	type-unabbreviate(value)	= {
+	let	type-str			=   type(value)
+
+	if type-str == type {
+		type-str			=   repr(value)
+	} else {
+		type-str			=   repr(type-str)
+	}
+
+	(
+		bool				:  "boolean",
+		int				:  "integer",
+		str				:  "string",
+	).at(
+		default				:   type-str,
+		type-str,
+	)
+}
+
+#let	debug-value(value)		= {
+	if value in (none, auto, true, false) or type(value) in (array, dictionary) {
+		repr(value)
+	} else {
+		(
+			type-unabbreviate(value),
+			repr(value),
+		).join(" ")
+	}
+}
+
+#let	mild-panic(
+	default				:   auto,
+	types				: ( ),
+	message,
+) = {
+	if auto != default {
+		assert(
+			message				:  "to-stuff: “default” argument expected {types}, or none, found {value}"
+								.replace("{types}", types.map(type-unabbreviate).join(", "))
+								.replace("{value}", debug-value(default)),
+			none == default or type(default) in types,
+		)
+
+		return default
+	}
+
+	panic(message)
+}
+

--- a/packages/preview/to-stuff/1.0.0/internals/version.typ
+++ b/packages/preview/to-stuff/1.0.0/internals/version.typ
@@ -1,0 +1,75 @@
+
+#import	"/internals/numbers.typ"	:   int
+#import	"/internals/utils.typ"		:   mild-panic, debug-value
+
+#let	version(
+	default				:   auto,
+	value,
+) = {
+	let	types				= (
+		std.version,
+	)
+
+	if type(value) in types {
+		return value
+	}
+
+
+	let	panic-message			=  "could not convert to version: " + repr(value)
+
+	if type(value) == array and value.len() > 0 {
+		return std.version(..value.flatten().map(version.with(
+			default				:   default,
+		)).map(array))
+	}
+
+	if type(value) == std.int {
+		if value < 0 {
+			return mild-panic(
+				default				:   default,
+				types				:   types,
+				"number must be greater than zero: " + repr(value),
+			)
+		}
+
+		return std.version(value)
+	}
+
+	if type(value) == std.str {
+		if regex("^\s*\d+(\s*\.\s*\d+)*\s*$") not in value {
+			return mild-panic(
+				default				:   default,
+				types				:   types,
+				panic-message,
+			)
+		}
+
+
+		let	to-int				=   int.with(
+			default				:   default,
+		)
+
+		return if "." in value {
+			std.version(..value.split(".").map(to-int))
+		} else {
+			std.version(to-int(value))
+		}
+	}
+
+	// Special error message in case of non-integer numbers
+	if type(value) in (std.float, std.decimal) {
+		return mild-panic(
+			default				:   default,
+			types				:   types,
+			"expected integer, array or version, found " + debug-value(value)
+		)
+	}
+
+
+	mild-panic(
+		default				:   default,
+		types				:   types,
+		panic-message,
+	)
+}
+

--- a/packages/preview/to-stuff/1.0.0/typst.toml
+++ b/packages/preview/to-stuff/1.0.0/typst.toml
@@ -1,0 +1,36 @@
+[package]
+name				= 'to-stuff'
+version				= '1.0.0'
+compiler			= '0.13.1'
+repository			= 'https://codeberg.org/boondoc/typst-to-stuff'
+license				= 'BSD-3-Clause'
+entrypoint			= 'exports.typ'
+description			= 'Safely parse string values into native data types: lengths, alignments, colors and more.'
+authors				= [
+	'Nik Mennega',
+]
+categories			= [
+	'scripting',
+	'utility',
+]
+keywords			= [
+	'string',
+	'parse',
+	'parsing',
+	'alignment',
+	'angle',
+	'bool',
+	'color',
+	'decimal',
+	'direction',
+	'float',
+	'fraction',
+	'int',
+	'number',
+	'length',
+	'ratio',
+	'relative',
+	'stroke',
+	'version',
+]
+


### PR DESCRIPTION
I am submitting
- [x] an update for a package

Description:

### Changed

- **Breaking:** less strict, more natural handling of integers and floats.
	- Integer and float conversions may accept integers, floats or decimals.
	- Float and generic number conversions may default to an integer, float, or decimal.
	- Integer conversions may only default to an integer (or `none`).

### Added

- New general-purpose function `stuff` to guess most appropriate conversion.
- Expose new conversions:
	- bool
	- decimal
	- version

### Removed

- **Breaking:** remove deprecated `quiet` argument from all direct conversion functions.
- **Breaking:** remove deprecated `scalar` function alias.
