### PR TITLE
vlna:0.2.0

### DIFF
--- a/packages/preview/vlna/0.2.0/CHANGELOG.md
+++ b/packages/preview/vlna/0.2.0/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## [0.2.0] – 2026
+
+Major rewrite of the core.
+
+### Fixed
+- **Jump-to-source preserved.** Feature #1 no longer rebuilds text with
+  `it.text.replace(" ", "~")` (which moved the source position of the affected
+  glyphs to the package). Both short words and titles now wrap the **original**
+  matched content in `#box(..)`, so clicking a glyph in the PDF jumps back to
+  the document, not to the package code.
+- Title alternation is ordered **longest-first**, so multi-word titles match
+  correctly (`Ing. arch.`, `dr. h. c.`, `pplk. gšt.` no longer lose to their
+  shorter prefixes).
+- Typo `plk` → `plk.` in the list of titles.
+- Non-period abbreviations get a trailing word boundary, so `viz` no longer
+  matches inside `vize` and `PhD` no longer matches the start of `PhDr.`.
+
+### Added
+- **Titles after a name** (`Ph.D.`, `PhD.`, `Th.D.`, `CSc.`, `DrSc.`, `DSc.`,
+  `DiS.`, `MBA`, `LL.M.`, `MSc.`) are bound to the preceding word.
+- **Chaining** of short words and titles into a single non-breaking run
+  (`k s bratrem`, `plk. gšt. doc. Mgr. et Mgr. Ing. Libor Kutěj`) — a unified
+  prefix run prevents adjacent rules from competing for the boundary word
+  (e.g. `za tzv. postup`).
+- **Two-letter words** with a lowercase second letter (`na`, `po`, `je`, `se`,
+  …) in addition to single letters.
+- `debug: true` mode that outlines every glued block.
+
+### Changed
+- Public API is unchanged: `#show: apply-vlna` still works. `apply-vlna` now
+  also accepts `debug: false`.
+
+## [0.1.1] – 2025-04-30
+- Short-word regex narrowed to `(\<\p{Lowercase}{1,2}\>)+ `.
+- Experimental list of titles/abbreviations before a name.
+
+## [0.1.0] – 2025-03-03
+- Initial non-breaking spaces after short prepositions/conjunctions.

--- a/packages/preview/vlna/0.2.0/LICENSE
+++ b/packages/preview/vlna/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 iamanro (formerly ShinoYumi)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/vlna/0.2.0/README.md
+++ b/packages/preview/vlna/0.2.0/README.md
@@ -1,0 +1,72 @@
+# `vlna` package for Typst
+
+In Czech typography, **„vlna"** (literally "wave") is a non-breaking space — the
+tilde `~` in Typst/LaTeX. This package inserts non-breaking spaces automatically
+so that lines never end with a one-/two-letter word, a title, or a common
+abbreviation.
+
+> Version 0.2.0 rewrites the core so that **jump-to-source keeps working** and
+> adds title/abbreviation handling with chaining support.
+
+## Usage
+
+```typ
+#import "@preview/vlna:0.2.0": apply-vlna
+#show: apply-vlna
+```
+
+Debug mode outlines every glued block (short-word runs, titles before a name,
+titles after a name):
+
+```typ
+#show: apply-vlna.with(debug: true)
+```
+
+## What it does
+
+- **One-/two-letter words** — `k`, `s`, `v`, `z`, `a`, `i`, but also `na`, `po`,
+  `je`, `se`, … are bound to the following word. First letter may be uppercase
+  (so a sentence may start with `V lese…`); the optional second letter must be
+  lowercase, so acronyms like `EU`, `AI`, `OSN` are left alone.
+- **Titles / abbreviations before a name** — `Ing. arch. Novák`,
+  `pplk. gšt. Svoboda`, `dr. h. c. Dvořák`, `viz tabulka`, `tzv. postup`, `s. 12`.
+- **Titles after a name** — `Novák, Ph.D.`, `Malý, CSc.`
+- **Chaining** — runs like `k s bratrem` or `plk. gšt. doc. Mgr. et Mgr. Ing.
+  Libor Kutěj` stay together as one block.
+
+## How it works (and why jump-to-source is preserved)
+
+A `show` rule that rebuilds text (`it.text.replace(" ", "~")`) produces **new**
+content whose source position points at the rule itself — so clicking the
+letter in the PDF jumps to the package code, not to your document.
+
+Version 0.2.0 instead wraps the **original matched content** in `#box(..)`.
+The box cannot break internally, yet the glyphs keep their original source
+span, so clicking them jumps to your document.
+
+**Trade-off:** inside a box, spaces do not stretch under justification and the
+words are not hyphenated. In practice this is not noticeable; a very long word
+right after a preposition could occasionally produce a slightly looser line.
+
+## Implementation status
+
+| # | Feature | 0.1.1 | 0.2.0 |
+|---|---------|:-----:|:-----:|
+| 1 | One-/two-letter words | ✅ (via `~`) | ✅ (box, source-safe) |
+| 9 | Abbreviations / titles **before** a name | ⚠️ partial | ✅ |
+| — | Titles **after** a name (`Ph.D.`, `CSc.`) | — | ✅ |
+| — | Chaining of words / titles | — | ✅ |
+| — | Debug visualisation | — | ✅ |
+| 2–8 | Digit groups, numbers + units, dates, … | ❌ | ❌ |
+
+The goal mirrors `luavlna` (Michal Hoftich) and the Czech typographic rules of
+the Institute of the Czech Language:
+<https://prirucka.ujc.cas.cz/?id=880>
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).
+
+## License
+
+MIT — © 2025–2026 iamanro.

--- a/packages/preview/vlna/0.2.0/lib.typ
+++ b/packages/preview/vlna/0.2.0/lib.typ
@@ -1,0 +1,134 @@
+// vlna 0.2.0 — česká sazba: nezlomitelné mezery („vlna").
+// Oproti 0.1.1 zachovává „skok do zdroje" (box místo přepisu textu na ~),
+// navíc řeší dvoupísmenná slova, řetězení, tituly před i za jménem a zkratky.
+//
+// Pravidla:
+//   1. Za jedno- a dvoupísmennými slovy řádek nekončí (k, s, v, z, a, i, …,
+//      ale i „po", „do", „je", „se") — mezera za nimi je nezlomitelná.
+//   2. Tituly a zkratky PŘED jménem/výrazem (Ing., doc., pplk. gšt., např.,
+//      viz, s., …) se váží k následujícímu slovu.
+//   3. Tituly ZA jménem (Ph.D., CSc., …) se váží k předchozímu slovu.
+//
+// Ladění: `#show: apply-vlna.with(debug: true)` orámuje všechny zásahy.
+
+// Vzor krátkého slova (1–2 písmena): první písmeno libovolné (věta smí začínat
+// „V lese…"), druhé jen malé — pravidlo se tak nedotkne zkratek typu EU, AI,
+// OSN. Sestavení do běhu s navazujícím slovem je níže (short-run).
+
+// --- Tituly a zkratky PŘED jménem -------------------------------------------
+#let before-list = (
+  // === Oslovení ===
+  "p.", "pan", "Pan", "pí.", "paní", "Paní", "sl.", // Česká
+  "Mr.", "Mrs.", "Ms.", // Anglická
+
+  // === Akademické tituly (před jménem) ===
+  // Bakalářské
+  "bc.", "Bc.", "BcA.",
+  // Magisterské a inženýrské
+  "mgr.", "Mgr.", "mga.", "MgA.",
+  "ing.", "Ing.", "Ing. arch.",
+  // Doktorské (tzv. „malé" a profesní)
+  "dr.", "Dr.", // Obecný doktorát (historický, již se neuděluje)
+  "mudr.", "MUDr.", // Lékařství
+  "mvdr.", "MVDr.", // Veterinární lékařství
+  "MDDr.", // Zubní lékařství
+  "judr.", "JUDr.", // Právo
+  "phdr.", "PhDr.", // Filosofie
+  "rndr.", "RNDr.", // Přírodní vědy
+  "PharmDr.", // Farmacie
+  "thdr.", "ThDr.", // Teologie (starší doktorát)
+  "ThLic.", // Licenciát teologie
+
+  // === Akademické hodnosti (vědecko-pedagogické) ===
+  "doc.", "Doc.", // Docent
+  "prof.", "Prof.", // Profesor
+  "akad.", // akademik (nejvyšší vědecká hodnost ČSAV, již se neuděluje)
+
+  // === Čestné tituly ===
+  "dr. h. c.", // Doctor honoris causa
+
+  // === Vojenské hodnosti ===
+  // Mužstvo
+  "voj.", "svob.",
+  // Poddůstojníci
+  "des.", "čet.", "rtn.",
+  // Praporčíci
+  "rtm.", "nrtm.", "prap.", "nprap.", "šprap.",
+  // Nižší důstojníci
+  "por.", "npor.", "kpt.",
+  // Vyšší důstojníci
+  "mjr.", "pplk.", "pplk. gšt.", "plk.", "plk. gšt.",
+  // Generálové
+  "brig.gen.", "genmjr.", "genpor.", "arm.gen.",
+  // === Policejní hodnosti (mimo již zavedené) ===
+  "stržm.", "nstržm.", "pprap.", "ppor.",
+
+  // === Zkratky ===
+  "aj.", "apod.", "atd.", "atp.", "cca", "č.", "čj.", "kupř.", "mj.",
+  "např.", "popř.", "pozn.", "př.", "příp.", "resp.", "s.", "str.", "sv.",
+  "tj.", "tzv.", "tzn.", "viz", "zvl.",
+)
+
+// --- Tituly ZA jménem --------------------------------------------------------
+#let after-list = (
+  "DiS.",
+  "Ph.D.", // Doktor (vědecký, standardní)
+  "PhD.", // zahraniční varianta
+  "PhD", // zahraniční varianta bez teček
+  "Th.D.", // Doktor teologie (vědecký)
+  "CSc.", // Kandidát věd (dobíhá)
+  "DrSc.", // Doktor věd (dobíhá)
+  "DSc.", // Doktor věd (UK a AV ČR)
+  "MBA", "LL.M.", "MSc.",
+)
+
+// --- Sestavení vzorů ---------------------------------------------------------
+#let escape-dot(t) = t.replace(".", "\\.")
+
+// Alternace: delší varianty první (jinak by „pplk." vyhrálo nad „pplk. gšt."
+// a „Ing." nad „Ing. arch."). Položky NEkončící tečkou dostanou koncovou
+// hranici slova, aby „PhD" nechytalo začátek „PhDr." ani „viz" slovo „vize".
+#let alternation(list) = {
+  list
+    .sorted(key: t => -t.len())
+    .map(t => escape-dot(t) + if not t.ends-with(".") { "\\>" } else { "" })
+    .join("|")
+}
+
+// Pravidla matchují CELÝ blok (krátká slova + jejich slovo / titul + jméno),
+// aby ho šlo obalit do #box a tím zamezit zlomu. Klíčové pro zachování
+// „skoku do zdroje": box propouští PŮVODNÍ `it` beze změny, takže glyfy si
+// drží zdrojovou pozici. (Kdybychom místo toho přepisovali `it.text`, nový
+// text by dostal pozici tohoto modulu a klik v PDF by mířil sem, ne do textu.)
+//
+// Kompromis oproti přepisu na ~: uvnitř boxu se mezery při justify nenatahují
+// a slovo v boxu se nezlomí dělením (u velmi dlouhých slov za předložkou proto
+// může vzniknout volnější řádek).
+
+// Předpona = jeden „lepivý" prvek: krátké slovo NEBO titul/zkratka před jménem.
+// Sloučení do jednoho vzoru je nutné kvůli řetězení — jinak by u „za tzv. X"
+// krátké slovo „za" pohltilo titul „tzv." jako své cílové slovo a titul by se
+// pak od „X" oddělil (a stejně u „Mgr. et Mgr. Ing. Novák").
+#let short-word = "\\<\\p{L}\\p{Ll}?\\>"
+#let prefix = "(?:" + short-word + "|\\<(?:" + alternation(before-list) + "))"
+
+// Běh předpon + cílové slovo:  „k s bratrem", „V současném", „za tzv. postup",
+// „prof. Ing. arch. Novák".
+#let prefix-run = regex("(?:" + prefix + " )+\\S+")
+// Slovo + titul ZA jménem:  „Novák, Ph.D."
+#let after-pattern = regex("\\S+ (?:" + alternation(after-list) + ")")
+
+// --- Aplikace ----------------------------------------------------------------
+#let apply-vlna(doc, debug: false) = {
+  // box(it) = nezlomitelný blok se zachovanou zdrojovou pozicí glyfů.
+  let glue(color) = if debug {
+    it => box(stroke: .5pt + color, outset: 1.5pt, it)
+  } else {
+    it => box(it)
+  }
+
+  show prefix-run: glue(purple)
+  show after-pattern: glue(blue)
+
+  doc
+}

--- a/packages/preview/vlna/0.2.0/typst.toml
+++ b/packages/preview/vlna/0.2.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vlna"
+version = "0.2.0"
+entrypoint = "lib.typ"
+authors = ["iamanro"]
+license = "MIT"
+description = "Czech non-breaking spaces (vlna): short words, titles before/after a name and common abbreviations — with jump-to-source preserved."
+repository = "https://github.com/iamanro/typst-vlna"
+keywords = ["czech", "typography", "non-breaking space", "vlna", "luavlna"]
+categories = ["utility"]
+exclude = ["examples"]


### PR DESCRIPTION
Update of my own package **vlna** from 0.1.1 to **0.2.0**.

> Note for review: the previously published versions list the author as
> `ShinoYumi`, which is my former GitHub username — the account was renamed to
> `iamanro` (so `github.com/ShinoYumi/typst-vlna` now redirects to
> `github.com/iamanro/typst-vlna`). Same author, same package.

### What's new in 0.2.0
- **Jump-to-source preserved.** The old rule rebuilt text with
  `it.text.replace(" ", "~")`, which moved the source position of the affected
  glyphs onto the package. 0.2.0 wraps the **original** matched content in
  `#box(..)` instead, so clicking a glyph in the PDF still jumps to the user's
  document.
- Unified short-word + title runs → fixes chaining (`za tzv. X`,
  `Mgr. et Mgr. Ing. Novák`).
- Titles **after** a name (`Ph.D.`, `CSc.`, …); two-letter words; `debug` mode.
- Longest-first title alternation; `plk.` typo fix; word boundaries so `viz`
  doesn't match inside `vize` and `PhD` doesn't match `PhDr.`.

Public API is unchanged (`#show: apply-vlna`). License stays MIT.