### PR TITLE
Update to fixed package check action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           git checkout ${{ github.base_ref }}
           git checkout $pr_head
           git rebase ${{ github.base_ref }} -X ours
-      - uses: typst/package-check@d6f8b5ed2ff237c5c615525c63ebe92152a5fadd # v0.6.0
+      - uses: typst/package-check@5c72da4ea8e2ec50e65050e94ce71e3ad94d6cfa # v0.6.0
         with:
           installation-id: ${{ secrets.GH_INSTALLATION_ID }}
           app-id: ${{ secrets.GH_APP_ID }}


### PR DESCRIPTION
The previous package check action still pulled in the `0.5.0` image.