### PR TITLE
gairm-import:0.8.0

### DIFF
--- a/packages/preview/gairm-import/0.8.0/CONTRIBUTING.md
+++ b/packages/preview/gairm-import/0.8.0/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing
+
+Thanks for taking the time to look. This is a small library package; almost
+any thoughtful contribution will be welcome — but a couple of conventions
+keep the release pipeline (release-please + Typst Universe) running smoothly.
+
+## Submitting a PR
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally and create a branch for your change.
+3. Make the changes, commit, and push to your fork.
+4. Open a Pull Request against `main` on this repository.
+
+Security issues should be reported privately per [`SECURITY.md`](SECURITY.md)
+instead of as a PR or issue.
+
+## Scope
+
+`gairm-import` implements **only** the canonical [JSON Resume schema](https://jsonresume.org/schema).
+Anything renderer-specific (theme colours, label overrides, header
+decorations, custom sections, …) belongs in the consuming Typst CV template,
+not here. PRs that add fields outside the canonical schema will be redirected
+to the appropriate downstream template repo.
+
+## Project layout
+
+```text
+lib.typ                              # public entry — `parse`, `validate`, `coerce`, combinators, lenses
+internal/kinds.typ                   # schema-kind primitives (str-type, content-type, object, array-of, …)
+internal/schema.typ                  # canonical resume-schema (faithful derivation) + resume-schema-strict (opt-in opinions)
+internal/assets/jsonresume-schema.json  # vendored upstream schema, pinned to v1.0.0
+internal/validate.typ                # validation engine (path-typed errors)
+internal/coerce.typ                  # coercion engine (content wrapping, null absorption)
+internal/json-schema.typ             # JSON Schema → Typst-schema translator
+internal/lens.typ                    # path-based functional editing of schemas
+tests/                               # fixtures — CI compiles each as a regression guard
+```
+
+## Bumping the vendored JSON Resume schema
+
+`internal/schema.typ` derives `resume-schema` from
+`internal/assets/jsonresume-schema.json` at module-load time, so the
+upstream document is the source of truth. To pull a newer upstream version:
+
+1. Replace `internal/assets/jsonresume-schema.json` with the chosen tag from
+   [jsonresume/resume-schema](https://github.com/jsonresume/resume-schema).
+2. Run `make test`. The translator handles the draft-04/-07 subset that the
+   canonical document uses; newer constructs (`allOf`/`anyOf`/`oneOf`,
+   `enum`/`const`, format-aware types beyond uri/email/date/date-time, open
+   objects, type unions, external `$ref`) panic with an "unsupported" message.
+   If a panic surfaces, extend `internal/json-schema.typ` rather than
+   silently dropping the constraint.
+3. Audit `_content-paths` and `_date-paths` in `internal/schema.typ` against
+   the bumped document. These lists are the opt-in `resume-schema-strict`
+   variant's opinions — `_content-paths` lifts free-text `string` fields to
+   Typst `content` for inline rendering; `_date-paths` lifts iso8601 `$ref`
+   fields (which the translator can't pick up from a `$ref` alone) to
+   `date-string` for regex validation. If a new free-text or iso8601-referenced
+   field lands in the upstream document, add its path here. The drift guard
+   in `_override-fold` will panic at module-load if an existing path's source
+   kind changes, so you'll see the audit prompt automatically.
+
+`feat:` commit if the bump introduces new fields or behaviour;
+`chore(deps):` if it's a no-op refresh.
+
+## Development loop
+
+Install Typst at the version CI uses — see `TYPST_VERSION` in
+`.github/workflows/build.yml`.
+
+```sh
+make             # compile every tests/*.typ fixture (= `make test`)
+make test        # same as above; the CI lint job runs this
+make check       # alias for `make test`
+make help        # summarise the available targets
+```
+
+`make test` is the local equivalent of the CI lint job — green here means CI
+lint will pass too.
+
+If you'd rather drive Typst directly:
+
+```sh
+for f in tests/*.typ; do typst compile --root . --format pdf "$f" /dev/null; done
+```
+
+`--format pdf` is required when the output path is `/dev/null` — Typst cannot
+infer the format from a path with no extension.
+
+## Conventional commits
+
+The repo uses [release-please](https://github.com/googleapis/release-please)
+to cut releases. Versioning is derived from commit messages on `main`, so
+each merged PR needs a clean conventional-commit message.
+
+| Prefix | Bump | Use for |
+|---|---|---|
+| `fix:` | patch | Bug fix, doc correction, broken link, validation gap |
+| `feat:` | minor | New schema field supported, new coercion, new public helper |
+| `feat!:` or `BREAKING CHANGE:` footer | major | API change that existing users would need to migrate |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | none | Internal changes that shouldn't trigger a release |
+
+PRs squash-merge with the PR title as the commit subject, so just make the
+**PR title** a conventional commit. The body of the squash commit comes from
+the PR description.
+
+## Adding schema coverage
+
+For a **new schema field**:
+
+1. Add (or extend) a fixture under `tests/` exercising the field — a valid
+   case and at least one rejection case for the validator.
+2. Implement the validation / coercion in `lib.typ` (or a module it imports).
+3. Update the README's "Usage" example if the field is end-user-visible.
+
+`feat:` commit.
+
+## First publication to Typst Universe
+
+The automated `submit-to-typst-universe` workflow only handles **updates** to
+an already-published package (the auto-generated PR body is the slim
+"update" variant). The very first submission to
+[typst/packages](https://github.com/typst/packages) must be opened manually
+so the maintainers can do a full new-package review.
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for how to report a vulnerability.

--- a/packages/preview/gairm-import/0.8.0/LICENSE
+++ b/packages/preview/gairm-import/0.8.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shane Murphy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/gairm-import/0.8.0/README.md
+++ b/packages/preview/gairm-import/0.8.0/README.md
@@ -1,0 +1,586 @@
+<h1 align="center">gairm-import</h1>
+
+<p align="center">
+  <a href="https://typst.app/universe/package/gairm-import"><img alt="gairm-import on Typst Universe" src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fgairm-import&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&style=flat-square"></a>
+  <a href="https://github.com/smur89/gairm-import/releases"><img alt="Latest GitHub release version of gairm-import" src="https://img.shields.io/github/v/release/smur89/gairm-import?style=flat-square"></a>
+  <a href="https://github.com/smur89/gairm-import/actions/workflows/build.yml"><img alt="GitHub Actions build workflow status on the gairm-import main branch" src="https://img.shields.io/github/actions/workflow/status/smur89/gairm-import/build.yml?style=flat-square"></a>
+  <a href="LICENSE"><img alt="MIT license badge linking to the gairm-import LICENSE file" src="https://img.shields.io/github/license/smur89/gairm-import?style=flat-square"></a>
+  <a href="https://github.com/smur89/gairm-import/stargazers"><img alt="Number of GitHub stargazers for gairm-import" src="https://img.shields.io/github/stars/smur89/gairm-import?style=flat-square"></a>
+</p>
+
+<p align="center">
+  JSON Schema → Typst dict coercer. Validate a JSON document against a JSON Schema (draft&nbsp;7 subset) and return a normalised Typst dict ready for downstream rendering. Ships with the <a href="https://jsonresume.org/schema">JSON Resume</a> schema and convenience entry points as the canonical bundled example.
+</p>
+
+<p align="center">
+  <sub><em>"gairm" is Irish for vocation. The package was originally a JSON Resume loader.</em></sub>
+</p>
+
+The engine is a pair of pure functions of `(schema, value)` — `validate` returns a
+list of `(path, message)` records, `coerce` returns the normalised dict — backed by
+combinators for hand-authoring Typst schemas (`object`, `array-of`, `str-type`,
+`content-type`, `number-type`, `enum-of`, `const-of`, format-specialised string
+kinds, `pattern-string`) and a translator (`schema-from-json-schema`) that converts
+JSON Schema (draft&nbsp;7 subset) into the same shape. Lens helpers
+(`lens-put`, `lens-over`, `add-field`, …) and introspection helpers
+(`describe-schema`, `paths-of-kind`, `kind-at`) round out the schema-editing
+surface.
+
+The [JSON Resume](https://jsonresume.org/) schema ships ready-to-use as
+`resume-schema` / `resume-schema-strict` — load a canonical `resume.json` via
+`parse` and hand the normalised dict to any compatible Typst CV template. Bring
+your own schema for any other JSON-Schema-shaped data format; the engine doesn't
+know or care that it's a CV.
+
+## Install
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": validate, coerce, parse
+```
+<!-- x-release-please-end -->
+
+## A minimal `resume.json`
+
+```json
+{
+  "basics": {
+    "name": "Seán Ó Murchú",
+    "label": "Senior Software Engineer",
+    "email": "sean@example.com",
+    "summary": "Backend engineer with eight years of experience."
+  },
+  "work": [
+    {
+      "name": "Acme Corp",
+      "position": "Senior Software Engineer",
+      "startDate": "2022-01",
+      "highlights": ["Led the event-sourcing platform migration."]
+    }
+  ]
+}
+```
+
+The full canonical schema covers thirteen sections:
+`basics`, `work`, `volunteer`, `education`, `awards`, `certificates`,
+`publications`, `skills`, `languages`, `interests`, `references`, `projects`,
+`meta`. The `$schema` top-level metadata field is also accepted. See
+[jsonresume.org/schema](https://jsonresume.org/schema) for every field.
+
+## Usage
+
+`parse` is the one-call entry point. The recommended form is
+`parse(path("resume.json"))` — the [`path`](https://typst.app/docs/reference/foundations/path/)
+value resolves against your own `.typ` (not the `@preview` cache), so
+you can use the natural relative path:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": parse
+
+#let resume = parse(path("resume.json"))
+```
+<!-- x-release-please-end -->
+
+A parsed dict, a `json("…")` wrap, or a Typst-root-relative `"/…"`
+string are also accepted — useful on older callers or when you've
+already loaded the document yourself:
+
+```typst
+// json() resolves the path against your .typ; parse takes the dict.
+#let resume = parse(json("resume.json"))
+
+// Typst-root-relative path string, resolved by parse itself.
+#let resume = parse("/resume.json")
+```
+
+The returned dict is a 1:1 mirror of the canonical schema — every kind comes
+from the upstream JSON Schema document. Format-annotated fields are gated by
+a regex (see [Format validation](#format-validation)); everything else
+passes through as JSON-native types. For example:
+
+```text
+resume.basics.name            str
+resume.basics.summary         str
+resume.basics.email           str (gated as email)
+resume.work.at(0).position    str
+resume.work.at(0).highlights  array of str
+resume.skills.at(0).keywords  array of str
+```
+
+For renderer-friendly opinions (free-text fields wrapped as Typst `content`,
+iso8601 `$ref` fields validated as dates), import `resume-schema-strict`
+instead and pass it via the `schema:` keyword — see [Two schemas](#two-schemas).
+
+Pass the model into any compatible renderer — e.g. [`altacv`](https://typst.app/universe/package/altacv):
+
+<!-- Known-ugly: two fences instead of one because release-please's block
+     wrap would also bump altacv:1.1.1 on every release. See
+     https://github.com/typst/packages/pull/5069#discussion_r3420827761 -->
+
+```typst
+#import "@preview/altacv:1.1.1": alta, palettes
+```
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": parse
+
+#alta(
+  parse(path("resume.json")),
+  preferences: (accent: palettes.navy),
+)
+```
+<!-- x-release-please-end -->
+
+`alta(cv, labels: (:), preferences: (:))` takes the JSON-Resume-shaped dict
+positionally; `labels` and `preferences` are optional dicts merged over the
+template defaults. See the [altacv README](https://github.com/smur89/alta-typst#readme)
+for the full surface.
+
+### Handling validation errors yourself
+
+Each error is a record `(path: ("basics", "email"), message: "expected string, got integer.")`. A typical step-by-step is:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": validate, coerce
+
+#let raw = json("resume.json")
+#let errors = validate(raw)
+#if errors.len() > 0 {
+  [Resume has #errors.len() issue(s).]
+} else {
+  let model = coerce(raw)
+  // render model …
+}
+```
+<!-- x-release-please-end -->
+
+## Errors
+
+`validate` returns a list of `(path, message)` records — empty list
+means the input is valid. `parse` validates first and aborts compilation
+with a combined report on the first invocation that finds issues, so every
+problem in the document surfaces in one error:
+
+```text
+error: assertion failed: gairm-import: found 3 problems in the input:
+  - basics.email: expected string, got integer.
+  - work[0].positon: unknown key "positon". Did you mean "position"?
+  - meta.foo: unknown key "foo". Valid keys: canonical, version, lastModified.
+```
+
+When a typo is within edit distance 2 of a valid key, the message
+surfaces a short "Did you mean …?" hint; otherwise it falls back to
+the full valid-keys list shown for `meta.foo`.
+
+JSON `null` is treated as if the key were absent — no validation
+error, dropped from the coerced model. Null elements inside arrays
+are dropped the same way. This matches the convention used by most
+JSON Resume emitters, where `"summary": null` is semantically
+equivalent to omitting the key. Unknown keys are still flagged even
+when their value is `null`, so typos do not slip through silently.
+
+Root null is rejected: if the entire input document is `null`,
+`validate`, `coerce`, and `parse` panic with
+`gairm-import: input must be a dict, got null.` The null-as-absent
+policy applies to leaf positions inside a document, not to the
+document itself.
+
+## Two schemas
+
+The package exports two values of the canonical schema:
+
+- **`resume-schema`** — a faithful 1:1 translation of the vendored
+  upstream JSON Schema document. Every kind comes from the source;
+  nothing is rewritten. This is the default when you call
+  `parse(data)` / `validate(data)` / `coerce(data)`.
+- **`resume-schema-strict`** — adds two layered opinions on top via
+  the lens API:
+  - free-text fields (`basics.summary`, `work[].summary`,
+    `work[].highlights[]`, etc.) are typed as Typst `content` so
+    they splice directly into markup
+  - iso8601 `$ref` fields (`startDate`, `endDate`, …) are validated
+    as ISO-8601 dates (the upstream document doesn't carry a
+    `format` annotation on them, just a regex inside a definition)
+
+Pass `schema: resume-schema-strict` to opt in:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": parse, resume-schema-strict
+
+#let resume = parse(path("resume.json"), schema: resume-schema-strict)
+```
+<!-- x-release-please-end -->
+
+The faithful default is the source-of-truth view; the strict variant
+is a renderer-ergonomics overlay. If you want a different mix, build
+your own by lensing over `resume-schema` — see
+[Targeted edits with lenses](#targeted-edits-with-lenses).
+
+## Format validation
+
+Fields the canonical schema annotates with `format: "uri"`,
+`format: "email"`, or `format: "date"` are gated by a regex during
+`validate` / `parse`. The patterns are deliberately permissive —
+they reject obvious malformations without claiming full RFC
+compliance — and each emits a path-qualified message with a
+canonical example:
+
+```text
+basics.email:           expected an email (e.g. "name@example.com").
+basics.url:             expected a URI (e.g. "https://example.com").
+certificates[0].date:   expected an ISO-8601 date (e.g. "2024-01-15").
+```
+
+`format: "date-time"` is supported too via the `datetime-string` kind:
+the canonical JSON Resume document doesn't currently carry any
+`date-time` annotations, so the kind only fires when a caller
+translates their own JSON Schema with `schema-from-json-schema`, or
+lens-overrides a field. `date-string` accepts `YYYY` / `YYYY-MM` /
+`YYYY-MM-DD`; `datetime-string` requires the full `YYYY-MM-DDTHH:MM:SS`
+shape with an optional fractional component and an optional `Z` or
+`±HH:MM` offset. The two are separate kinds on purpose — widening the
+date regex to also match datetime values would mislabel pure-date fields.
+
+Most date fields in JSON Resume (`work[].startDate`, `awards[].date`,
+`meta.lastModified`, …) use `$ref: "#/definitions/iso8601"` rather
+than `format: "date"`. The translator can't pick formats up from a
+`$ref` alone, so those fields stay as plain `str` in `resume-schema`.
+Switch to `resume-schema-strict` to validate them as dates, or build
+your own override list with `lens-put(lens(path), schema, date-string)`.
+
+Coercion is pass-through: format-checked values flow through to the
+model as plain strings, so renderers receive
+`model.basics.email == "name@example.com"` unchanged.
+
+For ad-hoc constraints outside the four built-in formats, build a
+`pattern-string(re, expected: …)` and target it via a lens or splice it
+into an extension schema. JSON Schema's `pattern` keyword on a plain
+string maps to this kind too — see [Supported JSON Schema keywords](#starting-from-a-json-schema-document)
+for the precedence rule when both `format` and `pattern` are present:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": (
+  resume-schema, lens, lens-put, pattern-string,
+)
+
+// Gate basics.location.countryCode as an ISO 3166-1 alpha-2 code.
+#let with-country-code = lens-put(
+  lens(("basics", "location", "countryCode")),
+  resume-schema,
+  pattern-string(
+    "^[A-Z]{2}$",
+    expected: "an ISO 3166-1 alpha-2 code (e.g. \"US\")",
+  ),
+)
+```
+<!-- x-release-please-end -->
+
+Typst's regex `match` finds a match anywhere in the string, so anchor
+the pattern yourself if you need a full-string match — `^…$` is the
+common case.
+
+## Building an extension schema
+
+`parse` is strict against declared fields in the canonical schema:
+keys that aren't declared *and* aren't covered by an upstream
+`additionalProperties` clause are rejected. (Upstream JSON Resume
+sets `additionalProperties: true` on every section's items, so extras
+in those positions pass through — see the note in the BYO section.)
+Renderers that need their own fields (alta-typst's
+`preferences`, `labels`, `focusAreas`; numeric language `rating`; publication
+`type` grouping; …) can build a JSON-Resume+ schema with the public
+combinators and pass it to `parse` / `validate` / `coerce` via the
+`schema:` keyword:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": (
+  resume-schema, parse, object, array-of, str-type, content-type,
+)
+
+// Splice the canonical shape and add renderer-specific fields.
+#let altacv-schema = object((
+  ..resume-schema.shape,
+  preferences: object((
+    accent: str-type,
+    headerLayout: str-type,
+  )),
+  labels: object((
+    work: str-type,
+    education: str-type,
+  )),
+  focusAreas: array-of(content-type),
+))
+
+#let model = parse(path("resume.json"), schema: altacv-schema)
+// render model with the renderer's own theme…
+```
+<!-- x-release-please-end -->
+
+When to reach for which API:
+
+- **`parse(data)`** — one call, aborts compilation with a combined report on
+  validation issues. Defaults to the canonical schema; pass `schema: …` to use
+  an extension.
+- **`validate(data)` / `coerce(data)`** — return data instead of aborting, so
+  you can present errors yourself (see the [step-by-step above](#handling-validation-errors-yourself)).
+  Same `schema:` default.
+
+`resume-schema.shape` is a plain dict, so `..resume-schema.shape` is the only
+operator you need to extend it. Per-section combinators (`work-item`,
+`volunteer-item`, …) are intentionally not exposed yet — splice the canonical
+top-level fields whole and add your own siblings.
+
+### Targeted edits with lenses
+
+Splicing `..resume-schema.shape` works for top-level additions but is awkward
+when the field you want to touch is three or four levels deep (`work` items'
+`highlights` element schema, `basics.email`, …). For those cases, lenses target
+a path inside the schema and return a new schema with the targeted node
+replaced or transformed:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": (
+  resume-schema, lens, lens-put, lens-over, add-field,
+  set-required, unset-required,
+  str-type, content-type, number-type, object,
+)
+
+// Widen basics.summary from content (rich) to str (plain) — useful if
+// you want the summary rendered as plain text instead of formatted:
+#let plain-summary = lens-put(
+  lens(("basics", "summary")), resume-schema, str-type,
+)
+
+// Add a numeric `rating` to every language entry — touches
+// resume-schema.shape.languages.elem.shape without re-spelling the wrapper:
+#let with-rating = add-field(
+  resume-schema, lens(("languages", "items")), "rating", number-type,
+)
+
+// Transform an existing node with a function:
+#let with-extra-meta = lens-over(
+  lens(("meta",)),
+  resume-schema,
+  meta => object((..meta.shape, source: str-type)),
+)
+
+// Make basics.name and basics.email required for your template
+// (canonical schema declares no required keys):
+#let strict-basics = set-required(
+  resume-schema, lens(("basics",)), ("name", "email"),
+)
+
+// Relax email back without re-spelling the rest of the required list:
+#let mixed-basics = unset-required(
+  strict-basics, lens(("basics",)), ("email",),
+)
+```
+<!-- x-release-please-end -->
+
+Path segments match JSON Schema keyword names: object keys as strings,
+the literal `"items"` to enter an array's element schema, and the
+literal `"additionalProperties"` to enter an object's `additional` (the
+additionalProperties schema; only valid when `additional` is a schema
+dict, not `true`). Composition (`lens-then(a, b)`) concatenates paths,
+so `lens-then(lens(("work",)), lens(("items", "highlights")))` is the
+same lens as `lens(("work", "items", "highlights"))`. The empty path
+`lens(())` is the identity lens.
+
+Operations:
+
+| Function | Shape | Behaviour |
+|---|---|---|
+| `lens(path)` | `path → lens` | Construct a lens from a path tuple |
+| `lens-get(l, schema)` | `lens, schema → sub-schema` | Read the targeted node |
+| `lens-put(l, schema, value)` | `lens, schema, sub → schema` | Replace the targeted node |
+| `lens-over(l, schema, fn)` | `lens, schema, (sub → sub) → schema` | Apply a function to the targeted node |
+| `lens-then(a, b)` | `lens, lens → lens` | Compose two lenses (path concatenation) |
+| `add-field(schema, parent, key, sub)` | … → schema | Add a key to the object at `parent` |
+| `remove-field(schema, parent, key)` | … → schema | Remove a key from the object at `parent` |
+| `set-required(schema, parent, keys)` | … → schema | Replace the object's `required-keys` list at `parent` |
+| `unset-required(schema, parent, keys)` | … → schema | Drop specific entries from the object's `required-keys` list at `parent` |
+
+Operations are functional — every `lens-put` / `lens-over` / `add-field` /
+`remove-field` / `set-required` / `unset-required` returns a NEW schema and leaves the input untouched, so you
+can build an extension schema by chaining edits without disturbing the
+canonical one. (Operations are top-level functions rather than methods because
+Typst parses `lens.put(…)` as a type-method lookup, not a closure call.)
+
+### Inspecting a schema
+
+When an extension schema misbehaves, `describe-schema`, `paths-of-kind`,
+and `kind-at` answer the three usual questions — *what does this thing
+look like?*, *where do my date strings live?*, *what kind is at this
+path?* — without `repr(schema)` or hand-walking `.shape`:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": (
+  resume-schema-strict, describe-schema, paths-of-kind, kind-at,
+)
+
+// Tree view of every leaf, with array sections suffixed `[]`.
+#describe-schema(resume-schema-strict)
+// basics:
+//   email    email-string
+//   name     str
+//   summary  content
+//   …
+// work[]:
+//   highlights[]  content
+//   startDate     date-string
+//   …
+
+// Every lens-compatible path whose terminal kind matches.
+#paths-of-kind(resume-schema-strict, "date-string")
+// → (("work", "items", "startDate"), …)
+
+// Kind at a single path — thin wrapper over lens-get.
+#kind-at(resume-schema-strict, ("basics", "summary"))  // "content"
+```
+<!-- x-release-please-end -->
+
+Array segments in returned path tuples use `"items"` so they plug
+straight into `lens(path)`; the `[]` suffix in `describe-schema`'s
+output is human-friendly visual only. Keys sort alphabetically so
+diffs across schema versions stay stable.
+
+The real leverage comes from folding `paths-of-kind` together with
+`lens-put` to bulk-edit every field of a kind in one pass — the list
+of paths is derived from the schema, so new fields an upstream JSON
+Resume bump introduces are covered automatically:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": (
+  resume-schema, paths-of-kind, lens, lens-put, pattern-string,
+)
+
+// Tighten every uri-string field to a corporate-domain pattern,
+// without enumerating the paths by hand.
+#let corporate-uri = pattern-string(
+  "^https://(corp|docs)\.example\.com/",
+  expected: "a corporate URL",
+)
+#let corporate-schema = paths-of-kind(resume-schema, "uri-string").fold(
+  resume-schema,
+  (schema, path) => lens-put(lens(path), schema, corporate-uri),
+)
+```
+<!-- x-release-please-end -->
+
+### JSON Pointer interop
+
+Lens paths and validator error paths are `(seg, seg, ...)` tuples — natural in Typst but they don't directly interoperate with external tooling that speaks [RFC 6901 JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) (editor extensions for schema-aware completion, schema diff tools, JSON Schema documentation generators, …). `path-to-pointer` / `pointer-to-path` cross the boundary:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": path-to-pointer, pointer-to-path
+
+#path-to-pointer(("basics", "email"))            // "/basics/email"
+#path-to-pointer(("work", 0, "highlights", 1))   // "/work/0/highlights/1"
+#path-to-pointer(("a/b",))                       // "/a~1b"     — `/` escapes as `~1`
+#path-to-pointer(("~tilde",))                    // "/~0tilde"  — `~` escapes as `~0`
+
+#pointer-to-path("/work/0/highlights/1")         // ("work", 0, "highlights", 1)
+#pointer-to-path("")                             // ()          — whole document
+#pointer-to-path("/")                            // ("",)       — empty-string key at root
+```
+<!-- x-release-please-end -->
+
+**Two addressing schemes share the same encoder** — pick the right one for your use case:
+
+- **Validator error paths** (mixed `str` / non-negative `int`) address into **data**. The output is a real RFC 6901 JSON Pointer that any JSON-Pointer-aware tool can dereference against the resume / data document.
+- **Lens and introspect paths** (`str`-only, with `"items"` for array elements and `"additionalProperties"` for the additional schema) address into the **schema**. The output is a JSON-Pointer-shaped string that names a schema location — meaningful to JSON Schema tooling that uses JSON Pointer in `$ref` (e.g. `#/properties/foo/items`), but **not** a data pointer.
+
+Encoding accepts `str` (object key) or `int` (non-negative — RFC 6901's array-index ABNF) segments; other types and negative ints panic. Decoding parses tokens matching that ABNF (`0` | `[1-9][0-9]*`) back to `int`; everything else stays `str`. Malformed `~` escapes (bare `~`, `~2`, `~<other>`) panic at decode rather than silently passing through.
+
+**Round-trip directions are asymmetric:**
+
+- `pointer → path → pointer` is **lossless** for any well-formed pointer.
+- `path → pointer → path` is lossless **except** when a `str` segment looks like an array index — `("0",)` decodes back as `(0,)`. In practice the validator and lens code never emit numeric strings, so this isn't a concern.
+
+### Starting from a JSON Schema document
+
+`schema-from-json-schema(parsed-schema)` translates a JSON Schema (draft 7
+subset) into a Typst schema dict. Use it when you already have an authoritative
+`.json` schema and don't want to keep a parallel Typst copy in sync:
+
+<!-- x-release-please-start-version -->
+```typst
+#import "@preview/gairm-import:0.8.0": (
+  schema-from-json-schema, coerce, object, array-of, content-type,
+)
+
+#let canonical = schema-from-json-schema(path("resume-schema.json"))
+#let altacv-schema = object((
+  ..canonical.shape,
+  focusAreas: array-of(content-type),
+))
+
+#let model = coerce(json("resume.json"), schema: altacv-schema)
+```
+<!-- x-release-please-end -->
+
+Supported JSON Schema keywords: `type` (`string`/`number`/`integer`/`array`/
+`object`/`boolean`/`null`), `format` (`uri` → `uri-string`, `email` → `email-string`,
+`date` → `date-string`, `date-time` → `datetime-string`),
+`pattern` → `pattern-string` (on plain string schemas only — when both
+`format` and `pattern` are present on the same node, `format` wins and
+`pattern` is dropped; compose two gates yourself via a lens if you
+need both), `enum` → `enum-of`, `const` → `const-of`,
+`properties`, `required`, `items`, internal `$ref`
+(`#/definitions/…` / `#/$defs/…`), `type: [X, "null"]` nullable unions
+(under the engine's null-as-absent policy these translate to plain `X`),
+constraint keywords on strings (`minLength` / `maxLength`), numbers
+(`minimum` / `maximum` / `exclusiveMinimum` / `exclusiveMaximum` /
+`multipleOf`), and arrays (`minItems` / `maxItems` / `uniqueItems`)
+— baked onto the kind dict as kebab-case fields and validated
+inline — and `additionalProperties` (a schema, `true`, or `false`
+— `false` matches the strict default; `true` permits extras without
+validation; a schema validates every extra against it, also reachable
+via the `map(value-schema)` combinator).
+Out of scope: `allOf` / `anyOf` / `oneOf` / `not`,
+`if` / `then` / `else`, `dependencies` (and the `dependentRequired` /
+`dependentSchemas` variants), `type: "object"` with neither `properties`
+nor `additionalProperties` (fully open),
+`type: [...]` unions with more than one non-null member, external `$ref`,
+and string formats other than the four listed above — every one of these
+panics with a clear "unsupported" message rather than silently dropping
+the constraint.
+
+A note on the canonical `resume-schema` and `additionalProperties`:
+the upstream JSON Resume document declares `additionalProperties: true`
+on every section's items, so the canonical schema accepts extras at
+runtime even though the README's headline framing is "strict". Strict
+applies to declared fields; `additionalProperties: true` from upstream
+is honoured. If you need stricter behaviour, use `resume-schema-strict`
+— it recursively strips `additional: true` from every nested object,
+restoring the "unknown keys are rejected" promise (typed extras
+declared via `additionalProperties: <schema>` are kept).
+
+## Scope
+
+The canonical surface — `parse`, `validate`, `coerce` —
+implements **only** the [JSON Resume schema](https://jsonresume.org/schema) and
+rejects unknown fields. Renderer-specific extensions are layered on top by the
+consuming template via the BYO API above; requests for renderer-specific
+fields in the canonical schema itself will be redirected to the relevant
+template repo.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Releases are cut by
+[release-please](https://github.com/googleapis/release-please) from
+conventional-commit titles on `main`.
+
+## License
+
+[MIT](LICENSE).

--- a/packages/preview/gairm-import/0.8.0/internal/assets/jsonresume-schema.json
+++ b/packages/preview/gairm-import/0.8.0/internal/assets/jsonresume-schema.json
@@ -1,0 +1,500 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "iso8601": {
+      "type": "string",
+      "description": "e.g. 2014-06-29",
+      "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "link to the version of the schema that can validate the resume",
+      "format": "uri"
+    },
+    "basics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "e.g. Web Developer"
+        },
+        "image": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
+        },
+        "email": {
+          "type": "string",
+          "description": "e.g. thomas@gmail.com",
+          "format": "email"
+        },
+        "phone": {
+          "type": "string",
+          "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+          "format": "uri"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Write a short 2-3 sentence biography about yourself"
+        },
+        "location": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
+            },
+            "postalCode": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+            },
+            "region": {
+              "type": "string",
+              "description": "The general region where you live. Can be a US state, or a province, for instance."
+            }
+          }
+        },
+        "profiles": {
+          "type": "array",
+          "description": "Specify any number of social networks that you participate in",
+          "additionalItems": false,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "network": {
+                "type": "string",
+                "description": "e.g. Facebook or Twitter"
+              },
+              "username": {
+                "type": "string",
+                "description": "e.g. neutralthoughts"
+              },
+              "url": {
+                "type": "string",
+                "description": "e.g. http://twitter.example.com/neutralthoughts",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      }
+    },
+    "work": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "location": {
+            "type": "string",
+            "description": "e.g. Menlo Park, CA"
+          },
+          "description": {
+            "type": "string",
+            "description": "e.g. Social Media Company"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple accomplishments",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "volunteer": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "organization": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify accomplishments and achievements",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "education": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "institution": {
+            "type": "string",
+            "description": "e.g. Massachusetts Institute of Technology"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://facebook.example.com",
+            "format": "uri"
+          },
+          "area": {
+            "type": "string",
+            "description": "e.g. Arts"
+          },
+          "studyType": {
+            "type": "string",
+            "description": "e.g. Bachelor"
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "score": {
+            "type": "string",
+            "description": "grade point average, e.g. 3.67/4.0"
+          },
+          "courses": {
+            "type": "array",
+            "description": "List notable courses/subjects",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. H1302 - Introduction to American history"
+            }
+          }
+        }
+      }
+    },
+    "awards": {
+      "type": "array",
+      "description": "Specify any awards you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "e.g. One of the 100 greatest minds of the century"
+          },
+          "date": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "awarder": {
+            "type": "string",
+            "description": "e.g. Time Magazine"
+          },
+          "summary": {
+            "type": "string",
+            "description": "e.g. Received for my work with Quantum Physics"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "type": "array",
+      "description": "Specify any certificates you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Certified Kubernetes Administrator"
+          },
+          "date": {
+            "type": "string",
+            "description": "e.g. 1989-06-12",
+            "format": "date"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://example.com",
+            "format": "uri"
+          },
+          "issuer": {
+            "type": "string",
+            "description": "e.g. CNCF"
+          }
+        }
+      }
+    },
+    "publications": {
+      "type": "array",
+      "description": "Specify your publications through your career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "e.g. IEEE, Computer Magazine"
+          },
+          "releaseDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html",
+            "format": "uri"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "List out your professional skill-set",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Web Development"
+          },
+          "level": {
+            "type": "string",
+            "description": "e.g. Master"
+          },
+          "keywords": {
+            "type": "array",
+            "description": "List some keywords pertaining to this skill",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. HTML"
+            }
+          }
+        }
+      }
+    },
+    "languages": {
+      "type": "array",
+      "description": "List any other languages you speak",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "e.g. English, Spanish"
+          },
+          "fluency": {
+            "type": "string",
+            "description": "e.g. Fluent, Beginner"
+          }
+        }
+      }
+    },
+    "interests": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Philosophy"
+          },
+          "keywords": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Friedrich Nietzsche"
+            }
+          }
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "List references you have received",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Timothy Cook"
+          },
+          "reference": {
+            "type": "string",
+            "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+          }
+        }
+      }
+    },
+    "projects": {
+      "type": "array",
+      "description": "Specify career projects",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short summary of project. e.g. Collated works of 2017."
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple features",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Directs you close but not quite there"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "description": "Specify special elements involved",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. AngularJS"
+            }
+          },
+          "startDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "endDate": {
+            "$ref": "#/definitions/iso8601"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Specify your role on this project or in company",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Team Lead, Speaker, Writer"
+            }
+          },
+          "entity": {
+            "type": "string",
+            "description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
+          },
+          "type": {
+            "type": "string",
+            "description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "The schema version and any other tooling configuration lives here",
+      "additionalProperties": true,
+      "properties": {
+        "canonical": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to latest version of this document",
+          "format": "uri"
+        },
+        "version": {
+          "type": "string",
+          "description": "A version field which follows semver - e.g. v1.0.0"
+        },
+        "lastModified": {
+          "type": "string",
+          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+        }
+      }
+    }
+  },
+  "title": "Resume Schema",
+  "type": "object"
+}

--- a/packages/preview/gairm-import/0.8.0/internal/coerce.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/coerce.typ
@@ -1,0 +1,98 @@
+// Assumes input has passed _validate. Unknown keys are dropped
+// silently rather than panicking; top-of-branch type checks catch
+// shape mismatches from direct callers who skipped validation.
+// assert(false, ...) over panic(...) for newline-preserving
+// diagnostics if these messages ever go multi-line.
+//
+// JSON `null` (Typst's `none`) at a value position is treated as if
+// the key were absent: it returns `none` from the per-value call so
+// the parent's object-pair filter or array-element filter drops it.
+// Downstream renderers see "key not in dict" instead of a stray
+// `none` value to special-case.
+//
+// An object whose every key coerced to none is itself coerced to
+// `none` (rather than an empty dict). That propagates "every key was
+// null" upward so the parent filter drops the object too — symmetric
+// with the leaf-null policy. Applied recursively, a resume whose only
+// section is itself all-null collapses all the way to `none` — the
+// consistent extension of the policy. Public callers go through the
+// lib.typ wrappers, which reject a null root explicitly so this
+// collapse never surprises a direct user of the engine.
+
+#import "errors.typ": _type-name-of
+
+#let _expect(expected, value) = (
+  "gairm-import: coerce expected " + expected + ", got " +
+    _type-name-of(value) + ". Run validate(data) first."
+)
+
+#let _coerce(schema, value) = {
+  // Null at any value position is "key absent". The parent (object
+  // or array branch below) is responsible for filtering this out.
+  if value == none { return none }
+  let kind = schema.kind
+  if kind == "content" {
+    assert(type(value) == str, message: _expect("a string", value))
+    return [#value]
+  }
+  // Format-specialised string kinds pass through identically to `str`
+  // — the regex gate fires in _validate, not here.
+  if kind in ("str", "date-string", "datetime-string", "uri-string", "email-string", "pattern-string") {
+    assert(type(value) == str, message: _expect("a string", value))
+    return value
+  }
+  if kind == "number" {
+    assert(type(value) in (int, float), message: _expect("a number", value))
+    return value
+  }
+  if kind == "bool" {
+    assert(type(value) == bool, message: _expect("a boolean", value))
+    return value
+  }
+  // Unreachable on validated input — top early return handles `none`,
+  // the only legal value.
+  if kind == "null" {
+    assert(false, message: _expect("null", value))
+  }
+  // Members are polymorphic — no single type to assert. Mirror the
+  // validator's membership check so direct-coerce callers fail loud.
+  if kind == "enum" {
+    assert(
+      value in schema.values,
+      message: _expect(
+        "one of " + schema.values.map(repr).join(", "),
+        value,
+      ),
+    )
+    return value
+  }
+  if kind == "array" {
+    assert(type(value) == array, message: _expect("an array", value))
+    // Drop null elements: a null in an array of strings would
+    // otherwise surface as a stray `none` to downstream renderers.
+    return value.map(elem => _coerce(schema.elem, elem)).filter(e => e != none)
+  }
+  if kind == "object" {
+    assert(type(value) == dictionary, message: _expect("an object", value))
+    let additional = schema.at("additional", default: none)
+    let coerced = value.pairs()
+      .filter(((key, _)) => key in schema.shape or additional != none)
+      .map(((key, sub-value)) => {
+        let sub = if key in schema.shape {
+          _coerce(schema.shape.at(key), sub-value)
+        } else if additional == true {
+          // `additionalProperties: true` — pass through; validate.typ
+          // mirrors this by returning `()` (no validation).
+          sub-value
+        } else {
+          _coerce(additional, sub-value)
+        }
+        (key, sub)
+      })
+      .filter(((_, coerced)) => coerced != none)
+      .to-dict()
+    if coerced.len() == 0 { return none }
+    return coerced
+  }
+  panic("gairm-import: internal — unknown schema kind " + repr(kind))
+}

--- a/packages/preview/gairm-import/0.8.0/internal/errors.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/errors.typ
@@ -1,0 +1,74 @@
+// Empty path renders as "<root>" so a top-level type error reads
+// `"<root>: expected object, got …"`.
+#let _format-path(parts) = {
+  if parts.len() == 0 { return "<root>" }
+  parts.enumerate().map(((i, part)) => {
+    if type(part) == int { "[" + str(part) + "]" }
+    else if i == 0 { part }
+    else { "." + part }
+  }).join("")
+}
+
+// Typst's `repr(type(...))` renders as `"int"` / `"dictionary"` /
+// `"type(none)"` — accurate but jarring. Translate to JSON-shaped
+// names for user-facing messages; unknown reprs fall through.
+#let _type-names = (
+  str: "string",
+  int: "integer",
+  float: "number",
+  bool: "boolean",
+  array: "array",
+  dictionary: "object",
+)
+
+// The `none` branch is defensive: the validator's null-as-absent rule
+// means _type-error never sees a null value today, but _type-name-of is
+// a general helper that may be reused by future code paths.
+#let _type-name-of(value) = {
+  if value == none { return "null" }
+  let raw = repr(type(value))
+  _type-names.at(raw, default: raw)
+}
+
+#let _format-report(errors) = {
+  let n = errors.len()
+  let noun = if n == 1 { "problem" } else { "problems" }
+  let lines = errors.map(e => "  - " + _format-path(e.path) + ": " + e.message)
+  "gairm-import: found " + str(n) + " " + noun + " in the input:\n" + lines.join("\n")
+}
+
+// Classic two-row Levenshtein edit distance. We fold over the
+// characters of `a`, carrying the previous DP row and producing the
+// next. Each new row is itself built by folding over the characters
+// of `b`, since cell `(i, j)` depends on `(i-1, j)`, `(i, j-1)` and
+// `(i-1, j-1)`. The base row is `0..n` (cost of deleting `j` chars
+// from `b` to reach the empty prefix of `a`).
+#let _edit-distance(a, b) = {
+  let ac = a.clusters()
+  let bc = b.clusters()
+  let n = bc.len()
+  let final-row = ac.enumerate().fold(range(0, n + 1), (prev, (i, ca)) => {
+    bc.enumerate().fold((i + 1,), (row, (j, cb)) => {
+      let cost = if ca == cb { 0 } else { 1 }
+      row + (calc.min(
+        prev.at(j + 1) + 1,  // deletion
+        row.at(j) + 1,       // insertion
+        prev.at(j) + cost,   // substitution
+      ),)
+    })
+  })
+  final-row.at(n)
+}
+
+// Pure: pick the candidate closest to `target` by edit distance, or
+// `none` if the best is outside `max-distance` (inclusive) or
+// `candidates` is empty. Single-pass fold — strict `<` keeps the
+// first-seen winner on ties, so the schema's declaration order
+// decides equidistant matches.
+#let _closest-match(target, candidates, max-distance) = {
+  let best = candidates.fold(none, (acc, c) => {
+    let d = _edit-distance(target, c)
+    if acc == none or d < acc.distance { (key: c, distance: d) } else { acc }
+  })
+  if best != none and best.distance <= max-distance { best.key } else { none }
+}

--- a/packages/preview/gairm-import/0.8.0/internal/introspect.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/introspect.typ
@@ -1,0 +1,145 @@
+// Schema-shape inspection helpers. Debugging an extension schema
+// otherwise means `repr(schema)` (noisy dict dump) or hand-walking
+// `.shape` accessors. Introspection here stays read-only; edits live
+// in lens.typ.
+//
+// Path tuples use lens-compatible segments — `"items"` for array
+// descent, `"additionalProperties"` for the additional schema — so
+// `paths-of-kind` output round-trips through `lens` and `lens-get`.
+// The `[]` suffix and the `*` row in `describe-schema` are
+// display-only (`*` is the conventional shorthand for "any key").
+
+#import "lens.typ": lens, lens-get
+
+#let _leaf-kinds = (
+  "str", "content", "number", "bool", "null",
+  "date-string", "datetime-string", "uri-string", "email-string", "pattern-string",
+  "enum",
+)
+
+// Alphabetical pair ordering — diff-stable output regardless of
+// dictionary insertion order in the source.
+#let _sorted-pairs(d) = d.pairs().sorted(key: p => p.at(0))
+
+// enum nodes carry their values inline for at-a-glance debugging;
+// every other kind name speaks for itself.
+#let _leaf-suffix(sub) = if sub.kind == "enum" {
+  "enum (" + sub.values.map(repr).join(", ") + ")"
+} else {
+  sub.kind
+}
+
+#let _pad-right(s, width) = s + " " * (width - s.len())
+
+// Returns the column-key (with `[]` suffix for array-of-leaf) for an
+// inline-rendered child, or `none` for children that emit their own
+// header line and don't contribute to the kind-column width.
+#let _column-key(key, sub) = {
+  if sub.kind == "object" { none }
+  else if sub.kind == "array" and sub.elem.kind in ("object", "array") { none }
+  else if sub.kind == "array" { key + "[]" }
+  else { key }
+}
+
+// One line for (key, sub) when sub is a leaf or array-of-leaf;
+// `none` for object / array-of-object/array since those emit their
+// own header line. Pulled out so the additional-key `"*"` path can
+// share the same rendering.
+#let _render-leaf-line(key, sub, indent, col) = {
+  if sub.kind == "array" and sub.elem.kind not in ("object", "array") {
+    indent + _pad-right(key + "[]", col) + _leaf-suffix(sub.elem)
+  } else if sub.kind not in ("object", "array") {
+    indent + _pad-right(key, col) + _leaf-suffix(sub)
+  } else {
+    none
+  }
+}
+
+// Recursive pretty-printer. `indent` prefixes every line at this
+// depth; nested children add two more spaces. `additional` is
+// rendered after the shape pairs, with key "*" (lens-compatible).
+#let _describe(schema, indent) = {
+  if schema.kind == "object" {
+    let pairs = _sorted-pairs(schema.shape)
+    let additional = schema.at("additional", default: none)
+    // `*` is the display-only key shown for the additional-schema row
+    // (lens-addressing uses "additionalProperties"). `(kind: "any")`
+    // is a display-only sentinel for `additional: true` — not a real
+    // engine kind, recognised by the leaf branch below and nowhere
+    // else.
+    let additional-pair = if additional == true {
+      ("*", (kind: "any"))
+    } else if type(additional) == dictionary {
+      ("*", additional)
+    } else {
+      none
+    }
+    let all-pairs = if additional-pair != none { pairs + (additional-pair,) } else { pairs }
+    let column-keys = all-pairs.map(((k, s)) => _column-key(k, s)).filter(k => k != none)
+    let col = if column-keys.len() == 0 { 0 } else {
+      calc.max(..column-keys.map(k => k.len())) + 2
+    }
+    let lines = all-pairs.map(((key, sub)) => {
+      if sub.kind == "object" {
+        indent + key + ":\n" + _describe(sub, indent + "  ")
+      } else if sub.kind == "array" and sub.elem.kind in ("object", "array") {
+        indent + key + "[]:\n" + _describe(sub.elem, indent + "  ")
+      } else if sub.kind == "any" {
+        // `additional: true` — print as a synthetic "any" leaf.
+        indent + _pad-right(key, col) + "any"
+      } else {
+        _render-leaf-line(key, sub, indent, col)
+      }
+    })
+    if lines.len() == 0 { "" } else { lines.join("\n") }
+  } else if schema.kind == "array" {
+    if schema.elem.kind in ("object", "array") {
+      indent + "[]:\n" + _describe(schema.elem, indent + "  ")
+    } else {
+      indent + "[] " + _leaf-suffix(schema.elem)
+    }
+  } else {
+    indent + _leaf-suffix(schema)
+  }
+}
+
+#let describe-schema(schema) = _describe(schema, "")
+
+// Collect every path whose terminal kind matches `kind-name`.
+// Walks `additional` when it's a schema dict (typed extras), using
+// the `"*"` segment so the path round-trips through lens.
+#let _walk-paths(schema, path, kind-name) = {
+  if schema.kind == "object" {
+    let shape-paths = _sorted-pairs(schema.shape)
+      .map(((key, sub)) => _walk-paths(sub, path + (key,), kind-name))
+      .fold((), (acc, ps) => acc + ps)
+    let additional = schema.at("additional", default: none)
+    let additional-paths = if type(additional) == dictionary {
+      _walk-paths(additional, path + ("additionalProperties",), kind-name)
+    } else { () }
+    shape-paths + additional-paths
+  } else if schema.kind == "array" {
+    _walk-paths(schema.elem, path + ("items",), kind-name)
+  } else if schema.kind == kind-name {
+    (path,)
+  } else {
+    ()
+  }
+}
+
+// Container kinds (`object`, `array`) are deliberately rejected — the
+// walker descends through them, so accepting them would silently
+// return () for every call and mask the typo.
+#let paths-of-kind(schema, kind-name) = {
+  assert(
+    kind-name in _leaf-kinds,
+    message: "gairm-import: paths-of-kind kind-name " + repr(kind-name) +
+      " is not a recognised leaf kind. Expected one of: " +
+      _leaf-kinds.join(", ") + ".",
+  )
+  _walk-paths(schema, (), kind-name)
+}
+
+// Thin wrapper over `lens-get(lens(path), schema).kind` — keeps the
+// common "what kind is at X" debugging step a single call.
+#let kind-at(schema, path) = lens-get(lens(path), schema).kind

--- a/packages/preview/gairm-import/0.8.0/internal/json-pointer.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/json-pointer.typ
@@ -1,0 +1,101 @@
+// RFC 6901 JSON Pointer interop. Path tuples used by lenses
+// (`("basics", "email")`) and validator error reports (`("work",
+// 0, "highlights", 1)`) <-> the "/basics/email" / "/work/0/
+// highlights/1" form external tooling (editor extensions, schema
+// linters, JSON Schema doc generators) expects.
+//
+// Two addressing schemes share the same encoder:
+//   - Validator error paths: address INTO data (mixed str|int,
+//     with non-negative ints for array indices). Encodes to a real
+//     RFC 6901 JSON Pointer that a data-aware tool can dereference.
+//   - Lens / introspect paths: address INTO a schema (str-only,
+//     with `"items"` for array elements and `"additionalProperties"`
+//     for the additional schema). Encodes to a JSON-Pointer-shaped
+//     string that addresses a schema position — meaningful to JSON
+//     Schema tooling that uses JSON Pointer in `$ref` (e.g.
+//     `#/properties/foo/items`), but NOT a data pointer.
+// The encoder doesn't distinguish; the caller picks the right
+// addressing scheme for the path they have.
+//
+// Encoding accepts str (object key) or int (non-negative array
+// index) segments; other types and negative ints panic. Decoding
+// parses tokens matching JSON Pointer's array-index ABNF (`0` |
+// `[1-9][0-9]*`) back to int; everything else stays str.
+//
+// Round-trip directions are asymmetric:
+//   - pointer → path → pointer is lossless for any well-formed
+//     pointer (the new path's segment types are determined by the
+//     decode regex, and the encoder reproduces the same bytes).
+//   - path → pointer → path is lossless EXCEPT when a str segment
+//     looks like an array index (e.g. `("0",)` decodes back as
+//     `(0,)`). Validator + lens code never emit numeric strings, so
+//     this isn't a concern in practice.
+
+// Order matters: `~1` → `/` first would let an `~1` token round-
+// trip wrong (e.g. `~01` should decode to `~1`, not `/0`). Encode
+// `~` first so subsequent `/` encodes don't see the new `~0` we
+// just introduced. Decode mirrors: `~1` before `~0`.
+#let _escape-token(s) = s.replace("~", "~0").replace("/", "~1")
+
+// RFC 6901 only defines two escape sequences: `~0` and `~1`. A
+// bare `~` or any `~<other>` is malformed and rejected — silently
+// passing it through would mask round-trip bugs in callers.
+#let _invalid-escape-re = regex("~($|[^01])")
+#let _unescape-token(s) = {
+  if s.match(_invalid-escape-re) != none {
+    panic(
+      "gairm-import: pointer-to-path got an invalid escape sequence in token: "
+        + repr(s) + ". RFC 6901 only allows `~0` (tilde) and `~1` (slash)."
+    )
+  }
+  s.replace("~1", "/").replace("~0", "~")
+}
+
+// RFC 6901 array-index ABNF: `0` | `[1-9][0-9]*` — leading zeros
+// (other than "0" itself) aren't valid array indices, so e.g. "01"
+// round-trips as the string "01" rather than becoming int 1.
+#let _int-token-re = regex("^(0|[1-9][0-9]*)$")
+#let _try-int(token) = if token.match(_int-token-re) != none { int(token) } else { token }
+
+// Convert a path tuple to an RFC 6901 JSON Pointer string. Empty
+// path → empty string (whole-document reference per spec).
+#let path-to-pointer(path) = {
+  if path.len() == 0 { return "" }
+  let parts = path.map(seg => {
+    if type(seg) == str { _escape-token(seg) }
+    else if type(seg) == int {
+      // RFC 6901 array-index ABNF is non-negative only — emitting
+      // "/-1" would round-trip back to the string "-1" (regex
+      // rejects the minus sign), silently breaking the round-trip
+      // property the README promises.
+      if seg < 0 {
+        panic(
+          "gairm-import: path-to-pointer expected a non-negative integer "
+            + "(RFC 6901 array indices), got: " + str(seg) + "."
+        )
+      }
+      str(seg)
+    }
+    else {
+      panic(
+        "gairm-import: path-to-pointer expected a str or int segment, got: "
+          + repr(seg) + " (" + repr(type(seg)) + ")."
+      )
+    }
+  })
+  "/" + parts.join("/")
+}
+
+// Inverse. Empty string → empty path. A bare "/" decodes to a
+// single empty-string segment (RFC 6901: "/" means "the empty
+// string key at root"). Otherwise the pointer must start with "/".
+#let pointer-to-path(pointer) = {
+  if pointer == "" { return () }
+  if not pointer.starts-with("/") {
+    panic(
+      "gairm-import: pointer-to-path expected \"\" or a pointer starting with \"/\", got: "
+        + repr(pointer) + "."
+    )
+  }
+  pointer.slice(1).split("/").map(_unescape-token).map(_try-int)
+}

--- a/packages/preview/gairm-import/0.8.0/internal/json-schema.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/json-schema.typ
@@ -1,0 +1,279 @@
+// JSON Schema (draft 7 subset) → Typst-schema translator. Anything
+// not supported panics rather than silently dropping the constraint.
+
+#import "kinds.typ": (
+  str-type, content-type, number-type, bool-type, null-type,
+  array-of, object,
+  date-string, datetime-string, uri-string, email-string, pattern-string,
+  enum-of, const-of,
+)
+
+#let _format-kinds = (
+  "uri": uri-string,
+  "email": email-string,
+  "date": date-string,
+  "date-time": datetime-string,
+)
+
+// One panic prefix so every diagnostic from this module is grep-able
+// by "schema-from-json-schema —".
+#let _bail(msg) = panic("gairm-import: schema-from-json-schema — " + msg)
+
+// `seen` is the chain of refs traversed so far; a repeat means a
+// cycle (e.g. `definitions.alias → alias`) — panic before Typst's
+// recursion limit fires deep in the stack.
+#let _resolve-ref(ref, root, seen) = {
+  if not ref.starts-with("#/") {
+    _bail("only internal $ref (starting with \"#/\") is supported, got: " + repr(ref) + ".")
+  }
+  if ref in seen {
+    _bail("cyclic $ref detected: " + seen.map(repr).join(" → ") + " → " + repr(ref) + ".")
+  }
+  if ref == "#/" {
+    _bail("$ref \"#/\" cannot reference the document root.")
+  }
+  let parts = ref.slice(2).split("/").filter(p => p != "")
+  parts.fold(root, (acc, key) => {
+    if type(acc) != dictionary or key not in acc {
+      _bail("$ref " + repr(ref) + " could not be resolved (segment " + repr(key) + " missing).")
+    }
+    acc.at(key)
+  })
+}
+
+#let _unsupported-keywords = (
+  "allOf", "anyOf", "oneOf", "not",
+  "if", "then", "else",
+  "dependencies", "dependentRequired", "dependentSchemas",
+)
+
+// Bail at translate time on bad-shape values; better than a kind
+// dict the validator can't reason about.
+#let _require-nonneg-int(js, key) = {
+  let v = js.at(key)
+  if type(v) != int or v < 0 {
+    _bail(repr(key) + " must be a non-negative integer, got: " + repr(v) + ".")
+  }
+  v
+}
+
+#let _require-number(js, key) = {
+  let v = js.at(key)
+  if type(v) not in (int, float) {
+    _bail(repr(key) + " must be a number, got: " + repr(v) + ".")
+  }
+  v
+}
+
+// Cross-constraint contradictions (min > max, etc.) translate cleanly
+// but reject every input — catch them up front so the diagnostic
+// fires at translate time, not as a mystery validation failure.
+#let _require-ordered(lower-key, lower, upper-key, upper, sep) = {
+  if lower != none and upper != none and not (lower <= upper) {
+    _bail(
+      lower-key + " (" + repr(lower) + ") " + sep + " " +
+        upper-key + " (" + repr(upper) + ") is unsatisfiable.",
+    )
+  }
+}
+#let _require-strict(lower-key, lower, upper-key, upper) = {
+  if lower != none and upper != none and not (lower < upper) {
+    _bail(
+      lower-key + " (" + repr(lower) + ") and " + upper-key + " (" +
+        repr(upper) + ") leave no satisfying value.",
+    )
+  }
+}
+
+#let _with-string-constraints(js, dict) = {
+  let result = dict
+  if "minLength" in js { result.insert("min-length", _require-nonneg-int(js, "minLength")) }
+  if "maxLength" in js { result.insert("max-length", _require-nonneg-int(js, "maxLength")) }
+  _require-ordered(
+    "minLength", result.at("min-length", default: none),
+    "maxLength", result.at("max-length", default: none),
+    ">",
+  )
+  result
+}
+
+#let _with-number-constraints(js, dict) = {
+  let result = dict
+  if "minimum" in js { result.insert("minimum", _require-number(js, "minimum")) }
+  if "maximum" in js { result.insert("maximum", _require-number(js, "maximum")) }
+  if "exclusiveMinimum" in js { result.insert("exclusive-minimum", _require-number(js, "exclusiveMinimum")) }
+  if "exclusiveMaximum" in js { result.insert("exclusive-maximum", _require-number(js, "exclusiveMaximum")) }
+  if "multipleOf" in js {
+    let v = _require-number(js, "multipleOf")
+    if v <= 0 { _bail("\"multipleOf\" must be > 0, got: " + repr(v) + ".") }
+    result.insert("multiple-of", v)
+  }
+  let mn = result.at("minimum", default: none)
+  let mx = result.at("maximum", default: none)
+  let emn = result.at("exclusive-minimum", default: none)
+  let emx = result.at("exclusive-maximum", default: none)
+  _require-ordered("minimum", mn, "maximum", mx, ">")
+  // Exclusive bound leaves no value when it meets/crosses an inclusive
+  // bound on the same side (e.g. exclusiveMinimum: 5 demands > 5,
+  // maximum: 5 demands ≤ 5).
+  _require-strict("exclusiveMinimum", emn, "maximum", mx)
+  _require-strict("minimum", mn, "exclusiveMaximum", emx)
+  _require-strict("exclusiveMinimum", emn, "exclusiveMaximum", emx)
+  result
+}
+
+#let _with-array-constraints(js, dict) = {
+  let result = dict
+  if "minItems" in js { result.insert("min-items", _require-nonneg-int(js, "minItems")) }
+  if "maxItems" in js { result.insert("max-items", _require-nonneg-int(js, "maxItems")) }
+  if "uniqueItems" in js {
+    let v = js.at("uniqueItems")
+    if type(v) != bool {
+      _bail("\"uniqueItems\" must be a boolean, got: " + repr(v) + ".")
+    }
+    if v { result.insert("unique-items", true) }
+  }
+  _require-ordered(
+    "minItems", result.at("min-items", default: none),
+    "maxItems", result.at("max-items", default: none),
+    ">",
+  )
+  result
+}
+
+#let _from-json-schema(js, root, seen) = {
+  if "$ref" in js {
+    let ref = js.at("$ref")
+    if type(ref) != str {
+      _bail("\"$ref\" must be a string, got: " + repr(type(ref)) + ".")
+    }
+    return _from-json-schema(
+      _resolve-ref(ref, root, seen),
+      root,
+      seen + (ref,),
+    )
+  }
+  for keyword in _unsupported-keywords {
+    if keyword in js {
+      _bail(
+        "unsupported JSON Schema keyword: " + repr(keyword) +
+          ". Composition keywords (allOf/anyOf/oneOf) and conditional schemas are out of scope.",
+      )
+    }
+  }
+  // enum / const take precedence over `type` — membership constrains
+  // shape on its own, so any accompanying type keyword is redundant.
+  if "enum" in js {
+    let values = js.at("enum")
+    if type(values) != array {
+      _bail("\"enum\" must be an array of values, got: " + repr(type(values)) + ".")
+    }
+    return enum-of(values)
+  }
+  if "const" in js { return const-of(js.at("const")) }
+  let t = js.at("type", default: none)
+  if t == "string" {
+    // Format wins over pattern when both are present — composing two
+    // gates is more moving parts than the engine needs.
+    let fmt = js.at("format", default: none)
+    let base = if fmt != none {
+      if fmt not in _format-kinds {
+        _bail("unsupported string format: " + repr(fmt) + ".")
+      }
+      _format-kinds.at(fmt)
+    } else {
+      let pat = js.at("pattern", default: none)
+      if pat != none {
+        if type(pat) != str {
+          _bail("\"pattern\" must be a string, got: " + repr(type(pat)) + ".")
+        }
+        pattern-string(pat, expected: "matching " + repr(pat))
+      } else {
+        str-type
+      }
+    }
+    return _with-string-constraints(js, base)
+  }
+  if t == "number" or t == "integer" {
+    return _with-number-constraints(js, number-type)
+  }
+  if t == "array" {
+    let items = js.at("items", default: none)
+    if items == none {
+      _bail("array schema missing \"items\".")
+    }
+    if type(items) != dictionary {
+      _bail("\"items\" must be a schema object, got: " + repr(type(items)) + ".")
+    }
+    return _with-array-constraints(js, array-of(_from-json-schema(items, root, seen)))
+  }
+  if t == "object" {
+    let has-props = "properties" in js
+    let has-ap = "additionalProperties" in js
+    // Fully open with no constraints inverts the engine's strict intent.
+    if not has-props and not has-ap {
+      _bail(
+        "open object schemas (`type: \"object\"` with no `properties` " +
+          "or `additionalProperties`) are out of scope; every field " +
+          "must be declared or covered by `additionalProperties`.",
+      )
+    }
+    let props = if has-props { js.at("properties") } else { (:) }
+    if type(props) != dictionary {
+      _bail("\"properties\" must be an object, got: " + repr(type(props)) + ".")
+    }
+    let required = js.at("required", default: ())
+    if type(required) != array {
+      _bail("\"required\" must be an array of field names, got: " + repr(type(required)) + ".")
+    }
+    let additional = if not has-ap {
+      none
+    } else {
+      let ap = js.at("additionalProperties")
+      if ap == false { none }
+      else if ap == true { true }
+      else if type(ap) == dictionary { _from-json-schema(ap, root, seen) }
+      else {
+        _bail("\"additionalProperties\" must be a schema, true, or false, got: " + repr(ap) + ".")
+      }
+    }
+    return object(
+      props.pairs().map(((k, v)) => (k, _from-json-schema(v, root, seen))).to-dict(),
+      required-keys: required,
+      additional: additional,
+    )
+  }
+  if t == "boolean" { return bool-type }
+  if t == "null" { return null-type }
+  if type(t) == array {
+    // [X, "null"] → X: under null-as-absent every kind already accepts
+    // null, so a wrapper would be a no-op. Multi-non-null unions need
+    // discriminated-union machinery that's out of scope.
+    if t.len() == 2 and "null" in t {
+      let non-null = t.filter(x => x != "null")
+      if non-null.len() == 1 {
+        return _from-json-schema((..js, type: non-null.at(0)), root, seen)
+      }
+    }
+    _bail(
+      "union `type` arrays are only supported as nullable wraps `[X, \"null\"]`, got: "
+        + repr(t) + "."
+    )
+  }
+  _bail("unrecognised JSON Schema fragment (no recognised \"type\" or \"$ref\"); keys: " + repr(js.keys()) + ".")
+}
+
+// `path("…")` is read via json() so callers can skip the double-wrap.
+// Non-dict/non-path inputs are rejected at the boundary so the
+// diagnostic carries the standard schema-from-json-schema prefix
+// instead of failing deep inside _from-json-schema.
+#let schema-from-json-schema(js) = {
+  let parsed = if type(js) == path {
+    json(js)
+  } else if type(js) == dictionary {
+    js
+  } else {
+    _bail("expected a parsed JSON Schema dict or path(...), got: " + repr(type(js)) + ".")
+  }
+  _from-json-schema(parsed, parsed, ())
+}

--- a/packages/preview/gairm-import/0.8.0/internal/kinds.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/kinds.typ
@@ -1,0 +1,86 @@
+// Schema-kind constants and constructors. Lives in its own module
+// because schema.typ depends on json-schema.typ (for derivation) and
+// json-schema.typ depends on these primitives — extracting them here
+// breaks the cycle.
+
+#let str-type     = (kind: "str")
+#let content-type = (kind: "content")
+#let number-type  = (kind: "number")
+#let bool-type    = (kind: "bool")
+
+// "Must be null or absent": `none` passes via the engine's global
+// early return, non-none hits the kind branch and errors.
+#let null-type    = (kind: "null")
+
+// Format-specialised string kinds — regex-gated in _validate;
+// deliberately permissive (reject obvious malformations, not full RFC).
+#let date-string     = (kind: "date-string")
+#let datetime-string = (kind: "datetime-string")
+#let uri-string      = (kind: "uri-string")
+#let email-string    = (kind: "email-string")
+
+// Per-instance regex gate — a constructor, not a constant, because
+// each schema node carries its own regex and hint.
+#let pattern-string(re, expected: "matching pattern") = (
+  kind: "pattern-string",
+  pattern: regex(re),
+  expected: expected,
+)
+
+#let array-of(elem) = (kind: "array", elem: elem)
+
+// Mixed-type members allowed — the validator's `in` check gates on
+// equality, not type. `const` is a singleton enum.
+#let enum-of(values) = (kind: "enum", values: values)
+#let const-of(value) = enum-of((value,))
+
+// `additional` controls keys not in `shape` (the engine-side name for
+// JSON Schema's `additionalProperties`): `none` / `false` → reject;
+// `true` → pass-through; schema dict → validate every extra against
+// it. `false` is accepted as a synonym for `none` so callers fluent
+// in JSON Schema can pass either. Bad-shape `additional` and
+// required-keys-not-covered both fail at construction, not as a
+// phantom validation error.
+#let object(shape, required-keys: (), additional: none) = {
+  // false ≡ none in our model; normalise so the constructor and the
+  // translator agree on what they accept.
+  let normalized = if additional == false { none } else { additional }
+  let additional-ok = (
+    normalized == none
+      or normalized == true
+      or (type(normalized) == dictionary and "kind" in normalized)
+  )
+  assert(
+    additional-ok,
+    message: "gairm-import: object() additional must be none, false, true, or a schema dict (with a `kind` field); got: " +
+      repr(additional) + ".",
+  )
+  // With `additional`, undeclared required keys are covered by the
+  // additional schema, so the subset check only applies when strict.
+  let unknown = if normalized == none {
+    required-keys.filter(k => k not in shape)
+  } else {
+    ()
+  }
+  assert(
+    unknown.len() == 0,
+    message: "gairm-import: object() required-keys references keys not in shape: " +
+      unknown.join(", ") + ".",
+  )
+  let base = (
+    kind: "object",
+    shape: shape,
+    required-keys: required-keys,
+  )
+  // Omitted when `none` so existing strict dicts keep their shape.
+  if normalized == none { base } else { (..base, additional: normalized) }
+}
+
+// `required-keys` kwarg for symmetry with `object` — required keys
+// on a pure map are still meaningful ("the document must contain
+// these specific keys, plus any number of others").
+#let map(value-schema, required-keys: ()) = object(
+  (:),
+  required-keys: required-keys,
+  additional: value-schema,
+)

--- a/packages/preview/gairm-import/0.8.0/internal/lens.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/lens.typ
@@ -1,0 +1,193 @@
+// Lens-style schema editing.
+//
+// Top-level lens-* functions rather than methods on a lens record:
+// Typst parses `dict.field(args)` as a type-method lookup, not a call
+// of the closure stored under that key, so methods would force
+// `(lens.put)(args)` at every call site.
+//
+// Path segments match the JSON Schema keyword name (not the engine
+// field name) so a lens path reads as a JSON Schema location:
+//   - object   : string key into `.shape`
+//   - object   : literal "additionalProperties" to enter `.additional`
+//                (only when set to a schema dict, not `true`)
+//   - array    : literal "items" to enter `.elem`
+//   - empty `()` : identity lens
+//
+// Shape-first precedence for objects: if `"additionalProperties"` is
+// both a literal property in `shape` and the additionalProperties
+// keyword name, the literal property wins (meta-schemas are the
+// realistic case where this collision arises). Reach the
+// additional-schema in that rare collision case via lens-over on the
+// parent — `p => p.additional` to read, `p => (..p, additional: new)`
+// to write.
+//
+// `lens-put` writes the replacement value verbatim — it doesn't
+// validate that the value is a well-formed schema dict at any
+// segment. Use the public `object` / `array-of` / kind constructors
+// to build the replacement.
+
+#let _bail(msg) = panic("gairm-import: " + msg)
+
+#let _require-object(parent, op) = {
+  if parent.kind != "object" {
+    _bail(
+      op + " expects an object schema at the lens target, got kind=" +
+        repr(parent.kind) + ".",
+    )
+  }
+}
+
+// Typst dicts are value types — `let new-shape = parent.shape` copies,
+// and `.insert` mutates the local without touching parent.
+#let _with-shape-set(parent, key, value) = {
+  let new-shape = parent.shape
+  new-shape.insert(key, value)
+  (..parent, shape: new-shape)
+}
+
+#let _descend(schema, segment) = {
+  if schema.kind == "object" {
+    // Shape lookup wins so a literal property named
+    // "additionalProperties" stays addressable.
+    if segment in schema.shape {
+      return schema.shape.at(segment)
+    }
+    if segment == "additionalProperties" {
+      let additional = schema.at("additional", default: none)
+      if type(additional) != dictionary {
+        _bail(
+          "lens segment \"additionalProperties\" requires the object's " +
+            "`additional` field to be a schema dict, got: " + repr(additional) + ".",
+        )
+      }
+      return additional
+    }
+    _bail(
+      "lens path segment " + repr(segment) + " not in object shape. " +
+        "Valid keys: " + schema.shape.keys().join(", ") + ".",
+    )
+  }
+  if schema.kind == "array" {
+    if segment != "items" {
+      _bail(
+        "lens segment for an array schema must be \"items\", got " +
+          repr(segment) + ".",
+      )
+    }
+    return schema.elem
+  }
+  _bail(
+    "lens cannot descend into a leaf schema (kind=" + repr(schema.kind) +
+      ") with segment " + repr(segment) + ".",
+  )
+}
+
+#let _get-at(schema, path) = {
+  let cursor = schema
+  for segment in path { cursor = _descend(cursor, segment) }
+  cursor
+}
+
+// _descend runs in both branches so an invalid segment surfaces the
+// same diagnostic from get and from put.
+#let _set-at(schema, path, value) = {
+  if path.len() == 0 { return value }
+  let (head, ..rest) = path
+  let new-sub = _set-at(_descend(schema, head), rest, value)
+  // Mirror _descend's shape-first precedence so a literal property
+  // named "additionalProperties" rewrites the shape entry, not the
+  // additional schema. _descend already bailed on any other invalid
+  // object segment, so the additionalProperties branch is the only
+  // remaining object case.
+  if schema.kind == "object" and head in schema.shape {
+    _with-shape-set(schema, head, new-sub)
+  } else if schema.kind == "object" {
+    (..schema, additional: new-sub)
+  } else {
+    (..schema, elem: new-sub)
+  }
+}
+
+#let lens(path) = (kind: "lens", path: path)
+
+#let lens-get(l, schema) = _get-at(schema, l.path)
+
+// `put` because `set` is a Typst keyword.
+#let lens-put(l, schema, value) = _set-at(schema, l.path, value)
+
+#let lens-over(l, schema, fn) = _set-at(schema, l.path, fn(_get-at(schema, l.path)))
+
+// `lens-then(a, b)` applies a then b — paths concatenate in that order.
+#let lens-then(a, b) = lens(a.path + b.path)
+
+// Collisions panic instead of overwriting silently — for the
+// overwrite-an-existing-key case, callers can reach for lens-put / lens-over.
+#let add-field(schema, parent-lens, key, sub-schema) = lens-over(
+  parent-lens,
+  schema,
+  parent => {
+    _require-object(parent, "add-field")
+    if key in parent.shape {
+      _bail(
+        "add-field key " + repr(key) + " already in object shape. " +
+          "Use lens-put / lens-over to replace an existing field.",
+      )
+    }
+    _with-shape-set(parent, key, sub-schema)
+  },
+)
+
+// Replace, not merge — mirrors lens-put. Keys must exist in shape
+// so a typo fails at edit time, not as a phantom "missing X" error.
+#let set-required(schema, parent-lens, keys) = lens-over(
+  parent-lens,
+  schema,
+  parent => {
+    _require-object(parent, "set-required")
+    let unknown = keys.filter(k => k not in parent.shape)
+    if unknown.len() > 0 {
+      _bail(
+        "set-required keys not in object shape: " + unknown.join(", ") +
+          ". Valid keys: " + parent.shape.keys().join(", ") + ".",
+      )
+    }
+    (..parent, required-keys: keys)
+  },
+)
+
+// Symmetric to set-required — relax specific keys without re-listing.
+// Absent-key panics so a stale "still required" assumption surfaces.
+#let unset-required(schema, parent-lens, keys) = lens-over(
+  parent-lens,
+  schema,
+  parent => {
+    _require-object(parent, "unset-required")
+    let absent = keys.filter(k => k not in parent.required-keys)
+    if absent.len() > 0 {
+      _bail(
+        "unset-required keys not in required-keys: " + absent.join(", ") +
+          ". Current required: " + parent.required-keys.join(", ") + ".",
+      )
+    }
+    (..parent, required-keys: parent.required-keys.filter(k => k not in keys))
+  },
+)
+
+// Absent-key panics rather than being a silent no-op so caller typos surface.
+#let remove-field(schema, parent-lens, key) = lens-over(
+  parent-lens,
+  schema,
+  parent => {
+    _require-object(parent, "remove-field")
+    if key not in parent.shape {
+      _bail(
+        "remove-field key " + repr(key) + " not in object shape. " +
+          "Valid keys: " + parent.shape.keys().join(", ") + ".",
+      )
+    }
+    let new-shape = parent.shape
+    let _ = new-shape.remove(key)
+    let new-required = parent.required-keys.filter(k => k != key)
+    (..parent, shape: new-shape, required-keys: new-required)
+  },
+)

--- a/packages/preview/gairm-import/0.8.0/internal/schema.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/schema.typ
@@ -1,0 +1,124 @@
+// Canonical JSON Resume schema (https://jsonresume.org/schema).
+// `resume-schema` is a faithful derivation of the upstream document;
+// `resume-schema-strict` layers content + date opinions via lens.
+// See README "Two schemas" for the trade-off.
+
+#import "kinds.typ": (
+  str-type, content-type, number-type, bool-type, null-type,
+  array-of, object, map,
+  date-string, datetime-string, uri-string, email-string, pattern-string,
+  enum-of, const-of,
+)
+#import "json-schema.typ": schema-from-json-schema
+#import "lens.typ": lens, lens-get, lens-put
+
+#let resume-schema = schema-from-json-schema(json("assets/jsonresume-schema.json"))
+
+// Free-text fields wrapped as Typst `content` in the strict variant.
+// Renderer ergonomics, not validation.
+#let _content-paths = (
+  ("basics", "summary"),
+  ("work", "items", "summary"),
+  ("work", "items", "highlights", "items"),
+  ("volunteer", "items", "summary"),
+  ("volunteer", "items", "highlights", "items"),
+  ("awards", "items", "summary"),
+  ("publications", "items", "summary"),
+  ("references", "items", "reference"),
+  ("projects", "items", "description"),
+  ("projects", "items", "highlights", "items"),
+)
+
+// iso8601 `$ref` fields. The upstream definition is a string with a
+// `pattern`, so the translator emits the iso8601 pattern-string for
+// these — the strict variant tightens that to date-string (rejects
+// month 00 / 13+, day 00 / 32+).
+#let _iso8601-date-paths = (
+  ("work", "items", "startDate"),
+  ("work", "items", "endDate"),
+  ("volunteer", "items", "startDate"),
+  ("volunteer", "items", "endDate"),
+  ("education", "items", "startDate"),
+  ("education", "items", "endDate"),
+  ("awards", "items", "date"),
+  ("publications", "items", "releaseDate"),
+  ("projects", "items", "startDate"),
+  ("projects", "items", "endDate"),
+)
+
+// `meta.lastModified` carries only a description in upstream — no
+// machine-readable pattern — so it lands as plain `str-type` in the
+// faithful schema. Strict still lifts it to date-string.
+#let _plain-date-paths = (
+  ("meta", "lastModified"),
+)
+
+// Source shape the translator emits for iso8601 $ref fields. The
+// pattern is hand-mirrored from upstream's `definitions/iso8601` so a
+// schema bump that retires or alters it surfaces as an override-fold
+// guard panic at load time, not as silent semantic drift.
+#let _iso8601-pattern = "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+#let _iso8601-source = pattern-string(
+  _iso8601-pattern,
+  expected: "matching " + repr(_iso8601-pattern),
+)
+
+// Pre-condition guard turns silent upstream drift into a load-time
+// panic — an override that ran unconditionally would mask the shape
+// change instead of surfacing it.
+#let _override-fold(schema, paths, expected-source, replacement, list-name) = {
+  paths.fold(schema, (s, p) => {
+    let l = lens(p)
+    let current = lens-get(l, s)
+    assert(
+      current == expected-source,
+      message: "gairm-import: " + list-name + " must target " +
+        repr(expected-source.kind) + " leaves only — " + repr(p) +
+        " is now " + repr(current.kind) + ". Audit upstream schema bump.",
+    )
+    lens-put(l, s, replacement)
+  })
+}
+
+// Strip `additional: true` (the JSON Resume upstream's permissive
+// "extras allowed" on every section's items) recursively. Typed
+// extras (`additional: <schema>`) are kept and recursed into; only
+// the unchecked-pass-through form is removed. Used by the strict
+// variant to restore the "rejected unknown keys" promise.
+#let _strip-permissive-additional(schema) = {
+  if schema.kind == "object" {
+    let new-shape = (:)
+    for (k, v) in schema.shape.pairs() {
+      new-shape.insert(k, _strip-permissive-additional(v))
+    }
+    let ap = schema.at("additional", default: none)
+    let new-additional = if type(ap) == dictionary {
+      _strip-permissive-additional(ap)
+    } else {
+      none
+    }
+    // Route through the public constructor so any future invariant
+    // added to `object()` applies here too.
+    object(new-shape, required-keys: schema.required-keys, additional: new-additional)
+  } else if schema.kind == "array" {
+    (..schema, elem: _strip-permissive-additional(schema.elem))
+  } else {
+    schema
+  }
+}
+
+#let resume-schema-strict = {
+  // Strip first so the override-folds run against a schema that
+  // doesn't carry the `additional: true` markers — paths and
+  // expectations stay simple.
+  let strict-base = _strip-permissive-additional(resume-schema)
+  let with-content = _override-fold(
+    strict-base, _content-paths, str-type, content-type, "_content-paths",
+  )
+  let with-iso = _override-fold(
+    with-content, _iso8601-date-paths, _iso8601-source, date-string, "_iso8601-date-paths",
+  )
+  _override-fold(
+    with-iso, _plain-date-paths, str-type, date-string, "_plain-date-paths",
+  )
+}

--- a/packages/preview/gairm-import/0.8.0/internal/validate.typ
+++ b/packages/preview/gairm-import/0.8.0/internal/validate.typ
@@ -1,0 +1,206 @@
+// Subtrees under unknown keys are not walked — their expected shape
+// is undefined.
+//
+// JSON `null` (Typst's `none`) at a value position is treated as if
+// the key were absent: no type error, no recursion. Per-key null
+// values in objects, null array elements, and entire-section nulls
+// are all absorbed by the top-of-function early return — recursion
+// handles them uniformly. The required-keys check below is the only
+// place that still needs an explicit null check (a present-but-null
+// required key must still count as missing). See README "Errors"
+// section for the user-facing rationale.
+
+#import "errors.typ": _type-name-of, _closest-match
+
+#let _err(path, msg) = ((path: path, message: msg),)
+
+#let _type-error(path, expected, value) = _err(
+  path,
+  "expected " + expected + ", got " + _type-name-of(value) + ".",
+)
+
+// Clusters, not bytes — JSON Schema talks "length" without pinning.
+#let _string-length-errs(schema, value, path) = {
+  let min = schema.at("min-length", default: none)
+  let max = schema.at("max-length", default: none)
+  if min == none and max == none { return () }
+  let n = value.clusters().len()
+  let errs = ()
+  if min != none and n < min {
+    errs += _err(path, "expected string length ≥ " + str(min) + ", got " + str(n) + ".")
+  }
+  if max != none and n > max {
+    errs += _err(path, "expected string length ≤ " + str(max) + ", got " + str(n) + ".")
+  }
+  errs
+}
+
+#let _number-range-errs(schema, value, path) = {
+  let errs = ()
+  let mn = schema.at("minimum", default: none)
+  if mn != none and value < mn {
+    errs += _err(path, "expected ≥ " + str(mn) + ", got " + str(value) + ".")
+  }
+  let mx = schema.at("maximum", default: none)
+  if mx != none and value > mx {
+    errs += _err(path, "expected ≤ " + str(mx) + ", got " + str(value) + ".")
+  }
+  let emn = schema.at("exclusive-minimum", default: none)
+  if emn != none and value <= emn {
+    errs += _err(path, "expected > " + str(emn) + ", got " + str(value) + ".")
+  }
+  let emx = schema.at("exclusive-maximum", default: none)
+  if emx != none and value >= emx {
+    errs += _err(path, "expected < " + str(emx) + ", got " + str(value) + ".")
+  }
+  let mult = schema.at("multiple-of", default: none)
+  if mult != none and calc.rem(value, mult) != 0 {
+    errs += _err(path, "expected multiple of " + str(mult) + ", got " + str(value) + ".")
+  }
+  errs
+}
+
+// Filter `none` first — coerce drops them, so raw counts would
+// validate inputs whose rendered model violates min-items. Duplicate
+// reports cite original positions so callers can find them.
+#let _array-constraint-errs(schema, value, path) = {
+  let errs = ()
+  let present = value.enumerate().filter(((_, elem)) => elem != none)
+  let n = present.len()
+  let min = schema.at("min-items", default: none)
+  if min != none and n < min {
+    errs += _err(path, "expected array length ≥ " + str(min) + ", got " + str(n) + ".")
+  }
+  let max = schema.at("max-items", default: none)
+  if max != none and n > max {
+    errs += _err(path, "expected array length ≤ " + str(max) + ", got " + str(n) + ".")
+  }
+  if schema.at("unique-items", default: false) {
+    for i in range(n) {
+      for j in range(i + 1, n) {
+        let (orig-i, left) = present.at(i)
+        let (orig-j, right) = present.at(j)
+        if left == right {
+          errs += _err(path, "expected unique items, duplicate at indices " + str(orig-i) + " and " + str(orig-j) + ".")
+          return errs
+        }
+      }
+    }
+  }
+  errs
+}
+
+// Tightened over the upstream JSON Resume regexes, which accept
+// impossible months / days because they use [0-1][0-9] / [0-3][0-9].
+// Deliberately permissive (no full RFC compliance). Message omits the
+// offending value — the path already names the field, the canonical
+// example in `expected` is the actionable hint.
+#let _format-specs = (
+  "date-string": (
+    pattern: regex("^([0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])|[0-9]{4}-(0[1-9]|1[0-2])|[0-9]{4})$"),
+    expected: "an ISO-8601 date (e.g. \"2024-01-15\")",
+  ),
+  "datetime-string": (
+    pattern: regex("^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|[+-]([01][0-9]|2[0-3]):[0-5][0-9])?$"),
+    expected: "an ISO-8601 datetime (e.g. \"2024-01-15T10:00:00Z\")",
+  ),
+  "uri-string": (
+    pattern: regex("^[A-Za-z][A-Za-z0-9+.\-]*://\S+$"),
+    expected: "a URI (e.g. \"https://example.com\")",
+  ),
+  "email-string": (
+    pattern: regex("^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$"),
+    expected: "an email (e.g. \"name@example.com\")",
+  ),
+)
+
+#let _validate(schema, value, path) = {
+  // Null at any value position is "key absent" — no error, no
+  // recursion. Single early return handles every shape uniformly:
+  // standalone scalars, array elements (via the per-element call),
+  // and per-key sub-values inside objects (via the per-key call).
+  if value == none { return () }
+  let kind = schema.kind
+  if kind in ("str", "content") {
+    if type(value) != str { return _type-error(path, "string", value) }
+    return _string-length-errs(schema, value, path)
+  }
+  if kind == "enum" {
+    if value in schema.values { return () }
+    return _err(
+      path,
+      "expected one of " + schema.values.map(repr).join(", ") +
+        ", got " + repr(value) + ".",
+    )
+  }
+  if kind in _format-specs {
+    if type(value) != str { return _type-error(path, "string", value) }
+    let spec = _format-specs.at(kind)
+    if value.match(spec.pattern) == none {
+      return _err(path, "expected " + spec.expected + ".")
+    }
+    return _string-length-errs(schema, value, path)
+  }
+  // pattern + hint travel on the schema node rather than via the
+  // _format-specs table above, since each instance is unique.
+  if kind == "pattern-string" {
+    if type(value) != str { return _type-error(path, "string", value) }
+    if value.match(schema.pattern) == none {
+      return _err(path, "expected " + schema.expected + ".")
+    }
+    return _string-length-errs(schema, value, path)
+  }
+  if kind == "number" {
+    if type(value) not in (int, float) { return _type-error(path, "number", value) }
+    return _number-range-errs(schema, value, path)
+  }
+  if kind == "bool" {
+    if type(value) != bool { return _type-error(path, "boolean", value) }
+    return ()
+  }
+  // `none` succeeds via the top early return; non-none can only fail.
+  if kind == "null" { return _type-error(path, "null", value) }
+  if kind == "array" {
+    if type(value) != array { return _type-error(path, "array", value) }
+    let elem-errs = value.enumerate()
+      .map(((i, elem)) => _validate(schema.elem, elem, path + (i,)))
+      .flatten()
+    return elem-errs + _array-constraint-errs(schema, value, path)
+  }
+  if kind == "object" {
+    if type(value) != dictionary { return _type-error(path, "object", value) }
+    let additional = schema.at("additional", default: none)
+    let per-key-errs = value.pairs().map(((key, sub-value)) => {
+      if key in schema.shape {
+        _validate(schema.shape.at(key), sub-value, path + (key,))
+      } else if additional == true {
+        // `additionalProperties: true` — no validation. coerce.typ
+        // mirrors this by passing the value through verbatim.
+        ()
+      } else if additional != none {
+        _validate(additional, sub-value, path + (key,))
+      } else {
+        // Strict branch: fuzzy suggestion if the typo is within edit
+        // distance 2 of a valid key, otherwise the full key list.
+        // Unknown key with null value still flagged — silently
+        // swallowing typos defeats the point of strict validation.
+        let suggestion = _closest-match(key, schema.shape.keys(), 2)
+        let tail = if suggestion != none {
+          "Did you mean " + repr(suggestion) + "?"
+        } else {
+          "Valid keys: " + schema.shape.keys().join(", ") + "."
+        }
+        _err(path + (key,), "unknown key " + repr(key) + ". " + tail)
+      }
+    }).flatten()
+    // A required key whose value is explicit null counts as missing —
+    // null-as-absent applies uniformly.
+    let required = schema.at("required-keys", default: ())
+    let missing-errs = required
+      .filter(k => k not in value or value.at(k) == none)
+      .map(k => _err(path + (k,), "missing required key " + repr(k) + "."))
+      .flatten()
+    return per-key-errs + missing-errs
+  }
+  panic("gairm-import: internal — unknown schema kind " + repr(kind))
+}

--- a/packages/preview/gairm-import/0.8.0/lib.typ
+++ b/packages/preview/gairm-import/0.8.0/lib.typ
@@ -1,0 +1,76 @@
+// Strict loader for canonical JSON Resume data
+// (https://jsonresume.org/schema). The engines under internal/ are
+// pure functions of (schema, value); see
+// tests/engine_schema_agnostic.typ for the BYO-schema contract.
+
+#import "internal/schema.typ": (
+  resume-schema, resume-schema-strict,
+  str-type, content-type, number-type, bool-type, null-type,
+  array-of, object, map,
+  date-string, datetime-string, uri-string, email-string, pattern-string,
+  enum-of, const-of,
+)
+#import "internal/validate.typ": _validate
+#import "internal/coerce.typ": _coerce
+#import "internal/errors.typ": _format-report
+#import "internal/json-schema.typ": schema-from-json-schema
+#import "internal/lens.typ": lens, lens-get, lens-put, lens-over, lens-then, add-field, remove-field, set-required, unset-required
+#import "internal/introspect.typ": describe-schema, paths-of-kind, kind-at
+#import "internal/json-pointer.typ": path-to-pointer, pointer-to-path
+
+// Engines treat `none` at any value position as "key absent" — right
+// for leaves inside a document, but a null root is always invalid
+// (no schema can validate "missing document"). One source of truth
+// for the message so docs and tests have something stable to pin.
+#let _reject-none-root(data) = {
+  if data == none { panic("gairm-import: input must be a dict, got null.") }
+}
+
+// Combined-report formatter, for callers handling errors themselves
+// instead of letting `parse` abort.
+#let format-errors(errors) = _format-report(errors)
+
+#let validate(data, schema: resume-schema) = {
+  _reject-none-root(data)
+  _validate(schema, data, ())
+}
+
+// Unknown keys are dropped silently rather than panicking, so direct
+// callers who skip validation don't get a Typst dictionary-access
+// panic.
+#let coerce(data, schema: resume-schema) = {
+  _reject-none-root(data)
+  _coerce(schema, data)
+}
+
+// `path("…")` resolves against the caller's .typ rather than the
+// @preview cache where this file lives — that's the headline form.
+// The "/…" string and pre-parsed dict are also accepted.
+#let parse(data, schema: resume-schema) = {
+  _reject-none-root(data)
+  let dict-data = if type(data) == path {
+    json(data)
+  } else if type(data) == str {
+    if not data.starts-with("/") {
+      panic(
+        "gairm-import: parse with a string path requires the path " +
+          "to start with \"/\" (resolved from the typst root). Got: " + repr(data) + ". " +
+          "For paths relative to your own .typ file, pass " +
+          "path(" + repr(data) + ") (or json(" + repr(data) + ")) in place of the path string.",
+      )
+    }
+    json(data)
+  } else if type(data) == dictionary {
+    data
+  } else {
+    panic(
+      "gairm-import: parse expected a dict, a path, or a string path, got " +
+        repr(type(data)) + ".",
+    )
+  }
+  let errors = _validate(schema, dict-data, ())
+  // assert preserves newlines in the diagnostic; panic repr-escapes
+  // them and collapses the bullet list onto one line.
+  assert(errors.len() == 0, message: format-errors(errors))
+  _coerce(schema, dict-data)
+}

--- a/packages/preview/gairm-import/0.8.0/typst.toml
+++ b/packages/preview/gairm-import/0.8.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "gairm-import"
+version = "0.8.0"
+entrypoint = "lib.typ"
+authors = ["Shane Murphy"]
+license = "MIT"
+description = "Parses and validates JSON against JSON Schema and returns a normalised dict; built in support for JSON Resumes."
+repository = "https://github.com/smur89/gairm-import"
+keywords = ["json", "json-resume", "resume", "cv", "loader", "schema"]
+categories = ["utility"]
+compiler = "0.15.0"


### PR DESCRIPTION
  <!--
  Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as
  `name:version` of the submitted package.
  -->

  I am submitting
  - [x] a new package
  - [ ] an update for a package
 
gairm-import is a strict loader for canonical JSON Resume data. It reads a resume.json file, validates it against the published schema, and returns a normalised Typst dict with free-text fields coerced to content — ready to hand to any compatible Typst CV template.
 
Useful because the JSON Resume promise of one resume.json across many renderers currently requires every Typst CV template to hand-translate the JSON into a Typst dict; this package centralises that work into a single dependency so renderers can stay focused on layout. The canonical schema is derived at module-load time from the vendored upstream JSON Schema document — the published spec is the single source of truth, not a hand-maintained mirror.

For templates that need their own fields (theme colours, label overrides, header decorations, …) the package exposes the underlying engines (validate / coerce) and a lens-style API (lens, lens-put, lens-over, add-field, remove-field) so an extension schema can be built on top of the canonical one without forking the loader — and schema-from-json-schema lets callers translate their own JSON Schema documents into Typst schemas if they prefer that source of truth over hand-rolled combinators.

  I have read and followed the submission guidelines and, in particular, I
  - [x] selected a name that isn't the most obvious or canonical name for what the package does
    - https://github.com/typst/packages/pull/5069#discussion_r3420918492
  - [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
  - [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
  - [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
  - [x] tested my package locally on my system and it worked
  - [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE

------

Related previous submission https://github.com/typst/packages/pull/5069 concerns raised addressed [x]