### PR TITLE
json-resume:0.1.1

### DIFF
--- a/packages/preview/json-resume/0.1.1/CONTRIBUTING.md
+++ b/packages/preview/json-resume/0.1.1/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+Thanks for taking the time to look. This is a small library package; almost
+any thoughtful contribution will be welcome — but a couple of conventions
+keep the release pipeline (release-please + Typst Universe) running smoothly.
+
+## Submitting a PR
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally and create a branch for your change.
+3. Make the changes, commit, and push to your fork.
+4. Open a Pull Request against `main` on this repository.
+
+Security issues should be reported privately per [`SECURITY.md`](SECURITY.md)
+instead of as a PR or issue.
+
+## Scope
+
+`json-resume` implements **only** the canonical [JSON Resume schema](https://jsonresume.org/schema).
+Anything renderer-specific (theme colours, label overrides, header
+decorations, custom sections, …) belongs in the consuming Typst CV template,
+not here. PRs that add fields outside the canonical schema will be redirected
+to the appropriate downstream template repo.
+
+## Project layout
+
+```text
+lib.typ           # public entry — `read-resume`, `parse-resume`
+tests/            # fixtures — CI compiles each as a regression guard
+```
+
+## Development loop
+
+Install Typst at the version CI uses — see `TYPST_VERSION` in
+`.github/workflows/build.yml`.
+
+```sh
+make             # compile every tests/*.typ fixture (= `make test`)
+make test        # same as above; the CI lint job runs this
+make check       # alias for `make test`
+make help        # summarise the available targets
+```
+
+`make test` is the local equivalent of the CI lint job — green here means CI
+lint will pass too.
+
+If you'd rather drive Typst directly:
+
+```sh
+for f in tests/*.typ; do typst compile --root . --format pdf "$f" /dev/null; done
+```
+
+`--format pdf` is required when the output path is `/dev/null` — Typst cannot
+infer the format from a path with no extension.
+
+## Conventional commits
+
+The repo uses [release-please](https://github.com/googleapis/release-please)
+to cut releases. Versioning is derived from commit messages on `main`, so
+each merged PR needs a clean conventional-commit message.
+
+| Prefix | Bump | Use for |
+|---|---|---|
+| `fix:` | patch | Bug fix, doc correction, broken link, validation gap |
+| `feat:` | minor | New schema field supported, new coercion, new public helper |
+| `feat!:` or `BREAKING CHANGE:` footer | major | API change that existing users would need to migrate |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | none | Internal changes that shouldn't trigger a release |
+
+PRs squash-merge with the PR title as the commit subject, so just make the
+**PR title** a conventional commit. The body of the squash commit comes from
+the PR description.
+
+## Adding schema coverage
+
+For a **new schema field**:
+
+1. Add (or extend) a fixture under `tests/` exercising the field — a valid
+   case and at least one rejection case for the validator.
+2. Implement the validation / coercion in `lib.typ` (or a module it imports).
+3. Update the README's "Usage" example if the field is end-user-visible.
+
+`feat:` commit.
+
+## First publication to Typst Universe
+
+The automated `submit-to-typst-universe` workflow only handles **updates** to
+an already-published package (the auto-generated PR body is the slim
+"update" variant). The very first submission to
+[typst/packages](https://github.com/typst/packages) must be opened manually
+so the maintainers can do a full new-package review.
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for how to report a vulnerability.

--- a/packages/preview/json-resume/0.1.1/LICENSE
+++ b/packages/preview/json-resume/0.1.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shane Murphy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/json-resume/0.1.1/README.md
+++ b/packages/preview/json-resume/0.1.1/README.md
@@ -1,0 +1,149 @@
+<h1 align="center">json-resume</h1>
+
+<p align="center">
+  <a href="https://typst.app/universe/package/json-resume"><img alt="json-resume on Typst Universe" src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fjson-resume&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/releases"><img alt="Latest GitHub release version of json-resume" src="https://img.shields.io/github/v/release/smur89/typst-json-resume?style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/actions/workflows/build.yml"><img alt="GitHub Actions build workflow status on the json-resume main branch" src="https://img.shields.io/github/actions/workflow/status/smur89/typst-json-resume/build.yml?style=flat-square"></a>
+  <a href="LICENSE"><img alt="MIT license badge linking to the json-resume LICENSE file" src="https://img.shields.io/github/license/smur89/typst-json-resume?style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/stargazers"><img alt="Number of GitHub stargazers for json-resume" src="https://img.shields.io/github/stars/smur89/typst-json-resume?style=flat-square"></a>
+</p>
+
+<p align="center">
+  Strict <a href="https://jsonresume.org/">JSON Resume</a> loader for Typst — validate a canonical <code>resume.json</code> against the <a href="https://jsonresume.org/schema">published schema</a>, then hand the normalised dict to any compatible CV template.
+</p>
+
+[JSON Resume](https://jsonresume.org/) is a portable JSON-based resume format —
+one `resume.json` file rendered by many themes across many output formats.
+This package brings that ecosystem to Typst: load and validate a canonical
+`resume.json`, then hand the normalised dict to any compatible Typst CV
+template. Strict to the published [schema](https://jsonresume.org/schema)
+(canonical source at [jsonresume/resume-schema](https://github.com/jsonresume/resume-schema/blob/v1.0.0/schema.json)):
+unknown fields are rejected, free-text fields are coerced to Typst `content`,
+and renderer-specific extensions belong in the consuming template — not here.
+
+Motivated by [smur89/alta-typst#48](https://github.com/smur89/alta-typst/issues/48).
+
+## Install
+
+```typst
+#import "@preview/json-resume:0.1.1": validate-resume, coerce-resume, parse-resume // x-release-please-version
+```
+
+## A minimal `resume.json`
+
+```json
+{
+  "basics": {
+    "name": "Seán Ó Murchú",
+    "label": "Senior Software Engineer",
+    "email": "sean@example.com",
+    "summary": "Backend engineer with eight years of experience."
+  },
+  "work": [
+    {
+      "name": "Acme Corp",
+      "position": "Senior Software Engineer",
+      "startDate": "2022-01",
+      "highlights": ["Led the event-sourcing platform migration."]
+    }
+  ]
+}
+```
+
+The full canonical schema covers thirteen sections:
+`basics`, `work`, `volunteer`, `education`, `awards`, `certificates`,
+`publications`, `skills`, `languages`, `interests`, `references`, `projects`,
+`meta`. The `$schema` top-level metadata field is also accepted. See
+[jsonresume.org/schema](https://jsonresume.org/schema) for every field.
+
+## Usage
+
+`parse-resume` is the one-call entry point. It accepts either a parsed dict
+or a Typst-root-relative path string:
+
+```typst
+#import "@preview/json-resume:0.1.1": parse-resume // x-release-please-version
+
+// Path relative to your own .typ — let Typst's json() resolve it.
+#let resume = parse-resume(json("resume.json"))
+
+// Or a Typst-root-relative path string, resolved by parse-resume itself.
+#let resume = parse-resume("/resume.json")
+```
+
+The returned dict mirrors the canonical schema. Free-text fields (`summary`,
+`description`, `highlights[]`, `reference`) are coerced to Typst `content`;
+everything else stays as JSON-native types. For example:
+
+```text
+resume.basics.name            str ("Seán Ó Murchú")
+resume.basics.summary         content (wrapped for direct rendering)
+resume.work.at(0).position    str
+resume.work.at(0).highlights  array of content
+resume.skills.at(0).keywords  array of str (tag-like, not coerced)
+```
+
+Pass the model into any compatible renderer — e.g. [`altacv`](https://typst.app/universe/package/altacv):
+
+```typst
+#import "@preview/altacv:1.1.1": alta, palettes
+#import "@preview/json-resume:0.1.1": parse-resume // x-release-please-version
+
+#alta(
+  parse-resume(json("resume.json")),
+  preferences: (accent: palettes.navy),
+)
+```
+
+`alta(cv, labels: (:), preferences: (:))` takes the JSON-Resume-shaped dict
+positionally; `labels` and `preferences` are optional dicts merged over the
+template defaults. See the [altacv README](https://github.com/smur89/alta-typst#readme)
+for the full surface.
+
+### Handling validation errors yourself
+
+Each error is a record `(path: ("basics", "email"), message: "expected string, got integer.")`. A typical step-by-step is:
+
+```typst
+#import "@preview/json-resume:0.1.1": validate-resume, coerce-resume // x-release-please-version
+
+#let raw = json("resume.json")
+#let errors = validate-resume(raw)
+#if errors.len() > 0 {
+  [Resume has #errors.len() issue(s).]
+} else {
+  let model = coerce-resume(raw)
+  // render model …
+}
+```
+
+## Errors
+
+`validate-resume` returns a list of `(path, message)` records — empty list
+means the input is valid. `parse-resume` calls `validate-resume` first and
+aborts compilation with a combined report on the first invocation that finds
+issues, so every problem in the document surfaces in one error:
+
+```text
+error: assertion failed: json-resume: found 3 problems in the input:
+  - basics.email: expected string, got integer.
+  - work[0].positon: unknown key "positon". Valid keys: name, location, description, position, url, startDate, endDate, summary, highlights.
+  - meta.foo: unknown key "foo". Valid keys: canonical, version, lastModified.
+```
+
+## Scope
+
+This package implements **only** the canonical JSON Resume schema.
+Template-specific extensions (theme colours, header decorations, label
+overrides, …) are layered on top by the consuming renderer. Requests for
+renderer-specific fields will be redirected to the relevant template repo.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Releases are cut by
+[release-please](https://github.com/googleapis/release-please) from
+conventional-commit titles on `main`.
+
+## License
+
+[MIT](LICENSE).

--- a/packages/preview/json-resume/0.1.1/internal/coerce.typ
+++ b/packages/preview/json-resume/0.1.1/internal/coerce.typ
@@ -1,0 +1,40 @@
+// Assumes input has passed _validate. Unknown keys are dropped
+// silently rather than panicking; top-of-branch type checks catch
+// shape mismatches from direct callers who skipped validation.
+// assert(false, ...) over panic(...) for newline-preserving
+// diagnostics if these messages ever go multi-line.
+
+#import "errors.typ": _type-name-of
+
+#let _expect(expected, value) = (
+  "json-resume: coerce-resume expected " + expected + ", got " +
+    _type-name-of(value) + ". Run validate-resume first."
+)
+
+#let _coerce(schema, value) = {
+  let kind = schema.kind
+  if kind == "content" {
+    assert(type(value) == str, message: _expect("a string", value))
+    return [#value]
+  }
+  if kind == "str" {
+    assert(type(value) == str, message: _expect("a string", value))
+    return value
+  }
+  if kind == "number" {
+    assert(type(value) in (int, float), message: _expect("a number", value))
+    return value
+  }
+  if kind == "array" {
+    assert(type(value) == array, message: _expect("an array", value))
+    return value.map(elem => _coerce(schema.elem, elem))
+  }
+  if kind == "object" {
+    assert(type(value) == dictionary, message: _expect("an object", value))
+    return value.pairs()
+      .filter(((key, _)) => key in schema.shape)
+      .map(((key, sub-value)) => (key, _coerce(schema.shape.at(key), sub-value)))
+      .to-dict()
+  }
+  panic("json-resume: internal — unknown schema kind " + repr(kind))
+}

--- a/packages/preview/json-resume/0.1.1/internal/errors.typ
+++ b/packages/preview/json-resume/0.1.1/internal/errors.typ
@@ -1,0 +1,35 @@
+// Empty path renders as "<root>" so a top-level type error reads
+// `"<root>: expected object, got …"`.
+#let _format-path(parts) = {
+  if parts.len() == 0 { return "<root>" }
+  parts.enumerate().map(((i, part)) => {
+    if type(part) == int { "[" + str(part) + "]" }
+    else if i == 0 { part }
+    else { "." + part }
+  }).join("")
+}
+
+// Typst's `repr(type(...))` renders as `"int"` / `"dictionary"` /
+// `"type(none)"` — accurate but jarring. Translate to JSON-shaped
+// names for user-facing messages; unknown reprs fall through.
+#let _type-names = (
+  str: "string",
+  int: "integer",
+  float: "number",
+  bool: "boolean",
+  array: "array",
+  dictionary: "object",
+)
+
+#let _type-name-of(value) = {
+  if value == none { return "null" }
+  let raw = repr(type(value))
+  _type-names.at(raw, default: raw)
+}
+
+#let _format-report(errors) = {
+  let n = errors.len()
+  let noun = if n == 1 { "problem" } else { "problems" }
+  let lines = errors.map(e => "  - " + _format-path(e.path) + ": " + e.message)
+  "json-resume: found " + str(n) + " " + noun + " in the input:\n" + lines.join("\n")
+}

--- a/packages/preview/json-resume/0.1.1/internal/schema.typ
+++ b/packages/preview/json-resume/0.1.1/internal/schema.typ
@@ -1,0 +1,169 @@
+// Each node carries a `kind` tag so the engines can dispatch on
+// structural type without ad-hoc type sniffing.
+
+#let str-type     = (kind: "str")
+#let content-type = (kind: "content")
+#let number-type  = (kind: "number")
+
+#let array-of(elem) = (kind: "array", elem: elem)
+
+// Default `()` preserves the canonical schema's all-optional stance.
+// Extension schemas opt in per-section; the validator emits
+// "missing required key" when an absent key is required. Reject
+// required-keys that don't appear in shape so a schema typo fails at
+// schema-construction time instead of as a phantom validation error.
+#let object(shape, required-keys: ()) = {
+  let unknown = required-keys.filter(k => k not in shape)
+  assert(
+    unknown.len() == 0,
+    message: "json-resume: object() required-keys references keys not in shape: " +
+      unknown.join(", ") + ".",
+  )
+  (
+    kind: "object",
+    shape: shape,
+    required-keys: required-keys,
+  )
+}
+
+// Canonical JSON Resume schema (https://jsonresume.org/schema).
+// All fields optional, types checked when present. Format checks for
+// dates / URLs / emails are v0.2+ work.
+
+#let _location = object((
+  address: str-type,
+  postalCode: str-type,
+  city: str-type,
+  countryCode: str-type,
+  region: str-type,
+))
+
+#let _profile = object((
+  network: str-type,
+  username: str-type,
+  url: str-type,
+))
+
+#let _basics = object((
+  name: str-type,
+  label: str-type,
+  image: str-type,
+  email: str-type,
+  phone: str-type,
+  url: str-type,
+  summary: content-type,
+  location: _location,
+  profiles: array-of(_profile),
+))
+
+#let _work-item = object((
+  name: str-type,
+  location: str-type,
+  description: str-type,
+  position: str-type,
+  url: str-type,
+  startDate: str-type,
+  endDate: str-type,
+  summary: content-type,
+  highlights: array-of(content-type),
+))
+
+#let _volunteer-item = object((
+  organization: str-type,
+  position: str-type,
+  url: str-type,
+  startDate: str-type,
+  endDate: str-type,
+  summary: content-type,
+  highlights: array-of(content-type),
+))
+
+#let _education-item = object((
+  institution: str-type,
+  url: str-type,
+  area: str-type,
+  studyType: str-type,
+  startDate: str-type,
+  endDate: str-type,
+  score: str-type,
+  courses: array-of(str-type),
+))
+
+#let _award = object((
+  title: str-type,
+  date: str-type,
+  awarder: str-type,
+  summary: content-type,
+))
+
+#let _certificate = object((
+  name: str-type,
+  date: str-type,
+  url: str-type,
+  issuer: str-type,
+))
+
+#let _publication = object((
+  name: str-type,
+  publisher: str-type,
+  releaseDate: str-type,
+  url: str-type,
+  summary: content-type,
+))
+
+#let _skill = object((
+  name: str-type,
+  level: str-type,
+  keywords: array-of(str-type),
+))
+
+#let _language = object((
+  language: str-type,
+  fluency: str-type,
+))
+
+#let _interest = object((
+  name: str-type,
+  keywords: array-of(str-type),
+))
+
+#let _reference = object((
+  name: str-type,
+  reference: content-type,
+))
+
+#let _project = object((
+  name: str-type,
+  description: content-type,
+  highlights: array-of(content-type),
+  keywords: array-of(str-type),
+  startDate: str-type,
+  endDate: str-type,
+  url: str-type,
+  roles: array-of(str-type),
+  entity: str-type,
+  type: str-type,
+))
+
+#let _meta = object((
+  canonical: str-type,
+  version: str-type,
+  lastModified: str-type,
+))
+
+#let resume-schema = object((
+  "$schema": str-type,
+  basics: _basics,
+  work: array-of(_work-item),
+  volunteer: array-of(_volunteer-item),
+  education: array-of(_education-item),
+  awards: array-of(_award),
+  certificates: array-of(_certificate),
+  publications: array-of(_publication),
+  skills: array-of(_skill),
+  languages: array-of(_language),
+  interests: array-of(_interest),
+  references: array-of(_reference),
+  projects: array-of(_project),
+  meta: _meta,
+))

--- a/packages/preview/json-resume/0.1.1/internal/validate.typ
+++ b/packages/preview/json-resume/0.1.1/internal/validate.typ
@@ -1,0 +1,52 @@
+// Subtrees under unknown keys are not walked — their expected shape
+// is undefined.
+
+#import "errors.typ": _type-name-of
+
+#let _type-error(path, expected, value) = ((
+  path: path,
+  message: "expected " + expected + ", got " + _type-name-of(value) + ".",
+),)
+
+#let _validate(schema, value, path) = {
+  let kind = schema.kind
+  if kind in ("str", "content") {
+    if type(value) != str { return _type-error(path, "string", value) }
+    return ()
+  }
+  if kind == "number" {
+    if type(value) not in (int, float) { return _type-error(path, "number", value) }
+    return ()
+  }
+  if kind == "array" {
+    if type(value) != array { return _type-error(path, "array", value) }
+    return value.enumerate()
+      .map(((i, elem)) => _validate(schema.elem, elem, path + (i,)))
+      .flatten()
+  }
+  if kind == "object" {
+    if type(value) != dictionary { return _type-error(path, "object", value) }
+    let per-key-errs = value.pairs().map(((key, sub-value)) => {
+      if key in schema.shape {
+        _validate(schema.shape.at(key), sub-value, path + (key,))
+      } else {
+        // Valid-keys list only assembled on the unknown-key branch so
+        // the happy path skips the join.
+        let valid-keys-str = schema.shape.keys().join(", ")
+        ((
+          path: path + (key,),
+          message: "unknown key " + repr(key) + ". Valid keys: " + valid-keys-str + ".",
+        ),)
+      }
+    }).flatten()
+    let required = schema.at("required-keys", default: ())
+    let missing-errs = required
+      .filter(k => k not in value)
+      .map(k => (
+        path: path + (k,),
+        message: "missing required key " + repr(k) + ".",
+      ))
+    return per-key-errs + missing-errs
+  }
+  panic("json-resume: internal — unknown schema kind " + repr(kind))
+}

--- a/packages/preview/json-resume/0.1.1/lib.typ
+++ b/packages/preview/json-resume/0.1.1/lib.typ
@@ -1,0 +1,45 @@
+// Strict loader for canonical JSON Resume data
+// (https://jsonresume.org/schema). The engines under internal/ are
+// pure (schema, value) functions; the public symbols below pre-bind
+// resume-schema. See tests/engine_schema_agnostic.typ.
+
+#import "internal/schema.typ": resume-schema
+#import "internal/validate.typ": _validate
+#import "internal/coerce.typ": _coerce
+#import "internal/errors.typ": _format-report
+
+// Returns a list of {path, message} records; empty = valid.
+#let validate-resume(data) = _validate(resume-schema, data, ())
+
+// Assumes data has passed validate-resume. Unknown keys are dropped
+// silently rather than panicking on direct callers.
+#let coerce-resume(data) = _coerce(resume-schema, data)
+
+// String paths must start with "/" because Typst resolves relative
+// paths against the file containing the call — for this package
+// that's the @preview cache, which is not what callers want.
+#let parse-resume(data) = {
+  let dict-data = if type(data) == str {
+    if not data.starts-with("/") {
+      panic(
+        "json-resume: parse-resume with a string path requires the path " +
+          "to start with \"/\" (resolved from the typst root). Got: " + repr(data) + ". " +
+          "To use a path relative to your own .typ file, call json() " +
+          "directly: parse-resume(json(" + repr(data) + ")).",
+      )
+    }
+    json(data)
+  } else if type(data) == dictionary {
+    data
+  } else {
+    panic(
+      "json-resume: parse-resume expected a dict or a string path, got " +
+        repr(type(data)) + ".",
+    )
+  }
+  let errors = validate-resume(dict-data)
+  // assert preserves newlines in the diagnostic; panic repr-escapes
+  // them and collapses the bullet list onto one line.
+  assert(errors.len() == 0, message: _format-report(errors))
+  coerce-resume(dict-data)
+}

--- a/packages/preview/json-resume/0.1.1/typst.toml
+++ b/packages/preview/json-resume/0.1.1/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "json-resume"
+version = "0.1.1"
+entrypoint = "lib.typ"
+authors = ["Shane Murphy"]
+license = "MIT"
+description = "Strict JSON Resume loader for CV templates."
+repository = "https://github.com/smur89/typst-json-resume"
+keywords = ["json-resume", "resume", "cv", "loader", "schema"]
+categories = ["utility"]
+compiler = "0.13.0"


### PR DESCRIPTION

  <!--
  Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as
  `name:version` of the submitted package.
  -->

  I am submitting
  - [x] a new package
  - [ ] an update for a package

  `json-resume` is a strict loader for canonical [JSON Resume](https://jsonresume.org/) data. It reads a `resume.json` file, validates it against the [published
  schema](https://jsonresume.org/schema), and returns a normalised Typst dict with free-text fields coerced to `content` — ready to hand to any compatible Typst CV template.
  Useful because the JSON Resume promise of one `resume.json` across many renderers currently requires every Typst CV template to hand-translate the JSON into a Typst dict;
  this package centralises that work into a single dependency so renderers can stay focused on layout.

  I have read and followed the submission guidelines and, in particular, I
  - [x] selected a name that isn't the most obvious or canonical name for what the package does
    - Explanation: The name mirrors the [JSON Resume](https://jsonresume.org/) project name because the package's sole purpose is to load documents conforming to *that
  specific standard*. It identifies the protocol the package implements, not a generic category — common JSON-Resume tooling across other ecosystems follows the same naming
  pattern (e.g. `jsonresume-cli`, `npm:resume-cli`, `python:json-resume`). Generic terms like `resume` or `cv` are deliberately avoided so they remain available for template
  packages.
  - [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
  - [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
  - [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
  - [x] tested my package locally on my system and it worked
  - [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE