### PR TITLE
json-resume:0.3.0

### DIFF
--- a/packages/preview/json-resume/0.3.0/CONTRIBUTING.md
+++ b/packages/preview/json-resume/0.3.0/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing
+
+Thanks for taking the time to look. This is a small library package; almost
+any thoughtful contribution will be welcome — but a couple of conventions
+keep the release pipeline (release-please + Typst Universe) running smoothly.
+
+## Submitting a PR
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally and create a branch for your change.
+3. Make the changes, commit, and push to your fork.
+4. Open a Pull Request against `main` on this repository.
+
+Security issues should be reported privately per [`SECURITY.md`](SECURITY.md)
+instead of as a PR or issue.
+
+## Scope
+
+`json-resume` implements **only** the canonical [JSON Resume schema](https://jsonresume.org/schema).
+Anything renderer-specific (theme colours, label overrides, header
+decorations, custom sections, …) belongs in the consuming Typst CV template,
+not here. PRs that add fields outside the canonical schema will be redirected
+to the appropriate downstream template repo.
+
+## Project layout
+
+```text
+lib.typ                              # public entry — `parse`, `validate`, `coerce`, combinators, lenses
+internal/kinds.typ                   # schema-kind primitives (str-type, content-type, object, array-of, …)
+internal/schema.typ                  # canonical resume-schema (faithful derivation) + resume-schema-strict (opt-in opinions)
+internal/assets/jsonresume-schema.json  # vendored upstream schema, pinned to v1.0.0
+internal/validate.typ                # validation engine (path-typed errors)
+internal/coerce.typ                  # coercion engine (content wrapping, null absorption)
+internal/json-schema.typ             # JSON Schema → Typst-schema translator
+internal/lens.typ                    # path-based functional editing of schemas
+tests/                               # fixtures — CI compiles each as a regression guard
+```
+
+## Bumping the vendored JSON Resume schema
+
+`internal/schema.typ` derives `resume-schema` from
+`internal/assets/jsonresume-schema.json` at module-load time, so the
+upstream document is the source of truth. To pull a newer upstream version:
+
+1. Replace `internal/assets/jsonresume-schema.json` with the chosen tag from
+   [jsonresume/resume-schema](https://github.com/jsonresume/resume-schema).
+2. Run `make test`. The translator handles the draft-04/-07 subset that the
+   canonical document uses; newer constructs (`allOf`/`anyOf`/`oneOf`,
+   `enum`/`const`, format-aware types beyond uri/email/date/date-time, open
+   objects, type unions, external `$ref`) panic with an "unsupported" message.
+   If a panic surfaces, extend `internal/json-schema.typ` rather than
+   silently dropping the constraint.
+3. Audit `_content-paths` and `_date-paths` in `internal/schema.typ` against
+   the bumped document. These lists are the opt-in `resume-schema-strict`
+   variant's opinions — `_content-paths` lifts free-text `string` fields to
+   Typst `content` for inline rendering; `_date-paths` lifts iso8601 `$ref`
+   fields (which the translator can't pick up from a `$ref` alone) to
+   `date-string` for regex validation. If a new free-text or iso8601-referenced
+   field lands in the upstream document, add its path here. The drift guard
+   in `_override-fold` will panic at module-load if an existing path's source
+   kind changes, so you'll see the audit prompt automatically.
+
+`feat:` commit if the bump introduces new fields or behaviour;
+`chore(deps):` if it's a no-op refresh.
+
+## Development loop
+
+Install Typst at the version CI uses — see `TYPST_VERSION` in
+`.github/workflows/build.yml`.
+
+```sh
+make             # compile every tests/*.typ fixture (= `make test`)
+make test        # same as above; the CI lint job runs this
+make check       # alias for `make test`
+make help        # summarise the available targets
+```
+
+`make test` is the local equivalent of the CI lint job — green here means CI
+lint will pass too.
+
+If you'd rather drive Typst directly:
+
+```sh
+for f in tests/*.typ; do typst compile --root . --format pdf "$f" /dev/null; done
+```
+
+`--format pdf` is required when the output path is `/dev/null` — Typst cannot
+infer the format from a path with no extension.
+
+## Conventional commits
+
+The repo uses [release-please](https://github.com/googleapis/release-please)
+to cut releases. Versioning is derived from commit messages on `main`, so
+each merged PR needs a clean conventional-commit message.
+
+| Prefix | Bump | Use for |
+|---|---|---|
+| `fix:` | patch | Bug fix, doc correction, broken link, validation gap |
+| `feat:` | minor | New schema field supported, new coercion, new public helper |
+| `feat!:` or `BREAKING CHANGE:` footer | major | API change that existing users would need to migrate |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | none | Internal changes that shouldn't trigger a release |
+
+PRs squash-merge with the PR title as the commit subject, so just make the
+**PR title** a conventional commit. The body of the squash commit comes from
+the PR description.
+
+## Adding schema coverage
+
+For a **new schema field**:
+
+1. Add (or extend) a fixture under `tests/` exercising the field — a valid
+   case and at least one rejection case for the validator.
+2. Implement the validation / coercion in `lib.typ` (or a module it imports).
+3. Update the README's "Usage" example if the field is end-user-visible.
+
+`feat:` commit.
+
+## First publication to Typst Universe
+
+The automated `submit-to-typst-universe` workflow only handles **updates** to
+an already-published package (the auto-generated PR body is the slim
+"update" variant). The very first submission to
+[typst/packages](https://github.com/typst/packages) must be opened manually
+so the maintainers can do a full new-package review.
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for how to report a vulnerability.

--- a/packages/preview/json-resume/0.3.0/LICENSE
+++ b/packages/preview/json-resume/0.3.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shane Murphy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/json-resume/0.3.0/README.md
+++ b/packages/preview/json-resume/0.3.0/README.md
@@ -1,0 +1,362 @@
+<h1 align="center">json-resume</h1>
+
+<p align="center">
+  <a href="https://typst.app/universe/package/json-resume"><img alt="json-resume on Typst Universe" src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fjson-resume&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/releases"><img alt="Latest GitHub release version of json-resume" src="https://img.shields.io/github/v/release/smur89/typst-json-resume?style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/actions/workflows/build.yml"><img alt="GitHub Actions build workflow status on the json-resume main branch" src="https://img.shields.io/github/actions/workflow/status/smur89/typst-json-resume/build.yml?style=flat-square"></a>
+  <a href="LICENSE"><img alt="MIT license badge linking to the json-resume LICENSE file" src="https://img.shields.io/github/license/smur89/typst-json-resume?style=flat-square"></a>
+  <a href="https://github.com/smur89/typst-json-resume/stargazers"><img alt="Number of GitHub stargazers for json-resume" src="https://img.shields.io/github/stars/smur89/typst-json-resume?style=flat-square"></a>
+</p>
+
+<p align="center">
+  Strict <a href="https://jsonresume.org/">JSON Resume</a> loader for Typst — validate a canonical <code>resume.json</code> against the <a href="https://jsonresume.org/schema">published schema</a>, then hand the normalised dict to any compatible CV template.
+</p>
+
+[JSON Resume](https://jsonresume.org/) is a portable JSON-based resume format —
+one `resume.json` file rendered by many themes across many output formats.
+This package brings that ecosystem to Typst: load and validate a canonical
+`resume.json`, then hand the normalised dict to any compatible Typst CV
+template. Strict to the published [schema](https://jsonresume.org/schema)
+(canonical source at [jsonresume/resume-schema](https://github.com/jsonresume/resume-schema/blob/v1.0.0/schema.json)):
+unknown fields are rejected, free-text fields are coerced to Typst `content`,
+and renderer-specific extensions belong in the consuming template — not here.
+
+Motivated by [smur89/alta-typst#48](https://github.com/smur89/alta-typst/issues/48).
+
+## Install
+
+```typst
+#import "@preview/json-resume:0.3.0": validate, coerce, parse // x-release-please-version
+```
+
+## A minimal `resume.json`
+
+```json
+{
+  "basics": {
+    "name": "Seán Ó Murchú",
+    "label": "Senior Software Engineer",
+    "email": "sean@example.com",
+    "summary": "Backend engineer with eight years of experience."
+  },
+  "work": [
+    {
+      "name": "Acme Corp",
+      "position": "Senior Software Engineer",
+      "startDate": "2022-01",
+      "highlights": ["Led the event-sourcing platform migration."]
+    }
+  ]
+}
+```
+
+The full canonical schema covers thirteen sections:
+`basics`, `work`, `volunteer`, `education`, `awards`, `certificates`,
+`publications`, `skills`, `languages`, `interests`, `references`, `projects`,
+`meta`. The `$schema` top-level metadata field is also accepted. See
+[jsonresume.org/schema](https://jsonresume.org/schema) for every field.
+
+## Usage
+
+`parse` is the one-call entry point. It accepts either a parsed dict
+or a Typst-root-relative path string:
+
+```typst
+#import "@preview/json-resume:0.3.0": parse // x-release-please-version
+
+// Path relative to your own .typ — let Typst's json() resolve it.
+#let resume = parse(json("resume.json"))
+
+// Or a Typst-root-relative path string, resolved by parse itself.
+#let resume = parse("/resume.json")
+```
+
+The returned dict is a 1:1 mirror of the canonical schema — every kind comes
+from the upstream JSON Schema document. Format-annotated fields are gated by
+a regex (see [Format validation](#format-validation)); everything else
+passes through as JSON-native types. For example:
+
+```text
+resume.basics.name            str
+resume.basics.summary         str
+resume.basics.email           str (gated as email)
+resume.work.at(0).position    str
+resume.work.at(0).highlights  array of str
+resume.skills.at(0).keywords  array of str
+```
+
+For renderer-friendly opinions (free-text fields wrapped as Typst `content`,
+iso8601 `$ref` fields validated as dates), import `resume-schema-strict`
+instead and pass it via the `schema:` keyword — see [Two schemas](#two-schemas).
+
+Pass the model into any compatible renderer — e.g. [`altacv`](https://typst.app/universe/package/altacv):
+
+```typst
+#import "@preview/altacv:1.1.1": alta, palettes
+#import "@preview/json-resume:0.3.0": parse // x-release-please-version
+
+#alta(
+  parse(json("resume.json")),
+  preferences: (accent: palettes.navy),
+)
+```
+
+`alta(cv, labels: (:), preferences: (:))` takes the JSON-Resume-shaped dict
+positionally; `labels` and `preferences` are optional dicts merged over the
+template defaults. See the [altacv README](https://github.com/smur89/alta-typst#readme)
+for the full surface.
+
+### Handling validation errors yourself
+
+Each error is a record `(path: ("basics", "email"), message: "expected string, got integer.")`. A typical step-by-step is:
+
+```typst
+#import "@preview/json-resume:0.3.0": validate, coerce // x-release-please-version
+
+#let raw = json("resume.json")
+#let errors = validate(raw)
+#if errors.len() > 0 {
+  [Resume has #errors.len() issue(s).]
+} else {
+  let model = coerce(raw)
+  // render model …
+}
+```
+
+## Errors
+
+`validate` returns a list of `(path, message)` records — empty list
+means the input is valid. `parse` validates first and aborts compilation
+with a combined report on the first invocation that finds issues, so every
+problem in the document surfaces in one error:
+
+```text
+error: assertion failed: json-resume: found 3 problems in the input:
+  - basics.email: expected string, got integer.
+  - work[0].positon: unknown key "positon". Valid keys: name, location, description, position, url, startDate, endDate, summary, highlights.
+  - meta.foo: unknown key "foo". Valid keys: canonical, version, lastModified.
+```
+
+JSON `null` is treated as if the key were absent — no validation
+error, dropped from the coerced model. Null elements inside arrays
+are dropped the same way. This matches the convention used by most
+JSON Resume emitters, where `"summary": null` is semantically
+equivalent to omitting the key. Unknown keys are still flagged even
+when their value is `null`, so typos do not slip through silently.
+
+Root null is rejected: if the entire input document is `null`,
+`validate`, `coerce`, and `parse` panic with
+`json-resume: input must be a dict, got null.` The null-as-absent
+policy applies to leaf positions inside a document, not to the
+document itself.
+
+## Two schemas
+
+The package exports two values of the canonical schema:
+
+- **`resume-schema`** — a faithful 1:1 translation of the vendored
+  upstream JSON Schema document. Every kind comes from the source;
+  nothing is rewritten. This is the default when you call
+  `parse(data)` / `validate(data)` / `coerce(data)`.
+- **`resume-schema-strict`** — adds two layered opinions on top via
+  the lens API:
+  - free-text fields (`basics.summary`, `work[].summary`,
+    `work[].highlights[]`, etc.) are typed as Typst `content` so
+    they splice directly into markup
+  - iso8601 `$ref` fields (`startDate`, `endDate`, …) are validated
+    as ISO-8601 dates (the upstream document doesn't carry a
+    `format` annotation on them, just a regex inside a definition)
+
+Pass `schema: resume-schema-strict` to opt in:
+
+```typst
+#import "@preview/json-resume:0.3.0": parse, resume-schema-strict // x-release-please-version
+
+#let resume = parse(json("resume.json"), schema: resume-schema-strict)
+```
+
+The faithful default is the source-of-truth view; the strict variant
+is a renderer-ergonomics overlay. If you want a different mix, build
+your own by lensing over `resume-schema` — see
+[Targeted edits with lenses](#targeted-edits-with-lenses).
+
+## Format validation
+
+Fields the canonical schema annotates with `format: "uri"`,
+`format: "email"`, or `format: "date"` are gated by a regex during
+`validate` / `parse`. The patterns are deliberately permissive — they
+reject obvious malformations without claiming full RFC compliance —
+and each emits a path-qualified message with a canonical example:
+
+```text
+basics.email:           expected an email (e.g. "name@example.com").
+basics.url:             expected a URI (e.g. "https://example.com").
+certificates[0].date:   expected an ISO-8601 date (e.g. "2024-01-15").
+```
+
+Most date fields in JSON Resume (`work[].startDate`, `awards[].date`,
+`meta.lastModified`, …) use `$ref: "#/definitions/iso8601"` rather
+than `format: "date"`. The translator can't pick formats up from a
+`$ref` alone, so those fields stay as plain `str` in `resume-schema`.
+Switch to `resume-schema-strict` to validate them as dates, or build
+your own override list with `lens-put(lens(path), schema, date-string)`.
+
+Coercion is pass-through: format-checked values flow through to the
+model as plain strings, so renderers receive
+`model.basics.email == "name@example.com"` unchanged.
+
+## Building an extension schema
+
+`parse` is strict against the canonical schema by design — unknown keys
+are rejected. Renderers that need their own fields (alta-typst's
+`preferences`, `labels`, `focusAreas`; numeric language `rating`; publication
+`type` grouping; …) can build a JSON-Resume+ schema with the public
+combinators and pass it to `parse` / `validate` / `coerce` via the
+`schema:` keyword:
+
+```typst
+#import "@preview/json-resume:0.3.0": ( // x-release-please-version
+  resume-schema, parse, object, array-of, str-type, content-type,
+)
+
+// Splice the canonical shape and add renderer-specific fields.
+#let altacv-schema = object((
+  ..resume-schema.shape,
+  preferences: object((
+    accent: str-type,
+    headerLayout: str-type,
+  )),
+  labels: object((
+    work: str-type,
+    education: str-type,
+  )),
+  focusAreas: array-of(content-type),
+))
+
+#let model = parse(json("resume.json"), schema: altacv-schema)
+// render model with the renderer's own theme…
+```
+
+When to reach for which API:
+
+- **`parse(data)`** — one call, aborts compilation with a combined report on
+  validation issues. Defaults to the canonical schema; pass `schema: …` to use
+  an extension.
+- **`validate(data)` / `coerce(data)`** — return data instead of aborting, so
+  you can present errors yourself (see the [step-by-step above](#handling-validation-errors-yourself)).
+  Same `schema:` default.
+
+`resume-schema.shape` is a plain dict, so `..resume-schema.shape` is the only
+operator you need to extend it. Per-section combinators (`work-item`,
+`volunteer-item`, …) are intentionally not exposed yet — splice the canonical
+top-level fields whole and add your own siblings.
+
+### Targeted edits with lenses
+
+Splicing `..resume-schema.shape` works for top-level additions but is awkward
+when the field you want to touch is three or four levels deep (`work` items'
+`highlights` element schema, `basics.email`, …). For those cases, lenses target
+a path inside the schema and return a new schema with the targeted node
+replaced or transformed:
+
+```typst
+#import "@preview/json-resume:0.3.0": ( // x-release-please-version
+  resume-schema, lens, lens-put, lens-over, add-field,
+  str-type, content-type, number-type, object,
+)
+
+// Widen basics.summary from content (rich) to str (plain) — useful if
+// you want the summary rendered as plain text instead of formatted:
+#let plain-summary = lens-put(
+  lens(("basics", "summary")), resume-schema, str-type,
+)
+
+// Add a numeric `rating` to every language entry — touches
+// resume-schema.shape.languages.elem.shape without re-spelling the wrapper:
+#let with-rating = add-field(
+  resume-schema, lens(("languages", "items")), "rating", number-type,
+)
+
+// Transform an existing node with a function:
+#let with-extra-meta = lens-over(
+  lens(("meta",)),
+  resume-schema,
+  meta => object((..meta.shape, source: str-type)),
+)
+```
+
+Path segments: object keys as strings, the literal `"items"` to enter an
+array's element schema. Composition (`lens-then(a, b)`) concatenates paths,
+so `lens-then(lens(("work",)), lens(("items", "highlights")))` is the same
+lens as `lens(("work", "items", "highlights"))`. The empty path `lens(())`
+is the identity lens.
+
+Operations:
+
+| Function | Shape | Behaviour |
+|---|---|---|
+| `lens(path)` | `path → lens` | Construct a lens from a path tuple |
+| `lens-get(l, schema)` | `lens, schema → sub-schema` | Read the targeted node |
+| `lens-put(l, schema, value)` | `lens, schema, sub → schema` | Replace the targeted node |
+| `lens-over(l, schema, fn)` | `lens, schema, (sub → sub) → schema` | Apply a function to the targeted node |
+| `lens-then(a, b)` | `lens, lens → lens` | Compose two lenses (path concatenation) |
+| `add-field(schema, parent, key, sub)` | … → schema | Add a key to the object at `parent` |
+| `remove-field(schema, parent, key)` | … → schema | Remove a key from the object at `parent` |
+
+Operations are functional — every `lens-put` / `lens-over` / `add-field` /
+`remove-field` returns a NEW schema and leaves the input untouched, so you
+can build an extension schema by chaining edits without disturbing the
+canonical one. (Operations are top-level functions rather than methods because
+Typst parses `lens.put(…)` as a type-method lookup, not a closure call.)
+
+### Starting from a JSON Schema document
+
+`schema-from-json-schema(parsed-schema)` translates a JSON Schema (draft 7
+subset) into a Typst schema dict. Use it when you already have an authoritative
+`.json` schema and don't want to keep a parallel Typst copy in sync:
+
+```typst
+#import "@preview/json-resume:0.3.0": ( // x-release-please-version
+  schema-from-json-schema, coerce, object, array-of, content-type,
+)
+
+#let canonical = schema-from-json-schema(json("resume-schema.json"))
+#let altacv-schema = object((
+  ..canonical.shape,
+  focusAreas: array-of(content-type),
+))
+
+#let model = coerce(json("resume.json"), schema: altacv-schema)
+```
+
+Supported JSON Schema keywords: `type` (`string`/`number`/`integer`/`array`/
+`object`), `format` (`uri` → `uri-string`, `email` → `email-string`,
+`date` → `date-string`), `properties`, `required`, `items`, internal `$ref`
+(`#/definitions/…` / `#/$defs/…`). Out of scope:
+`allOf` / `anyOf` / `oneOf` / `not`, `enum` / `const`,
+`if` / `then` / `else`, `dependencies` (and the `dependentRequired` /
+`dependentSchemas` variants), open object schemas (`type: "object"` without
+`properties`), `type: [...]` union arrays, external `$ref`, and string formats
+other than the three listed above (notably `date-time`, which would need its
+own datetime-string kind to avoid labelling a datetime then rejecting its
+values against a date-only regex) — every one of these panics with a clear
+"unsupported" message rather than silently dropping the constraint.
+
+## Scope
+
+The canonical surface — `parse`, `validate`, `coerce` —
+implements **only** the [JSON Resume schema](https://jsonresume.org/schema) and
+rejects unknown fields. Renderer-specific extensions are layered on top by the
+consuming template via the BYO API above; requests for renderer-specific
+fields in the canonical schema itself will be redirected to the relevant
+template repo.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Releases are cut by
+[release-please](https://github.com/googleapis/release-please) from
+conventional-commit titles on `main`.
+
+## License
+
+[MIT](LICENSE).

--- a/packages/preview/json-resume/0.3.0/internal/assets/jsonresume-schema.json
+++ b/packages/preview/json-resume/0.3.0/internal/assets/jsonresume-schema.json
@@ -1,0 +1,500 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "iso8601": {
+      "type": "string",
+      "description": "e.g. 2014-06-29",
+      "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "link to the version of the schema that can validate the resume",
+      "format": "uri"
+    },
+    "basics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "e.g. Web Developer"
+        },
+        "image": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
+        },
+        "email": {
+          "type": "string",
+          "description": "e.g. thomas@gmail.com",
+          "format": "email"
+        },
+        "phone": {
+          "type": "string",
+          "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+          "format": "uri"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Write a short 2-3 sentence biography about yourself"
+        },
+        "location": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
+            },
+            "postalCode": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+            },
+            "region": {
+              "type": "string",
+              "description": "The general region where you live. Can be a US state, or a province, for instance."
+            }
+          }
+        },
+        "profiles": {
+          "type": "array",
+          "description": "Specify any number of social networks that you participate in",
+          "additionalItems": false,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "network": {
+                "type": "string",
+                "description": "e.g. Facebook or Twitter"
+              },
+              "username": {
+                "type": "string",
+                "description": "e.g. neutralthoughts"
+              },
+              "url": {
+                "type": "string",
+                "description": "e.g. http://twitter.example.com/neutralthoughts",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      }
+    },
+    "work": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "location": {
+            "type": "string",
+            "description": "e.g. Menlo Park, CA"
+          },
+          "description": {
+            "type": "string",
+            "description": "e.g. Social Media Company"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple accomplishments",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "volunteer": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "organization": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify accomplishments and achievements",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "education": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "institution": {
+            "type": "string",
+            "description": "e.g. Massachusetts Institute of Technology"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "area": {
+            "type": "string",
+            "description": "e.g. Arts"
+          },
+          "studyType": {
+            "type": "string",
+            "description": "e.g. Bachelor"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "score": {
+            "type": "string",
+            "description": "grade point average, e.g. 3.67/4.0"
+          },
+          "courses": {
+            "type": "array",
+            "description": "List notable courses/subjects",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. H1302 - Introduction to American history"
+            }
+          }
+        }
+      }
+    },
+    "awards": {
+      "type": "array",
+      "description": "Specify any awards you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "e.g. One of the 100 greatest minds of the century"
+          },
+          "date": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "awarder": {
+            "type": "string",
+            "description": "e.g. Time Magazine"
+          },
+          "summary": {
+            "type": "string",
+            "description": "e.g. Received for my work with Quantum Physics"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "type": "array",
+      "description": "Specify any certificates you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Certified Kubernetes Administrator"
+          },
+          "date": {
+            "type": "string",
+            "description": "e.g. 1989-06-12",
+            "format": "date"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://example.com",
+            "format": "uri"
+          },
+          "issuer": {
+            "type": "string",
+            "description": "e.g. CNCF"
+          }
+        }
+      }
+    },
+    "publications": {
+      "type": "array",
+      "description": "Specify your publications through your career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "e.g. IEEE, Computer Magazine"
+          },
+          "releaseDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html",
+            "format": "uri"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "List out your professional skill-set",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Web Development"
+          },
+          "level": {
+            "type": "string",
+            "description": "e.g. Master"
+          },
+          "keywords": {
+            "type": "array",
+            "description": "List some keywords pertaining to this skill",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. HTML"
+            }
+          }
+        }
+      }
+    },
+    "languages": {
+      "type": "array",
+      "description": "List any other languages you speak",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "e.g. English, Spanish"
+          },
+          "fluency": {
+            "type": "string",
+            "description": "e.g. Fluent, Beginner"
+          }
+        }
+      }
+    },
+    "interests": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Philosophy"
+          },
+          "keywords": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Friedrich Nietzsche"
+            }
+          }
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "List references you have received",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Timothy Cook"
+          },
+          "reference": {
+            "type": "string",
+            "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+          }
+        }
+      }
+    },
+    "projects": {
+      "type": "array",
+      "description": "Specify career projects",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short summary of project. e.g. Collated works of 2017."
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple features",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Directs you close but not quite there"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "description": "Specify special elements involved",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. AngularJS"
+            }
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Specify your role on this project or in company",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Team Lead, Speaker, Writer"
+            }
+          },
+          "entity": {
+            "type": "string",
+            "description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
+          },
+          "type": {
+            "type": "string",
+            "description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "The schema version and any other tooling configuration lives here",
+      "additionalProperties": true,
+      "properties": {
+        "canonical": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to latest version of this document",
+          "format": "uri"
+        },
+        "version": {
+          "type": "string",
+          "description": "A version field which follows semver - e.g. v1.0.0"
+        },
+        "lastModified": {
+          "type": "string",
+          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+        }
+      }
+    }
+  },
+  "title": "Resume Schema",
+  "type": "object"
+}

--- a/packages/preview/json-resume/0.3.0/internal/coerce.typ
+++ b/packages/preview/json-resume/0.3.0/internal/coerce.typ
@@ -1,0 +1,65 @@
+// Assumes input has passed _validate. Unknown keys are dropped
+// silently rather than panicking; top-of-branch type checks catch
+// shape mismatches from direct callers who skipped validation.
+// assert(false, ...) over panic(...) for newline-preserving
+// diagnostics if these messages ever go multi-line.
+//
+// JSON `null` (Typst's `none`) at a value position is treated as if
+// the key were absent: it returns `none` from the per-value call so
+// the parent's object-pair filter or array-element filter drops it.
+// Downstream renderers see "key not in dict" instead of a stray
+// `none` value to special-case.
+//
+// An object whose every key coerced to none is itself coerced to
+// `none` (rather than an empty dict). That propagates "every key was
+// null" upward so the parent filter drops the object too — symmetric
+// with the leaf-null policy. Applied recursively, a resume whose only
+// section is itself all-null collapses all the way to `none` — the
+// consistent extension of the policy. Public callers go through the
+// lib.typ wrappers, which reject a null root explicitly so this
+// collapse never surprises a direct user of the engine.
+
+#import "errors.typ": _type-name-of
+
+#let _expect(expected, value) = (
+  "json-resume: coerce expected " + expected + ", got " +
+    _type-name-of(value) + ". Run validate(data) first."
+)
+
+#let _coerce(schema, value) = {
+  // Null at any value position is "key absent". The parent (object
+  // or array branch below) is responsible for filtering this out.
+  if value == none { return none }
+  let kind = schema.kind
+  if kind == "content" {
+    assert(type(value) == str, message: _expect("a string", value))
+    return [#value]
+  }
+  // Format-specialised string kinds pass through identically to `str`
+  // — the regex gate fires in _validate, not here.
+  if kind in ("str", "date-string", "uri-string", "email-string") {
+    assert(type(value) == str, message: _expect("a string", value))
+    return value
+  }
+  if kind == "number" {
+    assert(type(value) in (int, float), message: _expect("a number", value))
+    return value
+  }
+  if kind == "array" {
+    assert(type(value) == array, message: _expect("an array", value))
+    // Drop null elements: a null in an array of strings would
+    // otherwise surface as a stray `none` to downstream renderers.
+    return value.map(elem => _coerce(schema.elem, elem)).filter(e => e != none)
+  }
+  if kind == "object" {
+    assert(type(value) == dictionary, message: _expect("an object", value))
+    let coerced = value.pairs()
+      .filter(((key, _)) => key in schema.shape)
+      .map(((key, sub-value)) => (key, _coerce(schema.shape.at(key), sub-value)))
+      .filter(((_, coerced)) => coerced != none)
+      .to-dict()
+    if coerced.len() == 0 { return none }
+    return coerced
+  }
+  panic("json-resume: internal — unknown schema kind " + repr(kind))
+}

--- a/packages/preview/json-resume/0.3.0/internal/errors.typ
+++ b/packages/preview/json-resume/0.3.0/internal/errors.typ
@@ -1,0 +1,38 @@
+// Empty path renders as "<root>" so a top-level type error reads
+// `"<root>: expected object, got …"`.
+#let _format-path(parts) = {
+  if parts.len() == 0 { return "<root>" }
+  parts.enumerate().map(((i, part)) => {
+    if type(part) == int { "[" + str(part) + "]" }
+    else if i == 0 { part }
+    else { "." + part }
+  }).join("")
+}
+
+// Typst's `repr(type(...))` renders as `"int"` / `"dictionary"` /
+// `"type(none)"` — accurate but jarring. Translate to JSON-shaped
+// names for user-facing messages; unknown reprs fall through.
+#let _type-names = (
+  str: "string",
+  int: "integer",
+  float: "number",
+  bool: "boolean",
+  array: "array",
+  dictionary: "object",
+)
+
+// The `none` branch is defensive: the validator's null-as-absent rule
+// means _type-error never sees a null value today, but _type-name-of is
+// a general helper that may be reused by future code paths.
+#let _type-name-of(value) = {
+  if value == none { return "null" }
+  let raw = repr(type(value))
+  _type-names.at(raw, default: raw)
+}
+
+#let _format-report(errors) = {
+  let n = errors.len()
+  let noun = if n == 1 { "problem" } else { "problems" }
+  let lines = errors.map(e => "  - " + _format-path(e.path) + ": " + e.message)
+  "json-resume: found " + str(n) + " " + noun + " in the input:\n" + lines.join("\n")
+}

--- a/packages/preview/json-resume/0.3.0/internal/json-schema.typ
+++ b/packages/preview/json-resume/0.3.0/internal/json-schema.typ
@@ -1,0 +1,124 @@
+// JSON Schema (draft 7 subset) → Typst-schema translator. Anything
+// not supported panics rather than silently dropping the constraint.
+
+#import "kinds.typ": (
+  str-type, content-type, number-type, array-of, object,
+  date-string, uri-string, email-string,
+)
+
+// `date-time` is intentionally absent: the date-string regex is
+// date-only, so labelling a datetime field then rejecting its values
+// is worse than the up-front "unsupported format" panic.
+#let _format-kinds = (
+  "uri": uri-string,
+  "email": email-string,
+  "date": date-string,
+)
+
+// One panic prefix so every diagnostic from this module is grep-able
+// by "schema-from-json-schema —".
+#let _bail(msg) = panic("json-resume: schema-from-json-schema — " + msg)
+
+// `seen` is the chain of refs traversed so far; a repeat means a
+// cycle (e.g. `definitions.alias → alias`) — panic before Typst's
+// recursion limit fires deep in the stack.
+#let _resolve-ref(ref, root, seen) = {
+  if not ref.starts-with("#/") {
+    _bail("only internal $ref (starting with \"#/\") is supported, got: " + repr(ref) + ".")
+  }
+  if ref in seen {
+    _bail("cyclic $ref detected: " + seen.map(repr).join(" → ") + " → " + repr(ref) + ".")
+  }
+  if ref == "#/" {
+    _bail("$ref \"#/\" cannot reference the document root.")
+  }
+  let parts = ref.slice(2).split("/").filter(p => p != "")
+  parts.fold(root, (acc, key) => {
+    if type(acc) != dictionary or key not in acc {
+      _bail("$ref " + repr(ref) + " could not be resolved (segment " + repr(key) + " missing).")
+    }
+    acc.at(key)
+  })
+}
+
+#let _unsupported-keywords = (
+  "allOf", "anyOf", "oneOf", "not",
+  "enum", "const",
+  "if", "then", "else",
+  "dependencies", "dependentRequired", "dependentSchemas",
+)
+
+#let _from-json-schema(js, root, seen) = {
+  if "$ref" in js {
+    let ref = js.at("$ref")
+    if type(ref) != str {
+      _bail("\"$ref\" must be a string, got: " + repr(type(ref)) + ".")
+    }
+    return _from-json-schema(
+      _resolve-ref(ref, root, seen),
+      root,
+      seen + (ref,),
+    )
+  }
+  for keyword in _unsupported-keywords {
+    if keyword in js {
+      _bail(
+        "unsupported JSON Schema keyword: " + repr(keyword) +
+          ". Composition keywords (allOf/anyOf/oneOf), enum, and conditional schemas are out of scope.",
+      )
+    }
+  }
+  let t = js.at("type", default: none)
+  if t == "string" {
+    let fmt = js.at("format", default: none)
+    if fmt == none { return str-type }
+    if fmt not in _format-kinds {
+      _bail("unsupported string format: " + repr(fmt) + ".")
+    }
+    return _format-kinds.at(fmt)
+  }
+  if t == "number" or t == "integer" { return number-type }
+  if t == "array" {
+    let items = js.at("items", default: none)
+    if items == none {
+      _bail("array schema missing \"items\".")
+    }
+    if type(items) != dictionary {
+      _bail("\"items\" must be a schema object, got: " + repr(type(items)) + ".")
+    }
+    return array-of(_from-json-schema(items, root, seen))
+  }
+  if t == "object" {
+    // Engine is strict by design — can't represent open objects. A
+    // missing `properties` would silently invert the schema's intent.
+    if "properties" not in js {
+      _bail(
+        "open object schemas (`type: \"object\"` with no `properties`) " +
+          "are out of scope; every field must be declared.",
+      )
+    }
+    let props = js.at("properties")
+    if type(props) != dictionary {
+      _bail("\"properties\" must be an object, got: " + repr(type(props)) + ".")
+    }
+    let required = js.at("required", default: ())
+    if type(required) != array {
+      _bail("\"required\" must be an array of field names, got: " + repr(type(required)) + ".")
+    }
+    return object(
+      props.pairs().map(((k, v)) => (k, _from-json-schema(v, root, seen))).to-dict(),
+      required-keys: required,
+    )
+  }
+  if t in ("boolean", "null") {
+    _bail("unsupported JSON Schema type: " + repr(t) + ".")
+  }
+  if type(t) == array {
+    // null-as-absent already covers the common `["string", "null"]`
+    // nullable case at the validator level, so unions aren't needed.
+    _bail("union `type` arrays are unsupported, got: " + repr(t) + ".")
+  }
+  _bail("unrecognised JSON Schema fragment (no recognised \"type\" or \"$ref\"); keys: " + repr(js.keys()) + ".")
+}
+
+#let schema-from-json-schema(js) = _from-json-schema(js, js, ())

--- a/packages/preview/json-resume/0.3.0/internal/kinds.typ
+++ b/packages/preview/json-resume/0.3.0/internal/kinds.typ
@@ -1,0 +1,32 @@
+// Schema-kind constants and constructors. Lives in its own module
+// because schema.typ depends on json-schema.typ (for derivation) and
+// json-schema.typ depends on these primitives — extracting them here
+// breaks the cycle.
+
+#let str-type     = (kind: "str")
+#let content-type = (kind: "content")
+#let number-type  = (kind: "number")
+
+// Format-specialised string kinds — regex-gated in _validate;
+// deliberately permissive (reject obvious malformations, not full RFC).
+#let date-string  = (kind: "date-string")
+#let uri-string   = (kind: "uri-string")
+#let email-string = (kind: "email-string")
+
+#let array-of(elem) = (kind: "array", elem: elem)
+
+// Reject required-keys that don't appear in shape so a schema typo
+// fails at construction time, not as a phantom validation error.
+#let object(shape, required-keys: ()) = {
+  let unknown = required-keys.filter(k => k not in shape)
+  assert(
+    unknown.len() == 0,
+    message: "json-resume: object() required-keys references keys not in shape: " +
+      unknown.join(", ") + ".",
+  )
+  (
+    kind: "object",
+    shape: shape,
+    required-keys: required-keys,
+  )
+}

--- a/packages/preview/json-resume/0.3.0/internal/lens.typ
+++ b/packages/preview/json-resume/0.3.0/internal/lens.typ
@@ -1,0 +1,119 @@
+// Lens-style schema editing.
+//
+// Top-level lens-* functions rather than methods on a lens record:
+// Typst parses `dict.field(args)` as a type-method lookup, not a call
+// of the closure stored under that key, so methods would force
+// `(lens.put)(args)` at every call site.
+//
+// Path segments:
+//   - object: string key into `.shape`
+//   - array : literal "items" to enter `.elem`
+//   - empty `()` : identity lens
+
+#let _bail(msg) = panic("json-resume: " + msg)
+
+#let _require-object(parent, op) = {
+  if parent.kind != "object" {
+    _bail(
+      op + " expects an object schema at the lens target, got kind=" +
+        repr(parent.kind) + ".",
+    )
+  }
+}
+
+// Typst dicts are value types — `let new-shape = parent.shape` copies,
+// and `.insert` mutates the local without touching parent.
+#let _with-shape-set(parent, key, value) = {
+  let new-shape = parent.shape
+  new-shape.insert(key, value)
+  (..parent, shape: new-shape)
+}
+
+#let _descend(schema, segment) = {
+  if schema.kind == "object" {
+    if segment not in schema.shape {
+      _bail(
+        "lens path segment " + repr(segment) + " not in object shape. " +
+          "Valid keys: " + schema.shape.keys().join(", ") + ".",
+      )
+    }
+    return schema.shape.at(segment)
+  }
+  if schema.kind == "array" {
+    if segment != "items" {
+      _bail(
+        "lens segment for an array schema must be \"items\", got " +
+          repr(segment) + ".",
+      )
+    }
+    return schema.elem
+  }
+  _bail(
+    "lens cannot descend into a leaf schema (kind=" + repr(schema.kind) +
+      ") with segment " + repr(segment) + ".",
+  )
+}
+
+#let _get-at(schema, path) = {
+  let cursor = schema
+  for segment in path { cursor = _descend(cursor, segment) }
+  cursor
+}
+
+// _descend runs in both branches so an invalid segment surfaces the
+// same diagnostic from get and from put.
+#let _set-at(schema, path, value) = {
+  if path.len() == 0 { return value }
+  let (head, ..rest) = path
+  let new-sub = _set-at(_descend(schema, head), rest, value)
+  if schema.kind == "object" { _with-shape-set(schema, head, new-sub) }
+  else { (..schema, elem: new-sub) }
+}
+
+#let lens(path) = (kind: "lens", path: path)
+
+#let lens-get(l, schema) = _get-at(schema, l.path)
+
+// `put` because `set` is a Typst keyword.
+#let lens-put(l, schema, value) = _set-at(schema, l.path, value)
+
+#let lens-over(l, schema, fn) = _set-at(schema, l.path, fn(_get-at(schema, l.path)))
+
+// `lens-then(a, b)` applies a then b — paths concatenate in that order.
+#let lens-then(a, b) = lens(a.path + b.path)
+
+// Collisions panic instead of overwriting silently — for the
+// overwrite-an-existing-key case, callers can reach for lens-put / lens-over.
+#let add-field(schema, parent-lens, key, sub-schema) = lens-over(
+  parent-lens,
+  schema,
+  parent => {
+    _require-object(parent, "add-field")
+    if key in parent.shape {
+      _bail(
+        "add-field key " + repr(key) + " already in object shape. " +
+          "Use lens-put / lens-over to replace an existing field.",
+      )
+    }
+    _with-shape-set(parent, key, sub-schema)
+  },
+)
+
+// Absent-key panics rather than being a silent no-op so caller typos surface.
+#let remove-field(schema, parent-lens, key) = lens-over(
+  parent-lens,
+  schema,
+  parent => {
+    _require-object(parent, "remove-field")
+    if key not in parent.shape {
+      _bail(
+        "remove-field key " + repr(key) + " not in object shape. " +
+          "Valid keys: " + parent.shape.keys().join(", ") + ".",
+      )
+    }
+    let new-shape = parent.shape
+    let _ = new-shape.remove(key)
+    let new-required = parent.required-keys.filter(k => k != key)
+    (..parent, shape: new-shape, required-keys: new-required)
+  },
+)

--- a/packages/preview/json-resume/0.3.0/internal/schema.typ
+++ b/packages/preview/json-resume/0.3.0/internal/schema.typ
@@ -1,0 +1,70 @@
+// Canonical JSON Resume schema (https://jsonresume.org/schema).
+// `resume-schema` is a faithful derivation of the upstream document;
+// `resume-schema-strict` layers content + date opinions via lens.
+// See README "Two schemas" for the trade-off.
+
+#import "kinds.typ": (
+  str-type, content-type, number-type, array-of, object,
+  date-string, uri-string, email-string,
+)
+#import "json-schema.typ": schema-from-json-schema
+#import "lens.typ": lens, lens-get, lens-put
+
+#let resume-schema = schema-from-json-schema(json("assets/jsonresume-schema.json"))
+
+// Free-text fields wrapped as Typst `content` in the strict variant.
+// Renderer ergonomics, not validation.
+#let _content-paths = (
+  ("basics", "summary"),
+  ("work", "items", "summary"),
+  ("work", "items", "highlights", "items"),
+  ("volunteer", "items", "summary"),
+  ("volunteer", "items", "highlights", "items"),
+  ("awards", "items", "summary"),
+  ("publications", "items", "summary"),
+  ("references", "items", "reference"),
+  ("projects", "items", "description"),
+  ("projects", "items", "highlights", "items"),
+)
+
+// iso8601 `$ref` fields (translator can't pick formats up from a $ref
+// alone) plus meta.lastModified (no format annotation in upstream).
+#let _date-paths = (
+  ("work", "items", "startDate"),
+  ("work", "items", "endDate"),
+  ("volunteer", "items", "startDate"),
+  ("volunteer", "items", "endDate"),
+  ("education", "items", "startDate"),
+  ("education", "items", "endDate"),
+  ("awards", "items", "date"),
+  ("publications", "items", "releaseDate"),
+  ("projects", "items", "startDate"),
+  ("projects", "items", "endDate"),
+  ("meta", "lastModified"),
+)
+
+// Pre-condition guard turns silent upstream drift into a load-time
+// panic — an override that ran unconditionally would mask the shape
+// change instead of surfacing it.
+#let _override-fold(schema, paths, expected-source, replacement, list-name) = {
+  paths.fold(schema, (s, p) => {
+    let l = lens(p)
+    let current = lens-get(l, s)
+    assert(
+      current == expected-source,
+      message: "json-resume: " + list-name + " must target " +
+        repr(expected-source.kind) + " leaves only — " + repr(p) +
+        " is now " + repr(current.kind) + ". Audit upstream schema bump.",
+    )
+    lens-put(l, s, replacement)
+  })
+}
+
+#let resume-schema-strict = {
+  let with-content = _override-fold(
+    resume-schema, _content-paths, str-type, content-type, "_content-paths",
+  )
+  _override-fold(
+    with-content, _date-paths, str-type, date-string, "_date-paths",
+  )
+}

--- a/packages/preview/json-resume/0.3.0/internal/validate.typ
+++ b/packages/preview/json-resume/0.3.0/internal/validate.typ
@@ -1,0 +1,98 @@
+// Subtrees under unknown keys are not walked — their expected shape
+// is undefined.
+//
+// JSON `null` (Typst's `none`) at a value position is treated as if
+// the key were absent: no type error, no recursion. Per-key null
+// values in objects, null array elements, and entire-section nulls
+// are all absorbed by the top-of-function early return — recursion
+// handles them uniformly. The required-keys check below is the only
+// place that still needs an explicit null check (a present-but-null
+// required key must still count as missing). See README "Errors"
+// section for the user-facing rationale.
+
+#import "errors.typ": _type-name-of
+
+#let _type-error(path, expected, value) = ((
+  path: path,
+  message: "expected " + expected + ", got " + _type-name-of(value) + ".",
+),)
+
+// Tightened over the upstream JSON Resume regexes, which accept
+// impossible months / days because they use [0-1][0-9] / [0-3][0-9].
+// Deliberately permissive (no full RFC compliance). Message omits the
+// offending value — the path already names the field, the canonical
+// example in `expected` is the actionable hint.
+#let _format-specs = (
+  "date-string": (
+    pattern: regex("^([0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])|[0-9]{4}-(0[1-9]|1[0-2])|[0-9]{4})$"),
+    expected: "an ISO-8601 date (e.g. \"2024-01-15\")",
+  ),
+  "uri-string": (
+    pattern: regex("^[A-Za-z][A-Za-z0-9+.\-]*://\S+$"),
+    expected: "a URI (e.g. \"https://example.com\")",
+  ),
+  "email-string": (
+    pattern: regex("^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$"),
+    expected: "an email (e.g. \"name@example.com\")",
+  ),
+)
+
+#let _validate(schema, value, path) = {
+  // Null at any value position is "key absent" — no error, no
+  // recursion. Single early return handles every shape uniformly:
+  // standalone scalars, array elements (via the per-element call),
+  // and per-key sub-values inside objects (via the per-key call).
+  if value == none { return () }
+  let kind = schema.kind
+  if kind in ("str", "content") {
+    if type(value) != str { return _type-error(path, "string", value) }
+    return ()
+  }
+  if kind in _format-specs {
+    if type(value) != str { return _type-error(path, "string", value) }
+    let spec = _format-specs.at(kind)
+    if value.match(spec.pattern) == none {
+      return ((path: path, message: "expected " + spec.expected + "."),)
+    }
+    return ()
+  }
+  if kind == "number" {
+    if type(value) not in (int, float) { return _type-error(path, "number", value) }
+    return ()
+  }
+  if kind == "array" {
+    if type(value) != array { return _type-error(path, "array", value) }
+    return value.enumerate()
+      .map(((i, elem)) => _validate(schema.elem, elem, path + (i,)))
+      .flatten()
+  }
+  if kind == "object" {
+    if type(value) != dictionary { return _type-error(path, "object", value) }
+    let per-key-errs = value.pairs().map(((key, sub-value)) => {
+      if key in schema.shape {
+        _validate(schema.shape.at(key), sub-value, path + (key,))
+      } else {
+        // Valid-keys list only assembled on the unknown-key branch so
+        // the happy path skips the join. An unknown key with a null
+        // value is still flagged — silently swallowing typos would
+        // defeat the point of strict validation.
+        let valid-keys-str = schema.shape.keys().join(", ")
+        ((
+          path: path + (key,),
+          message: "unknown key " + repr(key) + ". Valid keys: " + valid-keys-str + ".",
+        ),)
+      }
+    }).flatten()
+    // A required key whose value is explicit null counts as missing —
+    // null-as-absent applies uniformly.
+    let required = schema.at("required-keys", default: ())
+    let missing-errs = required
+      .filter(k => k not in value or value.at(k) == none)
+      .map(k => (
+        path: path + (k,),
+        message: "missing required key " + repr(k) + ".",
+      ))
+    return per-key-errs + missing-errs
+  }
+  panic("json-resume: internal — unknown schema kind " + repr(kind))
+}

--- a/packages/preview/json-resume/0.3.0/lib.typ
+++ b/packages/preview/json-resume/0.3.0/lib.typ
@@ -1,0 +1,75 @@
+// Strict loader for canonical JSON Resume data
+// (https://jsonresume.org/schema). The engines under internal/ are
+// pure functions of (schema, value); see
+// tests/engine_schema_agnostic.typ for the BYO-schema contract.
+
+#import "internal/schema.typ": (
+  resume-schema, resume-schema-strict,
+  str-type, content-type, number-type, array-of, object,
+  date-string, uri-string, email-string,
+)
+#import "internal/validate.typ": _validate
+#import "internal/coerce.typ": _coerce
+#import "internal/errors.typ": _format-report
+#import "internal/json-schema.typ": schema-from-json-schema
+#import "internal/lens.typ": lens, lens-get, lens-put, lens-over, lens-then, add-field, remove-field
+
+// Engines treat `none` at any value position as "key absent" — right
+// for leaves inside a document, but a null root is always invalid
+// (no schema can validate "missing document"). One source of truth
+// for the message so docs and tests have something stable to pin.
+#let _reject-none-root(data) = {
+  if data == none { panic("json-resume: input must be a dict, got null.") }
+}
+
+// Combined-report formatter, for callers handling errors themselves
+// instead of letting `parse` abort.
+#let format-errors(errors) = _format-report(errors)
+
+#let validate(data, schema: resume-schema) = {
+  _reject-none-root(data)
+  _validate(schema, data, ())
+}
+
+// Unknown keys are dropped silently rather than panicking, so direct
+// callers who skip validation don't get a Typst dictionary-access
+// panic.
+#let coerce(data, schema: resume-schema) = {
+  _reject-none-root(data)
+  _coerce(schema, data)
+}
+
+// One-call composition. Accepts a parsed dict OR a Typst-root-relative
+// path string ("/…"); validates, aborts compilation with the combined
+// report on issues, otherwise coerces.
+//
+// String paths must start with "/" because Typst resolves relative
+// paths against the file containing the call — here that's the
+// @preview cache. For paths relative to the caller's own .typ, pass
+// `json("…")` instead.
+#let parse(data, schema: resume-schema) = {
+  _reject-none-root(data)
+  let dict-data = if type(data) == str {
+    if not data.starts-with("/") {
+      panic(
+        "json-resume: parse with a string path requires the path " +
+          "to start with \"/\" (resolved from the typst root). Got: " + repr(data) + ". " +
+          "To use a path relative to your own .typ file, pass " +
+          "json(" + repr(data) + ") in place of the path string.",
+      )
+    }
+    json(data)
+  } else if type(data) == dictionary {
+    data
+  } else {
+    panic(
+      "json-resume: parse expected a dict or a string path, got " +
+        repr(type(data)) + ".",
+    )
+  }
+  let errors = _validate(schema, dict-data, ())
+  // assert preserves newlines in the diagnostic; panic repr-escapes
+  // them and collapses the bullet list onto one line.
+  assert(errors.len() == 0, message: format-errors(errors))
+  _coerce(schema, dict-data)
+}

--- a/packages/preview/json-resume/0.3.0/typst.toml
+++ b/packages/preview/json-resume/0.3.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "json-resume"
+version = "0.3.0"
+entrypoint = "lib.typ"
+authors = ["Shane Murphy"]
+license = "MIT"
+description = "Strict JSON Resume loader for CV templates."
+repository = "https://github.com/smur89/typst-json-resume"
+keywords = ["json-resume", "resume", "cv", "loader", "schema"]
+categories = ["utility"]
+compiler = "0.13.0"


### PR DESCRIPTION
  <!--
  Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as
  `name:version` of the submitted package.
  -->

  I am submitting
  - [x] a new package
  - [ ] an update for a package

  `json-resume` is a strict loader for canonical [JSON Resume](https://jsonresume.org/) data. It reads a `resume.json` file, validates it against the [published
  schema](https://jsonresume.org/schema), and returns a normalised Typst dict with free-text fields coerced to `content` — ready to hand to any compatible Typst CV template.

  Useful because the JSON Resume promise of one `resume.json` across many renderers currently requires every Typst CV template to hand-translate the JSON into a Typst dict;
  this package centralises that work into a single dependency so renderers can stay focused on layout. The canonical schema is **derived at module-load time from the vendored
   upstream JSON Schema document** — the published spec is the single source of truth, not a hand-maintained mirror.

  For templates that need their own fields (theme colours, label overrides, header decorations, …) the package exposes the underlying engines (`validate` / `coerce`) and a
  lens-style API (`lens`, `lens-put`, `lens-over`, `add-field`, `remove-field`) so an extension schema can be built on top of the canonical one without forking the loader —
  and `schema-from-json-schema` lets callers translate their own JSON Schema documents into Typst schemas if they prefer that source of truth over hand-rolled combinators.

  I have read and followed the submission guidelines and, in particular, I
  - [x] selected a name that isn't the most obvious or canonical name for what the package does
    - Explanation: The name mirrors the [JSON Resume](https://jsonresume.org/) project name because the package's sole purpose is to load documents conforming to *that
  specific standard*. It identifies the protocol the package implements, not a generic category — common JSON-Resume tooling across other ecosystems follows the same naming
  pattern (e.g. `jsonresume-cli`, `npm:resume-cli`, `python:json-resume`). Generic terms like `resume` or `cv` are deliberately avoided so they remain available for template
  packages.
  - [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
  - [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
  - [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
  - [x] tested my package locally on my system and it worked
  - [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE