### PR TITLE
presio:0.2.2

### DIFF
--- a/packages/preview/presio/0.2.2/LICENSE
+++ b/packages/preview/presio/0.2.2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benedict Armstrong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/presio/0.2.2/README.md
+++ b/packages/preview/presio/0.2.2/README.md
@@ -1,0 +1,152 @@
+# presio
+
+Attach **speaker notes** and **embedded media** (GIF / MP4 / WebM) to PDF slides
+so they can be presented with the [presio.xyz](https://presio.xyz) viewer.
+
+`presio` is framework-agnostic — it works with [polylux](https://typst.app/universe/package/polylux),
+[touying](https://typst.app/universe/package/touying), or plain Typst pages. It
+only contributes two functions; layout and slide flow are up to your existing
+template.
+
+## Install
+
+```typ
+#import "@preview/presio:0.2.2": media, speaker-notes
+```
+
+Requires Typst 0.15 or newer (for the file `path` type). Users on Typst
+0.13–0.14 can pin to `@preview/presio:0.1.0`, which has a slightly more
+verbose bytes-based API.
+
+## Usage
+
+### Speaker notes
+
+```typ
+= Introduction
+
+Hello world.
+
+#speaker-notes[
+  Remember to mention the funding agency before the next slide.
+]
+```
+
+A JSON sidecar `notes-slide-<N>.json` is attached to the PDF. Multiple
+`speaker-notes[…]` calls on the same slide are concatenated into a single
+attachment, in source order.
+
+### Embedded media (local file)
+
+```typ
+#media(path("figures/demo.gif"), width: 60%)
+```
+
+`path("…")` is Typst 0.15's file-path type — it resolves relative to the
+file that constructed it, so the package can `read()` and `image()` the
+target on the caller's behalf. The bytes are embedded in the PDF via
+`pdf.attach` and a placement descriptor JSON is written alongside it.
+
+By default the in-slide preview is `image(source)`. For MP4 / WebM
+(which Typst can't render directly) pass an explicit `placeholder:
+image("poster.png")`, or `placeholder: none` to get a dark block.
+
+### Embedded media (URL)
+
+```typ
+#media(
+  "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif",
+  width: 40%,
+  aspect-ratio: 1,
+)
+```
+
+Nothing is attached to the PDF; the viewer fetches the URL at presentation time.
+
+### YouTube / Vimeo
+
+URLs from YouTube (`youtube.com/watch?v=…`, `youtu.be/…`, `youtube.com/embed/…`,
+`youtube.com/shorts/…`, `youtube-nocookie.com/embed/…`) and Vimeo
+(`vimeo.com/<id>`, `player.vimeo.com/video/<id>`) are detected automatically and
+emitted with `kind: "youtube"` / `kind: "vimeo"` plus an extracted `video_id`
+the viewer can use to build an iframe embed.
+
+```typ
+#media("https://www.youtube.com/watch?v=dQw4w9WgXcQ", width: 60%, aspect-ratio: 16/9)
+#media("https://vimeo.com/76979871", width: 60%, aspect-ratio: 16/9)
+```
+
+## `media` parameters
+
+| Parameter      | Default | Notes                                                                                                       |
+| -------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `source`       | —       | Either a `path` (from `path("…")`) or a `http(s)://` URL string                                             |
+| `name`         | `none`  | Override for the attachment filename / MIME sniff. Auto-derived from the path's filename when omitted.      |
+| `placeholder`  | `auto`  | `auto` → `image(source)` for files, dark block for URLs. `none` → force dark block. Any `content` → use it. |
+| `width`        | `auto`  | Length, ratio of the container width, or `auto` (natural width of `placeholder`, else container width)      |
+| `height`       | `auto`  | Length, ratio, or `auto` (derived from `placeholder` / `aspect-ratio` / 16:9)                               |
+| `aspect-ratio` | `none`  | Width/height ratio, e.g. `16/9`                                                                             |
+| `autoplay`     | `true`  | Forwarded to the viewer                                                                                     |
+| `loop`         | `true`  | Forwarded to the viewer                                                                                     |
+
+## Supported media types
+
+The MIME is sniffed from the extension of the source path's filename (file mode) or the URL (URL mode):
+
+| Extension | MIME         |
+| --------- | ------------ |
+| `.gif`    | `image/gif`  |
+| `.mp4`    | `video/mp4`  |
+| `.webm`   | `video/webm` |
+
+## Sidecar JSON schemas
+
+**`notes-slide-<N>.json`** — `notes` is always an array (one entry per
+`speaker-notes` call on that slide, in source order):
+
+```json
+{ "slide": "3", "notes": [ "<typst content>", "<typst content>" ] }
+```
+
+**`media-slide-<N>-<id>.json`**
+
+Common fields: `kind`, `slide`, `id`, `mime`, `x_pt`, `y_pt`, `w_pt`, `h_pt`,
+`autoplay`, `loop`. The remaining fields depend on `kind`:
+
+| `kind`    | Extra fields                     |
+| --------- | -------------------------------- |
+| `file`    | `filename` (PDF attachment name) |
+| `url`     | `url` (direct media URL)         |
+| `youtube` | `url`, `video_id`                |
+| `vimeo`   | `url`, `video_id`                |
+
+```json
+{
+  "kind": "file",
+  "slide": 3,
+  "id": "demo_gif",
+  "mime": "image/gif",
+  "x_pt": 72.0, "y_pt": 120.0, "w_pt": 432.0, "h_pt": 243.0,
+  "autoplay": true,
+  "loop": true,
+  "filename": "media-demo_gif.gif"
+}
+```
+
+## Examples
+
+A complete deck for each supported workflow lives under `examples/`. Each
+folder is self-contained (its own `demo.gif`) and is compiled to PDF
+alongside the source.
+
+| Framework   | Source                                                                                                                                | Compiled PDF                                                                                                         |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Plain Typst | [`examples/plain/example.typ`](https://github.com/benedict-armstrong/presio-typst-package/blob/v0.2.0/examples/plain/example.typ)     | [`example.pdf`](https://github.com/benedict-armstrong/presio-typst-package/blob/v0.2.0/examples/plain/example.pdf)   |
+| polylux     | [`examples/polylux/example.typ`](https://github.com/benedict-armstrong/presio-typst-package/blob/v0.2.0/examples/polylux/example.typ) | [`example.pdf`](https://github.com/benedict-armstrong/presio-typst-package/blob/v0.2.0/examples/polylux/example.pdf) |
+| touying     | [`examples/touying/example.typ`](https://github.com/benedict-armstrong/presio-typst-package/blob/v0.2.0/examples/touying/example.typ) | [`example.pdf`](https://github.com/benedict-armstrong/presio-typst-package/blob/v0.2.0/examples/touying/example.pdf) |
+
+Rebuild with `typst compile --root . examples/<framework>/example.typ examples/<framework>/example.pdf` from the repo root. The `--root .` flag is required so the file-`path` sandbox can resolve `demo.gif`.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/packages/preview/presio/0.2.2/src/lib.typ
+++ b/packages/preview/presio/0.2.2/src/lib.typ
@@ -1,0 +1,231 @@
+// presio: attach speaker notes and embedded media to PDF slides for presio.xyz
+
+#let _mime-for-ext(ext) = if ext == "gif" {
+  "image/gif"
+} else if ext == "mp4" {
+  "video/mp4"
+} else if ext == "webm" {
+  "video/webm"
+} else {
+  "application/octet-stream"
+}
+
+#let _youtube-id(url) = {
+  let m = url.match(
+    regex(
+      "(?:youtube\.com/watch\?(?:[^ ]*&)?v=|youtu\.be/|youtube(?:-nocookie)?\.com/embed/|youtube\.com/shorts/)([A-Za-z0-9_-]{11})",
+    ),
+  )
+  if m != none { m.captures.first() } else { none }
+}
+
+#let _vimeo-id(url) = {
+  let m = url.match(regex("vimeo\.com/(?:video/|channels/[^/]+/|groups/[^/]+/videos/)?(\d+)"))
+  if m != none { m.captures.first() } else { none }
+}
+
+// Embed a gif / mp4 / webm to be played by the presio viewer.
+//
+// `source` is one of:
+//   - a `path` (constructed with `path("figures/demo.gif")` at the call
+//     site): a local file. The bytes are read and attached to the PDF.
+//     For image formats (png, jpg, gif, svg, webp) the in-slide preview
+//     defaults to `image(source)`; video files (mp4, webm) get a dark
+//     block unless an explicit `placeholder` is given.
+//   - a string starting with "http://" or "https://": a URL. Nothing is
+//     attached to the PDF; the viewer fetches the URL at presentation
+//     time. YouTube and Vimeo URLs are detected automatically.
+//
+// `name` is normally derived from the path's filename. Pass it
+// explicitly to override the attachment filename / MIME sniffing.
+//
+// `placeholder`:
+//   - `auto` (default): for local image files, use `image(source)`;
+//     for videos and URLs, draw a dark block.
+//   - `none`: force a dark block.
+//   - any `content`: rendered as the preview.
+//
+// Videos play muted (no audio).
+#let media(
+  source,
+  name: none,
+  width: auto,
+  height: auto,
+  autoplay: true,
+  loop: true,
+  placeholder: auto,
+  aspect-ratio: none,
+) = (
+  layout(container => context {
+    // Use the physical page (`here().page()`), not the logical page counter.
+    // Under touying, `counter(page)` returns the same value for every
+    // subslide of an overlay group, so content that appears on multiple
+    // subslides would collide on a single attachment name (and Typst errors
+    // on a duplicate attachment). `here().page()` advances per physical page,
+    // matching how the presio viewer flips through the PDF — and matching
+    // what `speaker-notes` already uses. (In polylux the two agree.)
+    let page-num = here().page()
+    let is-path = type(source) == path
+    let is-url = (
+      type(source) == str
+        and (
+          source.starts-with("http://") or source.starts-with("https://")
+        )
+    )
+    assert(
+      is-path or is-url,
+      message: "presio.media: `source` must be a path or a http(s) URL string",
+    )
+
+    let derived-name = if is-path {
+      // Typst 0.15 doesn't expose path → string directly; parse repr().
+      let m = repr(source).match(regex("^path\\(\"(.+)\"\\)$"))
+      if m != none { m.captures.first().split("/").last() } else { "media" }
+    } else { source }
+    let ref-name = if name != none { name } else { derived-name }
+
+    let yt-id = if is-url { _youtube-id(source) } else { none }
+    let vimeo-id = if is-url and yt-id == none { _vimeo-id(source) } else { none }
+    let kind = if is-path {
+      "file"
+    } else if yt-id != none {
+      "youtube"
+    } else if vimeo-id != none {
+      "vimeo"
+    } else {
+      "url"
+    }
+
+    let safe-id = ref-name.replace(regex("[^A-Za-z0-9]"), "_")
+    let ext-source = ref-name.split("?").first().split("#").first()
+    let ext = lower(ext-source.split(".").last())
+    let mime = if kind == "youtube" or kind == "vimeo" {
+      "text/html"
+    } else {
+      _mime-for-ext(ext)
+    }
+
+    // `image()` can't decode video files, so the auto-preview only applies
+    // to extensions Typst can actually render; videos fall back to the
+    // dark block (pass an explicit `placeholder` for a poster frame).
+    let image-exts = ("png", "jpg", "jpeg", "gif", "svg", "svgz", "webp")
+    let resolved-placeholder = if placeholder == auto {
+      if is-path and ext in image-exts { image(source) } else { none }
+    } else { placeholder }
+
+    let w = if width == auto {
+      if resolved-placeholder != none {
+        let natural = measure(resolved-placeholder)
+        if natural.width > 0pt { natural.width } else { container.width }
+      } else {
+        container.width
+      }
+    } else if type(width) == ratio {
+      container.width * width
+    } else {
+      width
+    }
+    let h = if height != auto {
+      if type(height) == ratio { container.height * height } else { height }
+    } else if aspect-ratio != none {
+      w / aspect-ratio
+    } else if resolved-placeholder != none {
+      let natural = measure(resolved-placeholder)
+      if natural.width > 0pt {
+        w * (natural.height / natural.width)
+      } else {
+        w * 9 / 16
+      }
+    } else {
+      w * 9 / 16
+    }
+    let pos = here().position()
+
+    let media-filename = if kind == "file" {
+      "media-" + safe-id + "." + ext
+    } else { none }
+
+    if kind == "file" {
+      pdf.attach(
+        media-filename,
+        read(source, encoding: none),
+        mime-type: mime,
+        description: "Media: " + ref-name,
+      )
+    }
+
+    let meta = (
+      kind: kind,
+      slide: page-num,
+      id: safe-id,
+      mime: mime,
+      x_pt: pos.x.pt(),
+      y_pt: pos.y.pt(),
+      w_pt: w.pt(),
+      h_pt: h.pt(),
+      autoplay: autoplay,
+      loop: loop,
+    )
+    let meta-with-source = if kind == "file" {
+      meta + (filename: media-filename)
+    } else if kind == "youtube" {
+      meta + (url: source, video_id: yt-id)
+    } else if kind == "vimeo" {
+      meta + (url: source, video_id: vimeo-id)
+    } else {
+      meta + (url: source)
+    }
+    pdf.attach(
+      "media-slide-" + str(page-num) + "-" + safe-id + ".json",
+      bytes(json.encode(meta-with-source)),
+      mime-type: "application/json",
+      description: "Media placement for slide " + str(page-num),
+    )
+
+    block(
+      width: w,
+      height: h,
+      fill: if resolved-placeholder == none { rgb("#222") } else { none },
+      radius: 6pt,
+      clip: true,
+      if resolved-placeholder != none {
+        resolved-placeholder
+      } else {
+        align(center + horizon, text(fill: white)[▶ #ref-name])
+      },
+    )
+  })
+)
+
+#let _presio-notes-counter = counter("_presio-notes-call")
+
+// Attach speaker notes to the current slide as a JSON sidecar
+// (`notes-slide-<N>.json`) consumed by the presio viewer.
+//
+// Multiple calls on the same slide are concatenated into a single
+// attachment whose `notes` field is a list, in source order. Dedup is
+// counter-based — each call stamps its sequence number into the
+// metadata and only the call with the max number on a slide emits the
+// `pdf.attach`. (y-position dedup collides when calls are stacked
+// back-to-back with no separator content.)
+#let speaker-notes(notes) = {
+  _presio-notes-counter.step()
+  context {
+    let n = _presio-notes-counter.get().first()
+    [#metadata((notes: notes, n: n)) <_presio-notes>]
+    let pg = here().page()
+    let on-slide = query(<_presio-notes>).filter(el => el.location().page() == pg)
+    // `on-slide` is empty during early introspection passes (before
+    // metadata is observed). Skip emission until our own metadata is
+    // visible — by then `max-n` reflects the final state.
+    if on-slide.len() > 0 and n == calc.max(..on-slide.map(el => el.value.n)) {
+      let all-notes = on-slide.map(el => el.value.notes)
+      pdf.attach(
+        "notes-slide-" + str(pg) + ".json",
+        bytes(json.encode((slide: str(pg), notes: all-notes))),
+        mime-type: "application/json",
+        description: "Speaker notes for slide " + str(pg),
+      )
+    }
+  }
+}

--- a/packages/preview/presio/0.2.2/typst.toml
+++ b/packages/preview/presio/0.2.2/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "presio"
+version = "0.2.2"
+entrypoint = "src/lib.typ"
+authors = ["Benedict Armstrong <benedict.armstrong@inf.ethz.ch>"]
+license = "MIT"
+description = "Attach speaker notes and embedded media to PDF slides for presio.xyz"
+repository = "https://github.com/benedict-armstrong/presio-typst-package"
+keywords = ["presentation", "slides", "speaker-notes", "video", "pdf"]
+categories = ["visualization"]
+compiler = "0.15.0"
+exclude = ["examples/**", "tests/**"]


### PR DESCRIPTION
Bugfix release of [presio](https://github.com/benedict-armstrong/presio-typst-package).

- Fixed `unknown image format` error when passing a local video file (mp4/webm) to `media()`: the default `auto` placeholder used `image(source)` for every local path, which Typst can't decode for video. The auto-preview is now gated on image extensions; videos fall back to the dark placeholder block (an explicit `placeholder` can supply a poster frame). Reported by a user of the package.

I confirm that I am the author of the previous versions (0.1.0, 0.2.0, 0.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)