### PR TITLE
lasaveur:0.1.5

### DIFF
--- a/packages/preview/lasaveur/0.1.5/README.md
+++ b/packages/preview/lasaveur/0.1.5/README.md
@@ -1,0 +1,54 @@
+# Typst-lasaveur
+
+This is a Typst package for speedy mathematical input, inspired by [vim-latex](https://github.com/vim-latex/vim-latex).  This project is named after my Vim plugin [vimtex-lasaveur](https://github.com/yangwenbo99/vimtex-lasaveur), which ports the operations in vim-latex to [vimtex](https://github.com/lervag/vimtex). 
+
+## Usages in Typst
+
+Either use the file released in "Releases" or import using the following command:
+
+```typst
+#import "@preview/lasaveur:0.1.4": *
+```
+
+This script generates a Typst library that defines shorthand commands for various mathematical symbols and functions. Here's an overview of what it provides and how a user can use it:
+
+1. Mathematical Functions:
+   - Usage: `f<key>(argument)`
+   - Examples: `fh(x)` for hat, `ft(x)` for tilde, `f2(x)` for square root
+2. Font Styles:
+   - Usage: `f<key>(argument)`
+   - Examples: `fb(x)` for bold, `fbb(x)` for blackboard bold, `fca(x)` for calligraphic
+3. Greek Letters:
+   - Usage: `k<key>`
+   - Examples: `ka` for α (alpha), `kb` for β (beta), `kG` for Γ (capital Gamma)
+4. Common Mathematical Symbols:
+   - Usage: `g<key>`
+   - Examples: `g8` for ∞ (infinity), `gU` for ∪ (union), `gI` for ∩ (intersection)
+5. LaTeX-compatible Symbols:
+   - Usage: Direct LaTeX command names
+   - Examples: `partial` for ∂, `infty` for ∞, `cdot` for ⋅
+6. Arrows:
+   - Usage: `ar.<key>`
+   - Examples: `ar.l` for ←, `ar.r` for →, `ar.lr` for ↔
+
+Users can employ these shorthands in their Typst documents to quickly input mathematical symbols and functions. The exact prefix for each category (like `f` for functions or `k` for Greek letters) can be customized using command-line arguments when running the script.
+
+For instance, in a Typst document, after importing the generated library, a user could write:
+
+```typst
+$fh(x) + ka + g8 + ar.r$
+```
+
+This would produce: x̂ + α + ∞ + →
+
+The script provides a wide range of symbols covering most common mathematical notations, making it easier and faster to type complex mathematical expressions in Typst -- especially for users migrating from vim-latex.
+
+## Accompanying Vim Syntax File
+
+The syntax file provides more advanced and correct concealing for both Typst's built-in math syntax and the lasaveur shorthands.  Download the syntax file from the "Releases" section and place it in your `~/.vim/after/syntax/` directory.  The `syntax.vim` file in the repo is supposed to be used by the generation script and it _will not work_ if directly sourced in Vim.
+
+## License
+
+Following the previous project (`vimtex-lasaveur`), this project is licensed under the [WTFPL (Limited-liability license)](https://github.com/yangwenbo99/vimtex-lasaveur/blob/main/LICENSE.txt).  Basically, this means you can do whatever you want with it, but you cannot hold me liable for anything. 
+
+However, to satisfy the requirement for the Typst package repository, all files of `typst-lasaveur` that are published in the Typst package repository are also licensed under the MIT license.

--- a/packages/preview/lasaveur/0.1.5/README.md
+++ b/packages/preview/lasaveur/0.1.5/README.md
@@ -7,7 +7,7 @@ This is a Typst package for speedy mathematical input, inspired by [vim-latex](h
 Either use the file released in "Releases" or import using the following command:
 
 ```typst
-#import "@preview/lasaveur:0.1.4": *
+#import "@preview/lasaveur:0.1.5": *
 ```
 
 This script generates a Typst library that defines shorthand commands for various mathematical symbols and functions. Here's an overview of what it provides and how a user can use it:

--- a/packages/preview/lasaveur/0.1.5/typst-lasaveur.typ
+++ b/packages/preview/lasaveur/0.1.5/typst-lasaveur.typ
@@ -1,0 +1,102 @@
+#let fh(a) = $hat(#a)$
+#let ft(a) = $tilde(#a)$
+#let f2(a) = $sqrt(#a)$
+#let fb(a) = $bold(#a)$
+#let fbb(a) = $bb(#a)$
+#let fca(a) = $cal(#a)$
+#let g6 = $partial$
+#let g8 = $infinity$
+#let g0 = $nothing$
+#let go = $circle.stroked.tiny$
+#let g_ = $without$
+#let gd = $dot$
+#let gt = $times$
+#let gU = $union.big$
+#let gI = $inter.big$
+#let gb = $subset$
+#let gbeq = $subset.eq$
+#let gbne = $subset.neq$
+#let gbneq = $subset.neq$
+#let gp = $supset$
+#let gpeq = $supset.eq$
+#let gpne = $supset.neq$
+#let gpneq = $supset.neq$
+#let gal = $chevron.l$
+#let gar = $chevron.r$
+#let gV = $nabla$
+#let gdd = $dot.double$
+#let gddd = $dot.triple$
+#let gdddd = $dot.quad$
+#let g1 = $tilde.op$
+#let ka = $alpha$
+#let kb = $beta$
+#let kc = $chi$
+#let kd = $delta$
+#let ke = $epsilon.alt$
+#let kee = $epsilon$
+#let kf = $phi.alt$
+#let kff = $phi$
+#let kg = $gamma$
+#let kh = $eta$
+#let ki = $iota$
+#let kk = $kappa$
+#let kl = $lambda$
+#let km = $mu$
+#let kn = $nu$
+#let ko = $omicron$
+#let kp = $pi$
+#let kq = $theta$
+#let kr = $rho$
+#let ks = $sigma$
+#let kt = $tau$
+#let ku = $upsilon$
+#let kv = $sigma.alt$
+#let kw = $omega$
+#let kx = $xi$
+#let ky = $psi$
+#let kz = $zeta$
+#let kD = $Delta$
+#let kG = $Gamma$
+#let kL = $Lambda$
+#let kX = $Xi$
+#let kS = $Sigma$
+#let kU = $Upsilon$
+#let kF = $Phi$
+#let kW = $Omega$
+#let infty = $infinity$
+#let circ = $circle.stroked.tiny$
+#let setminus = $without$
+#let cdot = $dot.op$
+#let bigcup = $union.big$
+#let bigcap = $inter.big$
+#let prod = $product$
+#let to = $arrow.r$
+#let implies = $arrow.r.double$
+#let gets = $arrow.l$
+#let iff = $arrow.l.r.double.long$
+#let cdots = $dots.h.c$
+#let vdots = $dots.v$
+#let ddots = $dots.down$
+#let int = $integral$
+#let iint = $integral.double$
+#let iiint = $integral.triple$
+#let oint = $integral.cont$
+#let sim = $tilde.op$
+#let ne = $eq.not$
+#let ar = (
+	l: $arrow.l$,
+	r: $arrow.r$,
+	t: $arrow.t$,
+	b: $arrow.b$,
+	lr: $arrow.r.long$,
+	ll: $arrow.l.long$,
+	llr: $arrow.l.r.long$,
+	dl: $arrow.l.double$,
+	dr: $arrow.r.double$,
+	dlr: $arrow.l.r.double$,
+	dt: $arrow.t.double$,
+	db: $arrow.b.double$,
+	ldl: $arrow.l.long.double$,
+	ldr: $arrow.r.long.double$,
+	ldlr: $arrow.l.r.long.double$,
+)

--- a/packages/preview/lasaveur/0.1.5/typst.toml
+++ b/packages/preview/lasaveur/0.1.5/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "lasaveur"
+version = "0.1.5"
+entrypoint = "typst-lasaveur.typ"
+authors = ["Paul Yang <https://github.com/yangwenbo99>"]
+license = "MIT"
+description = "Porting vim-latex's math shorthands to Typst.  An accommendating vim syntax file is provided in the repo."
+
+repository = "https://github.com/yangwenbo99/typst-lasaveur"
+keywords = ["math", "syntactic sugar", "shortcut"]
+categories = ["utility"]
+compiler="0.15.0"


### PR DESCRIPTION

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: 

This is a Typst package for speedy mathematical input, inspired by [vim-latex](https://github.com/vim-latex/vim-latex). This project is named after my Vim plugin [vimtex-lasaveur](https://github.com/yangwenbo99/vimtex-lasaveur), which ports the operations in vim-latex to [vimtex](https://github.com/lervag/vimtex).

The newest typst version makes a few symbols obsolete.  Therefore, a few changes were made to make the compiler happy.