### PR TITLE
json-resume:0.1.0

### DIFF
--- a/packages/preview/json-resume/0.1.0/LICENSE
+++ b/packages/preview/json-resume/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shane Murphy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/json-resume/0.1.0/README.md
+++ b/packages/preview/json-resume/0.1.0/README.md
@@ -1,0 +1,140 @@
+<h1 align="center">json-resume</h1>
+
+<p align="center">
+  <a href="https://typst.app/universe/package/json-resume"><img alt="json-resume on Typst Universe" src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fjson-resume&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/releases"><img alt="Latest GitHub release version of json-resume" src="https://img.shields.io/github/v/release/smur89/typst-json-resume?style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/actions/workflows/build.yml"><img alt="GitHub Actions build workflow status on the json-resume main branch" src="https://img.shields.io/github/actions/workflow/status/smur89/typst-json-resume/build.yml?style=flat-square"></a>
+  <a href="LICENSE"><img alt="MIT license badge linking to the json-resume LICENSE file" src="https://img.shields.io/github/license/smur89/typst-json-resume?style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/stargazers"><img alt="Number of GitHub stargazers for json-resume" src="https://img.shields.io/github/stars/smur89/typst-json-resume?style=flat-square"></a>
+</p>
+
+<p align="center">
+  Strict <a href="https://jsonresume.org/">JSON Resume</a> loader for Typst — validate a canonical <code>resume.json</code> against the <a href="https://jsonresume.org/schema">published schema</a>, then hand the normalised dict to any compatible CV template.
+</p>
+
+[JSON Resume](https://jsonresume.org/) is a portable JSON-based resume format —
+one `resume.json` file rendered by many themes across many output formats.
+This package brings that ecosystem to Typst: load and validate a canonical
+`resume.json`, then hand the normalised dict to any compatible Typst CV
+template. Strict to the published [schema](https://jsonresume.org/schema)
+(canonical source at [jsonresume/resume-schema](https://github.com/jsonresume/resume-schema/blob/master/schema.json)):
+unknown fields are rejected, free-text fields are coerced to Typst `content`,
+and renderer-specific extensions belong in the consuming template — not here.
+
+Motivated by [smur89/alta-typst#48](https://github.com/smur89/alta-typst/issues/48).
+
+## Install
+
+```typst
+#import "@preview/json-resume:0.0.1": validate-resume, coerce-resume, parse-resume
+```
+
+## A minimal `resume.json`
+
+```json
+{
+  "basics": {
+    "name": "Seán Ó Murchú",
+    "label": "Senior Software Engineer",
+    "email": "sean@example.com",
+    "summary": "Backend engineer with eight years of experience."
+  },
+  "work": [
+    {
+      "name": "Acme Corp",
+      "position": "Senior Software Engineer",
+      "startDate": "2022-01",
+      "highlights": ["Led the event-sourcing platform migration."]
+    }
+  ]
+}
+```
+
+The full canonical schema covers thirteen sections:
+`basics`, `work`, `volunteer`, `education`, `awards`, `certificates`,
+`publications`, `skills`, `languages`, `interests`, `references`, `projects`,
+`meta`. The `$schema` top-level metadata field is also accepted. See
+[jsonresume.org/schema](https://jsonresume.org/schema) for every field.
+
+## Usage
+
+`parse-resume` is the one-call entry point. It accepts either a parsed dict
+or a Typst-root-relative path string:
+
+```typst
+#import "@preview/json-resume:0.0.1": parse-resume
+
+// Path relative to your own .typ — let Typst's json() resolve it.
+#let resume = parse-resume(json("resume.json"))
+
+// Or a Typst-root-relative path string, resolved by parse-resume itself.
+#let resume = parse-resume("/resume.json")
+```
+
+The returned dict mirrors the canonical schema. Free-text fields (`summary`,
+`description`, `highlights[]`, `reference`) are coerced to Typst `content`;
+everything else stays as JSON-native types. For example:
+
+```typst
+resume.basics.name            // str — "Seán Ó Murchú"
+resume.basics.summary         // content — wrapped for direct rendering
+resume.work.at(0).position    // str
+resume.work.at(0).highlights  // (content, content, …)
+resume.skills.at(0).keywords  // (str, str, …) — tag-like, not coerced
+```
+
+Pass the model into any compatible renderer — e.g. `altacv`:
+
+```typst
+#import "@preview/altacv:1.1.1": alta
+#import "@preview/json-resume:0.0.1": parse-resume
+
+#alta(parse-resume(json("resume.json")), preferences: (...), labels: (...))
+```
+
+### Handling validation errors yourself
+
+```typst
+#import "@preview/json-resume:0.0.1": validate-resume, coerce-resume
+
+#let raw = json("resume.json")
+#let errors = validate-resume(raw)
+#if errors.len() > 0 [
+  // each error is `(path: (...), message: "...")`
+  Resume has #errors.len() issue(s).
+] else [
+  #let model = coerce-resume(raw)
+  ...
+]
+```
+
+## Errors
+
+`validate-resume` returns a list of `(path, message)` records — empty list
+means the input is valid. `parse-resume` calls `validate-resume` first and
+aborts compilation with a combined report on the first invocation that finds
+issues, so every problem in the document surfaces in one error:
+
+```text
+error: assertion failed: json-resume: found 3 problems in the input:
+  - basics.email: expected string, got integer.
+  - work[0].positon: unknown key "positon". Valid keys: name, location, description, position, url, startDate, endDate, summary, highlights.
+  - meta.foo: unknown key "foo". Valid keys: canonical, version, lastModified.
+```
+
+## Scope
+
+This package implements **only** the canonical JSON Resume schema.
+Template-specific extensions (theme colours, header decorations, label
+overrides, …) are layered on top by the consuming renderer. Requests for
+renderer-specific fields will be redirected to the relevant template repo.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Releases are cut by
+[release-please](https://github.com/googleapis/release-please) from
+conventional-commit titles on `main`.
+
+## License
+
+[MIT](LICENSE).

--- a/packages/preview/json-resume/0.1.0/lib.typ
+++ b/packages/preview/json-resume/0.1.0/lib.typ
@@ -1,0 +1,45 @@
+// Strict loader for canonical JSON Resume data
+// (https://jsonresume.org/schema). The engines under internal/ are
+// pure (schema, value) functions; the public symbols below pre-bind
+// resume-schema. See tests/engine_schema_agnostic.typ.
+
+#import "internal/schema.typ": resume-schema
+#import "internal/validate.typ": _validate
+#import "internal/coerce.typ": _coerce
+#import "internal/errors.typ": _format-report
+
+// Returns a list of {path, message} records; empty = valid.
+#let validate-resume(data) = _validate(resume-schema, data, ())
+
+// Assumes data has passed validate-resume. Unknown keys are dropped
+// silently rather than panicking on direct callers.
+#let coerce-resume(data) = _coerce(resume-schema, data)
+
+// String paths must start with "/" because Typst resolves relative
+// paths against the file containing the call — for this package
+// that's the @preview cache, which is not what callers want.
+#let parse-resume(data) = {
+  let dict-data = if type(data) == str {
+    if not data.starts-with("/") {
+      panic(
+        "json-resume: parse-resume with a string path requires the path " +
+          "to start with \"/\" (resolved from the typst root). Got: " + repr(data) + ". " +
+          "To use a path relative to your own .typ file, call json() " +
+          "directly: parse-resume(json(" + repr(data) + ")).",
+      )
+    }
+    json(data)
+  } else if type(data) == dictionary {
+    data
+  } else {
+    panic(
+      "json-resume: parse-resume expected a dict or a string path, got " +
+        repr(type(data)) + ".",
+    )
+  }
+  let errors = validate-resume(dict-data)
+  // assert preserves newlines in the diagnostic; panic repr-escapes
+  // them and collapses the bullet list onto one line.
+  assert(errors.len() == 0, message: _format-report(errors))
+  coerce-resume(dict-data)
+}

--- a/packages/preview/json-resume/0.1.0/typst.toml
+++ b/packages/preview/json-resume/0.1.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "json-resume"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Shane Murphy"]
+license = "MIT"
+description = "Load and validate canonical JSON Resume data for any Typst CV template."
+repository = "https://github.com/smur89/typst-json-resume"
+keywords = ["json-resume", "resume", "cv", "loader", "schema"]
+categories = ["utility"]
+compiler = "0.13.0"


### PR DESCRIPTION

  <!--
  Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as
  `name:version` of the submitted package.
  -->

  I am submitting
  - [x] a new package
  - [ ] an update for a package

  `json-resume` is a strict loader for canonical [JSON Resume](https://jsonresume.org/) data. It reads a `resume.json` file, validates it against the [published
  schema](https://jsonresume.org/schema), and returns a normalised Typst dict with free-text fields coerced to `content` — ready to hand to any compatible Typst CV template.
  Useful because the JSON Resume promise of one `resume.json` across many renderers currently requires every Typst CV template to hand-translate the JSON into a Typst dict;
  this package centralises that work into a single dependency so renderers can stay focused on layout.

  I have read and followed the submission guidelines and, in particular, I
  - [x] selected a name that isn't the most obvious or canonical name for what the package does
    - Explanation: The name mirrors the [JSON Resume](https://jsonresume.org/) project name because the package's sole purpose is to load documents conforming to *that
  specific standard*. It identifies the protocol the package implements, not a generic category — common JSON-Resume tooling across other ecosystems follows the same naming
  pattern (e.g. `jsonresume-cli`, `npm:resume-cli`, `python:json-resume`). Generic terms like `resume` or `cv` are deliberately avoided so they remain available for template
  packages.
  - [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
  - [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
  - [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
  - [x] tested my package locally on my system and it worked
  - [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE