### PR TITLE
Add Brazilian Portuguese support for package tieffiction 0.2.0

### DIFF
--- a/packages/preview/tieffiction/0.2.0/README.md
+++ b/packages/preview/tieffiction/0.2.0/README.md
@@ -33,6 +33,7 @@ TiefFiction is internationalized (is that a word?) and currently has versions fo
 - English US
 - English UK
 - Deutsch DE
+- Português BR
 
 As TiefFiction uses TiefLang (obviously), selecting a language can either be done by passing the `language` parameter to `setup` or `book` (see below), or using TiefLang directly. Look at [TiefLang](https://github.com/Tiefseetauchner/TiefLang) for more information.
 

--- a/packages/preview/tieffiction/0.2.0/core/i18n.typ
+++ b/packages/preview/tieffiction/0.2.0/core/i18n.typ
@@ -6,6 +6,7 @@
   english-us: "en-us",
   english-uk: "en-uk",
   deutsch-de: "de-de",
+  portuguese-br: "pt-br"
 )
 
 #let ordinal-en = number => {
@@ -26,6 +27,8 @@
 }
 
 #let ordinal-de = number => [#number.]
+
+#let ordinal-br = number => [#number.]
 
 #let copyright-line = (holder, year) => {
   if holder != none and year != none {
@@ -145,11 +148,47 @@
   ordinal: ordinal-de,
 )
 
+#let i18n-pt-br = (
+  copyright-page: (holder, publisher, year, isbn, edition, license, extra) => (
+    copyright-line(holder, year),
+    if edition != none {
+      [Edição #ordinal-br(edition)]
+    },
+    if publisher != none and year != none {
+      [Publicado por #publisher em #year.]
+    } else if publisher != none {
+      [Publicado por #publisher.]
+    } else if year != none {
+      [Publicado em #year.]
+    } else {
+      none
+    },
+    [Todos os direitos reservados.],
+    ..extra,
+    ..if license != none {
+      (
+        v(20pt),
+        [Esta obra é licenciada sob uma #link(cc-url(license), [licença Creative Commons '#license']).\
+          #ccicon(license + "-badge", scale: 3)],
+        v(20pt),
+      )
+    },
+    if isbn != none {
+      [ISBN: #isbn\
+        #render-isbn(isbn)]
+    },
+  ),
+  chapter: chapter-number => [Capítulo #chapter-number],
+  table-of-content: [Sumário],
+  ordinal: ordinal-br,
+)
+
 #let setup-i18n = () => configure-translations(
   (
     en-us: i18n-en-us,
     en-uk: i18n-en-uk,
     de-de: i18n-de-de,
+    pt-br: i18n-pt-br,
   ),
   strict: true,
   default: "en-us",


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

## Description
Adds Brazilian Portuguese support for the internationalization of package tieffiction.

This was done by simply following the existing patterns of the `i18n.typ` file for US and UK English and German. 
