### PR TITLE
abntyp:0.1.5

### DIFF
--- a/packages/preview/abntyp/0.1.5/LICENSE
+++ b/packages/preview/abntyp/0.1.5/LICENSE
@@ -1,0 +1,45 @@
+MIT License
+
+Copyright (c) 2024-2026 Esdras
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+THIRD-PARTY LICENSES AND CREDITS
+================================
+
+abnTeX2 Inspiration
+-------------------
+This project was inspired by abnTeX2 (https://github.com/abntex/abntex2),
+a LaTeX package for formatting documents according to ABNT standards,
+maintained by Lauro César Araujo and the abnTeX2 team under the
+LaTeX Project Public License (LPPL).
+
+CSL ABNT Style
+--------------
+The file src/references/abnt.csl was adapted from the csl-abnt project
+(https://github.com/virgilinojuca/csl-abnt), which is released under
+CC0 1.0 Universal (Public Domain Dedication) by @virgilinojuca and @AAguiarCAM.
+
+Touying
+-------
+The slides template uses the Touying package for Typst presentations.
+Touying is available under its own license at:
+https://github.com/touying-typ/touying

--- a/packages/preview/abntyp/0.1.5/README.md
+++ b/packages/preview/abntyp/0.1.5/README.md
@@ -1,0 +1,307 @@
+# ABNTyp
+
+**ABNTyp** is a [Typst](https://typst.app) package for formatting Brazilian academic and technical documents in compliance with ABNT standards (Associação Brasileira de Normas Técnicas). It provides templates for theses, dissertations, articles, reports, books, and more — with author-date and numeric citation systems per NBR 10520:2023.
+
+---
+
+**ABNTyp — Base Normativa Typst** — Formatação de documentos técnicos e científicos brasileiros conforme normas ABNT para [Typst](https://typst.app).
+
+---
+
+## Sobre o Projeto
+
+O **ABNTyp** é um pacote Typst para formatação de documentos acadêmicos e técnicos em conformidade com as normas da ABNT (Associação Brasileira de Normas Técnicas).
+
+Este projeto está sendo escrito via Claude Code a partir das minhas orientações, fruto da experiência que tive com LaTeX, que começou na USP de São Carlos em 2000, por influência
+principalmente do Prof. Dr. Sadao Massago. Também neste período e local pude conhecer o Prof. Dr. Miguel Vinicius Santini Frasson, um dos criadores do abnTeX original, bem como o famoso texto "Uma introdução ao LaTeX 2e" do Prof. Dr. Lenimar Nunes Andrade. Anos mais tarde, tive contato com o excelente abnTeX2, do Prof. Dr. Lauro César Araujo. Todo o mérito deste projeto, portanto, deve ir para as pessoas e projetos citados acima, bem como criadores e comunidades do LaTeX e do Typst.
+
+O objetivo aqui é adaptar o projeto abnTeX2 para o caso do Typst, para servir como base na disciplina "Software Livre para Edição de Textos Matemáticos" em 2026 (Núcleo Livre). A parte de matemática, caixas decorativas e ambientes de teoremas — adaptada do trabalho do Prof. Lenimar — está no pacote companheiro **[FerrMat](https://github.com/3sdras/ferrmat)**.
+
+---
+
+## Instalação
+
+### Via Typst Universe (recomendado)
+
+```typst
+#import "@preview/abntyp:0.1.5": *
+```
+
+### Via Clone Local
+
+```bash
+git clone https://github.com/3sdras/abntyp.git
+```
+
+```typst
+#import "caminho/para/abntyp/lib.typ": *
+```
+
+---
+
+## Documentação
+
+A documentação do ABNTyp consiste nos seguintes arquivos:
+
+### Manuais
+
+| Arquivo                | Descrição                           |
+| ---------------------- | ----------------------------------- |
+| [`docs/manual-implementacao.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/docs/manual-implementacao.typ) | Manual completo da classe e funções |
+| [`docs/guia-rapido.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/docs/guia-rapido.typ) | Guia rápido para começar |
+
+### Modelos Canônicos (Exemplos)
+
+| Arquivo                                 | Tipo de Documento                           | Norma Principal |
+| --------------------------------------- | ------------------------------------------- | --------------- |
+| [`examples/tcc-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/tcc-exemplo.typ) | Trabalho acadêmico (tese, dissertação, TCC) | NBR 14724:2024 |
+| [`examples/artigo-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/artigo-exemplo.typ) | Artigo científico | NBR 6022:2018 |
+| [`examples/relatorio-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/relatorio-exemplo.typ) | Relatório técnico | NBR 10719:2015 |
+| [`examples/projeto-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/projeto-exemplo.typ) | Projeto de pesquisa | NBR 15287:2025 |
+| [`examples/livro-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/livro-exemplo.typ) | Livro | NBR 6029:2023 |
+| [`examples/periodico-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/periodico-exemplo.typ) | Publicação periódica | NBR 6021:2015 |
+| [`examples/poster-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/poster-exemplo.typ) | Pôster científico | NBR 15437:2006 |
+| [`examples/slides-defesa-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/slides-defesa-exemplo.typ) | Apresentação de slides | Boas práticas\* |
+| [`examples/citacao-numerica-exemplo.typ`](https://github.com/3sdras/abntyp/blob/v0.1.5/examples/citacao-numerica-exemplo.typ) | Sistema numérico de citações | NBR 10520:2023 |
+
+_\* A ABNT não possui norma específica para slides. O template segue boas práticas acadêmicas._
+
+### Arquivos de Referência
+
+| Arquivo                    | Descrição                             |
+| -------------------------- | ------------------------------------- |
+| `examples/referencias.bib` | Referências bibliográficas de exemplo |
+| `src/references/abnt.csl`  | Estilo CSL para formatação ABNT       |
+
+---
+
+## Normas Implementadas
+
+O ABNTyp implementa as seguintes normas ABNT (versões atualizadas):
+
+### Normas Principais
+
+| Norma     | Título                                    | Versão   |
+| --------- | ----------------------------------------- | -------- |
+| NBR 14724 | Trabalhos acadêmicos — Apresentação       | **2024** |
+| NBR 6023  | Referências — Elaboração                  | **2018** |
+| NBR 10520 | Citações em documentos — Apresentação     | **2023** |
+| NBR 6024  | Numeração progressiva das seções          | 2012     |
+| NBR 6027  | Sumário — Apresentação                    | 2012     |
+| NBR 6028  | Resumo, resenha e recensão — Apresentação | **2021** |
+
+### Normas para Tipos Específicos
+
+| Norma     | Título                                                      | Versão   |
+| --------- | ----------------------------------------------------------- | -------- |
+| NBR 6022  | Artigo em publicação periódica técnica e/ou científica      | 2018     |
+| NBR 6021  | Publicação periódica técnica e/ou científica — Apresentação | 2015     |
+| NBR 6029  | Livros e folhetos — Apresentação                            | **2023** |
+| NBR 10719 | Relatório técnico e/ou científico — Apresentação            | 2015     |
+| NBR 15287 | Projeto de pesquisa — Apresentação                          | **2025** |
+| NBR 15437 | Pôsteres técnicos e científicos — Apresentação              | 2006     |
+
+### Normas Complementares
+
+| Norma        | Título                                                     | Versão   |
+| ------------ | ---------------------------------------------------------- | -------- |
+| NBR 6032     | Abreviação de títulos de periódicos e publicações seriadas | 1989     |
+| NBR 6033     | Ordem alfabética                                           | 1989     |
+| NBR 6034     | Índice — Apresentação                                      | 2004     |
+| NBR 6025     | Revisão de originais e provas                              | 2002     |
+| NBR 12225    | Lombada — Apresentação                                     | 2004     |
+| NBR 5892     | Representação de datas e horas                             | **2019** |
+| NBR ISO 2108 | ISBN (Número Padrão Internacional de Livro)                | 2006     |
+| NBR 10525    | ISSN (Número Padrão Internacional para Publicação Seriada) | 2005     |
+| IBGE         | Normas de apresentação tabular                             | 1993     |
+
+---
+
+## Uso Rápido
+
+### Trabalho Acadêmico (Tese/Dissertação/TCC)
+
+```typst
+#import "@preview/abntyp:0.1.5": *
+
+// Metadados do trabalho — definidos uma única vez
+#show: dados.with(
+  titulo: "Uma proposta de pacote para normas ABNT em Typst",
+  subtitulo: [Material didático para a disciplina \ Software Livre para Edição de Textos Matemáticos],
+  autor: "Cláudio Código",
+  instituicao: "Universidade Federal de Jataí",
+  faculdade: "Instituto de Ciências Exatas e Tecnológicas",
+  programa: "PROFMAT - Programa de Mestrado Profissional em Rede em Matemática",
+  local: "Jataí",
+  ano: 2026,
+  natureza: "Dissertação",
+  objetivo: "Obtenção do título de Mestre",
+  orientador: "Prof. Dr. Esdras Teixeira Costa",
+  palavras-chave: ("ABNT", "Typst", "formatação"),
+  palavras-chave-en: ("ABNT", "Typst", "formatting"),
+)
+
+// Formatação ABNT (fonte, margens, headings, etc.)
+#show: normas-abnt.with(
+  fonte: "Times New Roman",
+  // arquivo-bibliografia: "referencias.bib",
+)
+
+// Elementos pré-textuais — dados vêm automaticamente
+#capa()
+#folha-rosto()
+#resumo[Texto do resumo...]
+#resumo-en[Abstract text...]
+#sumario()
+
+// Elementos textuais
+= Introdução
+
+Texto da introdução...
+
+= Desenvolvimento
+
+Texto do desenvolvimento...
+```
+
+### Artigo Científico
+
+```typst
+#import "@preview/abntyp:0.1.5": *
+
+#show: artigo.with(
+  titulo: "Título do Artigo",
+  autores: (
+    (name: "Autor Um", affiliation: "Universidade A", email: "autor1@exemplo.com"),
+    (name: "Autor Dois", affiliation: "Universidade B", email: "autor2@exemplo.com"),
+  ),
+  resumo: [Resumo em português...],
+  palavras-chave: ("palavra 1", "palavra 2"),
+  resumo-en: [Abstract in English...],
+  palavras-chave-en: ("keyword 1", "keyword 2"),
+)
+
+= Introdução
+
+Texto do artigo...
+```
+
+---
+
+## Sistemas de Citação
+
+O ABNTyp suporta os dois sistemas de chamada permitidos pela NBR 10520:2023:
+
+### Sistema Autor-Data (padrão)
+
+```typst
+// Citação entre parênteses
+#citar("Silva", 2023, pagina: 45)  // (SILVA, 2023, p. 45)
+
+// Autor no texto
+#citar-autor("Silva", 2023)  // Silva (2023)
+
+// Citação direta curta (posicional ou nomeada)
+#citacao-curta("Silva", 2023, 45)[Texto da citação]
+
+// Citação direta longa (recuo de 4cm, fonte 10pt)
+#citacao-longa("Silva", 2023, "45-46")[
+  Texto longo da citação com mais de três linhas...
+]
+
+// Citação sem referência (apenas aspas)
+#citacao-curta()[sic transit gloria mundi]
+```
+
+### Sistema Numérico
+
+O sistema numérico foi implementado inspirado no `abntex2-num.bst` do abnTeX2.
+
+```typst
+#import "@preview/abntyp:0.1.5": *
+
+#show: citacao-num-config
+
+O resultado foi positivo #citar-num("silva2023", pagina: 45).
+Outros autores #citar-num-multiplos(("santos2022", "costa2021")) confirmam.
+
+#bibliografia-numerica((
+  ("silva2023", [SILVA, J. *Título*. São Paulo: Editora, 2023.]),
+  ("santos2022", [SANTOS, M. Artigo. *Revista*, v. 1, 2022.]),
+))
+```
+
+**Nota:** Conforme NBR 10520:2023, o sistema numérico NÃO pode ser usado quando houver notas de rodapé.
+
+---
+
+## Aliases (nomes curtos)
+
+Todas as funções principais possuem aliases curtos. Ambas as formas são equivalentes — use a que preferir:
+
+| Função completa | Alias |
+| --- | --- |
+| `citacao-curta` | `ccurta` |
+| `citacao-longa` | `clonga` |
+| `citar-autor` | `cautor` |
+| `citar-indireto` | `cindireto` |
+| `citar-apud` | `capud` |
+| `citar-multiplos` | `cmultiplos` |
+| `citar-etal` | `cetal` |
+| `citar-entidade` | `centidade` |
+| `citar-titulo` | `ctitulo` |
+| `folha-rosto` | `rosto` |
+| `ficha-catalografica` | `ficha` |
+| `dedicatoria` | `dedica` |
+| `agradecimentos` | `agradece` |
+| `lista-siglas` | `siglas` |
+| `lista-simbolos` | `simbolos` |
+| `interpolacao` | `interp` |
+| `grifo-nosso` | `gnosso` |
+| `grifo-do-autor` | `gautor` |
+| `citar-num` | `cnum` |
+| `citar-num-linha` | `cnlinha` |
+| `citar-num-multiplos` | `cnmultiplos` |
+| `citar-num-apud` | `cnapud` |
+| `citacao-num-curta` | `cncurta` |
+| `citacao-num-longa` | `cnlonga` |
+| `bibliografia-numerica` | `bibnum` |
+
+---
+
+## Licença
+
+Este projeto é distribuído sob a licença **MIT**.
+
+O arquivo `abnt.csl` foi adaptado do projeto [csl-abnt](https://github.com/virgilinojuca/csl-abnt) (CC0/domínio público) por @virgilinojuca e @AAguiarCAM.
+
+---
+
+## Créditos e Agradecimentos
+
+Este projeto é quase um fork do **[abnTeX2](https://github.com/abntex/abntex2)**, o pacote LaTeX para formatação de documentos conforme normas ABNT, mantido por Lauro César Araujo e a equipe abnTeX2.
+
+A estrutura de documentação, os modelos canônicos de exemplos, e várias decisões de design são simples "ports" do excelente trabalho do abnTeX2, que há mais de uma década auxilia a comunidade acadêmica brasileira na produção de documentos em conformidade com as normas ABNT.
+
+Agradecemos especialmente:
+
+- **Lauro César Araujo** e a **equipe abnTeX2** - pelo trabalho pioneiro e contínua manutenção do abnTeX2
+- **Gerald Weber, Miguel Frasson, Leslie H. Watter** e demais integrantes do projeto abnTeX original
+- A **comunidade abnTeX** no Google Groups pelas discussões e contribuições
+
+### Recursos Utilizados
+
+- **Typst** - Sistema de tipografia moderno (https://typst.app)
+- **csl-abnt** - Estilo CSL para ABNT por @virgilinojuca e @AAguiarCAM
+- **Touying** - Pacote Typst para apresentações
+
+---
+
+## Suporte
+
+- **Issues:** https://github.com/3sdras/abntyp/issues
+- **Discussões:** https://github.com/3sdras/abntyp/discussions
+
+---
+
+_ABNTyp — Base Normativa Typst. Documentos técnicos e científicos brasileiros em Typst, compatíveis com as normas ABNT._

--- a/packages/preview/abntyp/0.1.5/lib.typ
+++ b/packages/preview/abntyp/0.1.5/lib.typ
@@ -1,0 +1,92 @@
+// ============================================================================
+// ABNTyp - ABNTyp Base Normativa Typst
+// ============================================================================
+//
+// Copyright (c) 2024-2026 Esdras
+// Licenca: MIT
+//
+// Este projeto foi inspirado no abnTeX2 (https://github.com/abntex/abntex2),
+// o excelente pacote LaTeX para formatacao de documentos conforme normas ABNT,
+// mantido por Lauro Cesar Araujo e a equipe abnTeX2.
+//
+// A estrutura de documentacao, os modelos canonicos de exemplos, e varias
+// decisoes de design foram influenciadas pelo trabalho do abnTeX2.
+//
+// Agradecimentos especiais:
+// - Lauro Cesar Araujo e equipe abnTeX2
+// - Gerald Weber, Miguel Frasson, Leslie H. Watter (abnTeX original)
+// - Sadao Massago
+// - Comunidade abnTeX
+//
+// ============================================================================
+// Baseado nas normas ABNT atualizadas (2018-2025)
+//
+// Normas implementadas:
+// - NBR 14724:2024 - Trabalhos academicos
+// - NBR 6023:2018 - Referencias
+// - NBR 10520:2023 - Citacoes (sistemas autor-data E numerico - ambos permitidos)
+// - NBR 6024:2012 - Numeracao progressiva
+// - NBR 6027:2012 - Sumario
+// - NBR 6028:2021 - Resumo
+// - NBR 6022:2018 - Artigo em publicacao periodica
+// - NBR 6021:2015 - Publicacao periodica
+// - NBR 6029:2023 - Livros e folhetos
+// - NBR 6032:1989 - Abreviacao de titulos
+// - NBR 6033:1989 - Ordem alfabetica
+// - NBR 6025:2002 - Revisao de originais e provas
+// - NBR 5892:2019 - Representacao de datas e horas
+// - NBR 15287:2025 - Projeto de pesquisa
+// - NBR 6034:2004 - Indice
+// - NBR 12225:2004 - Lombada
+// - NBR 10719:2015 - Relatorio tecnico
+// - NBR 15437:2006 - Posteres tecnicos e cientificos
+// - NBR ISO 2108:2006 - ISBN
+// - NBR 10525:2005 - ISSN
+// - IBGE 1993 - Normas de apresentacao tabular
+//
+// NOTA: Apresentacoes de slides NAO possuem norma ABNT especifica.
+// O template de slides (slides.typ) segue boas praticas academicas,
+// mas NAO representa exigencia normativa. As unicas normas ABNT
+// aplicaveis em slides sao NBR 6023 (referencias) e NBR 10520 (citacoes),
+// quando houver citacoes na apresentacao.
+
+// Core
+// setup.typ é usado internamente pelos templates — não exportado para o usuário
+#import "src/core/page.typ": *
+#import "src/core/fonts.typ": *
+#import "src/core/spacing.typ": *
+#import "src/core/sorting.typ": *
+#import "src/core/proofreading.typ": *
+#import "src/core/identifiers.typ": *
+#import "src/core/dates.typ": *  // NBR 5892:2019 - Representacao de datas e horas
+#import "src/core/metadata.typ": dados
+
+// Elementos pre-textuais
+#import "src/elements/cover.typ": *
+#import "src/elements/title-page.typ": *
+#import "src/elements/abstract.typ": *
+#import "src/elements/toc.typ": *
+#import "src/elements/index.typ": *  // NBR 6034:2004 - Indice
+#import "src/elements/spine.typ": *  // NBR 12225:2004 - Lombada
+
+// Elementos textuais
+#import "src/text/headings.typ": *
+#import "src/text/quotes.typ": *
+#import "src/text/figures.typ": *
+#import "src/text/tables.typ": *
+
+// Referencias
+#import "src/references/citation.typ": *        // Sistema autor-data (NBR 10520:2023)
+#import "src/references/numeric.typ": *         // Sistema numerico (NBR 10520:2023) - inspirado no abntex2-num.bst
+#import "src/references/bibliography.typ": *
+#import "src/references/abbreviations.typ": *  // NBR 6032:1989 - Abreviacao de titulos
+
+// Templates
+#import "src/templates/thesis.typ": *
+#import "src/templates/article.typ": *
+#import "src/templates/periodical.typ": *  // NBR 6021:2015 - Publicacao periodica
+#import "src/templates/book.typ": *  // NBR 6029:2023 - Livros e folhetos
+#import "src/templates/research-project.typ": *  // NBR 15287:2025 - Projeto de pesquisa
+#import "src/templates/technical-report.typ": *  // NBR 10719:2015 - Relatorio tecnico
+#import "src/templates/poster.typ": *  // NBR 15437:2006 - Posteres tecnicos e cientificos
+#import "src/templates/slides.typ": *  // Apresentacoes de slides (SEM NORMA ABNT - boas praticas)

--- a/packages/preview/abntyp/0.1.5/src/core/dates.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/dates.typ
@@ -1,0 +1,273 @@
+// Representacao de datas e horas conforme NBR 5892:2019
+// Informacao e documentacao - Representacao e formatos de tempo
+
+/// Abreviaturas dos meses conforme NBR 5892:2019
+/// Nota: "maio" nao e abreviado
+#let month-abbreviations = (
+  "janeiro": "jan.",
+  "fevereiro": "fev.",
+  "marco": "mar.",
+  "abril": "abr.",
+  "maio": "maio",
+  "junho": "jun.",
+  "julho": "jul.",
+  "agosto": "ago.",
+  "setembro": "set.",
+  "outubro": "out.",
+  "novembro": "nov.",
+  "dezembro": "dez.",
+)
+
+/// Nomes dos meses em portugues (array indexado por 1)
+/// Usar: month-names.at(mes - 1)
+#let month-names = (
+  "janeiro",    // 1
+  "fevereiro",  // 2
+  "marco",      // 3
+  "abril",      // 4
+  "maio",       // 5
+  "junho",      // 6
+  "julho",      // 7
+  "agosto",     // 8
+  "setembro",   // 9
+  "outubro",    // 10
+  "novembro",   // 11
+  "dezembro",   // 12
+)
+
+/// Nomes dos meses por extenso (para uso formal)
+#let month-names-full = month-names
+
+/// Dias da semana por extenso (array indexado por 0 = domingo)
+#let weekday-names = (
+  "domingo",        // 0
+  "segunda-feira",  // 1
+  "terca-feira",    // 2
+  "quarta-feira",   // 3
+  "quinta-feira",   // 4
+  "sexta-feira",    // 5
+  "sabado",         // 6
+)
+
+/// Dias da semana abreviados (formato 1)
+#let weekday-abbrev1 = (
+  "dom.",      // 0
+  "2a feira",  // 1
+  "3a feira",  // 2
+  "4a feira",  // 3
+  "5a feira",  // 4
+  "6a feira",  // 5
+  "sab.",      // 6
+)
+
+/// Dias da semana abreviados (formato 2)
+#let weekday-abbrev2 = (
+  "dom.",  // 0
+  "seg.",  // 1
+  "ter.",  // 2
+  "qua.",  // 3
+  "qui.",  // 4
+  "sex.",  // 5
+  "sab.",  // 6
+)
+
+/// Retorna o nome do mes por extenso
+/// - month: numero do mes (1-12)
+#let get-month-name(month) = {
+  month-names.at(month - 1)
+}
+
+/// Retorna a abreviatura do mes
+/// - month: numero do mes (1-12) ou nome do mes
+#let get-month-abbrev(month) = {
+  if type(month) == int {
+    let name = month-names.at(month - 1)
+    month-abbreviations.at(name)
+  } else {
+    month-abbreviations.at(lower(month))
+  }
+}
+
+/// Formata data no formato misto (padrao para texto corrido)
+/// Exemplo: "4 de abril de 2018"
+/// - day: dia
+/// - month: mes (numero 1-12)
+/// - year: ano
+#let format-date-mixed(day, month, year) = {
+  let month-name = month-names.at(month - 1)
+  [#day de #month-name de #year]
+}
+
+/// Formata data no formato resumido
+/// Exemplo: "4 abr. 2018"
+/// - day: dia
+/// - month: mes (numero 1-12)
+/// - year: ano
+#let format-date-short(day, month, year) = {
+  let month-name = month-names.at(month - 1)
+  let abbrev = month-abbreviations.at(month-name)
+  [#day #abbrev #year]
+}
+
+/// Formata data no formato numerico
+/// Exemplo: "04.04.2018"
+/// - day: dia
+/// - month: mes (numero 1-12)
+/// - year: ano
+#let format-date-numeric(day, month, year) = {
+  let d = if day < 10 { "0" + str(day) } else { str(day) }
+  let m = if month < 10 { "0" + str(month) } else { str(month) }
+  [#d.#m.#year]
+}
+
+/// Formata data a partir de um objeto datetime
+/// - date: objeto datetime do Typst
+/// - format: "mixed" (padrao), "short", "numeric"
+#let format-date(date, format: "mixed") = {
+  let day = date.day()
+  let month = date.month()
+  let year = date.year()
+
+  if format == "mixed" {
+    format-date-mixed(day, month, year)
+  } else if format == "short" {
+    format-date-short(day, month, year)
+  } else if format == "numeric" {
+    format-date-numeric(day, month, year)
+  } else {
+    format-date-mixed(day, month, year)
+  }
+}
+
+/// Formata hora no formato abreviado
+/// Exemplo: "8 h 21 min 32 s"
+/// - hour: hora
+/// - minute: minuto
+/// - second: segundo (opcional)
+#let format-time-abbrev(hour, minute, second: none) = {
+  if second != none {
+    [#hour h #minute min #second s]
+  } else {
+    [#hour h #minute min]
+  }
+}
+
+/// Formata hora no formato digital
+/// Exemplo: "08:21:32"
+/// - hour: hora
+/// - minute: minuto
+/// - second: segundo (opcional)
+#let format-time-digital(hour, minute, second: none) = {
+  let h = if hour < 10 { "0" + str(hour) } else { str(hour) }
+  let m = if minute < 10 { "0" + str(minute) } else { str(minute) }
+
+  if second != none {
+    let s = if second < 10 { "0" + str(second) } else { str(second) }
+    [#h:#m:#s]
+  } else {
+    [#h:#m]
+  }
+}
+
+/// Formata hora a partir de um objeto datetime
+/// - time: objeto datetime do Typst
+/// - format: "abbrev" (padrao), "digital"
+/// - show-seconds: mostrar segundos (default: true)
+#let format-time(time, format: "abbrev", show-seconds: true) = {
+  let hour = time.hour()
+  let minute = time.minute()
+  let second = if show-seconds { time.second() } else { none }
+
+  if format == "abbrev" {
+    format-time-abbrev(hour, minute, second: second)
+  } else if format == "digital" {
+    format-time-digital(hour, minute, second: second)
+  } else {
+    format-time-abbrev(hour, minute, second: second)
+  }
+}
+
+/// Converte numero para romano (1-21)
+#let to-roman(num) = {
+  let roman-numerals = (
+    "I", "II", "III", "IV", "V",
+    "VI", "VII", "VIII", "IX", "X",
+    "XI", "XII", "XIII", "XIV", "XV",
+    "XVI", "XVII", "XVIII", "XIX", "XX",
+    "XXI",
+  )
+  if num >= 1 and num <= 21 {
+    roman-numerals.at(num - 1)
+  } else {
+    str(num)
+  }
+}
+
+/// Formata seculo em algarismos romanos
+/// Exemplo: "seculo XX" ou "sec. XX"
+/// - century: numero do seculo
+/// - abbreviated: usar forma abreviada
+#let format-century(century, abbreviated: false) = {
+  let roman = to-roman(century)
+
+  if abbreviated {
+    [sec. #roman]
+  } else {
+    [seculo #roman]
+  }
+}
+
+/// Formata milenio em algarismos romanos
+/// Exemplo: "II milenio a.C." ou "II mil. a.C."
+/// - millennium: numero do milenio
+/// - bc: antes da era crista (default: false)
+/// - abbreviated: usar forma abreviada
+#let format-millennium(millennium, bc: false, abbreviated: false) = {
+  let roman = to-roman(millennium)
+  let suffix = if bc { " a.C." } else { "" }
+
+  if abbreviated {
+    [#roman mil.#suffix]
+  } else {
+    [#roman milenio#suffix]
+  }
+}
+
+/// Formata intervalo de meses para legendas bibliograficas
+/// Exemplo: "jan./mar." ou "janeiro/marco"
+/// - start-month: mes inicial (1-12)
+/// - end-month: mes final (1-12)
+/// - abbreviated: usar forma abreviada (default: true)
+#let format-month-range(start-month, end-month, abbreviated: true) = {
+  if abbreviated {
+    let start = get-month-abbrev(start-month)
+    let end = get-month-abbrev(end-month)
+    [#start/#end]
+  } else {
+    let start = month-names.at(start-month - 1)
+    let end = month-names.at(end-month - 1)
+    [#start/#end]
+  }
+}
+
+/// Data de acesso para documentos eletronicos
+/// Formato: "Acesso em: 15 jan. 2026."
+/// - day: dia
+/// - month: mes (1-12)
+/// - year: ano
+#let access-date(day, month, year) = {
+  let abbrev = get-month-abbrev(month)
+  [Acesso em: #day #abbrev #year.]
+}
+
+/// Data de acesso a partir de datetime
+/// - date: objeto datetime
+#let access-date-from(date) = {
+  access-date(date.day(), date.month(), date.year())
+}
+
+/// Data atual formatada
+/// - format: "mixed", "short", "numeric"
+#let today(format: "mixed") = {
+  format-date(datetime.today(), format: format)
+}

--- a/packages/preview/abntyp/0.1.5/src/core/fonts.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/fonts.typ
@@ -1,0 +1,87 @@
+// Configuração de fontes conforme NBR 14724:2024
+// Fonte: Arial ou Times New Roman
+// Tamanho: 12pt para texto, menor para citações longas, notas, legendas
+
+/// Fontes recomendadas pela ABNT
+#let abnt-fonts = (
+  serif: "Times New Roman",
+  sans: "Arial",
+)
+
+/// Tamanhos de fonte ABNT
+#let abnt-font-sizes = (
+  normal: 12pt,        // Texto principal
+  small: 10pt,         // Citações longas, notas de rodapé, legendas, fontes
+  footnote: 10pt,      // Notas de rodapé
+  caption: 10pt,       // Legendas de figuras e tabelas (pode ser 10 ou 11)
+  cover-title: 14pt,   // Título na capa (pode variar)
+  cover-author: 12pt,  // Nome do autor na capa
+)
+
+/// Aplica fonte padrão ABNT (Times New Roman, 12pt)
+#let abnt-font-setup(fonte-familia: "Times New Roman") = {
+  set text(
+    font: fonte-familia,
+    size: 12pt,
+    lang: "pt",
+    region: "BR",
+  )
+}
+
+/// Aplica configuração completa de fonte ABNT
+#let with-abnt-font(fonte-familia: "Times New Roman", body) = {
+  set text(
+    font: fonte-familia,
+    size: 12pt,
+    lang: "pt",
+    region: "BR",
+  )
+  body
+}
+
+/// Texto em tamanho reduzido (10pt) para citações longas, notas, legendas, fontes
+#let small-text(body) = {
+  text(size: 10pt, body)
+}
+
+/// Texto para notas de rodapé (alias de small-text)
+#let footnote-text = small-text
+
+/// Texto para legendas (alias de small-text)
+#let caption-text = small-text
+
+/// Configura notas de rodapé conforme ABNT
+/// - Separadas do texto por espaço simples e filete de 5 cm
+/// - Fonte tamanho 10
+/// - Alinhadas à margem esquerda
+#let abnt-footnote-setup() = {
+  set footnote.entry(
+    separator: line(length: 5cm, stroke: 0.5pt),
+    gap: 0.5em,
+  )
+}
+
+// === Atalhos de formatação inline ===
+
+/// Sublinhado — wrapper de #underline
+/// Exemplo: #sub[texto sublinhado]
+#let sub(body) = underline(body)
+
+/// Riscado — wrapper de #strike
+/// Exemplo: #risc[texto riscado]
+#let risc(body) = strike(body)
+
+/// Versalete — primeira letra em tamanho normal, restante em caixa alta 0.8em
+/// Requer string: #caps("Texto em Versalete")
+/// Com content (#caps[...]) cai em smallcaps nativo
+#let caps(texto) = {
+  if type(texto) == str {
+    let chars = texto.clusters()
+    if chars.len() > 0 {
+      chars.first()
+      text(size: 0.8em, upper(chars.slice(1).join()))
+    }
+  } else {
+    smallcaps(texto)
+  }
+}

--- a/packages/preview/abntyp/0.1.5/src/core/identifiers.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/identifiers.typ
@@ -1,0 +1,506 @@
+// Identificadores padrao internacionais conforme normas ABNT
+// NBR ISO 2108:2006 - ISBN
+// NBR 10525:2005 - ISSN
+
+// ============================================================================
+// ISBN - Numero Padrao Internacional de Livro (NBR ISO 2108:2006)
+// ============================================================================
+
+/// Calcula digito verificador do ISBN-13 usando modulo 10
+///
+/// Algoritmo:
+/// 1. Multiplicar cada um dos 12 primeiros digitos alternadamente por 1 e 3
+/// 2. Somar todos os produtos
+/// 3. Dividir a soma por 10 e obter o resto
+/// 4. Subtrair o resto de 10 (se resto = 0, digito = 0)
+///
+/// Parametros:
+/// - digits: string com os 12 primeiros digitos do ISBN (sem o digito verificador)
+///
+/// Retorna: digito verificador (string "0"-"9")
+///
+/// Exemplo:
+/// ```typst
+/// #isbn-check-digit("978011000222") // Retorna "4"
+/// ```
+#let isbn-check-digit(digits) = {
+  // Remove caracteres nao numericos
+  let clean = digits.replace(regex("[^0-9]"), "")
+
+  if clean.len() < 12 {
+    return none
+  }
+
+  // Pega apenas os 12 primeiros digitos
+  let d = clean.slice(0, 12)
+
+  // Calcula soma ponderada
+  let sum = 0
+  for i in range(12) {
+    let digit = int(d.at(i))
+    let weight = if calc.rem(i, 2) == 0 { 1 } else { 3 }
+    sum += digit * weight
+  }
+
+  // Calcula digito verificador
+  let remainder = calc.rem(sum, 10)
+  let check = if remainder == 0 { 0 } else { 10 - remainder }
+
+  str(check)
+}
+
+/// Valida ISBN-13 (verifica digito verificador)
+///
+/// Parametros:
+/// - isbn: ISBN completo (pode incluir hifens)
+///
+/// Retorna: true se valido, false se invalido
+///
+/// Exemplo:
+/// ```typst
+/// #validate-isbn("978-0-11-000222-4") // true
+/// #validate-isbn("978-0-11-000222-5") // false
+/// ```
+#let validate-isbn(isbn) = {
+  // Remove hifens e espacos
+  let clean = isbn.replace(regex("[^0-9]"), "")
+
+  if clean.len() != 13 {
+    return false
+  }
+
+  let calculated = isbn-check-digit(clean.slice(0, 12))
+  let provided = clean.at(12)
+
+  calculated == provided
+}
+
+/// Valida ISBN-10 (formato antigo)
+///
+/// Algoritmo modulo 11:
+/// 1. Multiplicar cada digito por peso decrescente (10, 9, 8, ..., 2)
+/// 2. Somar produtos
+/// 3. Resto da divisao por 11 deve ser 0
+///
+/// Parametros:
+/// - isbn: ISBN-10 (pode usar X como digito verificador)
+///
+/// Retorna: true se valido
+#let validate-isbn10(isbn) = {
+  let clean = isbn.replace(regex("[^0-9Xx]"), "")
+
+  if clean.len() != 10 {
+    return false
+  }
+
+  let sum = 0
+  for i in range(10) {
+    let char = clean.at(i)
+    let digit = if char == "X" or char == "x" { 10 } else { int(char) }
+    let weight = 10 - i
+    sum += digit * weight
+  }
+
+  calc.rem(sum, 11) == 0
+}
+
+/// Converte ISBN-10 para ISBN-13
+///
+/// Parametros:
+/// - isbn10: ISBN de 10 digitos
+///
+/// Retorna: ISBN-13 formatado
+///
+/// Exemplo:
+/// ```typst
+/// #isbn10-to-isbn13("0-393-04002-X") // "978-0-393-04002-9"
+/// ```
+#let isbn10-to-isbn13(isbn10) = {
+  // Remove formatacao
+  let clean = isbn10.replace(regex("[^0-9Xx]"), "")
+
+  if clean.len() != 10 {
+    return none
+  }
+
+  // Pega os 9 primeiros digitos (ignora digito verificador antigo)
+  let base = "978" + clean.slice(0, 9)
+
+  // Calcula novo digito verificador
+  let check = isbn-check-digit(base)
+
+  // Formata ISBN-13
+  base + check
+}
+
+/// Formata ISBN com hifens
+///
+/// Parametros:
+/// - isbn: ISBN sem formatacao (13 digitos)
+/// - group: codigo do grupo de registro (ex: "85" para Brasil)
+/// - registrant-len: tamanho do elemento registrante
+/// - publication-len: tamanho do elemento publicacao
+///
+/// Retorna: ISBN formatado com hifens
+///
+/// Nota: A estrutura do ISBN varia por editora. Esta funcao oferece
+/// formatacao basica. Para formatacao precisa, consulte a agencia ISBN.
+///
+/// Exemplo:
+/// ```typst
+/// #format-isbn("9788577777770", group: "85", registrant-len: 4, publication-len: 4)
+/// // "978-85-7777-7777-0"
+/// ```
+#let format-isbn(isbn, group: none, registrant-len: 4, publication-len: 4) = {
+  let clean = isbn.replace(regex("[^0-9]"), "")
+
+  if clean.len() != 13 {
+    return isbn
+  }
+
+  // Estrutura padrao: 978-XX-XXXX-XXXX-X
+  // Prefixo (3) - Grupo (variavel) - Registrante (variavel) - Publicacao (variavel) - Check (1)
+
+  let prefix = clean.slice(0, 3) // 978 ou 979
+
+  if group != none {
+    let group-len = group.len()
+    let start = 3
+    let g = clean.slice(start, start + group-len)
+    let r = clean.slice(start + group-len, start + group-len + registrant-len)
+    let p = clean.slice(start + group-len + registrant-len, 12)
+    let c = clean.slice(12, 13)
+
+    prefix + "-" + g + "-" + r + "-" + p + "-" + c
+  } else {
+    // Formatacao generica
+    prefix + "-" + clean.slice(3, 5) + "-" + clean.slice(5, 9) + "-" + clean.slice(9, 12) + "-" + clean.slice(12, 13)
+  }
+}
+
+/// Exibe ISBN formatado conforme NBR ISO 2108:2006
+///
+/// Parametros:
+/// - isbn: numero ISBN (com ou sem hifens)
+/// - format: formato de exibicao (true para exibir "ISBN" antes do numero)
+/// - product-form: forma do produto (opcional, ex: "brochura", "e-book")
+///
+/// Exemplo:
+/// ```typst
+/// #display-isbn("978-85-1234-567-8")
+/// // ISBN 978-85-1234-567-8
+///
+/// #display-isbn("978-85-1234-567-8", product-form: "e-book")
+/// // ISBN 978-85-1234-567-8 (e-book)
+/// ```
+#let display-isbn(isbn, format: true, product-form: none) = {
+  let result = if format { "ISBN " } else { "" }
+  result += isbn
+
+  if product-form != none {
+    result += " (" + product-form + ")"
+  }
+
+  result
+}
+
+/// Cria bloco de ISBN para ficha catalografica
+/// Exibe multiplos ISBN quando a publicacao tem diferentes formas
+///
+/// Parametros:
+/// - isbns: lista de tuplas (isbn, forma do produto)
+///
+/// Exemplo:
+/// ```typst
+/// #isbn-block((
+///   ("978-85-1234-567-8", "brochura"),
+///   ("978-85-1234-568-5", "capa dura"),
+///   ("978-85-1234-569-2", "e-book"),
+/// ))
+/// ```
+#let isbn-block(isbns) = {
+  set par(first-line-indent: 0pt)
+
+  for (isbn, form) in isbns {
+    [ISBN #isbn (#form) \ ]
+  }
+}
+
+// ============================================================================
+// ISSN - Numero Padrao Internacional para Publicacao Seriada (NBR 10525:2005)
+// ============================================================================
+
+/// Calcula digito verificador do ISSN usando modulo 11
+///
+/// Algoritmo:
+/// 1. Tomar os 7 primeiros digitos
+/// 2. Aplicar peso constante (8 a 2)
+/// 3. Multiplicar e somar
+/// 4. Dividir por 11 (modulo)
+/// 5. Subtrair resto de 11
+/// 6. Se resultado = 10, digito = X
+///
+/// Parametros:
+/// - digits: string com os 7 primeiros digitos do ISSN
+///
+/// Retorna: digito verificador (string "0"-"9" ou "X")
+///
+/// Exemplo:
+/// ```typst
+/// #issn-check-digit("0317847") // Retorna "1"
+/// ```
+#let issn-check-digit(digits) = {
+  // Remove caracteres nao numericos
+  let clean = digits.replace(regex("[^0-9]"), "")
+
+  if clean.len() < 7 {
+    return none
+  }
+
+  // Pega apenas os 7 primeiros digitos
+  let d = clean.slice(0, 7)
+
+  // Calcula soma ponderada
+  let sum = 0
+  for i in range(7) {
+    let digit = int(d.at(i))
+    let weight = 8 - i  // Pesos: 8, 7, 6, 5, 4, 3, 2
+    sum += digit * weight
+  }
+
+  // Calcula digito verificador
+  let remainder = calc.rem(sum, 11)
+  let check = if remainder == 0 { 0 } else { 11 - remainder }
+
+  if check == 10 {
+    "X"
+  } else {
+    str(check)
+  }
+}
+
+/// Valida ISSN (verifica digito verificador)
+///
+/// Parametros:
+/// - issn: ISSN completo no formato XXXX-XXXX
+///
+/// Retorna: true se valido, false se invalido
+///
+/// Exemplo:
+/// ```typst
+/// #validate-issn("0317-8471") // true
+/// #validate-issn("1050-124X") // true
+/// #validate-issn("0317-8472") // false
+/// ```
+#let validate-issn(issn) = {
+  // Remove hifens e espacos
+  let clean = issn.replace(regex("[^0-9Xx]"), "")
+
+  if clean.len() != 8 {
+    return false
+  }
+
+  let calculated = issn-check-digit(clean.slice(0, 7))
+  let provided = upper(clean.at(7))
+
+  upper(calculated) == provided
+}
+
+/// Formata ISSN com hifen
+///
+/// Parametros:
+/// - issn: ISSN sem formatacao (8 caracteres)
+///
+/// Retorna: ISSN no formato XXXX-XXXX
+///
+/// Exemplo:
+/// ```typst
+/// #format-issn("03178471") // "0317-8471"
+/// ```
+#let format-issn(issn) = {
+  let clean = issn.replace(regex("[^0-9Xx]"), "")
+
+  if clean.len() != 8 {
+    return issn
+  }
+
+  clean.slice(0, 4) + "-" + clean.slice(4, 8)
+}
+
+/// Exibe ISSN formatado conforme NBR 10525:2005
+///
+/// Parametros:
+/// - issn: numero ISSN (com ou sem hifen)
+/// - format: se true, exibe "ISSN" antes do numero
+///
+/// Exemplo:
+/// ```typst
+/// #display-issn("0317-8471")
+/// // ISSN 0317-8471
+/// ```
+#let display-issn(issn, format: true) = {
+  let formatted = format-issn(issn)
+  if format {
+    "ISSN " + formatted
+  } else {
+    formatted
+  }
+}
+
+/// Gera meta tag HTML para ISSN online
+/// Conforme NBR 10525:2005 secao 5.5
+///
+/// Parametros:
+/// - issn: numero ISSN
+///
+/// Retorna: string com meta tag HTML
+///
+/// Exemplo:
+/// ```typst
+/// #issn-meta-tag("1234-5678")
+/// // <META SCHEME="ISSN" NAME="identifier" CONTENT="1234-5678">
+/// ```
+#let issn-meta-tag(issn) = {
+  let formatted = format-issn(issn)
+  "<META SCHEME=\"ISSN\" NAME=\"identifier\" CONTENT=\"" + formatted + "\">"
+}
+
+/// Cria bloco de ISSN para ficha catalografica ou capa
+///
+/// Parametros:
+/// - issn: numero ISSN principal
+/// - title-key: titulo-chave (opcional)
+/// - support: suporte (impresso, online, CD-ROM)
+///
+/// Exemplo:
+/// ```typst
+/// #issn-block(
+///   "0100-1965",
+///   title-key: "Ciencia da Informacao (Brasilia. Online)",
+///   support: "online"
+/// )
+/// ```
+#let issn-block(issn, title-key: none, support: none) = {
+  set par(first-line-indent: 0pt)
+
+  [ISSN #format-issn(issn)]
+
+  if support != none {
+    [ (#support)]
+  }
+  [ \ ]
+
+  if title-key != none {
+    text(size: 10pt, style: "italic")[Titulo-chave: #title-key \ ]
+  }
+}
+
+/// Exibe multiplos ISSN relacionados
+/// Para publicacoes em diferentes suportes
+///
+/// Parametros:
+/// - isbns: lista de tuplas (issn, suporte)
+///
+/// Exemplo:
+/// ```typst
+/// #issn-multiple((
+///   ("0100-1965", "impresso"),
+///   ("1518-8353", "online"),
+/// ))
+/// ```
+#let issn-multiple(issns) = {
+  set par(first-line-indent: 0pt)
+
+  for (issn, support) in issns {
+    [ISSN #format-issn(issn) (#support) \ ]
+  }
+}
+
+// ============================================================================
+// Funcoes de conveniencia para referencias bibliograficas
+// ============================================================================
+
+/// Adiciona ISBN a referencia de livro
+/// Conforme NBR 6023
+///
+/// Exemplo:
+/// ```typst
+/// SILVA, Maria. *Manual de normas ABNT*. 2. ed. Sao Paulo: Atlas, 2023. #ref-isbn("978-85-1234-567-8")
+/// ```
+#let ref-isbn(isbn) = {
+  [ISBN #isbn.]
+}
+
+/// Adiciona ISSN a referencia de periodico
+/// Conforme NBR 6023
+///
+/// Exemplo:
+/// ```typst
+/// CIENCIA DA INFORMACAO. Brasilia: IBICT, 1972-. #ref-issn("0100-1965")
+/// ```
+#let ref-issn(issn) = {
+  [ISSN #format-issn(issn).]
+}
+
+// ============================================================================
+// Validacao e utilitarios
+// ============================================================================
+
+/// Verifica se string contem ISBN ou ISSN valido
+///
+/// Parametros:
+/// - text: texto a verificar
+///
+/// Retorna: dicionario com tipo ("isbn", "issn" ou none) e valor
+#let detect-identifier(text) = {
+  let clean = text.replace(regex("[^0-9Xx]"), "")
+
+  if clean.len() == 13 and validate-isbn(clean) {
+    (type: "isbn-13", value: clean, valid: true)
+  } else if clean.len() == 10 and validate-isbn10(clean) {
+    (type: "isbn-10", value: clean, valid: true)
+  } else if clean.len() == 8 and validate-issn(clean) {
+    (type: "issn", value: clean, valid: true)
+  } else {
+    (type: none, value: clean, valid: false)
+  }
+}
+
+/// Grupos de registro ISBN conhecidos
+#let isbn-groups = (
+  "0": "Paises de lingua inglesa",
+  "1": "Paises de lingua inglesa",
+  "2": "Paises de lingua francesa",
+  "3": "Paises de lingua alema",
+  "4": "Japao",
+  "5": "Russia (ex-URSS)",
+  "7": "China",
+  "65": "Brasil (antigo)",
+  "85": "Brasil",
+  "972": "Portugal",
+  "989": "Portugal",
+)
+
+/// Identifica pais/regiao pelo grupo de registro do ISBN
+#let isbn-country(isbn) = {
+  let clean = isbn.replace(regex("[^0-9]"), "")
+
+  if clean.len() < 5 {
+    return none
+  }
+
+  // Tenta identificar grupo (pode ter 1-5 digitos apos o prefixo)
+  let after-prefix = clean.slice(3)  // Pula 978/979
+
+  // Tenta grupos de tamanhos diferentes
+  for len in (3, 2, 1) {
+    if after-prefix.len() >= len {
+      let group = after-prefix.slice(0, len)
+      if group in isbn-groups {
+        return isbn-groups.at(group)
+      }
+    }
+  }
+
+  none
+}

--- a/packages/preview/abntyp/0.1.5/src/core/metadata.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/metadata.typ
@@ -1,0 +1,149 @@
+// Metadados compartilhados entre template e elementos
+//
+// Permite que dados() armazene metadados em state e que
+// elementos (capa, folha-rosto, resumo, etc.) os leiam
+// automaticamente, sem repetição.
+
+/// State global com metadados do documento
+#let abnt-metadata = state("abnt-metadata", (:))
+
+/// Resolve um parâmetro: usa o valor explícito se != none,
+/// senão busca no state, senão retorna fallback.
+/// IMPORTANTE: deve ser chamado dentro de um bloco `context`.
+#let _resolve(explicit, key, fallback: none) = {
+  if explicit != none {
+    explicit
+  } else {
+    let meta = abnt-metadata.get()
+    let val = meta.at(key, default: none)
+    if val != none { val } else { fallback }
+  }
+}
+
+// Verifica se um valor é considerado "vazio" (nada útil):
+// none, string vazia "", ou array vazio ()
+#let _vazio(val) = {
+  val == none or val == "" or val == ()
+}
+
+/// Armazena metadados do documento no state global.
+/// Os elementos (capa, folha-rosto, resumo, etc.) leem esses dados automaticamente.
+/// Valores vazios (none, "" e ()) são ignorados para não poluir o state.
+///
+/// - titulo: título do trabalho
+/// - subtitulo: subtítulo (opcional)
+/// - autor: nome do autor (singular, para templates de autor único)
+/// - autores: lista de autores (array de dicts, para templates multi-autor)
+/// - instituicao: nome da instituição
+/// - faculdade: faculdade/unidade
+/// - programa: programa de pós-graduação
+/// - local: cidade
+/// - ano: ano de depósito
+/// - natureza: natureza do trabalho
+/// - objetivo: objetivo
+/// - area: área de concentração
+/// - orientador: orientador
+/// - coorientador: coorientador (opcional)
+/// - palavras-chave: palavras-chave em português
+/// - palavras-chave-en: keywords em inglês
+#let dados(
+  titulo: none,
+  subtitulo: none,
+  autor: none,
+  autores: none,
+  instituicao: none,
+  faculdade: none,
+  programa: none,
+  local: none,
+  ano: none,
+  natureza: none,
+  objetivo: none,
+  area: none,
+  orientador: none,
+  coorientador: none,
+  palavras-chave: none,
+  palavras-chave-en: none,
+  ..args,
+) = {
+  // Filtrar valores vazios (none, "", ()) para não poluir o state
+  let campos = (
+    "titulo": titulo,
+    "subtitulo": subtitulo,
+    "autor": autor,
+    "autores": autores,
+    "instituicao": instituicao,
+    "faculdade": faculdade,
+    "programa": programa,
+    "local": local,
+    "ano": ano,
+    "natureza": natureza,
+    "objetivo": objetivo,
+    "area": area,
+    "orientador": orientador,
+    "coorientador": coorientador,
+    "palavras-chave": palavras-chave,
+    "palavras-chave-en": palavras-chave-en,
+  )
+  let meta = (:)
+  for (chave, valor) in campos {
+    if not _vazio(valor) { meta.insert(chave, valor) }
+  }
+
+  // Avisar sobre parâmetros nomeados desconhecidos (typos do usuário)
+  if args.named().len() > 0 {
+    panic("dados(): parâmetros desconhecidos: " + repr(args.named().keys()) + ". Verifique a ortografia.")
+  }
+
+  // Configurar metadados do PDF
+  if not _vazio(titulo) or not _vazio(autor) {
+    set document(
+      title: if not _vazio(titulo) { titulo } else { "" },
+      author: if not _vazio(autor) { autor } else { "" },
+    )
+  }
+
+  abnt-metadata.update(old => {
+    old + meta
+  })
+
+  // Passa body adiante (permite #show: dados.with(...))
+  // Em show rules, Typst passa o body do documento como único argumento posicional.
+  if args.pos().len() > 0 {
+    args.pos().first()
+  }
+}
+
+/// Converte valor para string de forma segura.
+/// Aceita int, float, string e content sem erro.
+/// Para content, retorna o próprio content (renderizável em Typst).
+#let _str-safe(val) = {
+  if type(val) == str { val }
+  else if type(val) == int or type(val) == float { str(val) }
+  else if val == none { "" }
+  else if type(val) == content { val }
+  else { str(val) }
+}
+
+/// Renderiza título e subtítulo no padrão ABNT.
+/// Título em maiúsculas negrito + ":" + subtítulo em tamanho diferenciado.
+///
+/// - titulo: título principal
+/// - subtitulo: subtítulo (opcional)
+/// - tamanho-titulo: tamanho da fonte do título (padrão: 14pt)
+/// - tamanho-subtitulo: tamanho da fonte do subtítulo (padrão: 14pt)
+#let _render-titulo(
+  titulo,
+  subtitulo: none,
+  tamanho-titulo: 14pt,
+  tamanho-subtitulo: 14pt,
+) = {
+  if titulo != none {
+    if subtitulo != none {
+      text(weight: "bold", size: tamanho-titulo, upper(titulo) + ":")
+      linebreak()
+      text(size: tamanho-subtitulo, subtitulo)
+    } else {
+      text(weight: "bold", size: tamanho-titulo, upper(titulo))
+    }
+  }
+}

--- a/packages/preview/abntyp/0.1.5/src/core/page.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/page.typ
@@ -1,0 +1,70 @@
+// Configuração de página conforme NBR 14724:2024
+// Formato A4 (21 cm x 29,7 cm)
+// Margens: superior e esquerda 3 cm, inferior e direita 2 cm
+
+/// Configuração padrão de página ABNT
+/// - papel: formato do papel (default: "a4")
+/// - margem-superior: margem superior (default: 3cm)
+/// - margem-inferior: margem inferior (default: 2cm)
+/// - margem-esquerda: margem esquerda (default: 3cm)
+/// - margem-direita: margem direita (default: 2cm)
+#let abnt-page-setup(
+  papel: "a4",
+  margem-superior: 3cm,
+  margem-inferior: 2cm,
+  margem-esquerda: 3cm,
+  margem-direita: 2cm,
+) = {
+  set page(
+    paper: papel,
+    margin: (
+      top: margem-superior,
+      bottom: margem-inferior,
+      left: margem-esquerda,
+      right: margem-direita,
+    ),
+  )
+}
+
+/// Aplica configuração de página ABNT ao documento
+#let with-abnt-page(body) = {
+  set page(
+    paper: "a4",
+    margin: (
+      top: 3cm,
+      bottom: 2cm,
+      left: 3cm,
+      right: 2cm,
+    ),
+  )
+  body
+}
+
+// Paginação
+// - Elementos pré-textuais: contados mas não numerados (ou algarismos romanos minúsculos)
+// - Elementos textuais e pós-textuais: algarismos arábicos, canto superior direito
+
+/// Inicia paginação em algarismos arábicos
+/// Usar no início da seção textual (Introdução)
+#let start-arabic-numbering() = {
+  counter(page).update(1)
+  set page(numbering: "1")
+}
+
+/// Configura paginação no canto superior direito (padrão ABNT)
+#let abnt-page-numbering() = {
+  set page(
+    numbering: "1",
+    number-align: top + right,
+  )
+}
+
+/// Paginação pré-textual (romanos minúsculos, opcional)
+#let pretextual-numbering() = {
+  set page(numbering: "i")
+}
+
+/// Remove numeração de página (para capa, folha de rosto)
+#let no-page-numbering() = {
+  set page(numbering: none)
+}

--- a/packages/preview/abntyp/0.1.5/src/core/proofreading.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/proofreading.typ
@@ -1,0 +1,242 @@
+// Sinais e simbolos de revisao conforme NBR 6025:2002
+// Revisao de originais e provas - Sinais convencionais
+
+/// Simbolos de correcao de texto conforme NBR 6025
+
+/// Marca texto para supressao (deletar)
+/// Exemplo: #suprimir[texto a remover]
+#let suprimir(body) = {
+  strike(body)
+}
+
+/// Marca texto para insercao
+/// Mostra onde inserir novo conteudo
+#let inserir(body) = {
+  text(fill: blue)[$arrow.b$#body]
+}
+
+/// Marca texto para substituicao
+/// Parametros:
+/// - old: texto original (sera riscado)
+/// - new: texto novo (em destaque)
+#let replace-text(old, new) = {
+  [#strike(old)#text(fill: blue, super[#new])]
+}
+
+/// Marca texto para transposicao
+/// Indica que elementos devem trocar de posicao
+#let transpose(a, b) = {
+  text(fill: rgb("#8B4513"))[$arrow.l.r$#a #sym.bar.v #b]
+}
+
+/// Indica que espaco deve ser unido (remover espaco)
+#let join-space() = {
+  text(fill: red)[$frown$]
+}
+
+/// Indica que deve separar (adicionar espaco)
+#let separate() = {
+  text(fill: red, sym.hash)
+}
+
+/// Referencia ao original - indica salto de trecho
+#let see-original() = {
+  text(fill: purple, [(v.o.)])
+}
+
+/// Indica duvida - revisor deve consultar autor
+#let duvida() = {
+  text(fill: orange, weight: "bold", [?])
+}
+
+/// Correcao indevida - manter texto original
+/// Equivale ao "stet" em ingles
+#let keep-original(body) = {
+  underline(stroke: (dash: "dotted"), body) + text(fill: green, size: 8pt, [ (vale)])
+}
+
+// === Codigos de correcao tipologica ===
+
+/// Marca texto para italico
+#let mark-italic(body) = {
+  underline(body) + text(fill: gray, size: 8pt, [ (it.)])
+}
+
+/// Marca texto para negrito
+#let mark-bold(body) = {
+  underline(stroke: 2pt, body) + text(fill: gray, size: 8pt, [ (ng)])
+}
+
+/// Marca texto para normal (remover italico/negrito)
+#let mark-normal(body) = {
+  body + text(fill: gray, size: 8pt, [ (rd)])
+}
+
+/// Marca texto para caixa alta (maiusculas)
+#let mark-uppercase(body) = {
+  body + text(fill: gray, size: 8pt, [ (CA)])
+}
+
+/// Marca texto para caixa baixa (minusculas)
+#let mark-lowercase(body) = {
+  body + text(fill: gray, size: 8pt, [ (Cb)])
+}
+
+/// Marca texto para versal-versalete
+#let mark-smallcaps(body) = {
+  body + text(fill: gray, size: 8pt, [ (Vv)])
+}
+
+// === Marcacoes de paragrafo ===
+
+/// Indica abertura de novo paragrafo
+#let new-paragraph() = {
+  text(fill: red, [#sym.chevron.r#sym.chevron.r])
+}
+
+/// Indica centralizacao
+#let center-text() = {
+  text(fill: blue, [#sym.arrow.l #sym.arrow.r])
+}
+
+/// Indica alinhamento a esquerda
+#let align-left() = {
+  text(fill: blue, sym.tack.l)
+}
+
+/// Indica alinhamento a direita
+#let align-right() = {
+  text(fill: blue, sym.tack.r)
+}
+
+// === Comentarios de revisao ===
+
+/// Adiciona comentario de revisao na margem
+/// Parametros:
+/// - body: texto principal
+/// - note: comentario do revisor
+#let review-note(body, note) = {
+  body + text(fill: red, size: 8pt, super[[#note]])
+}
+
+/// Adiciona comentario inline
+#let inline-comment(comment) = {
+  text(fill: rgb("#666666"), size: 9pt, style: "italic", [[#comment]])
+}
+
+// === Marcadores de revisao visual ===
+
+/// Destaca texto que precisa de atencao
+#let attention(body) = {
+  highlight(fill: yellow, body)
+}
+
+/// Destaca texto aprovado
+#let approved(body) = {
+  highlight(fill: rgb("#90EE90"), body)
+}
+
+/// Destaca texto com problema
+#let problem(body) = {
+  highlight(fill: rgb("#FFB6C1"), body)
+}
+
+// === Ambiente de revisao ===
+
+/// Aplica estilo de documento em revisao
+/// Adiciona margens para anotacoes e numeracao de linhas
+#let review-mode(body) = {
+  set page(
+    margin: (
+      top: 3cm,
+      bottom: 2cm,
+      left: 3cm,
+      right: 4cm, // Margem maior para anotacoes
+    ),
+  )
+  set par(
+    leading: 2em, // Espaco maior entre linhas para anotacoes
+  )
+  body
+}
+
+/// Cria caixa de anotacao na margem
+/// Para uso com place() em posicao absoluta
+#let margin-note(note) = {
+  place(
+    right,
+    dx: 3.5cm,
+    box(
+      width: 3cm,
+      stroke: 0.5pt + gray,
+      inset: 4pt,
+      radius: 2pt,
+      text(size: 8pt, fill: rgb("#333333"), note),
+    ),
+  )
+}
+
+// === Controle de alteracoes ===
+
+/// Marca texto adicionado (para controle de versoes)
+#let added(body) = {
+  text(fill: rgb("#006400"), body)
+}
+
+/// Marca texto removido (para controle de versoes)
+#let removed(body) = {
+  text(fill: rgb("#8B0000"), strike(body))
+}
+
+/// Marca texto modificado (para controle de versoes)
+#let modified(body) = {
+  text(fill: rgb("#0000CD"), body)
+}
+
+// === Legenda de simbolos ===
+
+/// Gera legenda explicativa dos simbolos de revisao
+#let review-legend() = {
+  set text(size: 10pt)
+  set par(first-line-indent: 0pt)
+
+  text(weight: "bold", [Legenda de Simbolos de Revisao (NBR 6025:2002)])
+
+  v(0.5em)
+
+  table(
+    columns: (auto, 1fr),
+    stroke: 0.5pt,
+    inset: 4pt,
+
+    [*Simbolo*], [*Significado*],
+
+    suprimir[texto], [Suprimir texto],
+    inserir[novo], [Inserir texto],
+    join-space(), [Unir (remover espaco)],
+    separate(), [Separar (adicionar espaco)],
+    see-original(), [Ver original (texto omitido)],
+    duvida(), [Duvida - consultar autor],
+    keep-original[texto], [Manter original (correcao indevida)],
+
+    mark-italic[texto], [Alterar para italico],
+    mark-bold[texto], [Alterar para negrito],
+    mark-normal[texto], [Alterar para normal],
+    mark-uppercase[texto], [Caixa alta (maiusculas)],
+    mark-lowercase[texto], [Caixa baixa (minusculas)],
+    mark-smallcaps[texto], [Versal versalete],
+
+    new-paragraph(), [Abrir paragrafo],
+    center-text(), [Centralizar],
+    align-left(), [Alinhar a esquerda],
+    align-right(), [Alinhar a direita],
+
+    attention[texto], [Atencao necessaria],
+    approved[texto], [Aprovado],
+    problem[texto], [Problema identificado],
+
+    added[texto], [Texto adicionado],
+    removed[texto], [Texto removido],
+    modified[texto], [Texto modificado],
+  )
+}

--- a/packages/preview/abntyp/0.1.5/src/core/setup.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/setup.typ
@@ -1,0 +1,153 @@
+// Configuração unificada ABNT para templates
+// Combina página, fonte, espaçamento, listas, headings, indentação e rodapé
+// em uma única chamada, eliminando duplicação entre templates.
+
+/// Aplica toda a configuração padrão ABNT ao documento.
+///
+/// Esta função reúne as regras comuns a todos os templates ABNT:
+/// - Página A4 com margens 3cm/2cm
+/// - Fonte (Times New Roman ou Arial), 12pt, português
+/// - Parágrafos com espaçamento 1,5 e recuo de 1,25cm
+/// - Listas com recuo de 2em
+/// - Headings de 5 níveis conforme NBR 6024:2012
+/// - Exclusão de indentação em headings, figuras, código, outline e termos
+/// - Notas de rodapé com filete de 5cm
+///
+/// Parâmetros:
+/// - fonte: família da fonte ("Times New Roman" ou "Arial")
+/// - headings-numeracao: numeração dos headings (padrão: "1.1")
+/// - level-1-pagebreak: se true, headings de nível 1 causam pagebreak (padrão: true)
+/// - suplemento-nivel1: texto usado em referências cruzadas para headings de nível 1
+///   (padrão: "Seção" — correto para artigos; use "Capítulo" para TCC, relatórios e livros)
+#let with-abnt-setup(
+  fonte: "Times New Roman",
+  headings-numeracao: "1.1",
+  level-1-pagebreak: true,
+  suplemento-nivel1: "Seção",
+  body,
+) = {
+  // Página A4 com margens ABNT
+  set page(
+    paper: "a4",
+    margin: (
+      top: 3cm,
+      bottom: 2cm,
+      left: 3cm,
+      right: 2cm,
+    ),
+  )
+
+  // Fonte padrão ABNT — com fallbacks para Mac, Windows, Linux e Typst.app.
+  // "New Computer Modern" é embutida no compilador Typst e funciona em qualquer ambiente.
+  let font-stack = if fonte == "Times New Roman" {
+    ("Times New Roman", "Times", "Linux Libertine", "New Computer Modern")
+  } else if fonte == "Arial" {
+    ("Arial", "Helvetica", "Liberation Sans", "Linux Biolinum", "Noto Sans")
+  } else {
+    (fonte,)
+  }
+
+  set text(
+    font: font-stack,
+    size: 12pt,
+    lang: "pt",
+    region: "BR",
+  )
+
+  // Parágrafo com espaçamento 1,5 e recuo de 1,25cm
+  set par(
+    leading: 1.5em * 0.65,
+    justify: true,
+    first-line-indent: (amount: 1.25cm, all: true),
+  )
+
+  // Listas e termos
+  set list(indent: 2em, body-indent: 0.5em)
+  set enum(indent: 2em, body-indent: 0.5em)
+  set terms(indent: 0em, hanging-indent: 2em, separator: [: ])
+
+  // Headings conforme NBR 6024:2012
+  set heading(numbering: headings-numeracao)
+  show heading: set heading(supplement: "Seção")
+  show heading.where(level: 1): set heading(supplement: suplemento-nivel1)
+
+  // Seção primária (nível 1): MAIÚSCULAS, negrito
+  show heading.where(level: 1): it => {
+    if level-1-pagebreak { pagebreak(weak: true) }
+    v(1.5em)
+    text(weight: "bold", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #upper(it.body)
+    ]
+    v(1.5em)
+  }
+
+  // Seção secundária (nível 2): MAIÚSCULAS, regular
+  show heading.where(level: 2): it => {
+    v(1.5em)
+    text(weight: "regular", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #upper(it.body)
+    ]
+    v(1.5em)
+  }
+
+  // Seção terciária (nível 3): Minúsculas, negrito
+  show heading.where(level: 3): it => {
+    v(1.5em)
+    text(weight: "bold", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #it.body
+    ]
+    v(1.5em)
+  }
+
+  // Seção quaternária (nível 4): Minúsculas, regular
+  show heading.where(level: 4): it => {
+    v(1.5em)
+    text(weight: "regular", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #it.body
+    ]
+    v(1.5em)
+  }
+
+  // Seção quinária (nível 5): Minúsculas, itálico
+  show heading.where(level: 5): it => {
+    v(1.5em)
+    text(weight: "regular", style: "italic", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #it.body
+    ]
+    v(1.5em)
+  }
+
+  // Exclusão de indentação em containers que não devem ser indentados
+  show heading: set par(first-line-indent: 0pt)
+  show figure: set par(first-line-indent: 0pt)
+  show raw.where(block: true): set par(first-line-indent: 0pt)
+  show outline: set par(first-line-indent: 0pt)
+  show terms: set par(first-line-indent: 0pt)
+
+  // Notas de rodapé com filete de 5cm
+  set footnote.entry(
+    separator: line(length: 5cm, stroke: 0.5pt),
+  )
+
+  body
+}

--- a/packages/preview/abntyp/0.1.5/src/core/sorting.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/sorting.typ
@@ -1,0 +1,344 @@
+// Ordenacao alfabetica conforme NBR 6033:1989
+// Criterios de aplicacao da ordem alfabetica em listas, indices, catalogos, bibliografias
+
+/// Artigos definidos por idioma (nao considerar na ordenacao)
+#let definite-articles = (
+  // Alemao
+  "der", "die", "das",
+  // Espanhol
+  "el", "la", "lo", "los", "las",
+  // Frances
+  "le", "la", "l'", "les",
+  // Ingles
+  "the",
+  // Italiano
+  "il", "lo", "l'", "la", "gli", "gl'", "i", "le",
+  // Portugues
+  "o", "a", "os", "as",
+)
+
+/// Artigos indefinidos por idioma (nao considerar na ordenacao)
+#let indefinite-articles = (
+  // Alemao (tambem podem ser numerais)
+  "ein", "eine",
+  // Espanhol (tambem podem ser numerais)
+  "un", "una",
+  // Frances (tambem podem ser numerais)
+  "un", "une",
+  // Ingles
+  "a", "an",
+  // Italiano
+  "un", "uno", "una", "un'",
+  // Portugues
+  "um", "uma", "uns", "umas",
+)
+
+/// Todos os artigos (definidos e indefinidos)
+#let all-articles = definite-articles + indefinite-articles
+
+/// Remove acentos e sinais diacriticos para ordenacao
+/// Conforme NBR 6033: letras com acentos sao alfabetadas sem as modificacoes
+///
+/// Exemplo:
+/// ```typst
+/// #remove-accents("Muller") // Retorna "Muller"
+/// #remove-accents("cafe") // Retorna "cafe"
+/// ```
+#let remove-accents(text) = {
+  let result = text
+  // Mapeamento de caracteres acentuados para seus equivalentes
+  let accent-map = (
+    // Minusculas
+    ("a", "a"), ("a", "a"), ("a", "a"), ("a", "a"), ("a", "a"),
+    ("e", "e"), ("e", "e"), ("e", "e"), ("e", "e"),
+    ("i", "i"), ("i", "i"), ("i", "i"), ("i", "i"),
+    ("o", "o"), ("o", "o"), ("o", "o"), ("o", "o"), ("o", "o"),
+    ("u", "u"), ("u", "u"), ("u", "u"), ("u", "u"),
+    ("c", "c"), ("n", "n"),
+    // Maiusculas
+    ("A", "A"), ("A", "A"), ("A", "A"), ("A", "A"), ("A", "A"),
+    ("E", "E"), ("E", "E"), ("E", "E"), ("E", "E"),
+    ("I", "I"), ("I", "I"), ("I", "I"), ("I", "I"),
+    ("O", "O"), ("O", "O"), ("O", "O"), ("O", "O"), ("O", "O"),
+    ("U", "U"), ("U", "U"), ("U", "U"), ("U", "U"),
+    ("C", "C"), ("N", "N"),
+  )
+
+  for (from, to) in accent-map {
+    result = result.replace(from, to)
+  }
+  result
+}
+
+/// Remove artigo inicial para ordenacao
+/// Conforme NBR 6033: artigos iniciais nao sao considerados na ordenacao
+///
+/// Parametros:
+/// - text: texto a processar
+/// - keep-articles-in-names: se true, mantem artigos que fazem parte de nomes proprios (ex: "La Fontaine")
+///
+/// Exemplo:
+/// ```typst
+/// #remove-initial-article("A batalha") // Retorna "batalha"
+/// #remove-initial-article("The book") // Retorna "book"
+/// ```
+#let remove-initial-article(text, keep-articles-in-names: false) = {
+  let words = text.split(" ")
+  if words.len() == 0 { return text }
+
+  let first-word = lower(words.at(0))
+
+  // Verifica se primeira palavra e um artigo
+  if first-word in all-articles or first-word.trim("'") in all-articles {
+    // Se deve manter artigos em nomes proprios, verifica se segunda palavra comeca com maiuscula
+    if keep-articles-in-names and words.len() > 1 {
+      let second-word = words.at(1)
+      if second-word.len() > 0 {
+        let first-char = second-word.at(0)
+        // Se segunda palavra comeca com maiuscula, pode ser nome proprio - manter artigo
+        if first-char == upper(first-char) and first-char != lower(first-char) {
+          return text
+        }
+      }
+    }
+    // Remove o artigo
+    words.slice(1).join(" ")
+  } else {
+    text
+  }
+}
+
+/// Gera chave de ordenacao para um texto conforme NBR 6033
+/// - Remove acentos
+/// - Ignora artigos iniciais
+/// - Converte para minusculas para comparacao
+///
+/// Parametros:
+/// - text: texto original
+/// - ignore-articles: se true, remove artigos iniciais
+///
+/// Exemplo:
+/// ```typst
+/// #sort-key("A batalha") // Retorna "batalha"
+/// #sort-key("Cafe") // Retorna "cafe"
+/// ```
+#let sort-key(text, ignore-articles: true) = {
+  let result = text
+
+  // Remove artigos iniciais se solicitado
+  if ignore-articles {
+    result = remove-initial-article(result)
+  }
+
+  // Remove acentos (simplificado - Typst nao tem suporte nativo)
+  // Para ordenacao correta, o texto ja deve estar normalizado
+
+  // Converte para minusculas
+  lower(result.trim())
+}
+
+/// Compara duas strings para ordenacao alfabetica conforme NBR 6033
+/// Metodo: palavra por palavra, e dentro de cada palavra, letra por letra
+///
+/// Retorna:
+/// - -1 se a < b
+/// - 0 se a == b
+/// - 1 se a > b
+///
+/// Exemplo:
+/// ```typst
+/// #compare-strings("Monte Alegre", "Monteiro") // -1 (Monte Alegre vem antes)
+/// ```
+#let compare-strings(a, b) = {
+  let key-a = sort-key(a)
+  let key-b = sort-key(b)
+
+  if key-a < key-b { -1 }
+  else if key-a > key-b { 1 }
+  else { 0 }
+}
+
+/// Ordena uma lista de strings conforme NBR 6033
+///
+/// Parametros:
+/// - items: lista de strings a ordenar
+/// - ignore-articles: se true, ignora artigos iniciais na ordenacao
+/// - key: funcao para extrair chave de ordenacao (opcional)
+///
+/// Exemplo:
+/// ```typst
+/// #let lista = ("O gato", "A casa", "Zebra", "Arvore")
+/// #sort-alphabetically(lista)
+/// // Resultado: ("Arvore", "A casa", "O gato", "Zebra")
+/// ```
+#let sort-alphabetically(items, ignore-articles: true, key: none) = {
+  if key != none {
+    items.sorted(key: it => sort-key(key(it), ignore-articles: ignore-articles))
+  } else {
+    items.sorted(key: it => sort-key(it, ignore-articles: ignore-articles))
+  }
+}
+
+/// Tipos de entrada para ordenacao de homografas conforme NBR 6033
+/// Ordem: autor proprio > autor entidade > assunto > titulo
+#let entry-types = (
+  author-person: 1,    // Autor (nome proprio)
+  author-entity: 2,    // Autor (entidade coletiva)
+  subject: 3,          // Assunto
+  title: 4,            // Titulo
+)
+
+/// Cria entrada para lista ordenada com tipo especificado
+///
+/// Parametros:
+/// - text: texto da entrada
+/// - entry-type: tipo da entrada (usar constantes de entry-types)
+///
+/// Exemplo:
+/// ```typst
+/// #let entradas = (
+///   make-entry("Brasil, Victor", entry-type: entry-types.author-person),
+///   make-entry("Brasil - Historia", entry-type: entry-types.subject),
+///   make-entry("Brasil, Ministerio", entry-type: entry-types.author-entity),
+/// )
+/// ```
+#let make-entry(text, entry-type: entry-types.title) = {
+  (text: text, entry-type: entry-type)
+}
+
+/// Ordena entradas homografas conforme NBR 6033
+/// Quando textos tem mesma grafia, ordena por tipo:
+/// 1. Autor (nome proprio)
+/// 2. Autor (entidade coletiva)
+/// 3. Assunto
+/// 4. Titulo
+#let sort-homographs(entries) = {
+  entries.sorted(key: it => {
+    let base-key = sort-key(it.text)
+    let type-key = str(it.entry-type)
+    base-key + "_" + type-key
+  })
+}
+
+/// Formata lista ordenada alfabeticamente
+///
+/// Parametros:
+/// - items: lista de strings ou conteudo
+/// - numbered: se true, adiciona numeracao
+/// - ignore-articles: se true, ignora artigos na ordenacao
+///
+/// Exemplo:
+/// ```typst
+/// #alphabetical-list(("Zebra", "Arvore", "Casa"))
+/// ```
+#let alphabetical-list(items, numbered: false, ignore-articles: true) = {
+  let sorted-items = sort-alphabetically(items, ignore-articles: ignore-articles)
+
+  if numbered {
+    enum(..sorted-items)
+  } else {
+    list(..sorted-items)
+  }
+}
+
+/// Indice alfabetico
+/// Cria um indice organizado por letras iniciais
+///
+/// Parametros:
+/// - items: lista de tuplas (termo, pagina) ou strings
+/// - show-letters: se true, mostra cabecalhos de letras
+///
+/// Exemplo:
+/// ```typst
+/// #alphabetical-index((
+///   ("Algoritmo", 15),
+///   ("Banco de dados", 23),
+///   ("Arvore", 18),
+/// ))
+/// ```
+#let alphabetical-index(items, show-letters: true) = {
+  // Ordena os itens
+  let sorted = items.sorted(key: it => {
+    if type(it) == array {
+      sort-key(it.at(0))
+    } else {
+      sort-key(it)
+    }
+  })
+
+  let current-letter = ""
+
+  for item in sorted {
+    let term = if type(item) == array { item.at(0) } else { item }
+    let page = if type(item) == array and item.len() > 1 { item.at(1) } else { none }
+
+    // Obtem primeira letra (sem acento, maiuscula)
+    let first-letter = upper(sort-key(term).at(0, default: ""))
+
+    // Mostra cabecalho de letra se mudou
+    if show-letters and first-letter != current-letter and first-letter != "" {
+      current-letter = first-letter
+      v(0.5em)
+      text(weight: "bold", size: 12pt, current-letter)
+      v(0.3em)
+    }
+
+    // Mostra entrada
+    if page != none {
+      [#term #box(width: 1fr, repeat[.]) #page \ ]
+    } else {
+      [#term \ ]
+    }
+  }
+}
+
+/// Regras para ordenacao de numerais conforme NBR 6033
+/// - Numeros precedem letras
+/// - Ordenar por valor numerico
+/// - Ordinais seguem seus cardinais correspondentes
+///
+/// Exemplo de ordem correta:
+/// 1, 2, 3, 3., 3o, 8, 8., 8o, 9, 10, 100, 1000
+#let extract-number(text) = {
+  // Tenta extrair numero do inicio do texto
+  let digits = ""
+  for char in text.codepoints() {
+    if "0123456789".contains(char) {
+      digits += char
+    } else {
+      break
+    }
+  }
+  if digits.len() > 0 {
+    int(digits)
+  } else {
+    none
+  }
+}
+
+/// Verifica se texto comeca com numero
+#let starts-with-number(text) = {
+  if text.len() == 0 { return false }
+  let first = text.at(0)
+  "0123456789".contains(first)
+}
+
+/// Ordena lista mista de numeros e texto conforme NBR 6033
+/// Numeros vem antes de letras, ordenados por valor
+#let sort-mixed(items) = {
+  // Separa itens que comecam com numero dos que comecam com letra
+  let numeric = items.filter(it => starts-with-number(str(it)))
+  let alpha = items.filter(it => not starts-with-number(str(it)))
+
+  // Ordena numericos por valor
+  let sorted-numeric = numeric.sorted(key: it => {
+    let num = extract-number(str(it))
+    if num != none { num } else { 0 }
+  })
+
+  // Ordena alfabeticos normalmente
+  let sorted-alpha = sort-alphabetically(alpha)
+
+  // Junta: numeros primeiro, depois letras
+  sorted-numeric + sorted-alpha
+}

--- a/packages/preview/abntyp/0.1.5/src/core/spacing.typ
+++ b/packages/preview/abntyp/0.1.5/src/core/spacing.typ
@@ -1,0 +1,81 @@
+// Configuração de espaçamentos conforme NBR 14724:2024
+
+/// Espaçamento entre linhas ABNT
+#let abnt-line-spacing = (
+  normal: 1.5em,       // Texto principal: 1,5
+  single: 1em,         // Espaçamento simples
+  double: 2em,         // Espaçamento duplo
+)
+
+/// Aplica espaçamento padrão ABNT (1,5 entre linhas)
+#let abnt-spacing-setup() = {
+  set par(
+    leading: 1.5em * 0.65,  // Typst usa leading, não line-height
+    justify: true,
+    first-line-indent: (amount: 1.25cm, all: true),  // Parágrafo com recuo de 1,25 cm
+  )
+}
+
+/// Aplica configuração completa de espaçamento ABNT
+#let with-abnt-spacing(body) = {
+  set par(
+    leading: 1.5em * 0.65,
+    justify: true,
+    first-line-indent: (amount: 1.25cm, all: true),
+  )
+  body
+}
+
+/// Espaçamento simples (para citações longas, notas, referências)
+#let single-spacing(body) = {
+  set par(leading: 1em * 0.65)
+  body
+}
+
+/// Espaçamento 1,5 (padrão para texto)
+#let one-half-spacing(body) = {
+  set par(leading: 1.5em * 0.65)
+  body
+}
+
+/// Espaçamento duplo
+#let double-spacing(body) = {
+  set par(leading: 2em * 0.65)
+  body
+}
+
+/// Bloco sem recuo de primeira linha
+#let no-indent(body) = {
+  set par(first-line-indent: 0pt)
+  body
+}
+
+/// Bloco com recuo específico (para citações longas: 4cm da margem esquerda)
+#let indented-block(recuo: 4cm, body) = {
+  pad(left: recuo)[
+    #set par(first-line-indent: 0pt)
+    #body
+  ]
+}
+
+// Espaçamentos específicos ABNT
+// - Entre título da seção e texto: 1 espaço de 1,5
+// - Entre texto e título da próxima seção: 1 espaço de 1,5
+// - Natureza do trabalho: recuo de 8 cm da margem esquerda
+
+/// Espaço vertical padrão entre seções
+#let section-spacing = v(1.5em)
+
+/// Bloco para natureza do trabalho (folha de rosto)
+/// Recuo de 8 cm da margem esquerda, espaçamento simples
+#let nature-block(body) = {
+  pad(left: 8cm)[
+    #set par(
+      leading: 1em * 0.65,
+      first-line-indent: 0pt,
+      justify: true,
+    )
+    #set text(size: 10pt)
+    #body
+  ]
+}

--- a/packages/preview/abntyp/0.1.5/src/elements/abstract.typ
+++ b/packages/preview/abntyp/0.1.5/src/elements/abstract.typ
@@ -1,0 +1,82 @@
+// Resumo e Abstract conforme NBR 6028:2021
+
+#import "../core/metadata.typ"
+
+/// Cria página de resumo conforme ABNT
+/// - titulo: "RESUMO" ou "ABSTRACT"
+/// - conteudo: texto do resumo (150-500 palavras para trabalhos acadêmicos)
+/// - palavras-chave: lista de palavras-chave (3 a 5)
+/// - rotulo-palavras-chave: "Palavras-chave" ou "Keywords"
+#let abstract-page(
+  titulo: "RESUMO",
+  conteudo: none,
+  palavras-chave: (),
+  rotulo-palavras-chave: "Palavras-chave",
+) = {
+  // Título centralizado, negrito
+  align(center)[
+    #text(weight: "bold", size: 12pt, titulo)
+  ]
+
+  v(1.5em)
+
+  // Texto do resumo (parágrafo único, espaçamento simples entre linhas)
+  set par(
+    leading: 1.5em * 0.65,
+    first-line-indent: 0pt,
+    justify: true,
+  )
+
+  conteudo
+
+  v(1.5em)
+
+  // Palavras-chave
+  if palavras-chave.len() > 0 {
+    set par(first-line-indent: 0pt)
+    [*#rotulo-palavras-chave:* #palavras-chave.join(". "). ]
+  }
+
+  pagebreak()
+}
+
+/// Resumo em português
+#let resumo(conteudo, palavras-chave: none) = {
+  context {
+    let kw = metadata._resolve(palavras-chave, "palavras-chave", fallback: ())
+    abstract-page(
+      titulo: "RESUMO",
+      conteudo: conteudo,
+      palavras-chave: kw,
+      rotulo-palavras-chave: "Palavras-chave",
+    )
+  }
+}
+
+/// Abstract em inglês
+#let resumo-en(conteudo, palavras-chave: none) = {
+  context {
+    let kw = metadata._resolve(palavras-chave, "palavras-chave-en", fallback: ())
+    abstract-page(
+      titulo: "ABSTRACT",
+      conteudo: conteudo,
+      palavras-chave: kw,
+      rotulo-palavras-chave: "Keywords",
+    )
+  }
+}
+
+/// Resumo em língua estrangeira (genérico)
+#let foreign-abstract(
+  titulo: "ABSTRACT",
+  conteudo: none,
+  palavras-chave: (),
+  rotulo-palavras-chave: "Keywords",
+) = {
+  abstract-page(
+    titulo: titulo,
+    conteudo: conteudo,
+    palavras-chave: palavras-chave,
+    rotulo-palavras-chave: rotulo-palavras-chave,
+  )
+}

--- a/packages/preview/abntyp/0.1.5/src/elements/cover.typ
+++ b/packages/preview/abntyp/0.1.5/src/elements/cover.typ
@@ -1,0 +1,78 @@
+// Capa conforme NBR 14724:2024
+// Elementos obrigatórios: instituição, autor, título, subtítulo, local, ano
+
+#import "../core/metadata.typ"
+
+/// Cria capa conforme ABNT
+/// - instituicao: nome da instituição (em maiúsculas)
+/// - autor: nome do autor
+/// - titulo: título do trabalho
+/// - subtitulo: subtítulo (opcional)
+/// - local: cidade
+/// - ano: ano de depósito
+#let capa(
+  instituicao: none,
+  faculdade: none,
+  programa: none,
+  autor: none,
+  titulo: none,
+  subtitulo: none,
+  local: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+
+  context {
+    let instituicao = metadata._resolve(instituicao, "instituicao")
+    let faculdade = metadata._resolve(faculdade, "faculdade")
+    let programa = metadata._resolve(programa, "programa")
+    let autor = metadata._resolve(autor, "autor")
+    let titulo = metadata._resolve(titulo, "titulo")
+    let subtitulo = metadata._resolve(subtitulo, "subtitulo")
+    let local = metadata._resolve(local, "local")
+    let ano = metadata._resolve(ano, "ano")
+
+    set align(center)
+
+    // Instituição (maiúsculas, negrito)
+    if instituicao != none {
+      text(weight: "bold", size: 12pt, upper(instituicao))
+      linebreak()
+    }
+
+    if faculdade != none {
+      text(weight: "bold", size: 12pt, upper(faculdade))
+      linebreak()
+    }
+
+    if programa != none {
+      text(weight: "bold", size: 12pt, upper(programa))
+    }
+
+    v(1fr)
+
+    // Autor
+    if autor != none {
+      text(size: 12pt, upper(autor))
+    }
+
+    v(1fr)
+
+    // Título (maiúsculas, negrito) + subtítulo
+    metadata._render-titulo(titulo, subtitulo: subtitulo)
+
+    v(1fr)
+
+    // Local e ano
+    if local != none {
+      text(size: 12pt, upper(local))
+      linebreak()
+    }
+
+    if ano != none {
+      text(size: 12pt, metadata._str-safe(ano))
+    }
+  }
+
+  pagebreak()
+}

--- a/packages/preview/abntyp/0.1.5/src/elements/index.typ
+++ b/packages/preview/abntyp/0.1.5/src/elements/index.typ
@@ -1,0 +1,371 @@
+// Indice conforme NBR 6034:2004
+//
+// Definicoes:
+// - Indice: Relacao de palavras/frases ordenadas que localiza e remete para
+//   informacoes no texto
+// - Cabecalho: Palavra(s) ou simbolo(s) que determina(m) a entrada
+// - Entrada: Unidade do indice (cabecalho + indicativo de localizacao)
+// - Subcabecalho: Palavra/simbolo que complementa o cabecalho
+// - Remissiva: Indicacao que remete a outro cabecalho (ver ou ver tambem)
+//
+// Tipos de indice:
+// - Quanto a ordenacao: alfabetica, sistematica, cronologica, numerica, alfanumerica
+// - Quanto ao enfoque: especial (autores, assuntos, titulos, etc.) ou geral
+
+/// Estado para armazenar entradas do indice
+#let index-entries = state("abnt-index-entries", ())
+
+/// Registra uma entrada no indice
+/// Esta funcao deve ser chamada no local do texto onde o termo aparece
+///
+/// Parametros:
+/// - termo: termo principal (cabecalho)
+/// - subtermo: subtermo/subcabecalho (opcional)
+/// - exibicao: texto a exibir no documento (se diferente do termo)
+///
+/// Exemplo:
+/// ```typst
+/// A #idx("algoritmo") e uma sequencia de instrucoes...
+/// #idx("algoritmo", subtermo: "de ordenacao")[Quicksort] e eficiente...
+/// ```
+#let idx(termo, subtermo: none, exibicao: none) = {
+  // Registrar entrada
+  context {
+    let current-page = counter(page).get().first()
+    let entry = (
+      term: termo,
+      subterm: subtermo,
+      page: current-page,
+    )
+    index-entries.update(entries => entries + (entry,))
+  }
+
+  // Exibir texto (se fornecido)
+  if exibicao != none {
+    exibicao
+  }
+}
+
+/// Cria uma entrada de indice sem exibir texto
+/// Use quando quiser indexar um termo que ja aparece no texto
+#let index-entry(termo, subtermo: none) = {
+  context {
+    let current-page = counter(page).get().first()
+    let entry = (
+      term: termo,
+      subterm: subtermo,
+      page: current-page,
+    )
+    index-entries.update(entries => entries + (entry,))
+  }
+}
+
+/// Remissiva "ver" - remete de um termo para outro
+/// Exemplo: Aviacao ver Aeronautica
+#let index-see(de, para) = {
+  (type: "see", from: de, to: para)
+}
+
+/// Remissiva "ver tambem" - amplia opcoes de consulta
+/// Exemplo: Ferias ver tambem Licenca
+#let index-see-also(de, para) = {
+  (type: "see-also", from: de, to: para)
+}
+
+/// Gera o indice alfabetico
+///
+/// Parametros:
+/// - titulo: titulo do indice (padrao: "INDICE")
+/// - rotulo-tipo: tipo do indice para o titulo (ex: "DE ASSUNTOS", "ONOMASTICO")
+/// - entradas-ver: lista de remissivas "ver"
+/// - entradas-ver-tambem: lista de remissivas "ver tambem"
+/// - colunas: numero de colunas (padrao: 2)
+/// - cabecalhos-letras: se true, mostra letras como cabecalhos de secao
+///
+/// Exemplo:
+/// ```typst
+/// #indice(
+///   rotulo-tipo: "DE ASSUNTOS",
+///   entradas-ver: (
+///     index-see("Aviacao", "Aeronautica"),
+///   ),
+///   entradas-ver-tambem: (
+///     index-see-also("Ferias", "Licenca"),
+///   ),
+/// )
+/// ```
+#let indice(
+  titulo: "INDICE",
+  rotulo-tipo: none,
+  entradas-ver: (),
+  entradas-ver-tambem: (),
+  colunas: 2,
+  cabecalhos-letras: true,
+) = {
+  // Titulo do indice
+  let full-title = if rotulo-tipo != none {
+    titulo + " " + rotulo-tipo
+  } else {
+    titulo
+  }
+
+  align(center)[
+    #text(weight: "bold", size: 12pt, full-title)
+  ]
+
+  v(1.5em)
+
+  context {
+    let entries = index-entries.final()
+
+    // Agrupar entradas por termo (convertendo content para string)
+    let grouped = (:)
+    for entry in entries {
+      let term-key = if type(entry.term) == str { entry.term } else { repr(entry.term) }
+      if term-key not in grouped {
+        grouped.insert(term-key, (term: entry.term, pages: (), subterms: (:)))
+      }
+
+      if entry.subterm != none {
+        let subterm-key = if type(entry.subterm) == str { entry.subterm } else { repr(entry.subterm) }
+        if subterm-key not in grouped.at(term-key).subterms {
+          grouped.at(term-key).subterms.insert(subterm-key, (subterm: entry.subterm, pages: ()))
+        }
+        grouped.at(term-key).subterms.at(subterm-key).pages.push(entry.page)
+      } else {
+        grouped.at(term-key).pages.push(entry.page)
+      }
+    }
+
+    // Ordenar termos alfabeticamente
+    let sorted-terms = grouped.keys().sorted()
+
+    // Agrupar por letra inicial
+    let by-letter = (:)
+    for term in sorted-terms {
+      let letter = upper(term.first())
+      if letter not in by-letter {
+        by-letter.insert(letter, ())
+      }
+      by-letter.at(letter).push(term)
+    }
+
+    // Processar remissivas "ver"
+    let see-map = (:)
+    for entry in entradas-ver {
+      if type(entry) == dictionary and entry.type == "see" {
+        see-map.insert(entry.from, entry.to)
+      }
+    }
+
+    // Processar remissivas "ver tambem"
+    let see-also-map = (:)
+    for entry in entradas-ver-tambem {
+      if type(entry) == dictionary and entry.type == "see-also" {
+        if entry.from not in see-also-map {
+          see-also-map.insert(entry.from, ())
+        }
+        see-also-map.at(entry.from).push(entry.to)
+      }
+    }
+
+    // Funcao para formatar paginas
+    let format-pages = pages => {
+      // Remover duplicatas e ordenar
+      let unique = pages.dedup().sorted()
+
+      // Agrupar paginas consecutivas
+      if unique.len() == 0 { return "" }
+
+      let result = ()
+      let start = unique.at(0)
+      let end = start
+
+      for i in range(1, unique.len()) {
+        let page = unique.at(i)
+        if page == end + 1 {
+          end = page
+        } else {
+          if start == end {
+            result.push(str(start))
+          } else {
+            result.push(str(start) + "-" + str(end))
+          }
+          start = page
+          end = page
+        }
+      }
+
+      // Adicionar ultimo grupo
+      if start == end {
+        result.push(str(start))
+      } else {
+        result.push(str(start) + "-" + str(end))
+      }
+
+      result.join(", ")
+    }
+
+    // Renderizar indice
+    set par(first-line-indent: 0pt)
+
+    columns(colunas, gutter: 1em)[
+      #for letter in by-letter.keys().sorted() {
+        // Cabecalho da letra
+        if cabecalhos-letras {
+          v(0.5em)
+          text(weight: "bold", size: 11pt, letter)
+          v(0.3em)
+        }
+
+        // Entradas desta letra
+        for term-key in by-letter.at(letter) {
+          let data = grouped.at(term-key)
+
+          // Verificar se e remissiva "ver"
+          if term-key in see-map {
+            [#data.term #emph[ver] #see-map.at(term-key)]
+            linebreak()
+          } else {
+            // Entrada normal
+            [#data.term]
+
+            // Paginas do termo principal
+            if data.pages.len() > 0 {
+              [, #format-pages(data.pages)]
+            }
+
+            linebreak()
+
+            // Subtermos (com recuo)
+            let sorted-subterms = data.subterms.keys().sorted()
+            for subterm-key in sorted-subterms {
+              let sub-data = data.subterms.at(subterm-key)
+              h(1em)
+              [#sub-data.subterm, #format-pages(sub-data.pages)]
+              linebreak()
+            }
+
+            // Remissiva "ver tambem"
+            if term-key in see-also-map {
+              h(1em)
+              [#emph[ver tambem] #see-also-map.at(term-key).join(", ")]
+              linebreak()
+            }
+          }
+        }
+      }
+    ]
+  }
+
+  pagebreak()
+}
+
+/// Indice de assuntos (wrapper para indice)
+#let indice-assuntos(
+  entradas-ver: (),
+  entradas-ver-tambem: (),
+  colunas: 2,
+) = {
+  indice(
+    rotulo-tipo: "DE ASSUNTOS",
+    entradas-ver: entradas-ver,
+    entradas-ver-tambem: entradas-ver-tambem,
+    colunas: colunas,
+  )
+}
+
+/// Indice onomastico (de nomes/autores)
+#let indice-onomastico(
+  entradas-ver: (),
+  entradas-ver-tambem: (),
+  colunas: 2,
+) = {
+  indice(
+    rotulo-tipo: "ONOMASTICO",
+    entradas-ver: entradas-ver,
+    entradas-ver-tambem: entradas-ver-tambem,
+    colunas: colunas,
+  )
+}
+
+/// Indice de autores
+#let indice-autores(
+  entradas-ver: (),
+  colunas: 2,
+) = {
+  indice(
+    rotulo-tipo: "DE AUTORES",
+    entradas-ver: entradas-ver,
+    colunas: colunas,
+  )
+}
+
+/// Indice geral (combina categorias)
+#let indice-geral(
+  entradas-ver: (),
+  entradas-ver-tambem: (),
+  colunas: 2,
+) = {
+  indice(
+    rotulo-tipo: none,
+    entradas-ver: entradas-ver,
+    entradas-ver-tambem: entradas-ver-tambem,
+    colunas: colunas,
+  )
+}
+
+/// Entrada de indice manual (para casos especiais)
+/// Use quando precisar de controle total sobre a entrada
+///
+/// Parametros:
+/// - termo: termo principal
+/// - qualificador: qualificador entre parenteses (opcional)
+/// - paginas: paginas (string ou lista)
+/// - subentradas: lista de subentradas
+///
+/// Exemplo:
+/// ```typst
+/// #manual-index-entry(
+///   termo: "Pedro II",
+///   qualificador: "Imperador do Brasil",
+///   paginas: "15-18, 45",
+/// )
+/// ```
+#let manual-index-entry(
+  termo: none,
+  qualificador: none,
+  paginas: none,
+  subentradas: (),
+) = {
+  set par(first-line-indent: 0pt)
+
+  // Termo principal
+  termo
+
+  // Qualificador
+  if qualificador != none {
+    [ (#qualificador)]
+  }
+
+  // Paginas
+  if paginas != none {
+    [, #paginas]
+  }
+
+  linebreak()
+
+  // Subentradas
+  for sub in subentradas {
+    h(1em)
+    if type(sub) == dictionary {
+      sub.termo
+      if "paginas" in sub and sub.paginas != none {
+        [, #sub.paginas]
+      }
+    } else {
+      sub
+    }
+    linebreak()
+  }
+}

--- a/packages/preview/abntyp/0.1.5/src/elements/spine.typ
+++ b/packages/preview/abntyp/0.1.5/src/elements/spine.typ
@@ -1,0 +1,318 @@
+// Lombada conforme NBR 12225:2004
+//
+// Estrutura da Lombada:
+// 1. Nome(s) do(s) autor(es) - quando houver
+// 2. Titulo
+// 3. Elementos alfanumericos de identificacao (volume, fasciculo, data)
+// 4. Logomarca da editora
+//
+// Recomendacao: Reservar 30mm na borda inferior para elementos de identificacao
+//
+// Tipos de lombada:
+// - Horizontal: titulo impresso horizontalmente quando o documento esta em posicao vertical
+// - Descendente: titulo impresso longitudinalmente, legivel do alto para o pe
+
+#import "../core/metadata.typ"
+
+// Converte valor para string (int/float → str, str → str, content → content)
+// Versão local para evitar problemas com metadata._str-safe em content blocks
+#let _to-str(val) = {
+  if type(val) == str { val }
+  else if type(val) == int or type(val) == float { str(val) }
+  else if val == none { "" }
+  else if type(val) == content { val }
+  else { str(val) }
+}
+
+/// Gera uma pagina de lombada para impressao separada
+///
+/// Parametros:
+/// - autor: nome do autor (pode ser abreviado)
+/// - titulo: titulo do trabalho (pode ser abreviado)
+/// - volume: numero do volume (opcional)
+/// - ano: ano (opcional)
+/// - instituicao: sigla da instituicao (opcional)
+/// - logo: imagem da logomarca (opcional)
+/// - orientacao: "descendente" ou "horizontal" (padrao: "descendente")
+/// - largura-lombada: largura da lombada (padrao: 2cm)
+/// - altura-lombada: altura da lombada (padrao: 29.7cm - A4)
+/// - espaco-reservado: espaco reservado na base (padrao: 30mm)
+///
+/// Nota: Esta funcao gera uma pagina separada com a lombada.
+/// Para impressao, a lombada deve ser cortada e aplicada ao dorso do trabalho.
+#let lombada(
+  autor: none,
+  titulo: none,
+  volume: none,
+  ano: none,
+  instituicao: none,
+  logo: none,
+  orientacao: "descendente",
+  largura-lombada: 2cm,
+  altura-lombada: 29.7cm,
+  espaco-reservado: 30mm,
+) = {
+  set page(
+    width: altura-lombada,
+    height: largura-lombada,
+    margin: 3mm,
+  )
+
+  context {
+    let autor = metadata._resolve(autor, "autor")
+    let titulo = metadata._resolve(titulo, "titulo")
+    let ano = metadata._resolve(ano, "ano")
+    let instituicao = metadata._resolve(instituicao, "instituicao")
+    let ano-str = if ano != none { _to-str(ano) }
+    let vol-str = if volume != none { "v. " + _to-str(volume) }
+
+    if orientacao == "descendente" {
+      // Lombada descendente - legivel do alto para o pe
+      // O texto e rotacionado 90 graus
+      set align(left + horizon)
+
+      box(
+        width: 100%,
+        height: 100%,
+      )[
+        #set text(size: 10pt)
+
+        // Layout horizontal (sera rotacionado na impressao)
+        #grid(
+          columns: (auto, 1fr, auto, auto),
+          gutter: 1em,
+          align: horizon,
+
+          // Autor
+          if autor != none {
+            text(weight: "bold", upper(autor))
+          },
+
+          // Titulo (centralizado, ocupa espaco restante)
+          align(center)[
+            #if titulo != none {
+              text(weight: "bold", upper(titulo))
+            }
+          ],
+
+          // Elementos alfanumericos
+          {
+            let elements = ()
+            if vol-str != none { elements.push(vol-str) }
+            if ano-str != none { elements.push(ano-str) }
+            if instituicao != none { elements.push(instituicao) }
+            elements.join(" ")
+          },
+
+          // Espaco reservado (30mm) + logo
+          box(width: espaco-reservado)[
+            #if logo != none {
+              align(center + horizon, logo)
+            }
+          ],
+        )
+      ]
+    } else {
+      // Lombada horizontal - para lombadas largas
+      set align(center + top)
+
+      box(
+        width: 100%,
+        height: 100%,
+      )[
+        #set text(size: 9pt)
+
+        // Autor
+        if autor != none {
+          text(weight: "bold", size: 10pt, upper(autor))
+          v(0.5em)
+        }
+
+        v(1fr)
+
+        // Titulo
+        if titulo != none {
+          text(weight: "bold", upper(titulo))
+        }
+
+        v(1fr)
+
+        // Elementos alfanumericos
+        {
+          if vol-str != none { vol-str }
+          if ano-str != none {
+            if vol-str != none { linebreak() }
+            ano-str
+          }
+          if instituicao != none {
+            linebreak()
+            instituicao
+          }
+        }
+
+        v(0.5em)
+
+        // Logo
+        if logo != none {
+          logo
+        }
+
+        // Espaco reservado
+        v(espaco-reservado)
+      ]
+    }
+  }
+
+  pagebreak()
+}
+
+/// Gera preview da lombada em uma caixa
+/// Util para visualizacao no documento
+///
+/// Parametros: mesmos da funcao lombada()
+/// Retorna: uma caixa com a lombada renderizada verticalmente
+#let lombada-preview(
+  autor: none,
+  titulo: none,
+  volume: none,
+  ano: none,
+  instituicao: none,
+  logo: none,
+  largura-lombada: 2cm,
+  altura-lombada: 20cm,
+  espaco-reservado: 30mm,
+) = {
+  context {
+    let autor = metadata._resolve(autor, "autor")
+    let titulo = metadata._resolve(titulo, "titulo")
+    let ano = metadata._resolve(ano, "ano")
+    let instituicao = metadata._resolve(instituicao, "instituicao")
+    let ano-str = if ano != none { _to-str(ano) }
+    let vol-str = if volume != none { "v. " + _to-str(volume) }
+
+    box(
+      width: largura-lombada,
+      height: altura-lombada,
+      stroke: 0.5pt + gray,
+      inset: 2mm,
+    )[
+      #set text(size: 8pt)
+      #set align(center)
+
+      // Autor (topo)
+      if autor != none {
+        rotate(-90deg, reflow: true)[
+          #text(weight: "bold", size: 7pt, upper(autor))
+        ]
+        v(0.3em)
+      }
+
+      v(1fr)
+
+      // Titulo (rotacionado)
+      if titulo != none {
+        rotate(-90deg, reflow: true)[
+          #text(weight: "bold", size: 8pt, upper(titulo))
+        ]
+      }
+
+      v(1fr)
+
+      // Elementos alfanumericos
+      rotate(-90deg, reflow: true)[
+        #{
+          let elements = ()
+          if vol-str != none { elements.push(vol-str) }
+          if ano-str != none { elements.push(ano-str) }
+          elements.join(" ")
+        }
+      ]
+
+      if instituicao != none {
+        v(0.3em)
+        rotate(-90deg, reflow: true)[
+          #text(size: 7pt, instituicao)
+        ]
+      }
+
+      v(0.5em)
+
+      // Logo
+      if logo != none {
+        logo
+      }
+
+      // Indicador de espaco reservado
+      v(0.3em)
+      line(length: 100%, stroke: 0.3pt + gray)
+      text(size: 5pt, fill: gray)[30mm]
+    ]
+  }
+}
+
+/// Gera texto formatado para lombada descendente
+/// Retorna o texto rotacionado para ser usado em outros contextos
+#let spine-text-descending(
+  autor: none,
+  titulo: none,
+  volume: none,
+  ano: none,
+) = {
+  context {
+    let autor = metadata._resolve(autor, "autor")
+    let titulo = metadata._resolve(titulo, "titulo")
+    let ano = metadata._resolve(ano, "ano")
+    let ano-str = if ano != none { _to-str(ano) }
+    let vol-str = if volume != none { "v. " + _to-str(volume) }
+
+    let parts = ()
+
+    if autor != none {
+      parts.push(text(weight: "bold", upper(autor)))
+    }
+
+    if titulo != none {
+      parts.push(text(weight: "bold", upper(titulo)))
+    }
+
+    let elements = ()
+    if vol-str != none { elements.push(vol-str) }
+    if ano-str != none { elements.push(ano-str) }
+
+    if elements.len() > 0 {
+      parts.push(elements.join(" "))
+    }
+
+    parts.join(h(2em))
+  }
+}
+
+/// Titulo de margem de capa
+/// Para itens cujas lombadas nao comportam inscricoes
+/// Titulo impresso longitudinalmente ao lado da lombada
+///
+/// Parametros:
+/// - titulo: titulo do trabalho
+/// - volume: numero do volume (opcional)
+/// - largura-margem: largura da margem (padrao: 1.5cm)
+#let margem-capa(
+  titulo: none,
+  volume: none,
+  largura-margem: 1.5cm,
+) = {
+  context {
+    let titulo = metadata._resolve(titulo, "titulo")
+
+    box(
+      width: largura-margem,
+      height: 100%,
+    )[
+      #set align(center + horizon)
+      #rotate(-90deg, reflow: true)[
+        #set text(size: 10pt)
+        #if titulo != none { upper(titulo) }
+        #if volume != none { [ - v. #volume] }
+      ]
+    ]
+  }
+}

--- a/packages/preview/abntyp/0.1.5/src/elements/title-page.typ
+++ b/packages/preview/abntyp/0.1.5/src/elements/title-page.typ
@@ -1,0 +1,121 @@
+// Folha de rosto conforme NBR 14724:2024
+// Anverso: autor, título, natureza, orientador, local, ano
+
+#import "../core/spacing.typ": nature-block
+#import "../core/metadata.typ"
+
+/// Cria folha de rosto conforme ABNT
+#let folha-rosto(
+  autor: none,
+  titulo: none,
+  subtitulo: none,
+  natureza: none,        // Natureza do trabalho (dissertação, tese, TCC)
+  objetivo: none,        // Objetivo (obtenção de grau)
+  instituicao: none,
+  area: none,            // Área de concentração
+  orientador: none,      // Orientador
+  coorientador: none,    // Coorientador
+  local: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+
+  context {
+    let autor = metadata._resolve(autor, "autor")
+    let titulo = metadata._resolve(titulo, "titulo")
+    let subtitulo = metadata._resolve(subtitulo, "subtitulo")
+    let natureza = metadata._resolve(natureza, "natureza")
+    let objetivo = metadata._resolve(objetivo, "objetivo")
+    let instituicao = metadata._resolve(instituicao, "instituicao")
+    let area = metadata._resolve(area, "area")
+    let orientador = metadata._resolve(orientador, "orientador")
+    let coorientador = metadata._resolve(coorientador, "coorientador")
+    let local = metadata._resolve(local, "local")
+    let ano = metadata._resolve(ano, "ano")
+
+    set align(center)
+
+    // Autor
+    if autor != none {
+      text(size: 12pt, upper(autor))
+    }
+
+    v(1fr)
+
+    // Título (maiúsculas, negrito) + subtítulo
+    metadata._render-titulo(titulo, subtitulo: subtitulo)
+
+    v(2cm)
+
+    // Natureza do trabalho (recuo de 8cm, espaço simples)
+    if natureza != none or objetivo != none or orientador != none {
+      set align(right)
+      box(width: 8cm)[
+        #set align(left)
+        #set par(
+          leading: 1em * 0.65,
+          first-line-indent: 0pt,
+          justify: true,
+        )
+        #set text(size: 10pt)
+
+        #if natureza != none { natureza }
+        #if objetivo != none { [ #objetivo] }
+        #if instituicao != none { linebreak(); instituicao }
+        #if area != none { linebreak(); [Área de concentração: #area] }
+
+        #if orientador != none {
+          linebreak()
+          linebreak()
+          [Orientador: #orientador]
+        }
+
+        #if coorientador != none {
+          linebreak()
+          [Coorientador: #coorientador]
+        }
+      ]
+    }
+
+    v(1fr)
+
+    // Local e ano
+    set align(center)
+    if local != none {
+      text(size: 12pt, upper(local))
+      linebreak()
+    }
+
+    if ano != none {
+      text(size: 12pt, metadata._str-safe(ano))
+    }
+  }
+
+  pagebreak()
+}
+
+/// Verso da folha de rosto (ficha catalográfica)
+/// Deve ocupar a parte inferior da página
+#let ficha-catalografica(conteudo) = {
+  set page(numbering: none)
+  v(1fr)
+
+  align(center)[
+    #box(
+      width: 12.5cm,
+      height: 7.5cm,
+      stroke: 0.5pt,
+      inset: 0.5cm,
+    )[
+      #set text(size: 10pt)
+      #set par(leading: 1em * 0.65)
+      #conteudo
+    ]
+  ]
+
+  pagebreak()
+}
+
+// Aliases curtos
+#let rosto = folha-rosto
+#let ficha = ficha-catalografica

--- a/packages/preview/abntyp/0.1.5/src/elements/toc.typ
+++ b/packages/preview/abntyp/0.1.5/src/elements/toc.typ
@@ -1,0 +1,182 @@
+// Sumário conforme NBR 6027:2012
+
+// Show rules para formatar entradas do sumário conforme NBR 6027/6024.
+// Compartilhado entre abnt-outline() e sumario().
+#let _abnt-outline-rules(body) = {
+  // Nível 1: MAIÚSCULAS + negrito
+  show outline.entry.where(level: 1): it => {
+    v(0.5em)
+    block[
+      #link(it.element.location())[
+        #text(weight: "bold")[#upper(it.body())]
+        #box(width: 1fr, it.fill)
+        #it.page()
+      ]
+    ]
+  }
+
+  // Nível 2: MAIÚSCULAS, regular
+  show outline.entry.where(level: 2): it => {
+    block[
+      #link(it.element.location())[
+        #h(1em)
+        #upper(it.body())
+        #box(width: 1fr, it.fill)
+        #it.page()
+      ]
+    ]
+  }
+
+  // Nível 3: Minúsculas + negrito
+  show outline.entry.where(level: 3): it => {
+    block[
+      #link(it.element.location())[
+        #h(2em)
+        #text(weight: "bold")[#it.body()]
+        #box(width: 1fr, it.fill)
+        #it.page()
+      ]
+    ]
+  }
+
+  // Nível 4: Minúsculas, regular
+  show outline.entry.where(level: 4): it => {
+    block[
+      #link(it.element.location())[
+        #h(3em)
+        #it.body()
+        #box(width: 1fr, it.fill)
+        #it.page()
+      ]
+    ]
+  }
+
+  // Nível 5: Minúsculas, itálico
+  show outline.entry.where(level: 5): it => {
+    block[
+      #link(it.element.location())[
+        #h(4em)
+        #text(style: "italic")[#it.body()]
+        #box(width: 1fr, it.fill)
+        #it.page()
+      ]
+    ]
+  }
+
+  body
+}
+
+/// Configura sumário conforme ABNT
+/// - Título "SUMARIO" centralizado, negrito
+/// - Indicativos de seção alinhados à esquerda
+/// - Entradas espelham a formatação dos headings (NBR 6027/6024)
+/// - Páginas ligadas por linha pontilhada
+#let abnt-outline() = {
+  // Título
+  align(center)[
+    #text(weight: "bold", size: 12pt, "SUMÁRIO")
+  ]
+
+  v(1.5em)
+
+  show: _abnt-outline-rules
+
+  outline(
+    title: none,
+    indent: 0pt,
+  )
+}
+
+/// Sumário customizado com mais controle
+#let sumario(
+  titulo: "SUMÁRIO",
+  profundidade: 3,
+) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, titulo)
+  ]
+
+  v(1.5em)
+
+  show: _abnt-outline-rules
+
+  outline(
+    title: none,
+    depth: profundidade,
+    indent: 0pt,
+  )
+
+  pagebreak()
+}
+
+/// Lista de ilustrações
+#let lista-ilustracoes() = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE ILUSTRAÇÕES")
+  ]
+
+  v(1.5em)
+
+  outline(
+    title: none,
+    target: figure.where(kind: image),
+      )
+
+  pagebreak()
+}
+
+/// Lista de tabelas
+#let lista-tabelas() = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE TABELAS")
+  ]
+
+  v(1.5em)
+
+  outline(
+    title: none,
+    target: figure.where(kind: table),
+      )
+
+  pagebreak()
+}
+
+/// Lista de abreviaturas e siglas
+/// - itens: dicionário de sigla -> significado
+#let lista-siglas(itens) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE ABREVIATURAS E SIGLAS")
+  ]
+
+  v(1.5em)
+
+  set par(first-line-indent: 0pt)
+
+  for (sigla, significado) in itens {
+    [#sigla #h(1em) #significado \ ]
+  }
+
+  pagebreak()
+}
+
+/// Lista de símbolos
+/// - itens: dicionário de símbolo -> significado
+#let lista-simbolos(itens) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE SÍMBOLOS")
+  ]
+
+  v(1.5em)
+
+  set par(first-line-indent: 0pt)
+
+  for (simbolo, significado) in itens {
+    [#simbolo #h(1em) #significado \ ]
+  }
+
+  pagebreak()
+}
+
+// Aliases curtos
+#let siglas = lista-siglas
+#let simbolos = lista-simbolos

--- a/packages/preview/abntyp/0.1.5/src/references/abbreviations.typ
+++ b/packages/preview/abntyp/0.1.5/src/references/abbreviations.typ
@@ -1,0 +1,394 @@
+// Abreviacao de titulos de periodicos conforme NBR 6032:1989
+// Abreviacao de titulos de periodicos e publicacoes seriadas
+
+/// Dicionario de abreviaturas padrao NBR 6032:1989
+/// Formato: palavra -> abreviatura
+#let abbreviation-dict = (
+  // A
+  "academia": "Acad.",
+  "administracao": "Adm.",
+  "agricultura": "Agric.",
+  "anais": "An.",
+  "analise": "Anal.",
+  "anuario": "Anu.",
+  "aplicado": "apl.",
+  "aplicada": "apl.",
+  "arquivo": "Arq.",
+  "associacao": "Assoc.",
+  "atualidade": "Atual.",
+  "atualidades": "Atual.",
+
+  // B
+  "biblioteca": "Bibl.",
+  "bibliografico": "bibliogr.",
+  "bibliografica": "bibliogr.",
+  "bibliografia": "Bibliogr.",
+  "biologia": "Biol.",
+  "biologico": "biol.",
+  "biologica": "biol.",
+  "boletim": "B.",
+  "brasileiro": "bras.",
+  "brasileira": "bras.",
+
+  // C
+  "caderno": "Cad.",
+  "cadernos": "Cad.",
+  "ciencia": "Ci.",
+  "ciencias": "Ci.",
+  "cientifico": "cient.",
+  "cientifica": "cient.",
+  "colecao": "Col.",
+  "comercio": "Com.",
+  "comercial": "com.",
+  "comunicacao": "Comun.",
+  "comunicacoes": "Comun.",
+  "congresso": "Congr.",
+  "cultura": "Cult.",
+  "cultural": "cult.",
+
+  // D
+  "desenvolvimento": "Desenv.",
+  "diario": "D.",
+  "direito": "Dir.",
+  "documentacao": "Doc.",
+
+  // E
+  "edicao": "Ed.",
+  "editora": "Ed.",
+  "educacao": "Educ.",
+  "educacional": "educ.",
+  "engenharia": "Eng.",
+  "escola": "Esc.",
+  "escolar": "esc.",
+  "estatistica": "Estat.",
+  "estatistico": "estat.",
+  "estudo": "Est.",
+  "estudos": "Est.",
+  "economia": "Econ.",
+  "economico": "econ.",
+  "economica": "econ.",
+
+  // F
+  "faculdade": "Fac.",
+  "fasciculo": "Fasc.",
+  "federacao": "Fed.",
+  "federal": "fed.",
+  "filosofia": "Fil.",
+  "filosofico": "filos.",
+  "filosofica": "filos.",
+  "folha": "F.",
+  "fundacao": "Fund.",
+
+  // G
+  "gazeta": "G.",
+  "geografia": "Geogr.",
+  "geografico": "geogr.",
+  "geografica": "geogr.",
+  "geologia": "Geol.",
+  "geologico": "geol.",
+  "geologica": "geol.",
+
+  // H
+  "historia": "Hist.",
+  "historico": "hist.",
+  "historica": "hist.",
+  "hospital": "Hosp.",
+  "hospitalar": "hosp.",
+
+  // I
+  "ilustracao": "Il.",
+  "ilustrado": "il.",
+  "ilustrada": "il.",
+  "indice": "Ind.",
+  "industria": "Industr.",
+  "industrial": "industr.",
+  "informacao": "Inf.",
+  "informacoes": "Inf.",
+  "informativo": "inform.",
+  "informativa": "inform.",
+  "instituto": "Inst.",
+  "internacional": "Inter.",
+
+  // J
+  "jornal": "J.",
+  "juridico": "jur.",
+  "juridica": "jur.",
+
+  // L
+  "laboratorio": "Lab.",
+  "legislacao": "Legisl.",
+  "legislativo": "legisl.",
+  "legislativa": "legisl.",
+  "literatura": "Lit.",
+  "literario": "lit.",
+  "literaria": "lit.",
+
+  // M
+  "medicina": "Med.",
+  "medico": "med.",
+  "medica": "med.",
+  "memoria": "Mem.",
+  "memorias": "Mem.",
+  "mensal": "mens.",
+  "ministerio": "Minist.",
+  "ministerial": "minist.",
+  "municipal": "mun.",
+  "musica": "Mus.",
+  "musical": "mus.",
+  "museu": "Mus.",
+
+  // N
+  "nacional": "nac.",
+  "noticia": "Not.",
+  "noticias": "Not.",
+  "numero": "Num.",
+
+  // O
+  "observacao": "Obs.",
+  "observacoes": "Obs.",
+  "observatorio": "Obs.",
+  "oficial": "of.",
+  "organizacao": "Org.",
+
+  // P
+  "pagina": "Pag.",
+  "paginas": "Pag.",
+  "pesquisa": "Pesq.",
+  "pesquisas": "Pesq.",
+  "politica": "Pol.",
+  "politico": "pol.",
+  "producao": "Prod.",
+  "publicacao": "Publ.",
+  "publicacoes": "Publ.",
+  "paulista": "paul.",
+
+  // Q
+  "quimica": "Quim.",
+  "quimico": "quim.",
+
+  // R
+  "referencia": "Ref.",
+  "referencias": "Ref.",
+  "regional": "reg.",
+  "relatorio": "Rel.",
+  "relatorios": "Rel.",
+  "resumo": "Res.",
+  "resumos": "Res.",
+  "revista": "R.",
+
+  // S
+  "secretaria": "Secr.",
+  "seminario": "Semin.",
+  "seminarios": "Semin.",
+  "serie": "Ser.",
+  "servico": "Serv.",
+  "servicos": "Serv.",
+  "sociedade": "Soc.",
+  "sociologia": "Sociol.",
+  "sociologico": "sociol.",
+  "sociologica": "sociol.",
+  "suplemento": "Supl.",
+
+  // T
+  "tecnica": "Tecn.",
+  "tecnico": "tecn.",
+  "tecnologia": "Tecnol.",
+  "tecnologico": "tecnol.",
+  "tecnologica": "tecnol.",
+  "trabalho": "Trab.",
+  "trabalhos": "Trab.",
+  "trimestral": "trim.",
+
+  // U
+  "universidade": "Univ.",
+  "universitario": "univ.",
+  "universitaria": "univ.",
+
+  // V
+  "volume": "Vol.",
+  "veterinaria": "Vet.",
+  "veterinario": "vet.",
+)
+
+/// Palavras que nao devem ser abreviadas (menos de 5 letras ou excecoes)
+#let no-abbreviate = (
+  "de", "da", "do", "das", "dos",
+  "e", "ou", "para", "por", "com", "sem",
+  "a", "o", "as", "os", "um", "uma", "uns", "umas",
+  "em", "no", "na", "nos", "nas",
+  "ao", "aos",
+  "lei", "ato", "art",
+)
+
+/// Artigos, preposicoes e conjuncoes a suprimir (exceto quando necessarios)
+#let suppressible-words = (
+  "de", "da", "do", "das", "dos",
+  "a", "o", "as", "os",
+  "um", "uma", "uns", "umas",
+  "para", "por", "com", "sem",
+  "em", "no", "na", "nos", "nas",
+  "ao", "aos",
+)
+
+/// Verifica se uma palavra deve ser suprimida
+/// - word: palavra a verificar
+#let should-suppress(word) = {
+  let lower-word = lower(word)
+  // Suprimir se for a primeira palavra (artigo inicial)
+  lower-word in suppressible-words
+}
+
+/// Verifica se uma palavra pode ser abreviada
+/// - word: palavra a verificar
+#let can-abbreviate(word) = {
+  let lower-word = lower(word)
+
+  // Nao abreviar palavras curtas (menos de 5 letras)
+  if word.len() < 5 and lower-word not in abbreviation-dict {
+    return false
+  }
+
+  // Nao abreviar se estiver na lista de excecoes
+  if lower-word in no-abbreviate {
+    return false
+  }
+
+  true
+}
+
+/// Obtem a abreviatura de uma palavra
+/// - word: palavra a abreviar
+/// - preserve-case: preservar maiusculas do original
+#let get-abbreviation(word, preserve-case: true) = {
+  let lower-word = lower(word)
+
+  if lower-word in abbreviation-dict {
+    let abbrev = abbreviation-dict.at(lower-word)
+
+    // Preservar maiuscula inicial se a palavra original tinha
+    if preserve-case and word.len() > 0 {
+      let first-char = word.at(0)
+      if first-char == upper(first-char) {
+        // Primeira letra era maiuscula
+        if abbrev.len() > 0 {
+          return upper(abbrev.at(0)) + abbrev.slice(1)
+        }
+      }
+    }
+
+    return abbrev
+  }
+
+  // Palavra nao encontrada no dicionario
+  // Tentar abreviar por truncamento (metodo normal)
+  if word.len() >= 5 {
+    // Verificar sufixos especiais
+    if lower-word.ends-with("logia") {
+      // Abreviar ate "l": Biologia -> Biol.
+      let base = word.slice(0, word.len() - 4)
+      return base + "."
+    } else if lower-word.ends-with("grafia") {
+      // Abreviar ate "gr": Geografia -> Geogr.
+      let base = word.slice(0, word.len() - 4)
+      return base + "."
+    } else if lower-word.ends-with("nomia") {
+      // Abreviar ate "n": Economia -> Econ.
+      let base = word.slice(0, word.len() - 4)
+      return base + "."
+    }
+  }
+
+  // Retornar palavra original se nao puder abreviar
+  word
+}
+
+/// Abrevia um titulo de periodico conforme NBR 6032:1989
+/// - title: titulo completo do periodico
+/// - suppress-articles: suprimir artigos e preposicoes (default: true)
+///
+/// Exemplo:
+/// ```typst
+/// #abbreviate-title("Revista Brasileira de Biologia")
+/// // Resultado: "R. bras. Biol."
+/// ```
+#let abbreviate-title(title, suppress-articles: true) = {
+  let words = title.split(" ")
+  let result = ()
+  let is-first = true
+
+  for word in words {
+    let lower-word = lower(word)
+
+    // Pular palavras vazias
+    if word.len() == 0 {
+      continue
+    }
+
+    // Verificar se deve suprimir
+    if suppress-articles and lower-word in suppressible-words {
+      // Manter "e" entre palavras compostas
+      if lower-word == "e" and not is-first {
+        result.push("e")
+      }
+      is-first = false
+      continue
+    }
+
+    // Verificar se pode abreviar
+    if can-abbreviate(word) {
+      result.push(get-abbreviation(word))
+    } else {
+      result.push(word)
+    }
+
+    is-first = false
+  }
+
+  result.join(" ")
+}
+
+/// Formata plural de abreviatura com traco-de-uniao
+/// Conforme NBR 6032: acrescentar traco + ultima letra do plural
+/// Exemplo: Academias -> Acad-s
+/// - singular-abbrev: abreviatura no singular
+/// - plural-suffix: sufixo do plural (default: "s")
+#let abbreviate-plural(singular-abbrev, plural-suffix: "s") = {
+  // Remover ponto final se houver
+  let abbrev = singular-abbrev
+  if abbrev.ends-with(".") {
+    abbrev = abbrev.slice(0, abbrev.len() - 1)
+  }
+
+  // Adicionar traco e sufixo (sem ponto)
+  abbrev + "-" + plural-suffix
+}
+
+/// Formata abreviatura de palavra composta
+/// Exemplo: medico-sanitarias -> med.-sanit.
+/// - compound-word: palavra composta com hifen
+#let abbreviate-compound(compound-word) = {
+  let parts = compound-word.split("-")
+  let abbreviated-parts = parts.map(part => get-abbreviation(part))
+  abbreviated-parts.join("-")
+}
+
+/// Formata titulo generico com identificacao do editor
+/// Para quando dois periodicos tem o mesmo titulo generico
+/// Exemplo: "Boletim Estatistico [IBGE]" -> "B. estat. IBGE"
+/// - title: titulo do periodico
+/// - editor: nome ou sigla do editor
+#let abbreviate-with-editor(title, editor) = {
+  let abbrev-title = abbreviate-title(title)
+  [#abbrev-title #editor]
+}
+
+/// Lista de exemplos de abreviaturas conforme NBR 6032
+#let abbreviation-examples = (
+  "Revista Brasileira de Biologia": "R. bras. Biol.",
+  "Revista Brasileira de Geografia": "R. bras. Geogr.",
+  "Revista Brasileira de Economia": "R. bras. Econ.",
+  "Memorias do Instituto Oswaldo Cruz": "Mem. Inst. Oswaldo Cruz",
+  "Boletim do INT": "B. INT",
+  "Ciencia e Cultura": "Ci. e Cult.",
+  "Anais da Academia Brasileira de Ciencias": "An. Acad. bras. Ci.",
+)

--- a/packages/preview/abntyp/0.1.5/src/references/abnt.csl
+++ b/packages/preview/abntyp/0.1.5/src/references/abnt.csl
@@ -1,0 +1,783 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" default-locale="pt-BR" xmlns="http://purl.org/net/xbiblio/csl">
+  <!--
+    ABNT NBR 6023:2018 / NBR 10520:2023 - Estilo autor-data
+
+    Adaptado para o pacote ABNTyp
+    Licença: MIT
+
+    Baseado no trabalho original de:
+    - Jucá da Costa (virgilino.neto@itec.ufpa.br)
+    - Antenor Aguiar C. A. Matos (antenoraguiarcam@gmail.com)
+
+    Fonte original: https://github.com/virgilinojuca/csl-abnt (CC0/domínio público)
+
+    Limitações conhecidas:
+    - Subtítulos aparecem em negrito junto com o título (limitação do CSL)
+    - Títulos sem autor: a primeira palavra deve estar em maiúsculas no .bib
+    - Legislação tem suporte limitado
+  -->
+  <info>
+    <title>ABNT NBR 6023:2018 / NBR 10520:2023 (ABNTyp)</title>
+    <title-short>ABNT</title-short>
+    <id>https://github.com/3sdras/abntyp/abnt.csl</id>
+    <link rel="self" href="https://github.com/3sdras/abntyp/abnt.csl"/>
+    <author>
+      <name>ABNTyp</name>
+    </author>
+    <contributor>
+      <name>Jucá da Costa</name>
+      <email>virgilino.neto@itec.ufpa.br</email>
+    </contributor>
+    <contributor>
+      <name>Antenor Aguiar C. A. Matos</name>
+      <email>antenoraguiarcam@gmail.com</email>
+      <uri>antenoraguiar.com.br</uri>
+    </contributor>
+    <category citation-format="author-date"/>
+    <updated>2026-01-31T00:00:00+00:00</updated>
+    <rights license="http://opensource.org/licenses/MIT">MIT License</rights>
+  </info>
+  <locale xml:lang="pt-BR">
+    <terms>
+      <term name="month-01" form="short">jan.</term>
+      <term name="month-02" form="short">fev.</term>
+      <term name="month-03" form="short">mar.</term>
+      <term name="month-04" form="short">abr.</term>
+      <term name="month-05" form="short">maio</term>
+      <term name="month-06" form="short">jun.</term>
+      <term name="month-07" form="short">jul.</term>
+      <term name="month-08" form="short">ago.</term>
+      <term name="month-09" form="short">set.</term>
+      <term name="month-10" form="short">out.</term>
+      <term name="month-11" form="short">nov.</term>
+      <term name="month-12" form="short">dez.</term>
+      <term name="editor" form="short">
+        <single>ed</single>
+        <multiple>ed</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>org</single>
+        <multiple>org</multiple>
+      </term>
+      <term name="script-writer">roteirista</term>
+      <term name="in">in</term>
+      <term name="accessed">acesso em</term>
+      <term name="no-place" form="short">s. l.</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <names variable="container-author" delimiter=", ">
+      <name delimiter="; " delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <et-al font-style="normal"/>
+      <label form="short" plural="never" prefix=" (" suffix=".)"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="collection-editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter" match="none">
+        <names variable="editor" delimiter=", " prefix=" (" suffix=")">
+          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=", " text-case="capitalize-first" suffix="."/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" prefix="Tradução: ">
+      <name et-al-min="3" et-al-use-first="1" initialize="false" sort-separator=" ">
+        <name-part name="given" text-case="capitalize-first"/>
+        <name-part name="family" text-case="capitalize-first"/>
+      </name>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <group delimiter=". ">
+      <names variable="author editor collection-editor editorial-director" delimiter="; ">
+        <name delimiter="; " delimiter-precedes-last="always" et-al-min="7" et-al-use-first="1" initialize="false" initialize-with=". " name-as-sort-order="all">
+          <name-part name="family" text-case="uppercase"/>
+          <name-part name="given"/>
+        </name>
+        <et-al font-style="normal"/>
+        <label form="short" plural="never" prefix=" (" suffix=".)"/>
+        <substitute>
+          <names variable="translator"/>
+          <text macro="title"/>
+        </substitute>
+      </names>
+      <text variable="authority"/>
+    </group>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" font-variant="normal" font-weight="normal" delimiter="; " delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with=". " name-as-sort-order="all">
+        <name-part name="family" text-case="capitalize-first" font-style="normal"/>
+      </name>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="paper-conference" match="any">
+            <text variable="title" form="short" text-case="uppercase"/>
+          </if>
+          <else-if type="motion_picture" match="any">
+            <text variable="title" form="short" text-case="uppercase" strip-periods="false" quotes="false" font-variant="normal" vertical-align="baseline" display="left-margin"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" text-case="uppercase" suffix="…"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-chapter">
+    <group delimiter=". ">
+      <names variable="author" delimiter="; ">
+        <name delimiter="; " delimiter-precedes-last="always" et-al-min="7" et-al-use-first="1" initialize="false" initialize-with=". " name-as-sort-order="all">
+          <name-part name="family" text-case="uppercase"/>
+          <name-part name="given"/>
+        </name>
+        <et-al/>
+        <label form="short"/>
+        <substitute>
+          <text macro="title"/>
+        </substitute>
+      </names>
+      <text variable="authority"/>
+    </group>
+  </macro>
+  <macro name="url">
+    <group delimiter=". ">
+      <group>
+        <text term="available at" text-case="capitalize-first" suffix=": "/>
+        <text variable="URL"/>
+      </group>
+      <group>
+        <text term="accessed" text-case="capitalize-first" suffix=": "/>
+        <date variable="accessed">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="short" text-case="lowercase" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="chapter bill article-newspaper article-journal article-magazine paper-conference post-weblog" match="any">
+        <text variable="title" strip-periods="false" quotes="false"/>
+      </if>
+      <else-if type="personal_communication" match="any">
+        <choose>
+          <if match="any" variable="title">
+            <text variable="title" font-weight="bold"/>
+          </if>
+          <else>
+            <text value="[Correspondência]" font-weight="bold"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="report webpage thesis" match="any">
+        <choose>
+          <if match="any" variable="container-title">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" font-weight="bold"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="title" font-weight="bold"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="paper-conference article" match="all">
+        <choose>
+          <if match="any" variable="container-title">
+            <text variable="container-title" font-weight="bold"/>
+          </if>
+          <else>
+            <text value="Anais" font-weight="bold" suffix=" [...]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="container-title" font-weight="bold"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if match="any" type="article-newspaper article-journal article-magazine">
+        <choose>
+          <if match="any" variable="publisher-place">
+            <text variable="publisher-place" suffix=": "/>
+          </if>
+          <else>
+            <text value="s. l." font-style="italic" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="any" variable="publisher-place publisher">
+            <choose>
+              <if variable="publisher-place">
+                <text variable="publisher-place" suffix=": "/>
+              </if>
+              <else-if type="entry-encyclopedia"/>
+              <else>
+                <text value="S. l." font-style="italic" prefix=" [" suffix="]: "/>
+              </else>
+            </choose>
+            <choose>
+              <if variable="publisher">
+                <text variable="publisher"/>
+              </if>
+              <else>
+                <text value="s. n." font-style="italic" prefix="[" suffix="]"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <group>
+              <text value="S. l." font-style="italic" prefix="[" suffix=": "/>
+              <text value="s. n." font-style="italic" suffix="]"/>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" variable="title author">
+          <text variable="event"/>
+        </if>
+        <else>
+          <text variable="event" text-case="uppercase"/>
+        </else>
+      </choose>
+      <text variable="edition" suffix="."/>
+      <choose>
+        <if match="any" variable="event-date">
+          <date date-parts="year" form="text" variable="event-date">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else>
+          <text macro="issued-year"/>
+        </else>
+      </choose>
+      <choose>
+        <if match="any" variable="event-place">
+          <text variable="event-place"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued" match="any">
+        <choose>
+          <if type="thesis" match="any">
+            <choose>
+              <if match="all" variable="submitted">
+                <date variable="submitted">
+                  <date-part name="day" suffix=" "/>
+                  <date-part name="month" text-case="lowercase" suffix=" "/>
+                  <date-part name="year"/>
+                </date>
+              </if>
+              <else>
+                <text macro="issued-dmy"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <text macro="issued-dmy"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text value="s. d." font-style="italic" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued" match="any">
+        <date date-parts="year" form="text" variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text value="[s.d.]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="book chapter" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group>
+              <number suffix=". " variable="edition"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" suffix=" ed."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="bill">
+        <group prefix=". " delimiter=", ">
+          <date variable="issued">
+            <date-part name="day"/>
+            <date-part prefix=" " name="month" form="short"/>
+            <date-part prefix=" " name="year"/>
+          </date>
+          <text variable="section" prefix="Sec. "/>
+          <text variable="page" prefix="p. " suffix="."/>
+        </group>
+      </if>
+      <else-if type="report" match="any">
+        <text variable="page" prefix="p. "/>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <text macro="volume-issue"/>
+          <text macro="page-locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="identifier">
+    <group delimiter=". ">
+      <text variable="ISBN" prefix="ISBN "/>
+      <text variable="ISSN" prefix="ISSN "/>
+      <text variable="DOI" prefix="DOI "/>
+    </group>
+  </macro>
+  <macro name="collection">
+    <group font-weight="normal" delimiter=", " prefix="(" suffix=")">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <label variable="locator" form="short"/>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="genre">
+    <text variable="genre"/>
+  </macro>
+  <macro name="place">
+    <choose>
+      <if match="any" variable="publisher-place">
+        <text variable="publisher-place"/>
+      </if>
+      <else>
+        <text term="no-place" form="short" font-style="italic" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <group>
+      <text variable="archive" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="volume-issue">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" is-numeric="volume">
+          <text variable="volume" prefix="v. "/>
+        </if>
+        <else>
+          <text variable="volume"/>
+        </else>
+      </choose>
+      <text variable="issue" prefix="n. "/>
+    </group>
+  </macro>
+  <macro name="publisher+issued">
+    <group delimiter=", ">
+      <text macro="publisher"/>
+      <text macro="issued"/>
+    </group>
+  </macro>
+  <macro name="issued-dmy">
+    <date variable="issued">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" form="short" text-case="lowercase" suffix=" "/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="place+publisher+date">
+    <choose>
+      <if type="personal_communication post-weblog" match="any">
+        <choose>
+          <if match="any" variable="publisher-place issued">
+            <group delimiter=", ">
+              <choose>
+                <if match="any" variable="publisher-place">
+                  <text variable="publisher-place"/>
+                </if>
+                <else>
+                  <text value="S. l." font-style="italic" prefix="[" suffix="]"/>
+                </else>
+              </choose>
+              <text macro="issued"/>
+            </group>
+          </if>
+          <else>
+            <text value="S. l." font-style="italic" prefix="[" suffix=","/>
+            <text value="s. d." font-style="italic" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="any" variable="issued publisher publisher-place">
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+          </if>
+          <else>
+            <group>
+              <text value="S. l" prefix="[" suffix=": "/>
+              <text value="s. n." suffix=", "/>
+              <text value="s. d."/>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="advisor-or-recipient">
+    <choose>
+      <if type="thesis" match="any">
+        <names variable="recipient" prefix="Orientador: ">
+          <name initialize="false" sort-separator="">
+            <name-part name="given"/>
+            <name-part name="family"/>
+          </name>
+        </names>
+      </if>
+      <else>
+        <names variable="recipient" prefix="Destinatário: ">
+          <name initialize="false" sort-separator="">
+            <name-part name="given"/>
+            <name-part name="family"/>
+          </name>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="physical-description">
+    <group delimiter=", ">
+      <text macro="number-of-volumes" suffix=" v."/>
+      <text macro="number-of-pages"/>
+      <text variable="medium"/>
+      <text variable="dimensions"/>
+    </group>
+  </macro>
+  <macro name="number-of-pages">
+    <choose>
+      <if match="all" is-numeric="number-of-pages">
+        <text variable="number-of-pages" suffix=" p."/>
+      </if>
+      <else>
+        <text variable="number-of-pages"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="number-of-volumes">
+    <choose>
+      <if match="any" is-numeric="number-of-volumes">
+        <text variable="number-of-volumes" suffix=" v."/>
+      </if>
+      <else>
+        <text variable="number-of-volumes"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="page-locator">
+    <text variable="page" prefix="p. "/>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="issued-year"/>
+      <key macro="author"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" entry-spacing="1">
+    <sort>
+      <key macro="author-short"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", ">
+              <text macro="container-title"/>
+              <text macro="place"/>
+              <text macro="locators"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="physical-description"/>
+            <text variable="note"/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </if>
+        <else-if type="chapter post-weblog" match="any">
+          <group delimiter=". " suffix=".">
+            <text macro="author-chapter"/>
+            <text macro="title"/>
+            <text macro="secondary-contributors"/>
+            <group delimiter=": ">
+              <text term="in" text-case="capitalize-first" font-style="italic"/>
+              <group delimiter=". ">
+                <text macro="container-contributors"/>
+                <text macro="container-title" font-weight="normal"/>
+              </group>
+            </group>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="place+publisher+date"/>
+            <text macro="physical-description"/>
+            <text macro="collection"/>
+            <text variable="note"/>
+            <text macro="locators"/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <choose>
+              <if match="any" variable="container-author">
+                <group delimiter=": ">
+                  <text term="in" text-case="capitalize-first" font-style="italic"/>
+                  <text macro="container-contributors"/>
+                </group>
+              </if>
+            </choose>
+            <text macro="container-title"/>
+            <text macro="advisor-or-recipient"/>
+            <text macro="translator"/>
+            <text macro="issued-year"/>
+            <text macro="physical-description"/>
+            <group delimiter=", ">
+              <group delimiter=" – ">
+                <text variable="genre"/>
+                <text variable="publisher" prefix=" " suffix=","/>
+              </group>
+              <text variable="publisher-place" prefix=" "/>
+              <text macro="issued"/>
+            </group>
+            <text variable="note" quotes="false"/>
+            <text macro="locators"/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="report">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <text macro="container-title"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="volume-issue"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="physical-description" prefix=" "/>
+            <text macro="collection"/>
+            <text variable="note"/>
+            <text macro="locators" suffix=". "/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=": ">
+              <choose>
+                <if match="all" variable="title author">
+                  <text term="in" text-case="capitalize-first" font-style="italic"/>
+                </if>
+              </choose>
+              <group delimiter=". ">
+                <text macro="container-contributors" text-case="uppercase"/>
+                <text macro="secondary-contributors"/>
+                <text macro="event"/>
+              </group>
+            </group>
+            <text macro="container-title" text-case="uppercase"/>
+            <text macro="place+publisher+date"/>
+            <text macro="physical-description"/>
+            <text variable="note"/>
+            <text macro="locators"/>
+            <text macro="identifier" prefix=" "/>
+            <text macro="url" prefix=" "/>
+          </group>
+        </else-if>
+        <else-if type="patent" match="any">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="translator"/>
+            <text variable="note"/>
+            <text variable="number"/>
+            <date variable="submitted" prefix="Depósito: ">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+            <text macro="issued" prefix="Concessão: "/>
+            <text variable="call-number"/>
+            <text variable="issue"/>
+            <text macro="physical-description"/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="map">
+          <group delimiter=". " suffix=".">
+            <text macro="author" suffix=". "/>
+            <text macro="title" suffix=", "/>
+            <text macro="issued" suffix=". "/>
+            <text variable="note" suffix=". "/>
+          </group>
+        </else-if>
+        <else-if type="bill">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text variable="number" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text variable="references" font-weight="bold"/>
+            <text variable="note"/>
+            <text macro="locators" suffix=". "/>
+          </group>
+        </else-if>
+        <else-if type="manuscript">
+          <group delimiter=". " suffix=".">
+            <text macro="author" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="place" suffix=", "/>
+            <text macro="issued" suffix=". "/>
+            <text macro="archive" suffix=". "/>
+          </group>
+        </else-if>
+        <else-if type="webpage">
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container-title"/>
+            <text macro="publisher+issued"/>
+            <text macro="genre" suffix=". "/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="motion_picture song" match="any">
+          <group delimiter=". " suffix=".">
+            <choose>
+              <if type="motion_picture" match="any">
+                <text variable="title" text-case="capitalize-first" font-weight="normal"/>
+                <group>
+                  <text term="director" text-case="capitalize-first" suffix=": "/>
+                  <names variable="director" delimiter=", ">
+                    <name and="text" et-al-min="4"/>
+                  </names>
+                </group>
+                <choose>
+                  <if match="any" variable="script-writer">
+                    <group>
+                      <text term="script-writer" text-case="capitalize-first" suffix=": "/>
+                      <names variable="script-writer"/>
+                    </group>
+                  </if>
+                </choose>
+              </if>
+              <else-if type="song" variable="collection-title" match="all">
+                <text macro="author"/>
+                <text variable="title" text-case="capitalize-first"/>
+                <group>
+                  <text term="in" text-case="capitalize-first" font-style="italic" suffix=": "/>
+                  <text variable="collection-title" text-case="capitalize-first" font-weight="bold"/>
+                </group>
+              </else-if>
+              <else-if type="song" match="all">
+                <text macro="author"/>
+                <text macro="title"/>
+              </else-if>
+            </choose>
+            <text macro="place+publisher+date"/>
+            <text variable="dimensions"/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=". " suffix=".">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="translator"/>
+            <text macro="advisor-or-recipient"/>
+            <text macro="edition"/>
+            <text macro="place+publisher+date"/>
+            <text macro="physical-description"/>
+            <text macro="collection"/>
+            <text variable="note"/>
+            <text macro="locators"/>
+            <text macro="identifier"/>
+            <text macro="url"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/packages/preview/abntyp/0.1.5/src/references/bibliography.typ
+++ b/packages/preview/abntyp/0.1.5/src/references/bibliography.typ
@@ -1,0 +1,105 @@
+// Integração com sistema de bibliografia do Typst
+// Formatação automática ABNT via CSL (NBR 6023:2018 / NBR 10520:2023)
+
+/// Configura bibliografia ABNT
+///
+/// Usa o arquivo CSL ABNT incluído no pacote para formatação automática
+/// das referências conforme NBR 6023:2018.
+///
+/// COMO INFORMAR O .bib (importante):
+/// Por uma limitação do Typst, um *caminho em string* passado a uma função de
+/// pacote é resolvido em relação ao pacote, e não ao SEU documento — então o
+/// arquivo ao lado do seu .typ não seria encontrado. A forma correta é passar
+/// o conteúdo lido com `read(...)`, que resolve o caminho a partir do seu
+/// documento:
+/// ```typst
+/// #abnt-bibliography(read("referencias.bib"))
+/// ```
+///
+/// Parâmetros:
+/// - arquivo: conteúdo do .bib via `read("arquivo.bib")` (recomendado),
+///   ou `bytes` via `read(..., encoding: none)`. Uma string simples ainda é
+///   aceita como caminho legado, mas resolve relativo ao pacote (desencorajado).
+/// - titulo: título da seção (padrão: "REFERÊNCIAS")
+/// - completa: se true, mostra todas as entradas; se false, apenas as citadas
+///
+/// Limitações conhecidas:
+/// - Subtítulos aparecem em negrito junto com o título (limitação do CSL)
+/// - Títulos sem autor: a primeira palavra deve estar em MAIÚSCULAS no .bib
+/// - Legislação tem suporte limitado
+#let abnt-bibliography(arquivo, titulo: "REFERÊNCIAS", completa: false) = {
+  // Título da seção de referências
+  heading(level: 1, numbering: none, titulo)
+
+  // Configuração de parágrafo para referências
+  // Recuo francês de 1,25cm, espaçamento simples
+  set par(
+    hanging-indent: 1.25cm,
+    first-line-indent: 0pt,
+    leading: 1em,
+  )
+
+  // Resolução da fonte de referências:
+  // - bytes  -> conteúdo lido com read(path, encoding: none)
+  // - string com conteúdo (de read(path)) -> convertida em bytes
+  // - string simples "arquivo.bib" -> caminho legado (relativo a ESTE módulo
+  //   do pacote; prefira read(...) para que o caminho seja relativo ao seu .typ)
+  let fonte = if type(arquivo) == bytes {
+    arquivo
+  } else if type(arquivo) == str and (arquivo.contains("\n") or arquivo.contains("@")) {
+    bytes(arquivo)
+  } else {
+    arquivo
+  }
+
+  // O CSL ABNT (abnt.csl) é resolvido em relação a este arquivo do pacote
+  bibliography(fonte, style: "abnt.csl", title: none, full: completa)
+}
+
+/// Configura citações para formato ABNT (OPCIONAL / retrocompatível).
+///
+/// As citações `@chave` já adotam automaticamente o estilo da bibliografia
+/// declarada por `#referencias(...)` (que usa o CSL ABNT). Portanto, NÃO é
+/// necessário chamar esta função --- o `@chave` funciona sozinho, bastando
+/// haver um `#referencias(...)` no documento. Mantida apenas para que
+/// documentos antigos com `#show: configurar-citacoes-abnt` continuem
+/// compilando.
+///
+/// Exemplo (a função é dispensável):
+/// ```typst
+/// Conforme @silva2023, a formatação é importante.
+/// Outros autores concordam @santos2022[p. 45].
+///
+/// #referencias("referencias.bib")
+/// ```
+///
+/// Formato gerado pelo CSL ABNT (NBR 10520:2023, inicial maiúscula):
+/// - No texto: (Silva, 2023)
+/// - Com página: (Silva, 2023, p. 45)
+/// - Autor na frase: Silva (2023) --- use #cite(<chave>, form: "prose")
+/// - Múltiplas obras: (Santos, 2022; Silva, 2023) --- cite @a@b juntos
+#let abnt-cite-setup(body) = body
+
+/// Wrapper em português para abnt-cite-setup
+///
+/// Exemplo:
+/// ```typst
+/// #show: configurar-citacoes-abnt
+/// ```
+#let configurar-citacoes-abnt = abnt-cite-setup
+
+/// Bibliografia ABNT simplificada (função wrapper)
+///
+/// Ideal para uso no final do documento. Informe o .bib com `read(...)` para
+/// que o caminho seja resolvido a partir do SEU documento:
+/// ```typst
+/// #referencias(read("referencias.bib"))
+/// ```
+///
+/// Parâmetros:
+/// - arquivo: conteúdo do .bib via `read("arquivo.bib")` (recomendado)
+/// - titulo: título da seção (padrão: "REFERÊNCIAS")
+/// - completa: se true, mostra todas as entradas; se false, apenas as citadas
+#let referencias(arquivo, titulo: "REFERÊNCIAS", completa: false) = {
+  abnt-bibliography(arquivo, titulo: titulo, completa: completa)
+}

--- a/packages/preview/abntyp/0.1.5/src/references/citation.typ
+++ b/packages/preview/abntyp/0.1.5/src/references/citation.typ
@@ -1,0 +1,276 @@
+// Sistema de citacoes e referencias conforme NBR 6023:2018 e NBR 10520:2023
+//
+// ============================================================================
+// SISTEMAS DE CHAMADA (NBR 10520:2023, secao 4)
+// ============================================================================
+//
+// A NBR 10520:2023 permite dois sistemas de chamada para citacoes:
+//
+// 1. SISTEMA AUTOR-DATA (este arquivo)
+//    - Formato: (Autor, ano) ou (Autor, ano, p. X)
+//    - Mais comum em trabalhos academicos no Brasil
+//    - Pode ser usado com notas de rodape
+//
+// 2. SISTEMA NUMERICO (ver numeric.typ)
+//    - Formato: (1) ou (1, p. X) ou sobrescrito
+//    - Permitido pela norma, inspirado no abntex2-num.bst
+//    - NAO pode ser usado com notas de rodape
+//
+// Escolha UM sistema e use consistentemente em todo o trabalho.
+//
+// ============================================================================
+
+// Este modulo fornece funcoes auxiliares para o sistema AUTOR-DATA
+// Para referências completas, usar arquivo .bib com estilo CSL ABNT
+// Para sistema numerico, ver: numeric.typ
+
+// ============================================================================
+// REGRA DE CAIXA NA CHAMADA (NBR 10520:2023)
+// ============================================================================
+// No sistema autor-data, o sobrenome na CHAMADA (na sentença ou entre
+// parênteses) leva apenas a INICIAL maiúscula — ex.: (Silva, 2023, p. 45).
+// A CAIXA ALTA do sobrenome entre parênteses era regra da NBR 10520:2002
+// (revogada) e permanece SOMENTE na lista de referências (NBR 6023:2018,
+// funções ref-* abaixo). O autor informa a grafia correta da chamada
+// (ex.: "Silva", "Brasil", "IBGE", "Organização Mundial da Saúde").
+
+// Sufixo de localização da fonte: , v. X, p. Y, <localização livre>
+// (NBR 10520:2023, 5.1 — volume/tomo antes da página; fontes não paginadas)
+#let _abnt-localizacao(volume: none, pagina: none, localizacao: none) = {
+  if volume != none { [, v. #volume] }
+  if pagina != none { [, p. #pagina] }
+  if localizacao != none { [, #localizacao] }
+}
+
+// Sufixo de expressão final da citação: , grifo nosso / , tradução nossa
+// (NBR 10520:2023, 5.1 — grifo/tradução indicados ao FINAL, dentro do parêntese)
+#let _abnt-expressao(grifo: none, traducao: none) = {
+  if grifo != none { [, grifo #grifo] }
+  if traducao != none { [, tradução #traducao] }
+}
+
+/// Citação autor-data entre parênteses — (Silva, 2023, p. 45)
+/// - autor: sobrenome (string), com apenas a inicial maiúscula (ou sigla)
+/// - ano: ano da publicação (int ou string)
+/// - pagina: página (opcional). Use string para intervalos: "42-43"
+/// - volume: volume/tomo antes da página (opcional) — (Senac, 1979, v. 1, p. 16)
+/// - localizacao: fontes não paginadas (opcional) — [cap. V, art. 49, inc. I]
+/// - grifo: "nosso" ou "do autor" (opcional) — (..., grifo nosso)
+/// - traducao: "nossa" ou "própria" (opcional) — (..., tradução nossa)
+#let citar(
+  autor,
+  ano,
+  pagina: none,
+  volume: none,
+  localizacao: none,
+  grifo: none,
+  traducao: none,
+) = {
+  [(#autor, #ano#_abnt-localizacao(volume: volume, pagina: pagina, localizacao: localizacao)#_abnt-expressao(grifo: grifo, traducao: traducao))]
+}
+
+/// Citação com autor na sentença — "Segundo Silva (2023, p. 45)..."
+/// Página/volume são opcionais (NBR 10520:2023: "Autor (ano, p. X)")
+#let citar-autor(autor, ano, pagina: none, volume: none) = {
+  [#autor (#ano#_abnt-localizacao(volume: volume, pagina: pagina))]
+}
+
+/// Citação indireta (paráfrase) — (Silva, 2023)
+/// Página/localização é opcional na citação indireta (NBR 10520:2023, 5.2)
+#let citar-indireto(autor, ano, pagina: none) = {
+  [(#autor, #ano#if pagina != none [, p. #pagina])]
+}
+
+/// Citação de citação (apud) — fonte original apud fonte consultada
+/// Na lista de referências, inclui-se SOMENTE a fonte consultada.
+/// - pagina-original: página na fonte original (opcional)
+/// - pagina: página na fonte consultada (opcional)
+#let citar-apud(
+  autor-original,
+  ano-original,
+  autor-secundario,
+  ano-secundario,
+  pagina-original: none,
+  pagina: none,
+) = {
+  [(#autor-original, #ano-original#if pagina-original != none [, p. #pagina-original] apud #autor-secundario, #ano-secundario#if pagina != none [, p. #pagina])]
+}
+
+/// Vários autores de uma MESMA obra (até 3) — (Silva; Santos; Costa, 2023)
+#let citar-multiplos(autores, ano, pagina: none) = {
+  let formatted = autores.join("; ")
+  [(#formatted, #ano#if pagina != none [, p. #pagina])]
+}
+
+/// Várias OBRAS citadas simultaneamente (autores/anos distintos)
+/// Separadas por ponto e vírgula, em ordem alfabética (NBR 10520:2023, 4.1)
+/// — (Fonseca, 1997; Paiva, 1997; Silva, 1997)
+/// - obras: lista de pares (autor, ano) ou trios (autor, ano, pagina)
+#let citar-varios(obras) = {
+  let parts = obras.map(o => {
+    if o.len() >= 3 and o.at(2) != none [#o.at(0), #o.at(1), p. #o.at(2)]
+    else [#o.at(0), #o.at(1)]
+  })
+  [(#parts.join("; "))]
+}
+
+/// Citação com mais de 3 autores (et al.) — (Silva et al., 2023)
+#let citar-etal(primeiro-autor, ano, pagina: none) = {
+  [(#primeiro-autor et al., #ano#if pagina != none [, p. #pagina])]
+}
+
+/// Citação de entidade coletiva — (Brasil, 2023) / (IBGE, 2011, p. 3)
+/// Informe o nome por extenso ou a sigla (siglas em CAIXA ALTA) na grafia certa.
+#let citar-entidade(entidade, ano, pagina: none) = {
+  [(#entidade, #ano#if pagina != none [, p. #pagina])]
+}
+
+/// Citação de obra sem autoria (entrada pelo título)
+/// Informe a 1ª palavra do título seguida de [...] quando houver mais palavras
+/// (NBR 10520:2023, 4.1) — ex.: citar-titulo([Anteprojeto [...]], 1987)
+#let citar-titulo(titulo, ano, pagina: none) = {
+  [(#titulo, #ano#if pagina != none [, p. #pagina])]
+}
+
+// ============================================================================
+// CITAÇÕES INTEGRADAS AO .bib  (caminho recomendado — ergonômico)
+// ============================================================================
+// Com um arquivo .bib + #referencias(...), o nome/ano vêm da entrada e a lista
+// de referências é gerada e mantida em sincronia automaticamente. Na maioria
+// dos casos basta a sintaxe nativa do Typst, sem nenhuma função:
+//   @silva2023            -> (Silva, 2023)
+//   @silva2023[p. 45]     -> (Silva, 2023, p. 45)
+//   @silva2023@santos2022 -> (Santos, 2022; Silva, 2023)   (várias obras)
+//   4+ autores            -> (Cormen et al., 2012)          (et al. automático)
+// As funções abaixo cobrem os dois casos que a sintaxe nativa não resolve.
+
+/// Autor na sentença, com página, a partir do .bib — "Silva (2023, p. 45)".
+/// Ergonômico: sobrenome e ano vêm da entrada `.bib`; a página é posicional.
+///   #pag(<silva2023>, 45)  ->  Silva (2023, p. 45)
+///   #pag(<silva2023>)      ->  Silva (2023)
+/// - chave: label da entrada, ex.: <silva2023>
+/// - pagina (posicional, opcional): número ou intervalo de página
+/// - autor (nomeado, opcional): sobrenomes na grafia da sentença. Use para 2–3
+///   autores, pois o motor do Typst só sabe juntar nomes com ";" — na sentença a
+///   NBR 10520:2023 pede "e" (Lima; Serrano entre parênteses, mas Lima e Serrano
+///   na frase). O ano continua vindo do `.bib`.
+///   #pag(<lima2024>, autor: "Lima e Serrano")      -> Lima e Serrano (2024)
+///   #pag(<lima2024>, 45, autor: "Lima e Serrano")  -> Lima e Serrano (2024, p. 45)
+#let pag(chave, autor: none, ..args) = {
+  let pagina = if args.pos().len() >= 1 { args.pos().at(0) } else { none }
+  if autor != none {
+    [#autor (#cite(chave, form: "year")#if pagina != none [, p. #pagina])]
+  } else {
+    cite(chave, form: "prose", supplement: if pagina != none [p. #pagina])
+  }
+}
+
+/// Citação de citação (apud) integrada ao .bib.
+/// A fonte CONSULTADA é uma chave `.bib` (entra na lista de referências e
+/// fornece autor/ano automaticamente); a fonte ORIGINAL, não acessada, é
+/// informada como texto, pois NÃO entra na lista (NBR 10520:2023, 5.3).
+///   #apud("Freire", 1994, <oliveira2021>, 25)
+///     ->  (Freire, 1994 apud Oliveira; Costa, 2021, p. 25)
+/// - autor-original, ano-original: dados da fonte não acessada (texto)
+/// - chave-consultada: label `<chave>` da obra efetivamente consultada
+/// - pagina (posicional, opcional): página na fonte consultada
+/// - pagina-original (nomeado, opcional): página na fonte original
+#let apud(autor-original, ano-original, chave-consultada, pagina-original: none, ..args) = {
+  let pagina = if args.pos().len() >= 1 { args.pos().at(0) } else { none }
+  [(#autor-original, #ano-original#if pagina-original != none [, p. #pagina-original] apud #cite(chave-consultada, form: "author"), #cite(chave-consultada, form: "year")#if pagina != none [, p. #pagina])]
+}
+
+/// Título da seção de referências
+#let referencias-titulo() = {
+  heading(level: 1, numbering: none, "REFERÊNCIAS")
+}
+
+// Funções para formatação manual de referências
+// (usar quando não for possível usar .bib)
+
+/// Formata referência de livro
+#let ref-livro(
+  autor: none,
+  titulo: none,
+  subtitulo: none,
+  edicao: none,
+  local: none,
+  editora: none,
+  ano: none,
+) = {
+  set par(
+    hanging-indent: 1.25cm,
+    first-line-indent: 0pt,
+  )
+
+  if autor != none { upper(autor); [. ] }
+  if titulo != none { strong(titulo) }
+  if subtitulo != none { [: #subtitulo] }
+  [. ]
+  if edicao != none { [#edicao. ed. ] }
+  if local != none { [#local: ] }
+  if editora != none { editora }
+  if ano != none { [, #ano.] }
+}
+
+/// Formata referência de artigo de periódico
+#let ref-artigo(
+  autor: none,
+  titulo: none,
+  revista: none,
+  local: none,
+  volume: none,
+  numero: none,
+  paginas: none,
+  mes: none,
+  ano: none,
+) = {
+  set par(
+    hanging-indent: 1.25cm,
+    first-line-indent: 0pt,
+  )
+
+  if autor != none { upper(autor); [. ] }
+  if titulo != none { [#titulo. ] }
+  if revista != none { strong(revista) }
+  if local != none { [, #local] }
+  if volume != none { [, v. #volume] }
+  if numero != none { [, n. #numero] }
+  if paginas != none { [, p. #paginas] }
+  if mes != none { [, #mes] }
+  if ano != none { [. #ano.] }
+}
+
+/// Formata referência de documento eletrônico
+#let ref-online(
+  autor: none,
+  titulo: none,
+  site: none,
+  ano: none,
+  url: none,
+  data-acesso: none,
+) = {
+  set par(
+    hanging-indent: 1.25cm,
+    first-line-indent: 0pt,
+  )
+
+  if autor != none { upper(autor); [. ] }
+  if titulo != none { strong(titulo); [. ] }
+  if site != none { [#site, ] }
+  if ano != none { ano }
+  [. ]
+  if url != none { [Disponível em: #url. ] }
+  if data-acesso != none { [Acesso em: #data-acesso.] }
+}
+
+// Aliases curtos
+#let cautor = citar-autor
+#let cindireto = citar-indireto
+#let capud = citar-apud
+#let cmultiplos = citar-multiplos
+#let cvarios = citar-varios
+#let cetal = citar-etal
+#let centidade = citar-entidade
+#let ctitulo = citar-titulo
+#let ref-titulo = referencias-titulo

--- a/packages/preview/abntyp/0.1.5/src/references/numeric.typ
+++ b/packages/preview/abntyp/0.1.5/src/references/numeric.typ
@@ -1,0 +1,527 @@
+// Sistema Numerico de Citacoes conforme NBR 10520:2023
+//
+// ============================================================================
+// SOBRE O SISTEMA NUMERICO
+// ============================================================================
+//
+// A NBR 10520:2023 (secao 4.2) permite dois sistemas de chamada para citacoes:
+// - Sistema autor-data (padrao no Brasil)
+// - Sistema numerico (permitido pela norma)
+//
+// Este modulo implementa o sistema numerico, inspirado no abntex2-num.bst
+// do pacote abntex2 para LaTeX.
+//
+// IMPORTANTE (NBR 10520:2023, secao 4.2):
+// "O sistema numerico NAO pode ser usado quando houver notas"
+// Isso significa que se voce usar o sistema numerico, NAO pode ter notas
+// de rodape no documento, pois haveria conflito na numeracao.
+//
+// ============================================================================
+// FUNCIONAMENTO
+// ============================================================================
+//
+// No sistema numerico:
+// - Citacoes sao indicadas por numeros arabicos consecutivos
+// - A numeracao remete a lista de referencias ao final do documento
+// - A numeracao NAO reinicia a cada pagina
+// - Fonte repetida recebe a MESMA numeracao da primeira ocorrencia
+//
+// Formatos permitidos (NBR 10520:2023):
+// - Entre parenteses: (15, p. 34)
+// - Em expoente (sobrescrito): ¹⁵, p. 34
+//
+// ============================================================================
+// INSPIRACAO
+// ============================================================================
+//
+// Este modulo foi inspirado no abntex2-num.bst do projeto abntex2
+// (https://github.com/abntex/abntex2), adaptado para a sintaxe do Typst.
+//
+// ============================================================================
+
+// Estado global para o sistema numerico
+// Armazena o mapeamento de chaves de citacao para numeros
+#let _numeric-citations = state("abnt-numeric-citations", (:))
+#let _numeric-counter = state("abnt-numeric-counter", 0)
+
+// ============================================================================
+// CONFIGURACAO DO SISTEMA NUMERICO
+// ============================================================================
+
+/// Configura o documento para usar o sistema numerico de citacoes
+///
+/// ATENCAO: O sistema numerico NAO pode ser usado com notas de rodape
+/// (NBR 10520:2023, secao 4.2). Esta funcao desabilita notas de rodape
+/// para evitar conflitos.
+///
+/// Parametros:
+/// - estilo: estilo de apresentacao ("parentheses" ou "superscript")
+///   - "parentheses": (1), (2, p. 45) - padrao
+///   - "superscript": ¹, ², p. 45 - sobrescrito
+/// - colchetes: tipo de delimitador para estilo parentheses
+///   - "()" - parenteses (padrao)
+///   - "[]" - colchetes
+///
+/// Exemplo:
+/// ```typst
+/// #show: citacao-num-config
+///
+/// Conforme demonstrado #citar-num(<silva2023>), o resultado foi positivo.
+/// ```
+#let citacao-num-config(
+  estilo: "parentheses",
+  colchetes: "()",
+  body,
+) = {
+  // Aviso importante sobre notas de rodape
+  // A NBR 10520:2023 proibe o uso simultaneo de sistema numerico e notas
+
+  // Armazenar configuracao no estado
+  let config = state("abnt-numeric-config", (
+    estilo: estilo,
+    colchetes: colchetes,
+  ))
+
+  // Resetar contadores no inicio do documento
+  _numeric-citations.update((:))
+  _numeric-counter.update(0)
+
+  body
+}
+
+// ============================================================================
+// FUNCOES DE CITACAO NUMERICA
+// ============================================================================
+
+/// Citacao numerica simples
+///
+/// Insere uma citacao no formato numerico. Se a referencia ja foi citada,
+/// reutiliza o mesmo numero.
+///
+/// Parametros:
+/// - chave: chave da referencia (string identificadora)
+/// - pagina: pagina (opcional)
+/// - estilo: "parentheses" ou "superscript" (opcional, usa padrao do documento)
+///
+/// Exemplos:
+/// ```typst
+/// O resultado foi confirmado #citar-num("silva2023").
+/// Conforme demonstrado #citar-num("santos2022", pagina: "45").
+/// ```
+///
+/// Formatos de saida (NBR 10520:2023):
+/// - Parenteses: (1) ou (1, p. 45)
+/// - Sobrescrito: ¹ ou ¹, p. 45
+#let citar-num(
+  chave,
+  pagina: none,
+  volume: none,
+  estilo: "parentheses",
+  colchetes: "()",
+) = {
+  context {
+    let citations = _numeric-citations.get()
+    let is-new = chave not in citations
+    let num = if is-new { _numeric-counter.get() + 1 } else { citations.at(chave) }
+
+    // Registrar nova citacao no estado (separado do calculo do numero)
+    if is-new {
+      _numeric-counter.update(num)
+      _numeric-citations.update(c => {
+        c.insert(chave, num)
+        c
+      })
+    }
+
+    // Formatar localizacao (pagina, volume)
+    let loc = if pagina != none or volume != none {
+      let parts = ()
+      if volume != none { parts.push([v. #volume]) }
+      if pagina != none { parts.push([p. #pagina]) }
+      [, #parts.join(", ")]
+    } else {
+      []
+    }
+
+    // Formatar saida conforme estilo
+    if estilo == "superscript" {
+      // Formato sobrescrito: ¹, p. 45
+      // Nota: sem espaco antes do sobrescrito (NBR 10520:2023)
+      super[#num#loc]
+    } else {
+      // Formato parenteses: (1, p. 45)
+      let (open, close) = if colchetes == "[]" {
+        ("[", "]")
+      } else {
+        ("(", ")")
+      }
+      [#open#num#loc#close]
+    }
+  }
+}
+
+/// Citacao numerica com autor no texto
+///
+/// Quando o nome do autor aparece na sentenca, apenas o numero vai
+/// entre parenteses ou sobrescrito.
+///
+/// Exemplo:
+/// ```typst
+/// Segundo Silva #citar-num-linha("silva2023", pagina: "45"), o resultado...
+/// ```
+///
+/// Saida: Segundo Silva (1, p. 45), o resultado...
+#let citar-num-linha(
+  chave,
+  pagina: none,
+  volume: none,
+  estilo: "parentheses",
+  colchetes: "()",
+) = {
+  citar-num(chave, pagina: pagina, volume: volume, estilo: estilo, colchetes: colchetes)
+}
+
+/// Citacao numerica multipla
+///
+/// Cita multiplas referencias de uma vez.
+///
+/// Exemplo:
+/// ```typst
+/// Varios autores confirmam #citar-num-multiplos(("silva2023", "santos2022", "costa2021")).
+/// ```
+///
+/// Saida: (1; 2; 3) ou ¹ ² ³
+#let citar-num-multiplos(
+  chaves,
+  estilo: "parentheses",
+  colchetes: "()",
+) = {
+  context {
+    let citations = _numeric-citations.get()
+    let counter-val = _numeric-counter.get()
+    let nums = ()
+    let new-entries = (:)
+    let next-num = counter-val
+
+    for chave in chaves {
+      if chave in citations {
+        nums.push(citations.at(chave))
+      } else if chave in new-entries {
+        nums.push(new-entries.at(chave))
+      } else {
+        next-num += 1
+        new-entries.insert(chave, next-num)
+        nums.push(next-num)
+      }
+    }
+
+    // Registrar novas citacoes no estado
+    if new-entries.len() > 0 {
+      _numeric-counter.update(next-num)
+      _numeric-citations.update(c => {
+        for (k, n) in new-entries {
+          c.insert(k, n)
+        }
+        c
+      })
+    }
+
+    if estilo == "superscript" {
+      super[#nums.map(str).join(", ")]
+    } else {
+      let (open, close) = if colchetes == "[]" {
+        ("[", "]")
+      } else {
+        ("(", ")")
+      }
+      [#open#nums.map(str).join("; ")#close]
+    }
+  }
+}
+
+/// Citacao numerica de citacao (apud)
+///
+/// Para citar uma fonte que voce nao teve acesso direto,
+/// citada em outra obra que voce consultou.
+///
+/// NBR 10520:2023: Na lista de referencias, inclua SOMENTE a fonte consultada.
+///
+/// Parametros:
+/// - chave-original: chave da fonte original (nao acessada)
+/// - pagina-original: pagina na fonte original (opcional)
+/// - chave-consultada: chave da fonte consultada
+/// - pagina-consultada: pagina na fonte consultada (opcional)
+///
+/// Exemplo:
+/// ```typst
+/// Segundo a teoria #citar-num-apud("freire1994", pagina-original: "13", "streck2017", pagina-consultada: "25").
+/// ```
+///
+/// Saida: (1 apud 2, p. 25)
+#let citar-num-apud(
+  chave-original,
+  chave-consultada,
+  pagina-original: none,
+  pagina-consultada: none,
+  estilo: "parentheses",
+  colchetes: "()",
+) = {
+  context {
+    let citations = _numeric-citations.get()
+    let counter-val = _numeric-counter.get()
+    let next-num = counter-val
+    let new-entries = (:)
+
+    // Numero para a referencia original
+    let orig-num = if chave-original in citations {
+      citations.at(chave-original)
+    } else {
+      next-num += 1
+      new-entries.insert(chave-original, next-num)
+      next-num
+    }
+
+    // Numero para a referencia consultada
+    let cons-num = if chave-consultada in citations {
+      citations.at(chave-consultada)
+    } else if chave-consultada in new-entries {
+      new-entries.at(chave-consultada)
+    } else {
+      next-num += 1
+      new-entries.insert(chave-consultada, next-num)
+      next-num
+    }
+
+    // Registrar novas citacoes no estado
+    if new-entries.len() > 0 {
+      _numeric-counter.update(next-num)
+      _numeric-citations.update(c => {
+        for (k, n) in new-entries {
+          c.insert(k, n)
+        }
+        c
+      })
+    }
+
+    let orig-loc = if pagina-original != none { [, p. #pagina-original] } else { [] }
+    let cons-loc = if pagina-consultada != none { [, p. #pagina-consultada] } else { [] }
+
+    if estilo == "superscript" {
+      super[#orig-num#orig-loc apud #cons-num#cons-loc]
+    } else {
+      let (open, close) = if colchetes == "[]" {
+        ("[", "]")
+      } else {
+        ("(", ")")
+      }
+      [#open#orig-num#orig-loc apud #cons-num#cons-loc#close]
+    }
+  }
+}
+
+// ============================================================================
+// CITACOES DIRETAS COM NUMERO
+// ============================================================================
+
+/// Citacao direta curta (ate 3 linhas) com numero
+///
+/// Formatada entre aspas duplas, com numero ao final.
+///
+/// Exemplo:
+/// ```typst
+/// #citacao-num-curta("silva2023", pagina: "45")[
+///   O resultado demonstrou significativa melhoria.
+/// ]
+/// ```
+///
+/// Saida: "O resultado demonstrou significativa melhoria" (1, p. 45).
+#let citacao-num-curta(
+  chave,
+  pagina: none,
+  estilo: "parentheses",
+  colchetes: "()",
+  body,
+) = {
+  ["#body" #citar-num(chave, pagina: pagina, estilo: estilo, colchetes: colchetes).]
+}
+
+/// Citacao direta longa (mais de 3 linhas) com numero
+///
+/// Formatada com recuo de 4cm, fonte menor, espacamento simples, sem aspas.
+/// Numero ao final da citacao.
+///
+/// Exemplo:
+/// ```typst
+/// #citacao-num-longa("silva2023", pagina: "45-46")[
+///   A teleconferencia permite ao individuo participar de um encontro
+///   nacional ou regional sem a necessidade de deixar seu local de
+///   origem. Tipos comuns de teleconferencia incluem o uso de televisao,
+///   telefone e computador.
+/// ]
+/// ```
+#let citacao-num-longa(
+  chave,
+  pagina: none,
+  estilo: "parentheses",
+  colchetes: "()",
+  body,
+) = {
+  set par(
+    first-line-indent: 0pt,
+    leading: 1em, // espacamento simples
+  )
+  set text(size: 10pt) // fonte menor
+
+  block(
+    inset: (left: 4cm),
+    [#body #citar-num(chave, pagina: pagina, estilo: estilo, colchetes: colchetes).]
+  )
+}
+
+// ============================================================================
+// BIBLIOGRAFIA NUMERADA
+// ============================================================================
+
+/// Bibliografia no sistema numerico
+///
+/// Gera a lista de referencias ordenada pela ordem de citacao no texto,
+/// com numeros correspondentes as citacoes.
+///
+/// NOTA: A NBR 6023:2018 permite ordenacao alfabetica ou por ordem de citacao.
+/// No sistema numerico, a ordenacao por ordem de citacao e mais intuitiva.
+///
+/// Parametros:
+/// - itens: lista de referencias no formato (chave, conteudo)
+/// - titulo: titulo da secao (padrao: "REFERENCIAS")
+///
+/// Exemplo:
+/// ```typst
+/// #bibliografia-numerica(
+///   (
+///     ("silva2023", [SILVA, J. *Titulo do livro*. Sao Paulo: Editora, 2023.]),
+///     ("santos2022", [SANTOS, M. Artigo importante. *Revista*, v. 1, 2022.]),
+///   )
+/// )
+/// ```
+#let bibliografia-numerica(
+  itens,
+  titulo: "REFERÊNCIAS",
+) = {
+  // Titulo da secao
+  heading(level: 1, numbering: none, titulo)
+
+  v(1em)
+
+  // Configuracao de paragrafo para referencias
+  set par(
+    hanging-indent: 0pt, // sem recuo frances no sistema numerico
+    first-line-indent: 0pt,
+    leading: 1em,
+  )
+
+  context {
+    let citations = _numeric-citations.get()
+
+    // Ordenar itens pela ordem de citacao
+    let ordered = itens.filter(item => item.at(0) in citations)
+                       .sorted(key: item => citations.at(item.at(0)))
+
+    // Itens nao citados vao ao final (se full: true)
+    let uncited = itens.filter(item => item.at(0) not in citations)
+
+    // Renderizar referencias numeradas
+    for item in ordered {
+      let (key, content) = item
+      let num = citations.at(key)
+
+      block(spacing: 0.8em)[
+        #text(weight: "bold")[#num] #h(0.5em) #content
+      ]
+    }
+
+    // Avisar sobre referencias nao citadas
+    if uncited.len() > 0 {
+      v(1em)
+      text(fill: gray, size: 9pt)[
+        _Nota: #uncited.len() referencia(s) nao citada(s) no texto foram omitidas._
+      ]
+    }
+  }
+}
+
+/// Referencia numerada individual (para uso manual)
+///
+/// Quando nao se usa arquivo .bib, permite criar referencias numeradas manualmente.
+///
+/// Parametros:
+/// - num: numero da referencia
+/// - conteudo: conteudo formatado da referencia (conforme NBR 6023:2018)
+#let ref-numerica(num, conteudo) = {
+  set par(
+    hanging-indent: 0pt,
+    first-line-indent: 0pt,
+  )
+
+  block(spacing: 0.8em)[
+    #text(weight: "bold")[#num] #h(0.5em) #conteudo
+  ]
+}
+
+// ============================================================================
+// AVISO SOBRE NOTAS DE RODAPE
+// ============================================================================
+
+/// Funcao para inserir aviso sobre incompatibilidade com notas
+///
+/// Use no inicio do documento quando adotar o sistema numerico.
+#let aviso-sistema-numerico() = {
+  text(size: 10pt, fill: gray, style: "italic")[
+    Este documento utiliza o sistema numerico de citacoes (NBR 10520:2023, secao 4.2).
+    Conforme a norma, o sistema numerico nao pode ser usado simultaneamente com
+    notas de rodape.
+  ]
+}
+
+// ============================================================================
+// UTILITARIOS
+// ============================================================================
+
+/// Obtem o numero atual de uma citacao (se ja foi citada)
+///
+/// Util para referencias cruzadas manuais.
+#let get-citation-number(chave) = {
+  context {
+    let citations = _numeric-citations.get()
+    if chave in citations {
+      str(citations.at(chave))
+    } else {
+      "?"
+    }
+  }
+}
+
+/// Reseta a numeracao de citacoes
+///
+/// Use apenas se precisar reiniciar a numeracao (ex: em livros com partes independentes).
+/// NOTA: A NBR 10520:2023 diz que a numeracao NAO deve reiniciar a cada pagina,
+/// mas pode ser reiniciada por capitulo em alguns casos.
+#let reset-numeric-citations() = {
+  _numeric-citations.update((:))
+  _numeric-counter.update(0)
+}
+
+/// Obtem o total de citacoes ate o momento
+#let get-citation-count() = {
+  context {
+    _numeric-counter.get()
+  }
+}
+
+// Aliases curtos
+#let cnum = citar-num
+#let cnlinha = citar-num-linha
+#let cnmultiplos = citar-num-multiplos
+#let cnapud = citar-num-apud
+#let cncurta = citacao-num-curta
+#let cnlonga = citacao-num-longa
+#let bibnum = bibliografia-numerica

--- a/packages/preview/abntyp/0.1.5/src/templates/article.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/article.typ
@@ -1,0 +1,123 @@
+// Template para artigo científico conforme NBR 6022:2018
+
+#import "../core/setup.typ": with-abnt-setup
+#import "../core/page.typ": *
+#import "../core/fonts.typ": *
+#import "../core/spacing.typ": *
+#import "../references/bibliography.typ": *
+
+/// Template para artigo científico
+///
+/// Parâmetros:
+/// - titulo: título do artigo
+/// - subtitulo: subtítulo (opcional)
+/// - autores: lista de autores com afiliação
+/// - resumo: resumo em português
+/// - resumo-en: abstract em inglês
+/// - palavras-chave: palavras-chave
+/// - palavras-chave-en: keywords
+/// - fonte: fonte a usar
+/// - colunas: número de colunas (1 ou 2)
+/// - arquivo-bibliografia: caminho para arquivo .bib (opcional)
+/// - titulo-bibliografia: título da seção de referências (padrão: "REFERÊNCIAS")
+#let artigo(
+  titulo: "",
+  subtitulo: none,
+  autores: (),
+  resumo: none,
+  resumo-en: none,
+  palavras-chave: (),
+  palavras-chave-en: (),
+  fonte: "Times New Roman",
+  colunas: 1,
+  arquivo-bibliografia: none,
+  titulo-bibliografia: "REFERÊNCIAS",
+  body,
+) = {
+  // Configuração do documento
+  set document(
+    title: titulo,
+    author: autores.map(a => a.name).join(", "),
+  )
+
+  show: with-abnt-setup.with(fonte: fonte, level-1-pagebreak: false)
+
+  // Paginação visível desde o início para artigos
+  set page(
+    numbering: "1",
+    number-align: top + right,
+  )
+
+  // Título centralizado, maiúsculas, negrito
+  align(center)[
+    #text(weight: "bold", size: 14pt, upper(titulo))
+    #if subtitulo != none {
+      linebreak()
+      text(size: 14pt, ": " + subtitulo)
+    }
+  ]
+
+  v(1em)
+
+  // Autores
+  for autor in autores {
+    align(center)[
+      #text(size: 12pt, autor.name)
+      #if "affiliation" in autor {
+        footnote(autor.affiliation)
+      }
+    ]
+  }
+
+  v(2em)
+
+  // Resumo
+  if resumo != none {
+    [*RESUMO*]
+    linebreak()
+    set par(first-line-indent: 0pt)
+    resumo
+    if palavras-chave.len() > 0 {
+      linebreak()
+      linebreak()
+      [*Palavras-chave:* #palavras-chave.join(". ").]
+    }
+    v(2em)
+  }
+
+  // Abstract
+  if resumo-en != none {
+    [*ABSTRACT*]
+    linebreak()
+    set par(first-line-indent: 0pt)
+    resumo-en
+    if palavras-chave-en.len() > 0 {
+      linebreak()
+      linebreak()
+      [*Keywords:* #palavras-chave-en.join(". ").]
+    }
+    v(2em)
+  }
+
+  // Corpo do artigo
+  if colunas == 2 {
+    columns(2, body)
+  } else {
+    body
+  }
+
+  // Bibliografia automática (se arquivo .bib fornecido)
+  if arquivo-bibliografia != none {
+    abnt-bibliography(arquivo-bibliografia, titulo: titulo-bibliografia)
+  }
+}
+
+/// Seção de artigo (sem numeração)
+#let article-section(titulo) = {
+  heading(level: 1, numbering: none, titulo)
+}
+
+/// Subseção de artigo
+#let article-subsection(titulo) = {
+  heading(level: 2, numbering: none, titulo)
+}

--- a/packages/preview/abntyp/0.1.5/src/templates/book.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/book.typ
@@ -1,0 +1,662 @@
+// Template para livros e folhetos conforme NBR 6029:2023
+// Informacao e documentacao - Livros e folhetos - Apresentacao
+
+#import "../core/setup.typ": with-abnt-setup
+#import "../core/page.typ": *
+#import "../core/fonts.typ": *
+#import "../core/spacing.typ": *
+#import "../core/dates.typ": *
+
+/// Template principal para livro ou folheto
+/// Conforme NBR 6029:2023
+///
+/// Parametros:
+/// - titulo: titulo da obra
+/// - subtitulo: subtitulo (opcional)
+/// - autor: nome do autor
+/// - editora: nome da editora
+/// - local: cidade de publicacao
+/// - ano: ano de publicacao
+/// - edicao: numero da edicao (a partir da 2a)
+/// - volume: numero do volume (se houver)
+/// - isbn: numero ISBN
+/// - fonte: fonte a usar
+/// - cabecalho: titulo corrente (opcional)
+#let livro(
+  titulo: "",
+  subtitulo: none,
+  autor: "",
+  editora: "",
+  local: "",
+  ano: datetime.today().year(),
+  edicao: none,
+  volume: none,
+  isbn: none,
+  fonte: "Times New Roman",
+  cabecalho: none,
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: autor,
+  )
+
+  show: with-abnt-setup.with(fonte: fonte, suplemento-nivel1: "Capítulo")
+
+  // Titulo corrente no alto da mancha (livro-especifico)
+  set page(
+    header: context {
+      if cabecalho != none {
+        let page-num = counter(page).get().first()
+        // Paginas pares: autor/titulo a esquerda
+        // Paginas impares: capitulo a direita
+        if calc.rem(page-num, 2) == 0 {
+          // Pagina par
+          text(size: 10pt, cabecalho)
+        } else {
+          // Pagina impar
+          align(right)[
+            #text(size: 10pt, cabecalho)
+          ]
+        }
+      }
+    },
+  )
+
+  // Livros usam 14pt para heading level 1 (diferente do padrão 12pt)
+  show heading.where(level: 1): it => {
+    pagebreak(weak: true)
+    v(1.5em)
+    text(weight: "bold", size: 14pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #upper(it.body)
+    ]
+    v(1.5em)
+  }
+
+  body
+}
+
+/// Primeira capa do livro
+/// Conforme NBR 6029:2023 - deve conter:
+/// - Nome do autor
+/// - Titulo e subtitulo por extenso
+/// - Nome da editora e/ou logomarca
+/// - Recomenda-se: edicao, local e ano
+///
+/// Parametros:
+/// - autor: nome do autor
+/// - titulo: titulo da obra
+/// - subtitulo: subtitulo (opcional)
+/// - editora: nome da editora
+/// - logo-editora: logomarca da editora (opcional)
+/// - edicao: numero da edicao (opcional)
+/// - local: cidade (opcional)
+/// - ano: ano (opcional)
+#let book-cover(
+  autor: "",
+  titulo: "",
+  subtitulo: none,
+  editora: "",
+  logo-editora: none,
+  edicao: none,
+  local: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+  set align(center)
+
+  v(2cm)
+
+  // Autor
+  text(size: 14pt, upper(autor))
+
+  v(1fr)
+
+  // Titulo
+  text(weight: "bold", size: 18pt, upper(titulo))
+
+  // Subtitulo
+  if subtitulo != none {
+    linebreak()
+    text(size: 14pt, ": " + subtitulo)
+  }
+
+  v(1fr)
+
+  // Edicao
+  if edicao != none {
+    text(size: 12pt)[#edicao. edicao]
+    v(0.5em)
+  }
+
+  // Editora
+  if logo-editora != none {
+    logo-editora
+    v(0.5em)
+  }
+  text(size: 12pt, editora)
+
+  v(1em)
+
+  // Local e ano
+  if local != none {
+    text(size: 12pt, local)
+    linebreak()
+  }
+  if ano != none {
+    text(size: 12pt, str(ano))
+  }
+
+  v(2cm)
+  pagebreak()
+}
+
+/// Quarta capa (contracapa)
+/// Conforme NBR 6029:2023 - deve conter:
+/// - ISBN (obrigatorio)
+/// - Codigo de barras (se houver)
+/// - Pode conter: resumo e endereco da editora
+///
+/// Parametros:
+/// - isbn: numero ISBN
+/// - codigo-barras: codigo de barras (imagem, opcional)
+/// - resumo: resumo do conteudo (opcional)
+/// - endereco-editora: endereco da editora (opcional)
+#let book-back-cover(
+  isbn: "",
+  codigo-barras: none,
+  resumo: none,
+  endereco-editora: none,
+) = {
+  set page(numbering: none)
+
+  v(1fr)
+
+  // Resumo
+  if resumo != none {
+    set par(first-line-indent: 0pt)
+    resumo
+    v(2em)
+  }
+
+  // Endereco da editora
+  if endereco-editora != none {
+    set text(size: 10pt)
+    endereco-editora
+    v(2em)
+  }
+
+  v(1fr)
+
+  // ISBN e codigo de barras
+  align(left)[
+    #text(size: 10pt)[ISBN #isbn]
+  ]
+
+  if codigo-barras != none {
+    v(0.5em)
+    codigo-barras
+  }
+
+  pagebreak()
+}
+
+/// Falsa folha de rosto (opcional)
+/// Apenas o titulo da obra
+#let half-title-page(titulo: "") = {
+  set page(numbering: none)
+  set align(center)
+
+  v(1fr)
+  text(size: 14pt, titulo)
+  v(1fr)
+
+  pagebreak()
+}
+
+/// Folha de rosto - anverso
+/// Conforme NBR 6029:2023 - elementos na ordem:
+/// a) Autor
+/// b) Titulo e subtitulo
+/// c) Outros colaboradores
+/// d) Indicacao de edicao (a partir da 2a)
+/// e) Numeracao do volume
+/// f) Editora
+/// g) Local de publicacao
+/// h) Ano de publicacao
+///
+/// Parametros:
+/// - autor: nome do autor
+/// - titulo: titulo
+/// - subtitulo: subtitulo (opcional)
+/// - colaboradores: outros colaboradores (tradutor, ilustrador, etc.)
+/// - edicao: numero da edicao (a partir da 2a)
+/// - volume: numero do volume (se houver)
+/// - editora: editora
+/// - local: cidade
+/// - ano: ano
+#let book-title-page(
+  autor: "",
+  titulo: "",
+  subtitulo: none,
+  colaboradores: none,
+  edicao: none,
+  volume: none,
+  editora: "",
+  local: "",
+  ano: none,
+) = {
+  set page(numbering: none)
+  set align(center)
+
+  // Autor
+  text(size: 12pt, upper(autor))
+
+  v(1fr)
+
+  // Titulo
+  text(weight: "bold", size: 16pt, upper(titulo))
+
+  // Subtitulo (diferenciado tipograficamente)
+  if subtitulo != none {
+    linebreak()
+    text(size: 14pt, ": " + subtitulo)
+  }
+
+  v(1em)
+
+  // Colaboradores
+  if colaboradores != none {
+    set text(size: 11pt)
+    colaboradores
+  }
+
+  v(1em)
+
+  // Edicao
+  if edicao != none {
+    text(size: 11pt)[#edicao. edicao]
+    v(0.5em)
+  }
+
+  // Volume
+  if volume != none {
+    text(size: 11pt)[Volume #volume]
+  }
+
+  v(1fr)
+
+  // Editora
+  text(size: 12pt, editora)
+
+  v(0.5em)
+
+  // Local
+  text(size: 12pt, local)
+
+  // Ano
+  if ano != none {
+    linebreak()
+    text(size: 12pt, str(ano))
+  }
+
+  pagebreak()
+}
+
+/// Folha de rosto - verso
+/// Conforme NBR 6029:2023 - deve conter:
+/// a) Direito autoral
+/// b) Direito de reproducao
+/// c) Titulo original (se traducao)
+/// d) Outros suportes disponiveis
+/// e) Creditos
+/// f) Ficha catalografica + nome e CRB do bibliotecario
+/// g) Dados da editora
+///
+/// Parametros:
+/// - ano-copyright: ano do copyright
+/// - detentor-copyright: detentor dos direitos
+/// - titulo-original: titulo original (se traducao)
+/// - direitos-reproducao: texto sobre direito de reproducao
+/// - outros-formatos: outros suportes disponiveis
+/// - creditos: creditos diversos
+/// - ficha-catalografica: conteudo da ficha catalografica
+/// - bibliotecario: nome e CRB do bibliotecario
+/// - dados-editora: dados da editora
+#let book-title-page-verso(
+  ano-copyright: none,
+  detentor-copyright: none,
+  titulo-original: none,
+  direitos-reproducao: none,
+  outros-formatos: none,
+  creditos: none,
+  ficha-catalografica: none,
+  bibliotecario: none,
+  dados-editora: none,
+) = {
+  set page(numbering: none)
+  set text(size: 10pt)
+  set par(first-line-indent: 0pt, leading: 1em * 0.65)
+
+  // Copyright
+  if ano-copyright != none and detentor-copyright != none {
+    [(c) #ano-copyright #detentor-copyright]
+    v(1em)
+  }
+
+  // Direito de reproducao
+  if direitos-reproducao != none {
+    direitos-reproducao
+    v(1em)
+  }
+
+  // Titulo original
+  if titulo-original != none {
+    [Titulo original: #emph[#titulo-original]]
+    v(1em)
+  }
+
+  // Outros suportes
+  if outros-formatos != none {
+    outros-formatos
+    v(1em)
+  }
+
+  // Creditos
+  if creditos != none {
+    creditos
+    v(1em)
+  }
+
+  v(1fr)
+
+  // Ficha catalografica (parte inferior)
+  if ficha-catalografica != none {
+    align(center)[
+      #box(
+        width: 12.5cm,
+        height: auto,
+        stroke: 0.5pt,
+        inset: 0.5cm,
+      )[
+        #ficha-catalografica
+
+        #if bibliotecario != none {
+          v(0.5em)
+          text(size: 9pt, bibliotecario)
+        }
+      ]
+    ]
+    v(1em)
+  }
+
+  // Dados da editora
+  if dados-editora != none {
+    align(center)[
+      #text(size: 9pt, dados-editora)
+    ]
+  }
+
+  pagebreak()
+}
+
+/// Dedicatoria
+/// Conforme NBR 6029:2023 - pagina impar
+#let book-dedication(conteudo) = {
+  set page(numbering: none)
+  v(1fr)
+  align(right)[
+    #box(width: 50%)[
+      #set par(first-line-indent: 0pt)
+      #set text(size: 11pt)
+      #conteudo
+    ]
+  ]
+  pagebreak()
+}
+
+/// Agradecimentos
+/// Conforme NBR 6029:2023 - pagina impar
+#let book-acknowledgments(conteudo) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "AGRADECIMENTOS")
+  ]
+  v(1.5em)
+  conteudo
+  pagebreak()
+}
+
+/// Epigrafe
+/// Conforme NBR 6029:2023 - pagina impar
+#let book-epigraph(citacao, autor) = {
+  set page(numbering: none)
+  v(1fr)
+  align(right)[
+    #box(width: 50%)[
+      #set par(first-line-indent: 0pt)
+      #set text(size: 11pt, style: "italic")
+      \u{201C}#citacao\u{201D}
+      #linebreak()
+      #set text(style: "normal")
+      [(#autor)]
+    ]
+  ]
+  pagebreak()
+}
+
+/// Lista de ilustracoes
+/// Conforme NBR 6029:2023 - ordem de apresentacao
+/// Formato: nome especifico + travessao + titulo + pagina
+#let book-list-illustrations() = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE ILUSTRACOES")
+  ]
+
+  v(1.5em)
+
+  outline(
+    title: none,
+    target: figure.where(kind: image),
+  )
+
+  pagebreak()
+}
+
+/// Lista de tabelas
+#let book-list-tables() = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE TABELAS")
+  ]
+
+  v(1.5em)
+
+  outline(
+    title: none,
+    target: figure.where(kind: table),
+  )
+
+  pagebreak()
+}
+
+/// Lista de abreviaturas e siglas
+/// Conforme NBR 6029:2023 - ordem alfabetica
+#let book-list-abbreviations(items) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE ABREVIATURAS E SIGLAS")
+  ]
+
+  v(1.5em)
+
+  set par(first-line-indent: 0pt)
+
+  // Ordenar alfabeticamente
+  let sorted-keys = items.keys().sorted()
+  for key in sorted-keys {
+    [#key #h(1em) #items.at(key) \ ]
+  }
+
+  pagebreak()
+}
+
+/// Lista de simbolos
+/// Conforme NBR 6029:2023 - ordem de apresentacao
+#let book-list-symbols(items) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "LISTA DE SIMBOLOS")
+  ]
+
+  v(1.5em)
+
+  set par(first-line-indent: 0pt)
+
+  for (symbol, meaning) in items {
+    [#symbol #h(1em) #meaning \ ]
+  }
+
+  pagebreak()
+}
+
+/// Sumario do livro
+/// Conforme NBR 6027
+#let book-toc(
+  titulo: "SUMARIO",
+  profundidade: 3,
+) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, titulo)
+  ]
+
+  v(1.5em)
+
+  outline(
+    title: none,
+    depth: profundidade,
+    indent: auto,
+  )
+
+  pagebreak()
+}
+
+/// Prefacio ou apresentacao
+/// Conforme NBR 6029:2023 - pagina impar, sem indicativo de secao
+/// Em novas edicoes: prefacio novo precede os anteriores
+#let book-preface(titulo: "PREFACIO", conteudo) = {
+  heading(level: 1, numbering: none, upper(titulo))
+  conteudo
+  pagebreak()
+}
+
+/// Apresentacao
+#let book-presentation(conteudo) = {
+  book-preface(titulo: "APRESENTACAO", conteudo)
+}
+
+/// Posfacio
+/// Conforme NBR 6029:2023 - elemento pos-textual opcional
+#let book-postface(conteudo) = {
+  heading(level: 1, numbering: none, "POSFACIO")
+  conteudo
+  pagebreak()
+}
+
+/// Glossario
+/// Conforme NBR 6029:2023 - elemento pos-textual opcional
+/// - items: dicionario termo -> definicao
+#let book-glossary(items) = {
+  heading(level: 1, numbering: none, "GLOSSARIO")
+
+  set par(first-line-indent: 0pt)
+
+  let sorted-keys = items.keys().sorted()
+  for key in sorted-keys {
+    [*#key:* #items.at(key) \ ]
+    v(0.5em)
+  }
+
+  pagebreak()
+}
+
+/// Apendice
+/// Conforme NBR 6029:2023 - identificacao: termo + travessao + titulo
+/// Multiplos: letras maiusculas consecutivas (A, B, C...)
+#let book-appendix(letra: "A", titulo: "", body) = {
+  heading(level: 1, numbering: none)[APENDICE #letra -- #titulo]
+  body
+  pagebreak()
+}
+
+/// Anexo
+/// Conforme NBR 6029:2023 - identificacao: termo + travessao + titulo
+/// Multiplos: letras maiusculas consecutivas (A, B, C...)
+#let book-annex(letra: "A", titulo: "", body) = {
+  heading(level: 1, numbering: none)[ANEXO #letra -- #titulo]
+  body
+  pagebreak()
+}
+
+/// Indice remissivo
+/// Conforme NBR 6034 - no final da publicacao
+#let book-index(titulo: "INDICE", entries) = {
+  heading(level: 1, numbering: none, upper(titulo))
+
+  set par(first-line-indent: 0pt)
+  set text(size: 10pt)
+
+  // Organizar por letra inicial
+  let by-letter = (:)
+  for (term, pages) in entries {
+    let letter = upper(term.at(0))
+    if letter not in by-letter {
+      by-letter.insert(letter, ())
+    }
+    by-letter.at(letter).push((term, pages))
+  }
+
+  for letter in by-letter.keys().sorted() {
+    text(weight: "bold", size: 11pt, letter)
+    linebreak()
+    for (term, pages) in by-letter.at(letter) {
+      [#term #box(width: 1fr, repeat[.]) #pages \ ]
+    }
+    v(0.5em)
+  }
+
+  pagebreak()
+}
+
+/// Colofao
+/// Conforme NBR 6029:2023 - ultima folha do miolo
+/// Especificacoes graficas da publicacao
+#let book-colophon(conteudo) = {
+  v(1fr)
+  set text(size: 10pt)
+  set par(first-line-indent: 0pt)
+  align(center)[
+    #conteudo
+  ]
+}
+
+/// Inicia numeracao das paginas (apos elementos pre-textuais)
+/// Conforme NBR 6029:2023:
+/// - Folhas iniciais ate o Sumario: contadas mas nao numeradas
+/// - Algarismos arabicos
+/// - Localizacao: fora da mancha, a criterio do projeto grafico
+#let book-start-numbering() = {
+  counter(page).update(1)
+  set page(
+    numbering: "1",
+    number-align: bottom + center,
+  )
+}
+
+/// Equacoes e formulas
+/// Conforme NBR 6029:2023 - numeradas com algarismos arabicos entre parenteses
+#let book-equation(body) = {
+  set math.equation(numbering: "(1)")
+  body
+}

--- a/packages/preview/abntyp/0.1.5/src/templates/periodical.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/periodical.typ
@@ -1,0 +1,450 @@
+// Template para publicacao periodica tecnica e/ou cientifica
+// Conforme NBR 6021:2015
+
+#import "../core/setup.typ": with-abnt-setup
+#import "../core/page.typ": *
+#import "../core/fonts.typ": *
+#import "../core/spacing.typ": *
+#import "../core/dates.typ": *
+#import "../references/abbreviations.typ": *
+
+/// Template principal para fasciculo de periodico
+///
+/// Parametros:
+/// - titulo: titulo do periodico
+/// - subtitulo: subtitulo (opcional)
+/// - issn: numero ISSN
+/// - volume: numero do volume
+/// - numero: numero do fasciculo
+/// - ano: ano de publicacao
+/// - mes-inicio: mes inicial (1-12)
+/// - mes-fim: mes final (1-12, opcional para periodo)
+/// - local: cidade de publicacao
+/// - editora: editora
+/// - instituicao: instituicao responsavel
+/// - doi: identificador DOI (opcional)
+/// - fonte: fonte a usar
+#let periodical(
+  titulo: "",
+  subtitulo: none,
+  issn: none,
+  volume: none,
+  numero: none,
+  ano: datetime.today().year(),
+  mes-inicio: none,
+  mes-fim: none,
+  local: none,
+  editora: none,
+  instituicao: none,
+  doi: none,
+  fonte: "Times New Roman",
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+  )
+
+  show: with-abnt-setup.with(fonte: fonte, level-1-pagebreak: false)
+
+  // Paginação e legenda bibliografica no rodape (periodico-especifico)
+  set page(
+    numbering: "1",
+    number-align: top + right,
+    footer: context {
+      let abbrev-title = abbreviate-title(titulo)
+      let month-text = if mes-inicio != none {
+        if mes-fim != none {
+          format-month-range(mes-inicio, mes-fim)
+        } else {
+          get-month-abbrev(mes-inicio)
+        }
+      } else { "" }
+
+      let page-num = counter(page).get().first()
+
+      set text(size: 10pt)
+      set align(left)
+      [#abbrev-title, #local, v. #volume, n. #numero, p. #page-num, #month-text #ano.]
+    },
+  )
+
+  body
+}
+
+/// Capa do fasciculo conforme NBR 6021:2015
+/// Primeira capa com elementos obrigatorios
+///
+/// Parametros:
+/// - titulo: titulo do periodico
+/// - subtitulo: subtitulo (opcional)
+/// - issn: numero ISSN (obrigatorio, canto superior direito)
+/// - volume: numero do volume
+/// - numero: numero do fasciculo
+/// - ano: ano
+/// - mes-inicio: mes inicial
+/// - mes-fim: mes final (opcional)
+/// - logo: logomarca (opcional)
+/// - suplemento: indicacao de suplemento (opcional)
+#let periodical-cover(
+  titulo: "",
+  subtitulo: none,
+  issn: none,
+  volume: none,
+  numero: none,
+  ano: none,
+  mes-inicio: none,
+  mes-fim: none,
+  logo: none,
+  suplemento: none,
+) = {
+  set page(numbering: none)
+
+  // ISSN no canto superior direito
+  if issn != none {
+    place(top + right)[
+      #text(size: 10pt)[ISSN #issn]
+    ]
+  }
+
+  v(2cm)
+
+  // Logomarca (se houver)
+  if logo != none {
+    align(center)[#logo]
+    v(1cm)
+  }
+
+  // Titulo e subtitulo
+  align(center)[
+    #text(weight: "bold", size: 16pt, upper(titulo))
+    #if subtitulo != none {
+      linebreak()
+      text(size: 14pt, subtitulo)
+    }
+  ]
+
+  v(1fr)
+
+  // Indicacao de suplemento
+  if suplemento != none {
+    align(center)[
+      #text(size: 12pt, suplemento)
+    ]
+    v(1em)
+  }
+
+  // Volume, numero e data
+  align(center)[
+    #text(size: 12pt)[
+      v. #volume
+      #h(1em)
+      n. #numero
+      #h(1em)
+      #if mes-inicio != none {
+        if mes-fim != none {
+          [#month-names.at(mes-inicio - 1)/#month-names.at(mes-fim - 1)]
+        } else {
+          month-names.at(mes-inicio - 1)
+        }
+      }
+      #h(0.5em)
+      #ano
+    ]
+  ]
+
+  v(2cm)
+  pagebreak()
+}
+
+/// Folha de rosto do fasciculo (anverso)
+/// Conforme NBR 6021:2015 secao 4.3.1
+///
+/// Parametros:
+/// - titulo: titulo do periodico
+/// - issn: numero ISSN
+/// - volume: numero do volume
+/// - numero: numero do fasciculo
+/// - paginas: intervalo de paginas (ex: "1-154")
+/// - ano: ano
+/// - mes-inicio: mes inicial
+/// - mes-fim: mes final (opcional)
+/// - local: cidade de publicacao
+#let periodical-title-page(
+  titulo: "",
+  issn: none,
+  volume: none,
+  numero: none,
+  paginas: none,
+  ano: none,
+  mes-inicio: none,
+  mes-fim: none,
+  local: none,
+) = {
+  set page(numbering: none)
+
+  // Titulo com destaque
+  align(center)[
+    #text(weight: "bold", size: 14pt, upper(titulo))
+  ]
+
+  v(2cm)
+
+  // ISSN acima da legenda bibliografica
+  if issn != none {
+    align(center)[
+      #text(size: 10pt)[ISSN #issn]
+    ]
+  }
+
+  v(1cm)
+
+  // Legenda bibliografica completa
+  let abbrev-title = abbreviate-title(titulo)
+  let month-text = if mes-inicio != none {
+    if mes-fim != none {
+      format-month-range(mes-inicio, mes-fim)
+    } else {
+      get-month-abbrev(mes-inicio)
+    }
+  } else { "" }
+
+  align(center)[
+    #text(size: 10pt)[
+      #abbrev-title, #local, v. #volume, n. #numero, p. #paginas, #month-text #ano.
+    ]
+  ]
+
+  v(1fr)
+  pagebreak()
+}
+
+/// Verso da folha de rosto
+/// Conforme NBR 6021:2015 secao 4.3.1.2
+///
+/// Parametros:
+/// - ano-copyright: ano do copyright
+/// - detentor-copyright: detentor dos direitos
+/// - direitos-reproducao: autorizacao de reproducao (opcional)
+/// - outros-formatos: outros suportes disponiveis (opcional)
+/// - catalogacao: dados de catalogacao na publicacao
+/// - creditos: creditos e outras informacoes
+#let periodical-title-page-verso(
+  ano-copyright: none,
+  detentor-copyright: none,
+  direitos-reproducao: none,
+  outros-formatos: none,
+  catalogacao: none,
+  creditos: none,
+) = {
+  set page(numbering: none)
+  set text(size: 10pt)
+  set par(first-line-indent: 0pt, leading: 1em * 0.65)
+
+  // Copyright
+  if ano-copyright != none and detentor-copyright != none {
+    [(c) #ano-copyright #detentor-copyright]
+    v(1em)
+  }
+
+  // Autorizacao de reproducao
+  if direitos-reproducao != none {
+    direitos-reproducao
+    v(1em)
+  }
+
+  // Outros suportes
+  if outros-formatos != none {
+    outros-formatos
+    v(1em)
+  }
+
+  // Creditos
+  if creditos != none {
+    creditos
+    v(1em)
+  }
+
+  v(1fr)
+
+  // Dados de catalogacao (parte inferior)
+  if catalogacao != none {
+    align(center)[
+      #box(
+        width: 12cm,
+        stroke: 0.5pt,
+        inset: 0.5cm,
+      )[
+        #catalogacao
+      ]
+    ]
+  }
+
+  pagebreak()
+}
+
+/// Sumario do fasciculo
+/// Conforme NBR 6027
+#let periodical-toc(
+  titulo: "SUMARIO",
+) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, titulo)
+  ]
+
+  v(1.5em)
+
+  outline(
+    title: none,
+    depth: 2,
+    indent: auto,
+  )
+
+  pagebreak()
+}
+
+/// Editorial
+/// Texto do editor apresentando o conteudo do fasciculo
+#let editorial(conteudo) = {
+  heading(level: 1, numbering: none, "EDITORIAL")
+  conteudo
+  pagebreak()
+}
+
+/// Legenda bibliografica completa
+/// Para uso no rodape de cada pagina ou folha de rosto
+///
+/// Parametros:
+/// - titulo: titulo do periodico (sera abreviado)
+/// - local: cidade
+/// - volume: numero do volume
+/// - numero: numero do fasciculo
+/// - paginas: paginas (ex: "1-154" para fasciculo, "9-21" para artigo)
+/// - mes-inicio: mes inicial (1-12)
+/// - mes-fim: mes final (1-12, opcional)
+/// - ano: ano
+#let bibliographic-legend(
+  titulo: "",
+  local: "",
+  volume: none,
+  numero: none,
+  paginas: none,
+  mes-inicio: none,
+  mes-fim: none,
+  ano: none,
+) = {
+  let abbrev-title = abbreviate-title(titulo)
+
+  let month-text = if mes-inicio != none {
+    if mes-fim != none {
+      format-month-range(mes-inicio, mes-fim)
+    } else {
+      get-month-abbrev(mes-inicio)
+    }
+  } else { "" }
+
+  text(size: 10pt)[
+    #abbrev-title, #local, v. #volume, n. #numero, p. #paginas, #month-text #ano.
+  ]
+}
+
+/// Artigo em periodico
+/// Conforme NBR 6022:2018 (integrado com NBR 6021:2015)
+///
+/// Parametros:
+/// - titulo: titulo do artigo
+/// - autores: lista de autores com afiliacao
+/// - resumo: resumo em portugues
+/// - palavras-chave: palavras-chave
+/// - resumo-en: abstract em ingles (opcional)
+/// - palavras-chave-en: keywords (opcional)
+#let periodical-article(
+  titulo: "",
+  autores: (),
+  resumo: none,
+  palavras-chave: (),
+  resumo-en: none,
+  palavras-chave-en: (),
+  body,
+) = {
+  // Titulo do artigo
+  align(center)[
+    #text(weight: "bold", size: 12pt, upper(titulo))
+  ]
+
+  v(1em)
+
+  // Autores
+  for autor in autores {
+    align(center)[
+      #text(size: 12pt, autor.name)
+      #if "affiliation" in autor {
+        footnote(autor.affiliation)
+      }
+    ]
+  }
+
+  v(2em)
+
+  // Resumo
+  if resumo != none {
+    set par(first-line-indent: 0pt)
+    [*RESUMO*]
+    linebreak()
+    resumo
+    if palavras-chave.len() > 0 {
+      linebreak()
+      linebreak()
+      [*Palavras-chave:* #palavras-chave.join(". ").]
+    }
+    v(2em)
+  }
+
+  // Abstract
+  if resumo-en != none {
+    set par(first-line-indent: 0pt)
+    [*ABSTRACT*]
+    linebreak()
+    resumo-en
+    if palavras-chave-en.len() > 0 {
+      linebreak()
+      linebreak()
+      [*Keywords:* #palavras-chave-en.join(". ").]
+    }
+    v(2em)
+  }
+
+  // Corpo do artigo
+  body
+}
+
+/// Instrucoes editoriais para autores
+/// Conforme NBR 6021:2015 secao 4.5.2
+#let author-guidelines(conteudo) = {
+  heading(level: 1, numbering: none, "INSTRUCOES PARA AUTORES")
+  set par(first-line-indent: 0pt)
+  conteudo
+}
+
+/// Suplemento de periodico
+/// Conforme NBR 6021:2015 secao 5.4
+///
+/// Parametros:
+/// - titulo-principal: titulo do periodico principal
+/// - titulo-suplemento: titulo do suplemento
+/// - volume: volume do periodico principal
+/// - ano: ano
+/// - issn: ISSN do periodico principal
+#let supplement-info(
+  titulo-principal: "",
+  titulo-suplemento: "",
+  volume: none,
+  ano: none,
+  issn: none,
+) = {
+  text(size: 10pt)[
+    Suplemento de: #titulo-principal, v. #volume, #ano.
+    #titulo-suplemento
+    #if issn != none { [ISSN #issn] }
+  ]
+}

--- a/packages/preview/abntyp/0.1.5/src/templates/poster.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/poster.typ
@@ -1,0 +1,513 @@
+// Template para Poster Tecnico e Cientifico conforme NBR 15437:2006
+//
+// Estrutura:
+// - Titulo (obrigatorio) - parte superior
+// - Subtitulo (opcional) - diferenciado tipograficamente ou separado por :
+// - Autor (obrigatorio) - logo abaixo do titulo
+// - Informacoes complementares (opcional) - instituicao, cidade, estado, pais, etc.
+// - Resumo (opcional) - ate 100 palavras, seguido de palavras-chave
+// - Conteudo (obrigatorio) - ideias centrais em texto/tabelas/ilustracoes
+// - Referencias (opcional) - conforme NBR 6023
+//
+// Dimensoes recomendadas:
+// - Largura: 0,60m a 0,90m
+// - Altura: 0,90m a 1,20m
+//
+// O poster deve ser legivel a pelo menos 1 metro de distancia
+
+/// Template principal para Poster Cientifico conforme NBR 15437:2006
+///
+/// Parametros:
+/// - titulo: titulo do poster (obrigatorio)
+/// - subtitulo: subtitulo (opcional)
+/// - autores: lista de autores (nome e afiliacao)
+/// - instituicao: instituicao principal
+/// - contato: informacoes de contato (email, endereco)
+/// - texto-resumo: resumo (ate 100 palavras)
+/// - palavras-chave: palavras-chave
+/// - num-colunas: numero de colunas para o conteudo (padrao: 3)
+/// - largura: largura do poster (padrao: 90cm)
+/// - altura: altura do poster (padrao: 120cm)
+/// - fonte: fonte a usar
+/// - tamanho-titulo: tamanho da fonte do titulo (padrao: 72pt)
+/// - tamanho-corpo: tamanho da fonte do corpo (padrao: 24pt)
+/// - fundo: cor de fundo (opcional)
+/// - cor-destaque: cor de destaque (opcional)
+#let poster(
+  titulo: "",
+  subtitulo: none,
+  autores: (),
+  instituicao: none,
+  contato: none,
+  texto-resumo: none,
+  palavras-chave: (),
+  num-colunas: 3,
+  largura: 90cm,
+  altura: 120cm,
+  fonte: "Arial",
+  tamanho-titulo: 72pt,
+  tamanho-corpo: 24pt,
+  fundo: white,
+  cor-destaque: rgb("#003366"),
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: autores.map(a => if type(a) == dictionary { a.name } else { a }).join(", "),
+  )
+
+  // Configuracao de pagina para poster
+  set page(
+    width: largura,
+    height: altura,
+    margin: 2cm,
+    fill: fundo,
+  )
+
+  // Configuracao de fonte
+  set text(
+    font: fonte,
+    size: tamanho-corpo,
+    lang: "pt",
+    region: "BR",
+  )
+
+  // Configuracao de paragrafo
+  set par(
+    leading: 1.2em,
+    justify: true,
+    first-line-indent: 0pt,
+  )
+
+  // Configuracao de headings para poster
+  show heading.where(level: 1): it => {
+    v(0.5em)
+    text(
+      weight: "bold",
+      size: tamanho-corpo * 1.5,
+      fill: cor-destaque,
+      upper(it.body),
+    )
+    v(0.5em)
+  }
+
+  show heading.where(level: 2): it => {
+    v(0.3em)
+    text(
+      weight: "bold",
+      size: tamanho-corpo * 1.2,
+      it.body,
+    )
+    v(0.3em)
+  }
+
+  // Cabecalho do poster (titulo, autores, instituicao)
+  align(center)[
+    // Titulo
+    #text(
+      weight: "bold",
+      size: tamanho-titulo,
+      fill: cor-destaque,
+      upper(titulo),
+    )
+
+    // Subtitulo
+    #if subtitulo != none {
+      linebreak()
+      text(
+        size: tamanho-titulo * 0.6,
+        ": " + subtitulo,
+      )
+    }
+
+    #v(1cm)
+
+    // Autores
+    #if autores.len() > 0 {
+      text(size: tamanho-corpo * 1.3)[
+        #for (i, autor) in autores.enumerate() {
+          if i > 0 { [, ] }
+          if type(autor) == dictionary {
+            text(weight: "bold", autor.name)
+            if "affiliation" in autor {
+              super(str(i + 1))
+            }
+          } else {
+            text(weight: "bold", autor)
+          }
+        }
+      ]
+      linebreak()
+
+      // Afiliacoes
+      v(0.5cm)
+      text(size: tamanho-corpo * 0.9)[
+        #for (i, autor) in autores.enumerate() {
+          if type(autor) == dictionary and "affiliation" in autor {
+            super(str(i + 1))
+            autor.affiliation
+            linebreak()
+          }
+        }
+      ]
+    }
+
+    // Instituicao principal
+    #if instituicao != none {
+      v(0.3cm)
+      text(size: tamanho-corpo, instituicao)
+    }
+
+    // Contato
+    #if contato != none {
+      linebreak()
+      text(size: tamanho-corpo * 0.8, contato)
+    }
+  ]
+
+  v(1cm)
+
+  // Linha divisoria
+  line(length: 100%, stroke: 2pt + cor-destaque)
+
+  v(1cm)
+
+  // Resumo (se fornecido)
+  if texto-resumo != none {
+    box(
+      width: 100%,
+      inset: 1em,
+      fill: cor-destaque.lighten(90%),
+      radius: 5pt,
+    )[
+      #text(weight: "bold", size: tamanho-corpo * 1.1)[RESUMO]
+      #linebreak()
+      #v(0.3em)
+      #texto-resumo
+      #if palavras-chave.len() > 0 {
+        v(0.5em)
+        text(weight: "bold")[Palavras-chave: ]
+        palavras-chave.join("; ")
+      }
+    ]
+    v(1cm)
+  }
+
+  // Conteudo em colunas
+  columns(num-colunas, gutter: 2em, body)
+}
+
+/// Secao de poster com caixa colorida
+#let poster-section(
+  titulo: none,
+  cor-destaque: rgb("#003366"),
+  body,
+) = {
+  box(
+    width: 100%,
+    inset: 1em,
+    stroke: 2pt + cor-destaque,
+    radius: 5pt,
+  )[
+    #if titulo != none {
+      align(center)[
+        #box(
+          fill: cor-destaque,
+          inset: 0.5em,
+          radius: 3pt,
+        )[
+          #text(weight: "bold", fill: white, upper(titulo))
+        ]
+      ]
+      v(0.5em)
+    }
+    #body
+  ]
+  v(1em)
+}
+
+/// Caixa de destaque para poster
+#let poster-highlight(
+  cor-destaque: rgb("#003366"),
+  body,
+) = {
+  box(
+    width: 100%,
+    inset: 1em,
+    fill: cor-destaque.lighten(90%),
+    radius: 5pt,
+  )[
+    #body
+  ]
+  v(0.5em)
+}
+
+/// Figura para poster
+/// Maior e com legenda mais visivel
+#let poster-figure(
+  body,
+  legenda: none,
+  origem: none,
+) = {
+  align(center)[
+    #body
+    #if legenda != none {
+      v(0.3em)
+      text(weight: "bold")[#legenda]
+    }
+    #if origem != none {
+      linebreak()
+      text(size: 0.8em)[Fonte: #origem]
+    }
+  ]
+  v(0.5em)
+}
+
+/// Referencias para poster
+/// Formato compacto, sem notas de rodape
+#let poster-references(itens) = {
+  text(weight: "bold", size: 1.2em)[REFERENCIAS]
+  v(0.3em)
+
+  set par(
+    hanging-indent: 1em,
+    first-line-indent: 0pt,
+  )
+  set text(size: 0.8em)
+
+  for item in itens {
+    item
+    linebreak()
+    v(0.2em)
+  }
+}
+
+/// Template de poster academico (com orientador)
+#let academic-poster(
+  titulo: "",
+  subtitulo: none,
+  autores: (),
+  orientador: none,
+  instituicao: none,
+  departamento: none,
+  contato: none,
+  texto-resumo: none,
+  palavras-chave: (),
+  num-colunas: 3,
+  largura: 90cm,
+  altura: 120cm,
+  fonte: "Arial",
+  tamanho-titulo: 72pt,
+  tamanho-corpo: 24pt,
+  fundo: white,
+  cor-destaque: rgb("#003366"),
+  logo: none,
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: autores.map(a => if type(a) == dictionary { a.name } else { a }).join(", "),
+  )
+
+  // Configuracao de pagina
+  set page(
+    width: largura,
+    height: altura,
+    margin: 2cm,
+    fill: fundo,
+  )
+
+  set text(
+    font: fonte,
+    size: tamanho-corpo,
+    lang: "pt",
+    region: "BR",
+  )
+
+  set par(
+    leading: 1.2em,
+    justify: true,
+    first-line-indent: 0pt,
+  )
+
+  show heading.where(level: 1): it => {
+    v(0.5em)
+    text(
+      weight: "bold",
+      size: tamanho-corpo * 1.5,
+      fill: cor-destaque,
+      upper(it.body),
+    )
+    v(0.5em)
+  }
+
+  show heading.where(level: 2): it => {
+    v(0.3em)
+    text(
+      weight: "bold",
+      size: tamanho-corpo * 1.2,
+      it.body,
+    )
+    v(0.3em)
+  }
+
+  // Cabecalho com logo
+  grid(
+    columns: if logo != none { (auto, 1fr, auto) } else { (1fr,) },
+    gutter: 1cm,
+    align: horizon,
+
+    // Logo esquerdo
+    if logo != none { logo },
+
+    // Titulo e informacoes
+    align(center)[
+      #text(
+        weight: "bold",
+        size: tamanho-titulo,
+        fill: cor-destaque,
+        upper(titulo),
+      )
+
+      #if subtitulo != none {
+        linebreak()
+        text(size: tamanho-titulo * 0.6, ": " + subtitulo)
+      }
+
+      #v(0.5cm)
+
+      // Autores
+      #text(size: tamanho-corpo * 1.2)[
+        #for (i, autor) in autores.enumerate() {
+          if i > 0 { [, ] }
+          if type(autor) == dictionary {
+            text(weight: "bold", autor.name)
+          } else {
+            text(weight: "bold", autor)
+          }
+        }
+      ]
+
+      // Orientador
+      #if orientador != none {
+        linebreak()
+        text(size: tamanho-corpo)[Orientador: #orientador]
+      }
+
+      #v(0.3cm)
+
+      // Instituicao
+      #if instituicao != none {
+        text(size: tamanho-corpo * 0.9, instituicao)
+      }
+      #if departamento != none {
+        linebreak()
+        text(size: tamanho-corpo * 0.8, departamento)
+      }
+
+      #if contato != none {
+        linebreak()
+        text(size: tamanho-corpo * 0.7, contato)
+      }
+    ],
+
+    // Logo direito (mesmo que esquerdo para simetria)
+    if logo != none { logo },
+  )
+
+  v(1cm)
+  line(length: 100%, stroke: 2pt + cor-destaque)
+  v(1cm)
+
+  // Resumo
+  if texto-resumo != none {
+    box(
+      width: 100%,
+      inset: 1em,
+      fill: cor-destaque.lighten(90%),
+      radius: 5pt,
+    )[
+      #text(weight: "bold", size: tamanho-corpo * 1.1)[RESUMO]
+      #linebreak()
+      #v(0.3em)
+      #texto-resumo
+      #if palavras-chave.len() > 0 {
+        v(0.5em)
+        text(weight: "bold")[Palavras-chave: ]
+        palavras-chave.join("; ")
+      }
+    ]
+    v(1cm)
+  }
+
+  // Conteudo
+  columns(num-colunas, gutter: 2em, body)
+}
+
+/// Cria um poster A0 (padrao para congressos)
+#let poster-a0(
+  titulo: "",
+  subtitulo: none,
+  autores: (),
+  instituicao: none,
+  contato: none,
+  texto-resumo: none,
+  palavras-chave: (),
+  num-colunas: 3,
+  fonte: "Arial",
+  cor-destaque: rgb("#003366"),
+  body,
+) = {
+  poster(
+    titulo: titulo,
+    subtitulo: subtitulo,
+    autores: autores,
+    instituicao: instituicao,
+    contato: contato,
+    texto-resumo: texto-resumo,
+    palavras-chave: palavras-chave,
+    num-colunas: num-colunas,
+    largura: 84.1cm,   // A0 width
+    altura: 118.9cm, // A0 height
+    fonte: fonte,
+    tamanho-titulo: 72pt,
+    tamanho-corpo: 24pt,
+    cor-destaque: cor-destaque,
+    body,
+  )
+}
+
+/// Cria um poster A1
+#let poster-a1(
+  titulo: "",
+  subtitulo: none,
+  autores: (),
+  instituicao: none,
+  contato: none,
+  texto-resumo: none,
+  palavras-chave: (),
+  num-colunas: 2,
+  fonte: "Arial",
+  cor-destaque: rgb("#003366"),
+  body,
+) = {
+  poster(
+    titulo: titulo,
+    subtitulo: subtitulo,
+    autores: autores,
+    instituicao: instituicao,
+    contato: contato,
+    texto-resumo: texto-resumo,
+    palavras-chave: palavras-chave,
+    num-colunas: num-colunas,
+    largura: 59.4cm,  // A1 width
+    altura: 84.1cm, // A1 height
+    fonte: fonte,
+    tamanho-titulo: 48pt,
+    tamanho-corpo: 18pt,
+    cor-destaque: cor-destaque,
+    body,
+  )
+}

--- a/packages/preview/abntyp/0.1.5/src/templates/research-project.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/research-project.typ
@@ -1,0 +1,389 @@
+// Template para Projeto de Pesquisa conforme NBR 15287:2025
+//
+// Estrutura:
+// - Parte Externa: Capa (opcional), Lombada (opcional)
+// - Pre-textual: Folha de rosto, Listas, Sumario
+// - Textual: Introducao, Desenvolvimento, Metodologia, Cronograma
+// - Pos-textual: Referencias, Glossario, Apendices, Anexos, Indice
+
+#import "../core/setup.typ": with-abnt-setup
+#import "../core/page.typ": *
+#import "../core/fonts.typ": *
+#import "../core/spacing.typ": *
+#import "../text/headings.typ": *
+#import "../elements/cover.typ": *
+#import "../elements/title-page.typ": *
+#import "../elements/toc.typ": *
+#import "../references/bibliography.typ": *
+
+/// Template principal para Projeto de Pesquisa conforme NBR 15287:2025
+///
+/// Parametros:
+/// - titulo: titulo do projeto
+/// - subtitulo: subtitulo (opcional)
+/// - autor: nome do(s) autor(es) - pode ser string ou array
+/// - instituicao: nome da entidade
+/// - local: cidade da entidade
+/// - ano: ano de entrega
+/// - tipo-projeto: tipo de projeto (ex: "Projeto de pesquisa apresentado...")
+/// - orientador: nome do orientador (opcional)
+/// - coorientador: nome do coorientador (opcional)
+/// - coordenador: nome do coordenador (opcional)
+/// - volume: numero do volume (se houver mais de um)
+/// - fonte: fonte a usar ("Times New Roman" ou "Arial")
+/// - arquivo-bibliografia: caminho para arquivo .bib (opcional)
+/// - titulo-bibliografia: titulo da secao de referencias
+#let projeto-pesquisa(
+  titulo: "",
+  subtitulo: none,
+  autor: "",
+  instituicao: "",
+  local: "",
+  ano: datetime.today().year(),
+  tipo-projeto: none,
+  orientador: none,
+  coorientador: none,
+  coordenador: none,
+  volume: none,
+  fonte: "Times New Roman",
+  arquivo-bibliografia: none,
+  titulo-bibliografia: "REFERENCIAS",
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: if type(autor) == array { autor.join(", ") } else { autor },
+  )
+
+  show: with-abnt-setup.with(fonte: fonte)
+
+  // Conteudo
+  body
+
+  // Bibliografia automatica (se arquivo .bib fornecido)
+  if arquivo-bibliografia != none {
+    abnt-bibliography(arquivo-bibliografia, titulo: titulo-bibliografia)
+  }
+}
+
+/// Capa para Projeto de Pesquisa conforme NBR 15287:2025
+/// Elementos na ordem:
+/// 1. Nome da entidade (quando solicitado)
+/// 2. Nome(s) do(s) autor(es)
+/// 3. Titulo
+/// 4. Subtitulo (se houver) - precedido de dois pontos
+/// 5. Numero do volume (se houver mais de um)
+/// 6. Local (cidade) da entidade
+/// 7. Ano de entrega
+#let project-cover(
+  instituicao: none,
+  autor: none,
+  titulo: none,
+  subtitulo: none,
+  volume: none,
+  local: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+  set align(center)
+
+  // Instituicao (maiusculas, negrito)
+  if instituicao != none {
+    text(weight: "bold", size: 12pt, upper(instituicao))
+  }
+
+  v(1fr)
+
+  // Autor(es)
+  if autor != none {
+    if type(autor) == array {
+      for a in autor {
+        text(size: 12pt, upper(a))
+        linebreak()
+      }
+    } else {
+      text(size: 12pt, upper(autor))
+    }
+  }
+
+  v(1fr)
+
+  // Titulo (maiusculas, negrito)
+  if titulo != none {
+    text(weight: "bold", size: 14pt, upper(titulo))
+  }
+
+  // Subtitulo (precedido de dois-pontos)
+  if subtitulo != none {
+    text(size: 14pt, ": " + subtitulo)
+  }
+
+  // Volume
+  if volume != none {
+    v(0.5em)
+    text(size: 12pt, "Volume " + str(volume))
+  }
+
+  v(1fr)
+
+  // Local e ano
+  if local != none {
+    text(size: 12pt, upper(local))
+    linebreak()
+  }
+
+  if ano != none {
+    text(size: 12pt, str(ano))
+  }
+
+  pagebreak()
+}
+
+/// Folha de rosto para Projeto de Pesquisa conforme NBR 15287:2025
+/// Elementos na ordem:
+/// 1. Nome(s) do(s) autor(es)
+/// 2. Titulo
+/// 3. Subtitulo (se houver)
+/// 4. Numero do volume (se houver)
+/// 5. Tipo de projeto + nome da entidade
+/// 6. Nome do orientador/coorientador/coordenador (se houver)
+/// 7. Local (cidade)
+/// 8. Ano da entrega
+#let project-title-page(
+  autor: none,
+  titulo: none,
+  subtitulo: none,
+  volume: none,
+  tipo-projeto: none,
+  instituicao: none,
+  orientador: none,
+  coorientador: none,
+  coordenador: none,
+  local: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+  set align(center)
+
+  // Autor(es)
+  if autor != none {
+    if type(autor) == array {
+      for a in autor {
+        text(size: 12pt, upper(a))
+        linebreak()
+      }
+    } else {
+      text(size: 12pt, upper(autor))
+    }
+  }
+
+  v(1fr)
+
+  // Titulo (maiusculas, negrito)
+  if titulo != none {
+    text(weight: "bold", size: 14pt, upper(titulo))
+  }
+
+  // Subtitulo
+  if subtitulo != none {
+    text(size: 14pt, ": " + subtitulo)
+  }
+
+  // Volume
+  if volume != none {
+    v(0.5em)
+    text(size: 12pt, "Volume " + str(volume))
+  }
+
+  v(2cm)
+
+  // Tipo de projeto e orientadores (recuo de 8cm, espaco simples)
+  if tipo-projeto != none or orientador != none or coordenador != none {
+    set align(right)
+    box(width: 8cm)[
+      #set align(left)
+      #set par(
+        leading: 1em * 0.65,
+        first-line-indent: 0pt,
+        justify: true,
+      )
+      #set text(size: 10pt)
+
+      #if tipo-projeto != none { tipo-projeto }
+      #if instituicao != none { linebreak(); instituicao }
+
+      #if orientador != none {
+        linebreak()
+        linebreak()
+        [Orientador: #orientador]
+      }
+
+      #if coorientador != none {
+        linebreak()
+        [Coorientador: #coorientador]
+      }
+
+      #if coordenador != none {
+        linebreak()
+        [Coordenador: #coordenador]
+      }
+    ]
+  }
+
+  v(1fr)
+
+  // Local e ano
+  set align(center)
+  if local != none {
+    text(size: 12pt, upper(local))
+    linebreak()
+  }
+
+  if ano != none {
+    text(size: 12pt, str(ano))
+  }
+
+  pagebreak()
+}
+
+/// Cronograma simples do projeto (tabela atividades × períodos)
+/// Para um cronograma mais elaborado (Gantt com barras, cores e dependências),
+/// use a função `cronograma()` do pacote FerrMat.
+///
+/// Parametros:
+/// - titulo: titulo da secao (padrao: "CRONOGRAMA")
+/// - atividades: lista de atividades (strings)
+/// - periodos: lista de periodos (ex: ("Jan", "Fev", "Mar", ...))
+/// - marcacoes: matriz de booleanos indicando quando cada atividade ocorre
+///             marcacoes.at(i).at(j) = true se atividade i ocorre no periodo j
+#let cronograma-simples(
+  titulo: "CRONOGRAMA",
+  atividades: (),
+  periodos: (),
+  marcacoes: (),
+) = {
+  heading(level: 1, titulo)
+
+  let num-periods = periodos.len()
+  let num-activities = atividades.len()
+
+  // Criar colunas: primeira para atividades, demais para periodos
+  let cols = (auto,) + (1fr,) * num-periods
+
+  table(
+    columns: cols,
+    stroke: 0.5pt,
+    inset: 6pt,
+    align: (left,) + (center,) * num-periods,
+
+    // Cabecalho
+    [*Atividades*],
+    ..periodos.map(p => [*#p*]),
+
+    // Linhas de atividades
+    ..{
+      let cells = ()
+      for (i, activity) in atividades.enumerate() {
+        cells.push(activity)
+        for j in range(num-periods) {
+          if marcacoes.len() > i and marcacoes.at(i).len() > j and marcacoes.at(i).at(j) {
+            cells.push([X])
+          } else {
+            cells.push([])
+          }
+        }
+      }
+      cells
+    }
+  )
+}
+
+/// Recursos do projeto
+/// Cria uma secao listando os recursos necessarios
+///
+/// Parametros:
+/// - titulo: titulo da secao (padrao: "RECURSOS")
+/// - itens: lista de tuplas (descricao, valor) ou apenas descricoes
+/// - total: valor total (opcional, calculado automaticamente se valores forem numeros)
+#let recursos(
+  titulo: "RECURSOS",
+  itens: (),
+  total: none,
+) = {
+  heading(level: 1, titulo)
+
+  if itens.len() > 0 {
+    // Verificar se itens tem valores
+    let has-values = if type(itens.at(0)) == array { itens.at(0).len() > 1 } else { false }
+
+    if has-values {
+      // Tabela com descricao e valores
+      table(
+        columns: (1fr, auto),
+        stroke: none,
+        inset: 6pt,
+        align: (left, right),
+
+        table.hline(stroke: 1pt),
+        [*Descricao*], [*Valor (R\$)*],
+        table.hline(stroke: 0.5pt),
+
+        ..{
+          let cells = ()
+          for item in itens {
+            cells.push(item.at(0))
+            cells.push(str(item.at(1)))
+          }
+          cells
+        },
+
+        table.hline(stroke: 0.5pt),
+
+        // Total
+        if total != none {
+          ([*Total*], [*#str(total)*])
+        } else {
+          // Calcular total se possivel
+          let sum = itens.fold(0, (acc, item) => {
+            if type(item.at(1)) == int or type(item.at(1)) == float {
+              acc + item.at(1)
+            } else {
+              acc
+            }
+          })
+          ([*Total*], [*#str(sum)*])
+        },
+
+        table.hline(stroke: 1pt),
+      )
+    } else {
+      // Lista simples
+      for item in itens {
+        [- #item]
+        linebreak()
+      }
+    }
+  }
+}
+
+/// Glossario para projeto de pesquisa
+/// Conforme NBR 15287 - ordem alfabetica
+#let glossario-projeto(itens) = {
+  heading(level: 1, numbering: none, "GLOSSARIO")
+
+  set par(first-line-indent: 0pt)
+
+  // Ordenar itens alfabeticamente
+  let sorted-items = itens.pairs().sorted(key: p => p.at(0))
+
+  for (termo, definicao) in sorted-items {
+    [*#termo:* #definicao]
+    linebreak()
+    v(0.5em)
+  }
+
+  pagebreak()
+}
+
+// apendice() e anexo() são definidos em src/text/headings.typ (funções globais do pacote)

--- a/packages/preview/abntyp/0.1.5/src/templates/slides.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/slides.typ
@@ -1,0 +1,651 @@
+// Template para Apresentacao de Slides Academicos
+//
+// IMPORTANTE: NAO EXISTE NORMA ABNT ESPECIFICA PARA SLIDES
+//
+// A ABNT (Associacao Brasileira de Normas Tecnicas) nao possui nenhuma norma
+// dedicada a apresentacoes de slides. Nao ha regras oficiais para:
+// - Fonte, tamanho ou espacamento
+// - Layout ou quantidade de texto por slide
+// - Estrutura ou organizacao do conteudo
+// - Cores ou elementos visuais
+//
+// Este template oferece um formato padronizado para apresentacoes academicas
+// baseado em boas praticas e convencoes comuns em instituicoes brasileiras,
+// mas NAO representa uma exigencia normativa da ABNT.
+//
+// Normas ABNT que PODEM ser aplicadas em slides (quando relevante):
+// - NBR 6023:2018 - Referencias bibliograficas (se houver citacoes)
+// - NBR 10520:2023 - Citacoes em documentos (formato autor-data)
+//
+// Baseado no pacote Touying para Typst
+// Documentacao: https://touying-typ.github.io/docs/intro/
+
+#import "@preview/touying:0.7.4": *
+#import themes.simple: *
+#import themes.university: *
+
+// Re-exportar funcoes de citacao do ABNTyp para uso em slides
+#import "../references/citation.typ": citar, citar-autor, citar-multiplos, citar-etal, citar-entidade, citar-titulo
+
+// =============================================================================
+// TEMPLATE PRINCIPAL: slides()
+// =============================================================================
+
+/// Template principal para apresentacao de slides academicos
+///
+/// NOTA: Nao existe norma ABNT para slides. Este template segue boas praticas
+/// academicas comuns no Brasil, mas nao representa exigencia normativa.
+///
+/// Parametros:
+/// - titulo: titulo da apresentacao
+/// - subtitulo: subtitulo (opcional)
+/// - autor: nome do autor/apresentador
+/// - orientador: orientador (opcional, para defesas de TCC/dissertacao/tese)
+/// - instituicao: nome da instituicao
+/// - departamento: departamento/programa (opcional)
+/// - data: data da apresentacao (padrao: data atual)
+/// - logo: logotipo da instituicao (opcional, imagem)
+/// - proporcao: proporcao da tela ("16-9" ou "4-3", padrao: "16-9")
+/// - fonte: fonte a usar (padrao: "Arial")
+/// - cor-primaria: cor principal (padrao: azul institucional)
+/// - cor-secundaria: cor secundaria (opcional)
+#let slides(
+  titulo: "",
+  subtitulo: none,
+  autor: "",
+  orientador: none,
+  instituicao: "",
+  departamento: none,
+  data: datetime.today(),
+  logo: none,
+  proporcao: "16-9",
+  fonte: "Arial",
+  cor-primaria: rgb("#003366"),
+  cor-secundaria: rgb("#666666"),
+  body,
+) = {
+  // Nota sobre ausencia de norma ABNT
+  // (Este comentario serve como documentacao para quem ler o codigo-fonte)
+  // A ABNT nao possui norma especifica para apresentacoes de slides.
+  // As escolhas de formatacao neste template sao baseadas em:
+  // 1. Boas praticas de design de apresentacoes
+  // 2. Convencoes comuns em instituicoes academicas brasileiras
+  // 3. Recomendacoes de legibilidade (fonte 18-24pt para corpo)
+
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: autor,
+  )
+
+  // Configuracao de texto base
+  set text(
+    font: fonte,
+    lang: "pt",
+    region: "BR",
+  )
+
+  // Aplicar tema Touying com configuracoes academicas
+  show: simple-theme.with(
+    aspect-ratio: proporcao,
+    primary: cor-primaria,
+    secondary: cor-secundaria,
+    footer: [#instituicao #h(1fr) #autor],
+  )
+
+  // Slide de titulo personalizado
+  touying-slide-wrapper(self => {
+    touying-slide(self: self, setting: body => {
+      set align(center + horizon)
+      body
+    })[
+      // Logo (se fornecido)
+      #if logo != none {
+        logo
+        v(0.5em)
+      }
+
+      // Instituicao
+      #text(size: 18pt, fill: cor-secundaria, upper(instituicao))
+
+      #if departamento != none {
+        linebreak()
+        text(size: 14pt, fill: cor-secundaria, departamento)
+      }
+
+      #v(1em)
+
+      // Titulo
+      #text(size: 32pt, weight: "bold", fill: cor-primaria, titulo)
+
+      // Subtitulo
+      #if subtitulo != none {
+        linebreak()
+        v(0.3em)
+        text(size: 20pt, fill: cor-secundaria, subtitulo)
+      }
+
+      #v(1.5em)
+
+      // Autor
+      #text(size: 18pt, autor)
+
+      // Orientador (para defesas)
+      #if orientador != none {
+        linebreak()
+        v(0.3em)
+        text(size: 14pt)[Orientador(a): #orientador]
+      }
+
+      #v(1em)
+
+      // Data
+      #text(size: 14pt, fill: cor-secundaria)[
+        #data.display("[day] de [month repr:long] de [year]")
+      ]
+    ]
+  })
+
+  // Conteudo da apresentacao
+  body
+}
+
+// =============================================================================
+// TEMPLATE PARA DEFESA DE TCC/DISSERTACAO/TESE
+// =============================================================================
+
+/// Template especializado para defesa de trabalho academico
+///
+/// NOTA: Nao existe norma ABNT para slides de defesa. Este template segue
+/// convencoes comuns em bancas de defesa no Brasil.
+///
+/// Parametros adicionais alem de slides():
+/// - grau: grau pretendido (ex: "Bacharel em Ciencia da Computacao")
+/// - programa: programa de pos-graduacao (para mestrado/doutorado)
+/// - banca: membros da banca (lista de nomes)
+#let slides-defesa(
+  titulo: "",
+  subtitulo: none,
+  autor: "",
+  orientador: none,
+  coorientador: none,
+  instituicao: "",
+  departamento: none,
+  grau: none,
+  programa: none,
+  banca: (),
+  data: datetime.today(),
+  logo: none,
+  proporcao: "16-9",
+  fonte: "Arial",
+  cor-primaria: rgb("#003366"),
+  cor-secundaria: rgb("#666666"),
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: autor,
+  )
+
+  set text(
+    font: fonte,
+    lang: "pt",
+    region: "BR",
+  )
+
+  show: simple-theme.with(
+    aspect-ratio: proporcao,
+    primary: cor-primaria,
+    secondary: cor-secundaria,
+    footer: [#instituicao #h(1fr) Defesa de #if programa != none { "Dissertacao/Tese" } else { "TCC" }],
+  )
+
+  // Slide de titulo para defesa
+  touying-slide-wrapper(self => {
+    touying-slide(self: self, setting: body => {
+      set align(center + horizon)
+      body
+    })[
+      #if logo != none {
+        logo
+        v(0.3em)
+      }
+
+      #text(size: 16pt, fill: cor-secundaria, upper(instituicao))
+
+      #if departamento != none {
+        linebreak()
+        text(size: 12pt, fill: cor-secundaria, departamento)
+      }
+
+      #if programa != none {
+        linebreak()
+        text(size: 12pt, fill: cor-secundaria, programa)
+      }
+
+      #v(0.8em)
+
+      #text(size: 28pt, weight: "bold", fill: cor-primaria, titulo)
+
+      #if subtitulo != none {
+        linebreak()
+        v(0.2em)
+        text(size: 18pt, fill: cor-secundaria, subtitulo)
+      }
+
+      #v(1em)
+
+      #text(size: 16pt, autor)
+
+      #v(0.5em)
+
+      #grid(
+        columns: if coorientador != none { (1fr, 1fr) } else { (1fr,) },
+        gutter: 1em,
+        text(size: 12pt)[
+          *Orientador(a):* \
+          #orientador
+        ],
+        if coorientador != none {
+          text(size: 12pt)[
+            *Coorientador(a):* \
+            #coorientador
+          ]
+        },
+      )
+
+      #v(0.5em)
+
+      #if grau != none {
+        text(size: 11pt, fill: cor-secundaria)[
+          Trabalho apresentado para obtencao do grau de #grau
+        ]
+      }
+
+      #v(0.3em)
+
+      #text(size: 12pt, fill: cor-secundaria)[
+        #data.display("[day] de [month repr:long] de [year]")
+      ]
+    ]
+  })
+
+  body
+
+  // Slide final com agradecimentos (padrao em defesas)
+  touying-slide-wrapper(self => {
+    touying-slide(self: self, setting: body => {
+      set align(center + horizon)
+      body
+    })[
+      #text(size: 36pt, weight: "bold", fill: cor-primaria)[
+        Obrigado!
+      ]
+
+      #v(1em)
+
+      #text(size: 18pt)[Perguntas?]
+
+      #v(2em)
+
+      #if banca.len() > 0 {
+        text(size: 14pt, fill: cor-secundaria)[
+          *Banca Examinadora:* \
+          #banca.join(" | ")
+        ]
+      }
+    ]
+  })
+}
+
+// =============================================================================
+// FUNCOES AUXILIARES PARA SLIDES
+// =============================================================================
+
+/// Slide de sumario/agenda
+///
+/// Uso comum em apresentacoes academicas para mostrar estrutura
+#let slide-sumario(
+  titulo: "Sumario",
+  itens: (),
+  cor-primaria: rgb("#003366"),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self)[
+      #text(size: 24pt, weight: "bold")[#titulo]
+      #v(0.5em)
+      #set text(size: 20pt)
+      #set enum(numbering: "1.", body-indent: 1em)
+
+      #for (i, item) in itens.enumerate() {
+        [#text(fill: cor-primaria, weight: "bold", str(i + 1) + ".") #item \ ]
+        v(0.5em)
+      }
+    ]
+  })
+}
+
+/// Slide de secao (divisor)
+///
+/// Usado para marcar inicio de nova secao da apresentacao
+#let slide-secao(
+  titulo: "",
+  subtitulo: none,
+  cor-primaria: rgb("#003366"),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self, setting: body => {
+      set align(center + horizon)
+      body
+    })[
+      #text(size: 36pt, weight: "bold", fill: cor-primaria, titulo)
+
+      #if subtitulo != none {
+        v(0.5em)
+        text(size: 20pt, fill: cor-primaria.lighten(30%), subtitulo)
+      }
+    ]
+  })
+}
+
+/// Slide com citacao em destaque
+///
+/// Para apresentar citacoes importantes de forma visual
+/// Segue NBR 10520:2023 para formato da citacao
+#let slide-citacao(
+  quote: "",
+  autor: "",
+  ano: "",
+  pagina: none,
+  cor-primaria: rgb("#003366"),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self, setting: body => {
+      set align(center + horizon)
+      body
+    })[
+      #box(
+        width: 80%,
+        inset: 2em,
+        stroke: (left: 4pt + cor-primaria),
+        fill: cor-primaria.lighten(95%),
+      )[
+        #set text(size: 22pt, style: "italic")
+        #set par(leading: 1.2em)
+        "#quote"
+      ]
+
+      #v(1em)
+
+      // Formato NBR 10520:2023 para citacao
+      #text(size: 16pt, fill: cor-primaria)[
+        (#upper(autor), #ano#if pagina != none [, p. #pagina])
+      ]
+    ]
+  })
+}
+
+/// Slide de referencias
+///
+/// NOTA: As referencias em slides devem seguir NBR 6023:2018
+/// Este e um dos poucos aspectos onde uma norma ABNT se aplica
+#let slide-referencias(
+  titulo: "Referencias",
+  itens: (),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self)[
+      #text(size: 24pt, weight: "bold")[#titulo]
+      #v(0.5em)
+      #set text(size: 14pt)
+      #set par(
+        hanging-indent: 1em,
+        first-line-indent: 0pt,
+        leading: 0.8em,
+      )
+
+      // Nota sobre a norma aplicavel
+      #text(size: 10pt, fill: gray)[
+        _Formatacao conforme NBR 6023:2018_
+      ]
+
+      #v(0.5em)
+
+      #for item in itens {
+        item
+        v(0.3em)
+      }
+    ]
+  })
+}
+
+/// Slide de figura com fonte
+///
+/// Quando incluir figuras de terceiros, a fonte deve ser citada
+/// seguindo as normas de citacao (NBR 10520:2023)
+#let slide-figura(
+  titulo: none,
+  imagem: none,
+  legenda: none,
+  origem: none,
+  ano-fonte: none,
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self)[
+      #if titulo != none {
+        text(size: 24pt, weight: "bold", titulo)
+        v(0.5em)
+      }
+      #align(center)[
+        #if imagem != none { imagem }
+
+        #if legenda != none {
+          v(0.5em)
+          text(size: 14pt, weight: "bold", legenda)
+        }
+
+        #if origem != none {
+          v(0.3em)
+          text(size: 12pt, fill: gray)[
+            Fonte: #if ano-fonte != none {
+              [(#upper(origem), #ano-fonte)]
+            } else {
+              origem
+            }
+          ]
+        }
+      ]
+    ]
+  })
+}
+
+/// Slide comparativo (duas colunas)
+#let slide-comparativo(
+  titulo: "",
+  titulo-esquerda: "",
+  conteudo-esquerda: [],
+  titulo-direita: "",
+  conteudo-direita: [],
+  cor-primaria: rgb("#003366"),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self)[
+      #text(size: 24pt, weight: "bold")[#titulo]
+      #v(0.5em)
+      #grid(
+        columns: (1fr, 1fr),
+        gutter: 2em,
+
+        // Coluna esquerda
+        [
+          #align(center)[
+            #text(weight: "bold", fill: cor-primaria, size: 18pt, titulo-esquerda)
+          ]
+          #v(0.5em)
+          #conteudo-esquerda
+        ],
+
+        // Coluna direita
+        [
+          #align(center)[
+            #text(weight: "bold", fill: cor-primaria, size: 18pt, titulo-direita)
+          ]
+          #v(0.5em)
+          #conteudo-direita
+        ],
+      )
+    ]
+  })
+}
+
+/// Slide de metodologia
+///
+/// Formato comum para apresentar metodologia de pesquisa
+#let slide-metodologia(
+  titulo: "Metodologia",
+  tipo-pesquisa: none,
+  abordagem: none,
+  procedimentos: (),
+  instrumentos: (),
+  cor-primaria: rgb("#003366"),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self)[
+      #text(size: 24pt, weight: "bold")[#titulo]
+      #v(0.5em)
+      #grid(
+        columns: (1fr, 1fr),
+        gutter: 1.5em,
+        row-gutter: 1em,
+
+        if tipo-pesquisa != none {
+          [
+            #text(weight: "bold", fill: cor-primaria)[Tipo de Pesquisa] \
+            #tipo-pesquisa
+          ]
+        },
+
+        if abordagem != none {
+          [
+            #text(weight: "bold", fill: cor-primaria)[Abordagem] \
+            #abordagem
+          ]
+        },
+
+        if procedimentos.len() > 0 {
+          [
+            #text(weight: "bold", fill: cor-primaria)[Procedimentos] \
+            #list(..procedimentos)
+          ]
+        },
+
+        if instrumentos.len() > 0 {
+          [
+            #text(weight: "bold", fill: cor-primaria)[Instrumentos] \
+            #list(..instrumentos)
+          ]
+        },
+      )
+    ]
+  })
+}
+
+/// Slide de resultados com destaque numerico
+#let slide-resultado-numerico(
+  titulo: "Resultados",
+  itens: (), // Lista de (valor, descricao)
+  cor-primaria: rgb("#003366"),
+) = {
+  touying-slide-wrapper(self => {
+    touying-slide(self: self)[
+      #text(size: 24pt, weight: "bold")[#titulo]
+      #v(0.5em)
+      #set align(center)
+
+      #if itens.len() > 0 {
+        grid(
+          columns: itens.len(),
+          gutter: 2em,
+
+          ..itens.map(item => {
+            box(
+              inset: 1em,
+              [
+                #text(size: 48pt, weight: "bold", fill: cor-primaria, item.at(0)) \
+                #text(size: 14pt, item.at(1))
+              ]
+            )
+          })
+        )
+      }
+    ]
+  })
+}
+
+// =============================================================================
+// FUNCOES DE ANIMACAO (TOUYING)
+// =============================================================================
+
+// Re-exportar funcoes de animacao do Touying para conveniencia
+// Estas permitem revelacao progressiva de conteudo
+
+/// Pausa - conteudo apos #pause aparece no proximo clique
+/// Exemplo:
+/// - Primeiro item
+/// #pause
+/// - Segundo item (aparece depois)
+#let slide-pause = pause
+
+/// Revelacao condicional
+/// only(2)[Este texto so aparece no passo 2]
+/// only("2-")[Este texto aparece do passo 2 em diante]
+/// only("1, 3")[Este texto aparece nos passos 1 e 3]
+#let slide-only = only
+
+/// Revelacao com espaco reservado
+/// uncover(2)[Este texto fica invisivel ate o passo 2, mas ocupa espaco]
+#let slide-uncover = uncover
+
+// =============================================================================
+// ESTILOS DE COR PRE-DEFINIDOS
+// =============================================================================
+
+/// Cores institucionais comuns em universidades brasileiras
+#let cores-usp = (primary: rgb("#004A8F"), secondary: rgb("#FFB81C"))
+#let cores-unicamp = (primary: rgb("#003366"), secondary: rgb("#C41230"))
+#let cores-unesp = (primary: rgb("#1E3A5F"), secondary: rgb("#B8860B"))
+#let cores-ufrj = (primary: rgb("#003366"), secondary: rgb("#FF6600"))
+#let cores-ufmg = (primary: rgb("#003366"), secondary: rgb("#FFD700"))
+#let cores-ufrgs = (primary: rgb("#003366"), secondary: rgb("#C8102E"))
+#let cores-ufsc = (primary: rgb("#003366"), secondary: rgb("#007A33"))
+#let cores-ufpr = (primary: rgb("#003366"), secondary: rgb("#C8102E"))
+#let cores-unb = (primary: rgb("#003366"), secondary: rgb("#006633"))
+#let cores-ufpe = (primary: rgb("#800000"), secondary: rgb("#FFD700"))
+
+// Cores neutras para uso geral
+#let cores-academico = (primary: rgb("#003366"), secondary: rgb("#666666"))
+#let cores-moderno = (primary: rgb("#2C3E50"), secondary: rgb("#E74C3C"))
+#let cores-clean = (primary: rgb("#34495E"), secondary: rgb("#3498DB"))
+
+// =============================================================================
+// DOCUMENTACAO E AVISOS
+// =============================================================================
+
+/// Funcao para inserir nota sobre ausencia de norma ABNT
+/// Pode ser usada no primeiro slide ou em slide de metodologia
+#let nota-sem-norma-abnt() = {
+  text(size: 10pt, fill: gray, style: "italic")[
+    Nota: A ABNT nao possui norma especifica para apresentacoes de slides. \
+    Este formato segue boas praticas academicas, nao exigencias normativas.
+  ]
+}
+
+/// Aviso sobre citacoes em slides
+/// Para uso quando houver citacoes na apresentacao
+#let aviso-citacoes() = {
+  text(size: 10pt, fill: gray, style: "italic")[
+    Citacoes formatadas conforme NBR 10520:2023. \
+    Referencias conforme NBR 6023:2018.
+  ]
+}

--- a/packages/preview/abntyp/0.1.5/src/templates/technical-report.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/technical-report.typ
@@ -1,0 +1,508 @@
+// Template para Relatorio Tecnico e/ou Cientifico conforme NBR 10719:2015
+//
+// Estrutura:
+// Parte Externa:
+// - Capa (opcional)
+// - Lombada (opcional)
+//
+// Parte Interna - Pre-textuais:
+// - Folha de rosto (obrigatorio)
+// - Errata (opcional)
+// - Agradecimentos (opcional)
+// - Resumo na lingua vernacula (obrigatorio)
+// - Lista de ilustracoes (opcional)
+// - Lista de tabelas (opcional)
+// - Lista de abreviaturas e siglas (opcional)
+// - Lista de simbolos (opcional)
+// - Sumario (obrigatorio)
+//
+// Parte Interna - Textuais:
+// - Introducao (obrigatorio)
+// - Desenvolvimento (obrigatorio)
+// - Consideracoes finais (obrigatorio)
+//
+// Parte Interna - Pos-textuais:
+// - Referencias (obrigatorio)
+// - Glossario (opcional)
+// - Apendice (opcional)
+// - Anexo (opcional)
+// - Indice (opcional)
+// - Formulario de identificacao (opcional)
+
+#import "../core/setup.typ": with-abnt-setup
+#import "../core/page.typ": *
+#import "../core/fonts.typ": *
+#import "../core/spacing.typ": *
+#import "../text/headings.typ": *
+#import "../elements/toc.typ": *
+#import "../elements/abstract.typ": *
+#import "../references/bibliography.typ": *
+
+/// Template principal para Relatorio Tecnico conforme NBR 10719:2015
+///
+/// Parametros:
+/// - titulo: titulo do relatorio
+/// - subtitulo: subtitulo (opcional)
+/// - numero-relatorio: numero do relatorio
+/// - codigo-relatorio: codigo de identificacao (sigla+categoria+data+assunto+sequencial)
+/// - instituicao: nome do orgao ou entidade responsavel
+/// - endereco-instituicao: endereco da instituicao
+/// - titulo-projeto: titulo do projeto/programa/plano relacionado
+/// - autores: lista de autores (nome e qualificacao)
+/// - classificacao: classificacao de seguranca (opcional)
+/// - issn: ISSN se houver
+/// - local: cidade da instituicao
+/// - ano: ano de publicacao
+/// - volume: numero do volume (se mais de um)
+/// - fonte: fonte a usar
+/// - arquivo-bibliografia: arquivo .bib (opcional)
+/// - titulo-bibliografia: titulo da secao de referencias
+#let relatorio(
+  titulo: "",
+  subtitulo: none,
+  numero-relatorio: none,
+  codigo-relatorio: none,
+  instituicao: "",
+  endereco-instituicao: none,
+  titulo-projeto: none,
+  autores: (),
+  classificacao: none,
+  issn: none,
+  local: "",
+  ano: datetime.today().year(),
+  volume: none,
+  fonte: "Times New Roman",
+  arquivo-bibliografia: none,
+  titulo-bibliografia: "REFERENCIAS",
+  body,
+) = {
+  // Configuracao do documento
+  set document(
+    title: titulo,
+    author: autores.map(a => if type(a) == dictionary { a.name } else { a }).join(", "),
+  )
+
+  show: with-abnt-setup.with(fonte: fonte, suplemento-nivel1: "Capítulo")
+
+  // Conteudo
+  body
+
+  // Bibliografia automatica
+  if arquivo-bibliografia != none {
+    abnt-bibliography(arquivo-bibliografia, titulo: titulo-bibliografia)
+  }
+}
+
+/// Capa para Relatorio Tecnico conforme NBR 10719:2015
+/// Primeira capa - recomenda-se incluir:
+/// - Nome e endereco da instituicao responsavel
+/// - Numero do relatorio
+/// - ISSN (se houver)
+/// - Titulo e subtitulo (se houver)
+/// - Classificacao de seguranca (se houver)
+#let report-cover(
+  instituicao: none,
+  endereco-instituicao: none,
+  numero-relatorio: none,
+  issn: none,
+  titulo: none,
+  subtitulo: none,
+  classificacao: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+  set align(center)
+
+  // Instituicao e endereco
+  if instituicao != none {
+    text(weight: "bold", size: 12pt, upper(instituicao))
+    linebreak()
+  }
+
+  if endereco-instituicao != none {
+    text(size: 10pt, endereco-instituicao)
+  }
+
+  v(1cm)
+
+  // Numero do relatorio e ISSN
+  if numero-relatorio != none {
+    text(size: 11pt, "Relatorio n. " + str(numero-relatorio))
+    linebreak()
+  }
+
+  if issn != none {
+    text(size: 10pt, "ISSN " + issn)
+  }
+
+  v(1fr)
+
+  // Titulo e subtitulo
+  if titulo != none {
+    text(weight: "bold", size: 14pt, upper(titulo))
+  }
+
+  if subtitulo != none {
+    linebreak()
+    text(size: 14pt, ": " + subtitulo)
+  }
+
+  v(1fr)
+
+  // Classificacao de seguranca
+  if classificacao != none {
+    box(
+      stroke: 1pt,
+      inset: 0.5em,
+    )[
+      #text(weight: "bold", classificacao)
+    ]
+    v(1cm)
+  }
+
+  // Ano
+  if ano != none {
+    text(size: 12pt, str(ano))
+  }
+
+  pagebreak()
+}
+
+/// Folha de rosto para Relatorio Tecnico conforme NBR 10719:2015
+///
+/// Anverso:
+/// a) Nome do orgao ou entidade responsavel
+/// b) Titulo do projeto/programa/plano relacionado
+/// c) Titulo do relatorio
+/// d) Subtitulo (precedido de dois pontos)
+/// e) Numero do volume (se mais de um)
+/// f) Codigo de identificacao
+/// g) Classificacao de seguranca
+/// h) Nome do autor ou autor-entidade
+/// i) Local (cidade) da instituicao
+/// j) Ano de publicacao
+#let report-title-page(
+  instituicao: none,
+  titulo-projeto: none,
+  titulo: none,
+  subtitulo: none,
+  volume: none,
+  codigo-relatorio: none,
+  classificacao: none,
+  autores: (),
+  local: none,
+  ano: none,
+) = {
+  set page(numbering: none)
+  set align(center)
+
+  // Instituicao
+  if instituicao != none {
+    text(weight: "bold", size: 12pt, upper(instituicao))
+    v(0.5cm)
+  }
+
+  // Titulo do projeto relacionado
+  if titulo-projeto != none {
+    text(size: 11pt, titulo-projeto)
+    v(1cm)
+  }
+
+  v(1fr)
+
+  // Titulo e subtitulo
+  if titulo != none {
+    text(weight: "bold", size: 14pt, upper(titulo))
+  }
+
+  if subtitulo != none {
+    text(size: 14pt, ": " + subtitulo)
+  }
+
+  // Volume
+  if volume != none {
+    v(0.5em)
+    text(size: 12pt, "Volume " + str(volume))
+  }
+
+  v(1cm)
+
+  // Codigo de identificacao
+  if codigo-relatorio != none {
+    text(size: 10pt, codigo-relatorio)
+    v(0.5cm)
+  }
+
+  // Classificacao de seguranca
+  if classificacao != none {
+    box(
+      stroke: 1pt,
+      inset: 0.5em,
+    )[
+      #text(weight: "bold", size: 10pt, classificacao)
+    ]
+  }
+
+  v(1fr)
+
+  // Autores
+  if autores.len() > 0 {
+    for autor in autores {
+      if type(autor) == dictionary {
+        text(size: 12pt, autor.name)
+        if "qualification" in autor {
+          linebreak()
+          text(size: 10pt, autor.qualification)
+        }
+      } else {
+        text(size: 12pt, autor)
+      }
+      v(0.5em)
+    }
+  }
+
+  v(1fr)
+
+  // Local e ano
+  if local != none {
+    text(size: 12pt, local)
+    linebreak()
+  }
+
+  if ano != none {
+    text(size: 12pt, str(ano))
+  }
+
+  pagebreak()
+}
+
+/// Verso da folha de rosto
+/// Contem equipe tecnica e/ou dados de catalogacao
+#let report-title-page-verso(
+  equipe-tecnica: none,
+  dados-catalogacao: none,
+) = {
+  set page(numbering: none)
+
+  // Equipe tecnica (opcional)
+  if equipe-tecnica != none {
+    align(center)[
+      #text(weight: "bold", size: 11pt, "EQUIPE TECNICA")
+    ]
+    v(1em)
+
+    for member in equipe-tecnica {
+      if type(member) == dictionary {
+        [*#member.funcao:* #member.nome]
+      } else {
+        member
+      }
+      linebreak()
+    }
+
+    v(2cm)
+  }
+
+  // Dados de catalogacao (parte inferior)
+  v(1fr)
+
+  if dados-catalogacao != none {
+    align(center)[
+      #box(
+        width: 12.5cm,
+        stroke: 0.5pt,
+        inset: 0.5cm,
+      )[
+        #set text(size: 10pt)
+        #set par(leading: 1em * 0.65)
+        #dados-catalogacao
+      ]
+    ]
+  }
+
+  pagebreak()
+}
+
+/// Errata para Relatorio Tecnico
+/// Formato de tabela: Folha, Linha, Onde se le, Leia-se
+#let errata(
+  referencia: none,
+  itens: (),
+) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "ERRATA")
+  ]
+
+  v(1.5em)
+
+  // Referencia da publicacao
+  if referencia != none {
+    set par(first-line-indent: 0pt)
+    referencia
+    v(1em)
+  }
+
+  // Tabela de erros
+  if itens.len() > 0 {
+    table(
+      columns: (auto, auto, 1fr, 1fr),
+      stroke: 0.5pt,
+      inset: 6pt,
+      align: left,
+
+      [*Folha*], [*Linha*], [*Onde se le*], [*Leia-se*],
+
+      ..{
+        let cells = ()
+        for item in itens {
+          cells.push(str(item.pagina))
+          cells.push(str(item.linha))
+          cells.push(item.errado)
+          cells.push(item.correto)
+        }
+        cells
+      }
+    )
+  }
+
+  pagebreak()
+}
+
+/// Agradecimentos para Relatorio Tecnico
+#let agradecimentos-relatorio(conteudo) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "AGRADECIMENTOS")
+  ]
+  v(1.5em)
+  conteudo
+  pagebreak()
+}
+
+/// Resumo para Relatorio Tecnico conforme NBR 6028
+#let resumo-relatorio(conteudo, palavras-chave: ()) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "RESUMO")
+  ]
+
+  v(1.5em)
+
+  set par(
+    leading: 1.5em * 0.65,
+    first-line-indent: 0pt,
+    justify: true,
+  )
+
+  conteudo
+
+  v(1.5em)
+
+  if palavras-chave.len() > 0 {
+    [*Palavras-chave:* #palavras-chave.join(". ").]
+  }
+
+  pagebreak()
+}
+
+/// Formulario de identificacao para Relatorio Tecnico
+/// Obrigatorio quando nao utilizados dados de catalogacao-na-publicacao
+#let formulario-identificacao(
+  titulo: none,
+  classificacao: none,
+  numero-relatorio: none,
+  tipo-relatorio: none,
+  data: none,
+  autores: (),
+  instituicoes: (),
+  texto-resumo: none,
+  palavras-chave: (),
+  edicao: none,
+  paginas: none,
+  volume: none,
+  issn: none,
+  distribuicao: none,
+  distribuidor: none,
+  preco: none,
+  observacoes: none,
+) = {
+  heading(level: 1, numbering: none, "FORMULARIO DE IDENTIFICACAO")
+
+  let field(label, value) = {
+    if value != none {
+      [*#label:* #value]
+      linebreak()
+    }
+  }
+
+  set par(first-line-indent: 0pt)
+
+  field("Titulo", titulo)
+  field("Classificacao de seguranca", classificacao)
+  field("Numero", numero-relatorio)
+  field("Tipo de relatorio", tipo-relatorio)
+  field("Data", data)
+
+  if autores.len() > 0 {
+    [*Autores:*]
+    linebreak()
+    for autor in autores {
+      [- #if type(autor) == dictionary { autor.name } else { autor }]
+      linebreak()
+    }
+  }
+
+  if instituicoes.len() > 0 {
+    [*Instituicoes:*]
+    linebreak()
+    for inst in instituicoes {
+      [- #inst]
+      linebreak()
+    }
+  }
+
+  v(0.5em)
+
+  if texto-resumo != none {
+    [*Resumo:*]
+    linebreak()
+    texto-resumo
+    linebreak()
+  }
+
+  if palavras-chave.len() > 0 {
+    [*Palavras-chave:* #palavras-chave.join("; ")]
+    linebreak()
+  }
+
+  v(0.5em)
+
+  field("Edicao", edicao)
+  field("Numero de paginas", paginas)
+  field("Volume", volume)
+  field("ISSN", issn)
+  field("Distribuicao", distribuicao)
+  field("Distribuidor", distribuidor)
+  field("Preco", preco)
+  field("Observacoes", observacoes)
+
+  pagebreak()
+}
+
+/// Codigo de identificacao do relatorio
+/// Formato: sigla da instituicao + categoria + data + assunto + numero sequencial
+///
+/// Exemplo: INPE-RPE-2024-EST-001
+#let report-code(
+  codigo-instituicao: "",
+  categoria: "",
+  ano: none,
+  assunto: "",
+  sequencia: 1,
+  separador: "-",
+) = {
+  // Formatar numero com zeros a esquerda
+  let seq-str = if sequencia < 10 { "00" + str(sequencia) }
+                else if sequencia < 100 { "0" + str(sequencia) }
+                else { str(sequencia) }
+
+  [#codigo-instituicao#separador#categoria#separador#if ano != none {str(ano) + separador}#assunto#separador#seq-str]
+}

--- a/packages/preview/abntyp/0.1.5/src/templates/thesis.typ
+++ b/packages/preview/abntyp/0.1.5/src/templates/thesis.typ
@@ -1,0 +1,107 @@
+// Template para tese/dissertação/TCC conforme NBR 14724:2024
+
+#import "../core/setup.typ": with-abnt-setup
+#import "../core/page.typ": *
+#import "../core/fonts.typ": *
+#import "../core/spacing.typ": *
+#import "../text/headings.typ": *
+#import "../elements/cover.typ": *
+#import "../elements/title-page.typ": *
+#import "../elements/abstract.typ": *
+#import "../elements/toc.typ": *
+#import "../references/bibliography.typ": *
+
+/// Template de formatação para trabalhos acadêmicos (tese, dissertação, TCC)
+///
+/// Configura página, fonte, parágrafos, headings e demais elementos visuais
+/// conforme NBR 14724:2024. Os metadados do trabalho (título, autor, etc.)
+/// devem ser definidos via dados().
+///
+/// Parâmetros:
+/// - fonte: fonte a usar ("Times New Roman" ou "Arial")
+/// - arquivo-bibliografia: caminho para arquivo .bib (opcional)
+/// - titulo-bibliografia: título da seção de referências (padrão: "REFERÊNCIAS")
+#let normas-abnt(
+  fonte: "Times New Roman",
+  arquivo-bibliografia: none,
+  titulo-bibliografia: "REFERÊNCIAS",
+  body,
+) = {
+  show: with-abnt-setup.with(fonte: fonte, suplemento-nivel1: "Capítulo")
+
+  // Nota: metadados do PDF (title, author) são definidos por dados().
+  // Se o usuário não usar dados(), o PDF ficará sem metadados.
+
+  // Conteúdo
+  body
+
+  // Bibliografia automática (se arquivo .bib fornecido)
+  if arquivo-bibliografia != none {
+    abnt-bibliography(arquivo-bibliografia, titulo: titulo-bibliografia)
+  }
+}
+
+// Alias de retrocompatibilidade (0.1.2 usava abntcc)
+#let abntcc = normas-abnt
+
+/// Marca início da parte pré-textual (sem numeração visível).
+/// Deve ser chamado após a capa, antes da folha de rosto.
+/// A contagem inicia na folha de rosto conforme NBR 14724:2024.
+#let pretextual() = {
+  counter(page).update(1)
+  set page(numbering: none)
+}
+
+/// Marca início da parte textual (numeração arábica visível).
+/// NÃO reinicia o contador — a numeração continua da contagem
+/// iniciada na folha de rosto, conforme NBR 14724:2024.
+#let textual() = {
+  set page(numbering: "1", number-align: top + right)
+}
+
+/// Marca início da parte pós-textual (referências, apêndices, anexos).
+/// A numeração arábica continua sem interrupção, conforme NBR 14724:2024.
+#let postextual() = {
+  set page(numbering: "1", number-align: top + right)
+}
+
+/// Página de dedicatória
+#let dedicatoria(conteudo) = {
+  set page(numbering: none)
+  v(1fr)
+  align(right)[
+    #box(width: 50%)[
+      #set par(first-line-indent: 0pt)
+      #conteudo
+    ]
+  ]
+  pagebreak()
+}
+
+/// Página de agradecimentos
+#let agradecimentos(conteudo) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, "AGRADECIMENTOS")
+  ]
+  v(1.5em)
+  conteudo
+  pagebreak()
+}
+
+/// Epígrafe
+#let epigrafe(citacao, autor) = {
+  set page(numbering: none)
+  v(1fr)
+  align(right)[
+    #box(width: 50%)[
+      #set par(first-line-indent: 0pt)
+      \u{201C}#citacao\u{201D} \
+      [(#autor)]
+    ]
+  ]
+  pagebreak()
+}
+
+// Aliases curtos
+#let dedica = dedicatoria
+#let agradece = agradecimentos

--- a/packages/preview/abntyp/0.1.5/src/text/figures.typ
+++ b/packages/preview/abntyp/0.1.5/src/text/figures.typ
@@ -1,0 +1,155 @@
+// Figuras, quadros, tabelas e ilustrações conforme NBR 14724:2024 e IBGE
+
+/// Configuração de figuras conforme ABNT
+/// - Legenda na parte superior: tipo, número, traço, título
+/// - Fonte na parte inferior
+/// - Centralizadas
+#let abnt-figure-setup() = {
+  show figure: it => {
+    set align(center)
+    it
+  }
+
+  show figure.caption: it => {
+    set text(size: 10pt)
+    it
+  }
+}
+
+/// Container genérico para elementos com título, numeração e fonte (ABNT).
+/// É a única forma de criar um `figure()` no ABNTyp.
+/// O `suplemento` é inferido automaticamente a partir do `tipo`:
+/// - `"imagem"` → "Figura" (padrão)
+/// - `"tabela"` → "Tabela"
+/// - `"quadro"` → "Quadro"
+///
+/// Uso:
+/// ```typst
+/// #container(legenda: "Meu título", origem: "O autor")[
+///   #imagem("foto.png")
+/// ]
+/// ```
+#let container(
+  body,
+  legenda: none,
+  origem: none,
+  nota: none,
+  tipo: "imagem",
+  suplemento: auto,
+  ..args,
+) = {
+  // Traduz strings em português para os tipos nativos do Typst.
+  // Backward-compat: aceita também os tipos nativos `image` e `table`
+  // (usados antes da renomeação para "imagem"/"tabela"), de modo que
+  // código existente com `tipo: image` ou `tipo: table` continue funcionando.
+  let resolved-kind = if tipo == "imagem" or tipo == image { image }
+    else if tipo == "tabela" or tipo == table { table }
+    else { tipo }
+
+  let supp = if suplemento != auto { suplemento }
+    else if resolved-kind == image { "Figura" }
+    else if resolved-kind == table { "Tabela" }
+    else if resolved-kind == "quadro" { "Quadro" }
+    else { "Figura" }
+
+  figure(
+    body,
+    caption: if legenda != none { legenda },
+    kind: resolved-kind,
+    supplement: supp,
+    ..args,
+  )
+
+  if origem != none {
+    align(center)[
+      #text(size: 10pt)[Fonte: #origem]
+    ]
+  }
+
+  if nota != none {
+    align(left)[
+      #text(size: 10pt)[Nota: #nota]
+    ]
+  }
+}
+
+/// Wrapper para `image()` em português.
+///
+/// Parâmetros nomeados:
+/// - largura: largura (auto, relativa ou fração)
+/// - altura: altura (auto, relativa ou fração)
+/// - ajuste: modo de ajuste ("cobrir", "conter", "esticar")
+/// - alternativo: texto alternativo para acessibilidade
+/// - pagina: página do PDF a extrair (auto = primeira)
+/// - formato: formato da imagem (auto ou string)
+/// - escala: escala de renderização (auto ou string)
+/// - icc: perfil de cor ICC (auto, string ou bytes)
+/// - ..outros: parâmetros adicionais repassados a `image()`
+///
+/// Uso (dentro de um `container`):
+/// ```typst
+/// #container(legenda: "Logo", origem: "O autor")[
+///   #imagem("logo.png", largura: 80%)
+/// ]
+/// ```
+#let imagem(
+  caminho,
+  largura: auto,
+  altura: auto,
+  ajuste: "cobrir",
+  alternativo: none,
+  pagina: auto,
+  formato: auto,
+  escala: auto,
+  icc: auto,
+  ..outros,
+) = {
+  // Traduz valores de ajuste para o Typst
+  let resolved-fit = if ajuste == "cobrir" { "cover" }
+    else if ajuste == "conter" { "contain" }
+    else if ajuste == "esticar" { "stretch" }
+    else { ajuste }
+
+  image(
+    caminho,
+    width: largura,
+    height: altura,
+    fit: resolved-fit,
+    alt: alternativo,
+    page: pagina,
+    format: formato,
+    scaling: escala,
+    icc: icc,
+    ..outros,
+  )
+}
+
+/// Quadro: tabela textual com bordas fechadas (conforme IBGE).
+/// Aceita os mesmos parâmetros de `table()`.
+///
+/// Uso (dentro de um `container`):
+/// ```typst
+/// #container(legenda: "Glossário", tipo: "quadro", origem: "O autor")[
+///   #quadro(columns: 2,
+///     [*Termo*], [*Definição*],
+///     [Algoritmo], [Sequência finita de instruções],
+///   )
+/// ]
+/// ```
+#let quadro(..args) = {
+  table(..args)
+}
+
+/// Fonte da figura (para usar avulso abaixo de um elemento)
+#let fonte(conteudo) = {
+  align(center)[
+    #text(size: 10pt)[Fonte: #conteudo]
+  ]
+}
+
+/// Nota da figura (para usar avulso abaixo de um elemento)
+#let nota-figura(conteudo) = {
+  align(left)[
+    #text(size: 10pt)[Nota: #conteudo]
+  ]
+}

--- a/packages/preview/abntyp/0.1.5/src/text/headings.typ
+++ b/packages/preview/abntyp/0.1.5/src/text/headings.typ
@@ -1,0 +1,173 @@
+// Seções e subseções conforme NBR 6024:2012
+
+/// Configuração de títulos de seção conforme ABNT
+/// - Seção primária: MAIÚSCULAS, negrito
+/// - Seção secundária: MAIÚSCULAS, sem negrito
+/// - Seção terciária: Minúsculas, negrito
+/// - Seção quaternária: Minúsculas, sem negrito
+/// - Seção quinária: Minúsculas, itálico
+#let abnt-heading-setup() = {
+  // Seção primária (nível 1): MAIÚSCULAS, negrito
+  show heading.where(level: 1): it => {
+    pagebreak(weak: true)
+    v(1.5em)
+    text(
+      weight: "bold",
+      size: 12pt,
+      upper(it.body),
+    )
+    v(1.5em)
+  }
+
+  // Seção secundária (nível 2): MAIÚSCULAS, normal
+  show heading.where(level: 2): it => {
+    v(1.5em)
+    text(
+      weight: "regular",
+      size: 12pt,
+      upper(it.body),
+    )
+    v(1.5em)
+  }
+
+  // Seção terciária (nível 3): Minúsculas, negrito
+  show heading.where(level: 3): it => {
+    v(1.5em)
+    text(
+      weight: "bold",
+      size: 12pt,
+      it.body,
+    )
+    v(1.5em)
+  }
+
+  // Seção quaternária (nível 4): Minúsculas, normal
+  show heading.where(level: 4): it => {
+    v(1.5em)
+    text(
+      weight: "regular",
+      size: 12pt,
+      it.body,
+    )
+    v(1.5em)
+  }
+
+  // Seção quinária (nível 5): Minúsculas, itálico
+  show heading.where(level: 5): it => {
+    v(1.5em)
+    text(
+      weight: "regular",
+      style: "italic",
+      size: 12pt,
+      it.body,
+    )
+    v(1.5em)
+  }
+}
+
+/// Aplica formatação de headings ABNT
+#let with-abnt-headings(body) = {
+  set heading(numbering: "1.1")
+
+  show heading.where(level: 1): it => {
+    pagebreak(weak: true)
+    v(1.5em)
+    text(weight: "bold", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #upper(it.body)
+    ]
+    v(1.5em)
+  }
+
+  show heading.where(level: 2): it => {
+    v(1.5em)
+    text(weight: "regular", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #upper(it.body)
+    ]
+    v(1.5em)
+  }
+
+  show heading.where(level: 3): it => {
+    v(1.5em)
+    text(weight: "bold", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #it.body
+    ]
+    v(1.5em)
+  }
+
+  show heading.where(level: 4): it => {
+    v(1.5em)
+    text(weight: "regular", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #it.body
+    ]
+    v(1.5em)
+  }
+
+  show heading.where(level: 5): it => {
+    v(1.5em)
+    text(weight: "regular", style: "italic", size: 12pt)[
+      #if it.numbering != none {
+        counter(heading).display()
+        h(0.5em)
+      }
+      #it.body
+    ]
+    v(1.5em)
+  }
+
+  body
+}
+
+/// Título sem numeração — para Referências, Glossário, Apêndices etc.
+/// Aparece no sumário. Nível padrão: 1 (seção primária).
+/// Exemplo: #titulo-sem-num[REFERÊNCIAS]  ou  #titulo-sem-num("REFERÊNCIAS")
+/// O suplemento é fixado em "Seção" para que @label produza "Seção X"
+/// e não "Capítulo X" mesmo em templates que usam suplemento-nivel1: "Capítulo".
+#let titulo-sem-num(titulo, nivel: 1) = {
+  show heading: set heading(supplement: "Seção")
+  heading(level: nivel, numbering: none, upper(titulo))
+}
+
+// Alias de retrocompatibilidade
+#let secao = titulo-sem-num
+
+/// Apêndice ABNT — material elaborado pelo próprio autor.
+/// Cria heading nível 1 sem numeração automática; a letra é fornecida pelo autor (A, B, C...).
+/// Aparece no sumário. @label produz "Apêndice A".
+/// Exemplo: #apendice("A", "Questionário aplicado") <apendice-a>
+#let apendice(letra, titulo) = {
+  show heading: set heading(supplement: "Apêndice " + upper(letra))
+  heading(level: 1, numbering: none)[APÊNDICE #upper(letra) -- #upper(titulo)]
+}
+
+/// Anexo ABNT — material NÃO elaborado pelo autor.
+/// Cria heading nível 1 sem numeração automática; a letra é fornecida pelo autor (A, B, C...).
+/// Aparece no sumário. @label produz "Anexo A".
+/// Exemplo: #anexo("A", "Norma NBR 14724") <anexo-a>
+#let anexo(letra, titulo) = {
+  show heading: set heading(supplement: "Anexo " + upper(letra))
+  heading(level: 1, numbering: none)[ANEXO #upper(letra) -- #upper(titulo)]
+}
+
+/// Título de elemento pré-textual (não aparece no sumário)
+#let pretextual-title(titulo) = {
+  align(center)[
+    #text(weight: "bold", size: 12pt, upper(titulo))
+  ]
+  v(1.5em)
+}

--- a/packages/preview/abntyp/0.1.5/src/text/quotes.typ
+++ b/packages/preview/abntyp/0.1.5/src/text/quotes.typ
@@ -1,0 +1,133 @@
+// Citações conforme NBR 10520:2023
+
+/// Citação direta curta (até 3 linhas)
+/// Incorporada ao parágrafo, entre aspas duplas
+///
+/// Aceita parâmetros posicionais ou nomeados:
+///   #citacao-curta("Silva", "2023", "45")[Texto]
+///   #citacao-curta(autor: "Silva", ano: "2023")[Texto]
+///   #citacao-curta()[Texto]
+#let citacao-curta(
+  autor: none,
+  ano: none,
+  pagina: none,
+  volume: none,
+  localizacao: none,
+  grifo: none,
+  traducao: none,
+  ..args,
+) = {
+  let pos = args.pos()
+  let body = pos.last()
+  let rest = pos.slice(0, -1)
+  if autor == none and rest.len() >= 1 { autor = rest.at(0) }
+  if ano == none and rest.len() >= 2 { ano = rest.at(1) }
+  if pagina == none and rest.len() >= 3 { pagina = rest.at(2) }
+  [\u{201C}#body\u{201D}]
+  let tem-fonte = (
+    autor != none or ano != none or pagina != none
+      or volume != none or localizacao != none
+      or grifo != none or traducao != none
+  )
+  if tem-fonte {
+    // Sobrenome com apenas a inicial maiúscula (NBR 10520:2023);
+    // a CAIXA ALTA da chamada era regra da NBR 10520:2002 (revogada).
+    [ (]
+    if autor != none { autor }
+    if ano != none {
+      if autor != none { [, ] }
+      [#ano]
+    }
+    if volume != none { [, v. #volume] }
+    if pagina != none { [, p. #pagina] }
+    if localizacao != none { [, #localizacao] }
+    if grifo != none { [, grifo #grifo] }
+    if traducao != none { [, tradução #traducao] }
+    [)]
+  }
+}
+
+/// Citação direta longa (mais de 3 linhas)
+/// Recuo de 4 cm da margem esquerda, fonte tamanho 10, espaçamento simples
+///
+/// Aceita parâmetros posicionais ou nomeados:
+///   #citacao-longa("Silva", "2023", "45-46")[Texto longo...]
+///   #citacao-longa(autor: "Silva", ano: "2023")[Texto longo...]
+///   #citacao-longa()[Texto longo...]
+#let citacao-longa(
+  autor: none,
+  ano: none,
+  pagina: none,
+  volume: none,
+  localizacao: none,
+  grifo: none,
+  traducao: none,
+  ..args,
+) = {
+  let pos = args.pos()
+  let body = pos.last()
+  let rest = pos.slice(0, -1)
+  if autor == none and rest.len() >= 1 { autor = rest.at(0) }
+  if ano == none and rest.len() >= 2 { ano = rest.at(1) }
+  if pagina == none and rest.len() >= 3 { pagina = rest.at(2) }
+  let tem-fonte = (
+    autor != none or ano != none or pagina != none
+      or volume != none or localizacao != none
+      or grifo != none or traducao != none
+  )
+  v(1em)
+  pad(left: 4cm)[
+    #set text(size: 10pt)
+    #set par(
+      leading: 1em * 0.65,
+      first-line-indent: 0pt,
+      justify: true,
+    )
+    #body
+    #if tem-fonte {
+      // Sobrenome com apenas a inicial maiúscula (NBR 10520:2023).
+      [ (]
+      if autor != none { autor }
+      if ano != none {
+        if autor != none { [, ] }
+        [#ano]
+      }
+      if volume != none { [, v. #volume] }
+      if pagina != none { [, p. #pagina] }
+      if localizacao != none { [, #localizacao] }
+      if grifo != none { [, grifo #grifo] }
+      if traducao != none { [, tradução #traducao] }
+      [)]
+    }
+  ]
+  v(1em)
+}
+
+/// Supressão de texto [...]
+#let supressao = [[...]]
+
+/// Interpolação de texto [texto]
+#let interpolacao(texto) = {
+  [\[#texto\]]
+}
+
+/// Destaque/ênfase em trecho de citação (aplica itálico ao trecho).
+///
+/// IMPORTANTE (NBR 10520:2023, 5.1): a INDICAÇÃO "grifo nosso" / "grifo do
+/// autor" deve aparecer ao FINAL da citação, dentro dos parênteses, após a
+/// página — ex.: (Souto, 1916, p. 46, grifo nosso). Por isso o indicador é
+/// passado via o parâmetro `grifo:` da função de citação, e estas funções
+/// apenas aplicam o itálico ao trecho destacado:
+///   #citacao-curta("Souto", 1916, 46, grifo: "nosso")[A #grifo-nosso[clareza]...]
+#let grifo-nosso(texto) = emph(texto)
+
+/// Destaque já existente no original (itálico). Ver `grifo-nosso`;
+/// use `grifo: "do autor"` na função de citação para a indicação final.
+#let grifo-do-autor(texto) = emph(texto)
+
+// Aliases curtos
+#let ccurta = citacao-curta
+#let clonga = citacao-longa
+#let interp = interpolacao
+#let gnosso = grifo-nosso
+#let gautor = grifo-do-autor

--- a/packages/preview/abntyp/0.1.5/src/text/tables.typ
+++ b/packages/preview/abntyp/0.1.5/src/text/tables.typ
@@ -1,0 +1,40 @@
+// Tabelas conforme IBGE e NBR 14724:2024
+
+/// Configuração de tabelas conforme ABNT/IBGE
+/// - Bordas apenas superior, inferior e separando cabeçalho
+/// - Legenda na parte superior
+/// - Fonte na parte inferior
+#let abnt-table-setup() = {
+  show figure.where(kind: table): it => {
+    set align(center)
+    it
+  }
+}
+
+/// Tabela no padrão IBGE (sem bordas laterais).
+/// Formatador de conteúdo — deve ser usada dentro de `container()`.
+/// Aceita os mesmos parâmetros de `table()`, mas aplica `stroke: none`
+/// automaticamente (padrão IBGE: sem bordas laterais).
+///
+/// Uso (dentro de um `container`):
+/// ```typst
+/// #container(legenda: "População", tipo: "tabela", origem: "IBGE (2023)")[
+///   #tabela(columns: 2,
+///     table.hline(stroke: 1.5pt),
+///     [*Região*], [*População*],
+///     table.hline(stroke: 0.75pt),
+///     [Nordeste], [57M],
+///     table.hline(stroke: 1.5pt),
+///   )
+/// ]
+/// ```
+#let tabela(..args) = {
+  table(stroke: none, ..args)
+}
+
+/// Nota de tabela
+#let nota-tabela(conteudo) = {
+  align(left)[
+    #text(size: 10pt)[Nota: #conteudo]
+  ]
+}

--- a/packages/preview/abntyp/0.1.5/typst.toml
+++ b/packages/preview/abntyp/0.1.5/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "abntyp"
+version = "0.1.5"
+entrypoint = "lib.typ"
+authors = ["Esdras"]
+license = "MIT"
+description = "Format academic documents following Brazilian ABNT standards."
+repository = "https://github.com/3sdras/abntyp"
+keywords = ["abnt", "tcc", "tese", "thesis", "artigo", "paper", "acadêmico", "brasileiro"]
+categories = ["paper", "thesis", "report"]
+exclude = ["docs/*", "examples/*", "*.pdf", "CREDITS.md", "README-typst.md", "CLAUDE.md", ".gitignore", ".claude/*", ".DS_Store", ".kilo/*", "ABNTypst.code-workspace", "bugfixes.md"]


### PR DESCRIPTION
Bugfix release of `@preview/abntyp`, superseding the still-unmerged 0.1.4 (this PR was for 0.1.4; the folder was swapped to 0.1.5, so 0.1.4 is skipped — same as the already-skipped 0.1.1).

**Fix:** in-sentence (narrative) author-date citations with 2–3 authors. The `#pag` helper gained an optional `autor:` argument so the running-text form uses "e" as ABNT NBR 10520:2023 requires (`Lima e Serrano (2024)`), while the parenthetical form keeps `;` (`(Lima; Serrano, 2024)`). The year still comes from the `.bib`; fully backward compatible.

Validated by compiling real documents (academic template + slides) against the exact published package layout.