### PR TITLE
merman:0.1.0

### DIFF
--- a/packages/preview/merman/0.1.0/LICENSE
+++ b/packages/preview/merman/0.1.0/LICENSE
@@ -1,0 +1,4 @@
+This project is dual-licensed under either of:
+
+- Apache License, Version 2.0 (`LICENSE-APACHE`)
+- MIT License (`LICENSE-MIT`)

--- a/packages/preview/merman/0.1.0/LICENSE-APACHE
+++ b/packages/preview/merman/0.1.0/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/preview/merman/0.1.0/LICENSE-MIT
+++ b/packages/preview/merman/0.1.0/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 merman contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/merman/0.1.0/README.md
+++ b/packages/preview/merman/0.1.0/README.md
@@ -1,0 +1,152 @@
+# merman
+
+Render Mermaid diagrams in Typst with the `merman` Rust renderer.
+
+`merman` embeds a WebAssembly plugin so Typst documents can render Mermaid diagrams directly during compilation while reusing the parser, layout, and SVG renderer from the broader `merman` project.
+
+## Quick Start
+
+Import `mermaid` and pass a Mermaid source string:
+
+```typst
+#import "@preview/merman:0.1.0": mermaid
+
+#mermaid("
+flowchart TD
+  A[Write Mermaid] --> B[Render with merman]
+  B --> C[Embed SVG in Typst]
+")
+```
+
+## Version Mapping
+
+| Typst package | merman source version | Notes |
+| --- | --- | --- |
+| `0.1.0` | `0.8.0-alpha.1` | Initial Typst package built from the 0.8 alpha line; Typst package versions advance independently. |
+
+## Examples
+
+- [basic.typ](examples/basic.typ): minimal `#mermaid(...)` usage.
+- [raw-block.typ](examples/raw-block.typ): document-wide Mermaid fences with `show-mermaid-blocks`.
+- [options.typ](examples/options.typ): themes, stable ids, `mermaid-result`, SVG export, and placeholder errors.
+- [print.typ](examples/print.typ): print-friendly white-background output.
+- [presentation.typ](examples/presentation.typ): dark slide-sized output.
+- [svg-export.typ](examples/svg-export.typ): raw SVG and structured render payloads.
+
+## Raw Blocks
+
+Use `show-mermaid-blocks` with Typst's `raw.where` selector:
+
+~~~typst
+#import "@preview/merman:0.1.0": show-mermaid-blocks
+
+#show raw.where(lang: "mermaid"): show-mermaid-blocks(width: 100%)
+
+```mermaid
+flowchart LR
+  Source --> Typst
+  Typst --> SVG
+```
+~~~
+
+Avoid setting a fixed `id` in a document-wide raw-block show rule unless the document has only one Mermaid block; otherwise multiple diagrams will share the same SVG id.
+
+## API
+
+### `mermaid(source, ..)`
+
+Renders a Mermaid string or raw block as an SVG image.
+
+Common parameters:
+
+- `width`, `height`, `fit`, `alt`: forwarded to Typst's `image`.
+- `scale`: wraps the rendered image with Typst `scale`; accepts ratios such as `120%` or numbers such as `1.2`.
+- `pipeline`: `"resvg-safe"` by default for Typst rendering. Use `"parity"` when you need Mermaid-like SVG DOM output, or `"readable"` for inline SVG inspection.
+- `id`: stable SVG root id. `diagram-id` is kept as the lower-level binding name and takes precedence when both are provided.
+- `background`: SVG root background color, mapped to `svg.root_background_color`.
+- `theme-name`: Mermaid theme name, such as `"base"` or `"dark"`.
+- `theme`: Mermaid `themeVariables`.
+- `site-config`: full Mermaid site config object.
+- `host-theme`: merman host theme profile object.
+- `layout`: full binding layout object. This overrides the shorthand layout parameters below.
+- `text-measurer`: `"vendored"` or `"deterministic"`.
+- `viewport-width`, `viewport-height`, `math-renderer`: layout shorthands.
+- `scoped-css`, `css-override-policy`, `drop-native-duplicate-fallbacks`: advanced SVG post-processing shorthands.
+- `fixed-today`: `YYYY-MM-DD` for date-sensitive diagrams.
+- `error-mode`: `"panic"` by default. Use `"placeholder"` or `"text"` to show diagram errors in the document instead of failing the Typst compile. These modes handle structured errors returned by `merman`; missing wasm files, Typst plugin loading failures, invalid `error-mode` values, and SVG image decoding failures still fail the Typst compile.
+- `options`: escape hatch; when present, it is passed through directly to the Rust binding options and overrides shorthand parameters.
+
+### `mermaid-svg(source, ..)`
+
+Returns the rendered SVG as a string instead of embedding it as an image.
+
+### `mermaid-result(source, ..)`
+
+Returns a structured render payload:
+
+```typst
+#let result = mermaid-result("flowchart TD\nA --> B")
+#if result.ok {
+  result.svg
+} else {
+  result.message
+}
+```
+
+### `validate-mermaid(source, ..)`
+
+Returns the validation payload produced by the Rust bindings:
+
+```typst
+#let result = validate-mermaid("flowchart TD\nA --> B")
+#result.code_name
+```
+
+### `mermaid-raw(block, ..)`
+
+Convenience wrapper for raw blocks. This is intended for `#show raw.where(...)` rules.
+
+### `show-mermaid-blocks(..)`
+
+Returns a raw block show handler. This is the shortest way to enable Mermaid fences across a Typst document:
+
+```typst
+#show raw.where(lang: "mermaid"): show-mermaid-blocks(width: 100%)
+```
+
+## Development
+
+The Typst package uses its own version track and is not locked to the Rust crate version.
+
+Build the default minimal Typst package locally:
+
+```sh
+cargo run -p xtask -- build-typst-package
+```
+
+The package is written to:
+
+```sh
+dist/typst/merman/0.1.0
+```
+
+For local `@preview` smoke tests, copy the built package under a preview namespace package path and compile with `--package-path`:
+
+```sh
+mkdir -p target/typst-preview/preview/merman
+cp -R dist/typst/merman/0.1.0 target/typst-preview/preview/merman/
+typst compile --package-path target/typst-preview \
+  dist/typst/merman/0.1.0/examples/options.typ \
+  target/typst-smoke/options.pdf
+```
+
+The default package build is size-oriented and does not enable `core-full`. Build the larger full-config/full-sanitization artifact with:
+
+```sh
+cargo run -p xtask -- build-typst-package --profile full
+```
+
+## Current Limits
+
+- Output is SVG embedded through Typst `image`; diagrams are not Typst-native vector elements.
+- Browser-only Mermaid interactions such as script callbacks and popup behavior are not expected to work in static Typst output.

--- a/packages/preview/merman/0.1.0/examples/basic.typ
+++ b/packages/preview/merman/0.1.0/examples/basic.typ
@@ -1,0 +1,12 @@
+#import "@preview/merman:0.1.0": mermaid
+
+= merman Typst Basic Example
+
+#mermaid(
+  "flowchart TD
+    A[Write Mermaid] --> B[Render with merman]
+    B --> C[Embed SVG in Typst]
+  ",
+  width: 90%,
+  alt: "A flowchart rendered by merman",
+)

--- a/packages/preview/merman/0.1.0/examples/options.typ
+++ b/packages/preview/merman/0.1.0/examples/options.typ
@@ -1,0 +1,50 @@
+#import "@preview/merman:0.1.0": mermaid, mermaid-result, mermaid-svg, validate-mermaid
+
+= merman Typst Options Example
+
+#let source = "flowchart LR
+  Start([Start]) --> Parse[Parse]
+  Parse --> Render[Render SVG]
+  Render --> Done([Done])
+"
+
+#let validation = validate-mermaid(source)
+#let render-result = mermaid-result(source, pipeline: "readable")
+#let failed-result = mermaid-result("flowchart TD\n  A -->")
+
+Validation result: `#validation.code_name`
+
+Render result: `#render-result.code_name`
+
+Failed render result: `#failed-result.code_name`
+
+#mermaid(
+  source,
+  width: 95%,
+  id: "typst-options-demo",
+  scale: 1.05,
+  background: "#f8fafc",
+  theme-name: "base",
+  theme: (
+    primaryColor: "#0f172a",
+    primaryTextColor: "#f8fafc",
+    primaryBorderColor: "#38bdf8",
+    lineColor: "#475569",
+  ),
+)
+
+#let svg = mermaid-svg(source, pipeline: "readable")
+
+SVG starts with:
+
+```text
+#svg.slice(0, 80)
+```
+
+Diagram errors can stay visible in drafts:
+
+#mermaid(
+  "flowchart TD\n  A -->",
+  width: 95%,
+  error-mode: "placeholder",
+)

--- a/packages/preview/merman/0.1.0/examples/presentation.typ
+++ b/packages/preview/merman/0.1.0/examples/presentation.typ
@@ -1,0 +1,53 @@
+#import "@preview/merman:0.1.0": mermaid, show-mermaid-blocks
+
+#set page(width: 16cm, height: 9cm, margin: 12mm, fill: rgb("#111827"))
+#set text(fill: rgb("#e5e7eb"))
+
+#show raw.where(lang: "mermaid"): show-mermaid-blocks(
+  width: 100%,
+  background: "#111827",
+  host-theme: (
+    appearance: "dark",
+    roles: (
+      canvas: "#111827",
+      surface: "#1f2937",
+      text: "#e5e7eb",
+      border: "#475569",
+      line: "#93c5fd",
+      actor_background: "#1f2937",
+      actor_border: "#60a5fa",
+      actor_text: "#e5e7eb",
+    ),
+  ),
+)
+
+= Mermaid in slides
+
+#mermaid(
+  "flowchart LR
+    Idea[Idea] --> Demo[Typst slide]
+    Demo --> PDF[PDF deck]
+  ",
+  width: 100%,
+  background: "#111827",
+  host-theme: (
+    appearance: "dark",
+    roles: (
+      canvas: "#111827",
+      surface: "#1f2937",
+      text: "#e5e7eb",
+      border: "#475569",
+      line: "#93c5fd",
+    ),
+  ),
+)
+
+```mermaid
+sequenceDiagram
+  participant Speaker
+  participant Typst
+  participant merman
+  Speaker->>Typst: Write a Mermaid fence
+  Typst->>merman: Render with the dark host theme
+  merman-->>Typst: Return slide-safe SVG
+```

--- a/packages/preview/merman/0.1.0/examples/print.typ
+++ b/packages/preview/merman/0.1.0/examples/print.typ
@@ -1,0 +1,24 @@
+#import "@preview/merman:0.1.0": mermaid
+
+#set page(paper: "a4", margin: 20mm)
+
+= Print-friendly Mermaid
+
+#let source = "flowchart TD
+  Draft[Draft Mermaid] --> Review[Review in Typst]
+  Review --> Export[Export PDF]
+"
+
+#mermaid(
+  source,
+  width: 100%,
+  background: "#ffffff",
+  theme-name: "base",
+  theme: (
+    primaryColor: "#f8fafc",
+    primaryTextColor: "#111827",
+    primaryBorderColor: "#2563eb",
+    lineColor: "#475569",
+  ),
+  alt: "A print-friendly flowchart rendered by merman",
+)

--- a/packages/preview/merman/0.1.0/examples/raw-block.typ
+++ b/packages/preview/merman/0.1.0/examples/raw-block.typ
@@ -1,0 +1,19 @@
+#import "@preview/merman:0.1.0": show-mermaid-blocks
+
+#show raw.where(lang: "mermaid"): show-mermaid-blocks(
+  width: 100%,
+  pipeline: "readable",
+  alt: "A Mermaid diagram rendered from a raw block",
+)
+
+= merman Typst Raw Block Example
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Typst
+  participant merman
+  User->>Typst: Write a mermaid raw block
+  Typst->>merman: Call the wasm plugin
+  merman-->>Typst: Return SVG bytes
+```

--- a/packages/preview/merman/0.1.0/examples/svg-export.typ
+++ b/packages/preview/merman/0.1.0/examples/svg-export.typ
@@ -1,0 +1,25 @@
+#import "@preview/merman:0.1.0": mermaid-result, mermaid-svg
+
+= SVG export
+
+#let source = "flowchart LR
+  Source[Mermaid source] --> SVG[SVG string]
+  Source --> Result[Structured result]
+"
+
+#let svg = mermaid-svg(source, pipeline: "readable")
+#let result = mermaid-result(source, pipeline: "readable")
+
+Render result: `#result.code_name`
+
+SVG starts with:
+
+```text
+#svg.slice(0, 120)
+```
+
+Result SVG starts with:
+
+```text
+#result.svg.slice(0, 120)
+```

--- a/packages/preview/merman/0.1.0/lib.typ
+++ b/packages/preview/merman/0.1.0/lib.typ
@@ -1,0 +1,729 @@
+#let _merman-plugin = plugin("merman_typst_plugin.wasm")
+
+#let _source-text(source) = {
+  if type(source) == str {
+    source
+  } else {
+    source.text
+  }
+}
+
+#let _theme-name(theme-name, base-theme) = {
+  if theme-name != none {
+    theme-name
+  } else {
+    base-theme
+  }
+}
+
+#let _diagram-id(id, diagram-id) = {
+  if diagram-id != none {
+    diagram-id
+  } else {
+    id
+  }
+}
+
+#let _layout-options(
+  layout,
+  text-measurer,
+  math-renderer,
+  viewport-width,
+  viewport-height,
+) = {
+  if layout != none {
+    layout
+  } else {
+    (
+      viewport_width: viewport-width,
+      viewport_height: viewport-height,
+      text_measurer: text-measurer,
+      math_renderer: math-renderer,
+    )
+  }
+}
+
+#let _scale-factor(factor) = {
+  if type(factor) == int or type(factor) == float {
+    factor * 100%
+  } else {
+    factor
+  }
+}
+
+#let _scaled(body, factor) = {
+  if factor == none {
+    body
+  } else {
+    scale(x: _scale-factor(factor), y: _scale-factor(factor), reflow: true, body)
+  }
+}
+
+#let _error-message(result) = {
+  if result.message == none {
+    result.code_name
+  } else {
+    result.message
+  }
+}
+
+#let _diagram-error(result, error-mode, width) = {
+  if error-mode == "text" {
+    text(fill: rgb("#b91c1c"))[merman: #_error-message(result)]
+  } else if error-mode == "placeholder" {
+    block(
+      width: width,
+      inset: 8pt,
+      fill: rgb("#fff7f7"),
+      stroke: rgb("#ef4444"),
+    )[
+      #strong[merman diagram error]
+      #linebreak()
+      #_error-message(result)
+    ]
+  } else {
+    panic("unknown merman error-mode: " + str(error-mode))
+  }
+}
+
+#let _site-config(site-config, theme, theme-name, base-theme) = {
+  if site-config != none {
+    site-config
+  } else if theme != none or theme-name != none or base-theme != none {
+    (
+      theme: _theme-name(theme-name, base-theme),
+      themeVariables: theme,
+    )
+  } else {
+    none
+  }
+}
+
+#let _binding-options(
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  if options != none {
+    options
+  } else {
+    (
+      fixed_today: fixed-today,
+      fixed_local_offset_minutes: fixed-local-offset-minutes,
+      site_config: _site-config(site-config, theme, theme-name, base-theme),
+      host_theme: host-theme,
+      layout: _layout-options(
+        layout,
+        text-measurer,
+        math-renderer,
+        viewport-width,
+        viewport-height,
+      ),
+      svg: (
+        diagram_id: _diagram-id(id, diagram-id),
+        pipeline: pipeline,
+        root_background_color: background,
+        scoped_css: scoped-css,
+        css_override_policy: css-override-policy,
+        drop_native_duplicate_fallbacks: drop-native-duplicate-fallbacks,
+      ),
+    )
+  }
+}
+
+#let _options-bytes(options) = {
+  if options == none {
+    bytes(())
+  } else {
+    bytes(json.encode(options))
+  }
+}
+
+#let _render-svg-bytes(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  let source-text = _source-text(source)
+  let binding-options = _binding-options(
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+  )
+
+  let result = json(_merman-plugin.render_svg_json(bytes(source-text), _options-bytes(binding-options)))
+  if result.ok {
+    bytes(result.svg)
+  } else {
+    panic(_error-message(result))
+  }
+}
+
+#let _render-svg-result(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  let source-text = _source-text(source)
+  let binding-options = _binding-options(
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+  )
+
+  json(_merman-plugin.render_svg_json(bytes(source-text), _options-bytes(binding-options)))
+}
+
+#let _validate-payload(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  let source-text = _source-text(source)
+  let binding-options = _binding-options(
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+  )
+
+  json(_merman-plugin.validate_json(bytes(source-text), _options-bytes(binding-options)))
+}
+
+#let _mermaid-image(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+  width: auto,
+  height: auto,
+  fit: "contain",
+  alt: none,
+) = {
+  image(
+    _render-svg-bytes(
+      source,
+      options: options,
+      site-config: site-config,
+      host-theme: host-theme,
+      theme: theme,
+      theme-name: theme-name,
+      base-theme: base-theme,
+      pipeline: pipeline,
+      id: id,
+      diagram-id: diagram-id,
+      background: background,
+      layout: layout,
+      scoped-css: scoped-css,
+      css-override-policy: css-override-policy,
+      drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+      text-measurer: text-measurer,
+      math-renderer: math-renderer,
+      viewport-width: viewport-width,
+      viewport-height: viewport-height,
+      fixed-today: fixed-today,
+      fixed-local-offset-minutes: fixed-local-offset-minutes,
+    ),
+    format: "svg",
+    width: width,
+    height: height,
+    fit: fit,
+    alt: alt,
+  )
+}
+
+#let mermaid-svg(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  str(_render-svg-bytes(
+    source,
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+  ))
+}
+
+#let mermaid-result(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  _render-svg-result(
+    source,
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+  )
+}
+
+#let validate-mermaid(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+) = {
+  _validate-payload(
+    source,
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+  )
+}
+
+#let mermaid(
+  source,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+  width: auto,
+  height: auto,
+  fit: "contain",
+  scale: none,
+  alt: none,
+  error-mode: "panic",
+) = {
+  if error-mode == "panic" {
+    _scaled(_mermaid-image(
+      source,
+      options: options,
+      site-config: site-config,
+      host-theme: host-theme,
+      theme: theme,
+      theme-name: theme-name,
+      base-theme: base-theme,
+      pipeline: pipeline,
+      id: id,
+      diagram-id: diagram-id,
+      background: background,
+      layout: layout,
+      scoped-css: scoped-css,
+      css-override-policy: css-override-policy,
+      drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+      text-measurer: text-measurer,
+      math-renderer: math-renderer,
+      viewport-width: viewport-width,
+      viewport-height: viewport-height,
+      fixed-today: fixed-today,
+      fixed-local-offset-minutes: fixed-local-offset-minutes,
+      width: width,
+      height: height,
+      fit: fit,
+      alt: alt,
+    ), scale)
+  } else {
+    let result = _render-svg-result(
+      source,
+      options: options,
+      site-config: site-config,
+      host-theme: host-theme,
+      theme: theme,
+      theme-name: theme-name,
+      base-theme: base-theme,
+      pipeline: pipeline,
+      id: id,
+      diagram-id: diagram-id,
+      background: background,
+      layout: layout,
+      scoped-css: scoped-css,
+      css-override-policy: css-override-policy,
+      drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+      text-measurer: text-measurer,
+      math-renderer: math-renderer,
+      viewport-width: viewport-width,
+      viewport-height: viewport-height,
+      fixed-today: fixed-today,
+      fixed-local-offset-minutes: fixed-local-offset-minutes,
+    )
+
+    if result.ok {
+      _scaled(image(
+        bytes(result.svg),
+        format: "svg",
+        width: width,
+        height: height,
+        fit: fit,
+        alt: alt,
+      ), scale)
+    } else {
+      _diagram-error(result, error-mode, width)
+    }
+  }
+}
+
+#let mermaid-raw(
+  block,
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+  width: auto,
+  height: auto,
+  fit: "contain",
+  scale: none,
+  alt: none,
+  error-mode: "panic",
+) = {
+  mermaid(
+    block.text,
+    options: options,
+    site-config: site-config,
+    host-theme: host-theme,
+    theme: theme,
+    theme-name: theme-name,
+    base-theme: base-theme,
+    pipeline: pipeline,
+    id: id,
+    diagram-id: diagram-id,
+    background: background,
+    layout: layout,
+    scoped-css: scoped-css,
+    css-override-policy: css-override-policy,
+    drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+    text-measurer: text-measurer,
+    math-renderer: math-renderer,
+    viewport-width: viewport-width,
+    viewport-height: viewport-height,
+    fixed-today: fixed-today,
+    fixed-local-offset-minutes: fixed-local-offset-minutes,
+    width: width,
+    height: height,
+    fit: fit,
+    scale: scale,
+    alt: alt,
+    error-mode: error-mode,
+  )
+}
+
+#let show-mermaid-blocks(
+  options: none,
+  site-config: none,
+  host-theme: none,
+  theme: none,
+  theme-name: none,
+  base-theme: none,
+  pipeline: "resvg-safe",
+  id: none,
+  diagram-id: none,
+  background: none,
+  layout: none,
+  scoped-css: none,
+  css-override-policy: none,
+  drop-native-duplicate-fallbacks: none,
+  text-measurer: none,
+  math-renderer: none,
+  viewport-width: none,
+  viewport-height: none,
+  fixed-today: none,
+  fixed-local-offset-minutes: none,
+  width: 100%,
+  height: auto,
+  fit: "contain",
+  scale: none,
+  alt: none,
+  error-mode: "placeholder",
+) = block => mermaid-raw(
+  block,
+  options: options,
+  site-config: site-config,
+  host-theme: host-theme,
+  theme: theme,
+  theme-name: theme-name,
+  base-theme: base-theme,
+  pipeline: pipeline,
+  id: id,
+  diagram-id: diagram-id,
+  background: background,
+  layout: layout,
+  scoped-css: scoped-css,
+  css-override-policy: css-override-policy,
+  drop-native-duplicate-fallbacks: drop-native-duplicate-fallbacks,
+  text-measurer: text-measurer,
+  math-renderer: math-renderer,
+  viewport-width: viewport-width,
+  viewport-height: viewport-height,
+  fixed-today: fixed-today,
+  fixed-local-offset-minutes: fixed-local-offset-minutes,
+  width: width,
+  height: height,
+  fit: fit,
+  scale: scale,
+  alt: alt,
+  error-mode: error-mode,
+)

--- a/packages/preview/merman/0.1.0/typst.toml
+++ b/packages/preview/merman/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "merman"
+version = "0.1.0"
+entrypoint = "lib.typ"
+compiler = "0.14.0"
+authors = ["Mingzhen Zhuang <@Latias94>"]
+license = "MIT OR Apache-2.0"
+description = "Render Mermaid diagrams as SVG."
+repository = "https://github.com/Latias94/merman"
+keywords = ["mermaid", "diagrams", "svg", "wasm"]
+categories = ["visualization", "integration"]
+exclude = ["examples/**"]


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description: [Merman](https://github.com/Latias94/merman) renders Mermaid diagram source to SVG from Typst through a WebAssembly plugin. It is useful for documents, slides, and reports that need flowcharts, sequence diagrams, and other Mermaid diagrams without leaving the Typst workflow.

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
  - Explanation: The name `merman` is a related mythological word and a small nod to Mermaid, but it is not the canonical or most descriptive package name such as `mermaid` or `mermaid-renderer`.
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

Local checks run:
- `cargo test -p merman-typst-plugin`
- `cargo run -p xtask -- build-typst-package`
- `cargo run -p xtask -- profile-budget check-wasm --profile typst-wasm --wasm target/wasm32-unknown-unknown/wasm-size/merman_typst_plugin.wasm`
- compiled all package examples with `typst compile --package-path packages`
- compiled an external `@preview/merman:0.1.0` import smoke document
- `cargo build --release --manifest-path bundler/Cargo.toml`
- `bundler/target/release/bundler`