### PR TITLE
vlna:0.3.0

### DIFF
--- a/packages/preview/vlna/0.3.0/CHANGELOG.md
+++ b/packages/preview/vlna/0.3.0/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+## [0.3.0] – 2026-07-21
+
+Implements the full ÚJČ line-breaking guideline
+([prirucka.ujc.cas.cz/?id=880](https://prirucka.ujc.cas.cz/?id=880)) and the
+luavlna command set — every rule group individually switchable.
+
+### Added
+- `bind-two-letter-words: false` — binds only one-letter words; two-letter
+  words (`na`, `po`, `je`, `se`, …) may end a line. The strict Czech rule
+  concerns one-letter prepositions/conjunctions; binding all two-letter words
+  can noticeably worsen line breaking in narrow layouts.
+- `short-words` — an explicit, case-sensitive set of words to bind, replacing
+  the built-in short-word pattern. Accepts a string of single letters
+  (`"vksuozVKSUOZAI"`) or an array of words (`("v", "k", "na", "Na")`).
+  Takes precedence over `bind-two-letter-words`. Titles and abbreviations
+  are bound regardless.
+- **luavlna parity** (see the command mapping table in the README):
+  - `short-words` also accepts a per-language dictionary
+    (`(cs: "AIiVvOoUuSsZzKk", sk: …)`), resolved against `text.lang` —
+    the equivalent of `\singlechars`. Languages not listed are left
+    unprocessed, as in luavlna.
+  - `lang: "cs"` forces one language's set for the whole document,
+    ignoring `text.lang` — the equivalent of `\preventsinglelang`.
+  - **Initials** (`M. J. Hegel`, `Ž. Zíbrt`) are bound to the following word
+    and chain with titles (`Ing. B. Novák`). `initials: false` turns this
+    off; `compound-initials: ("Ch",)` declares multi-letter initials — the
+    equivalent of `\compoundinitials`.
+  - Mid-document toggles `#vlna-off()` / `#vlna-on()` and
+    `#vlna-debug-on()` / `#vlna-debug-off()` — the equivalents of
+    `\preventsingleoff/on` and `\preventsingledebugon/off`.
+- **ÚJČ rules** (prirucka.ujc.cas.cz/?id=880), each with its own toggle:
+  - `numbers` + `units` — digit grouping (`2 500`, `25,325 23`, phone
+    numbers `+420 800 123 987`), number + symbol (`50 %`, `§ 23`, `* 1921`,
+    `† 2000`) and number + unit/abbreviation/currency (`10 kg`, `19 °C`,
+    `5 str.`, `1 000 000 Kč`, `250 €`). The unit list is exported as
+    `default-units` and can be replaced or extended.
+  - `ratios` — scales, ratios and division (`1 : 50 000`, `10 : 2 = 5`).
+  - `dates` + `months` — day and month hold together, the year may
+    separate (`21. 6. | 2024`, `16. ledna | 1972`).
+  - `number-word` (off by default — aggressive) — number + counted noun
+    (`500 lidí`, `strana 2`, `5. pluk`, `II. patro`, `Karel IV.`).
+  - `abbreviations` — compound abbreviations and codes (`a. s.`,
+    `s. r. o.`, `př. n. l.`, `PS PČR`, `FF UK`, `ČSN 01 6910`).
+  - `dashes` — a spaced dash stays at the end of a line (`slovo –`);
+    an unspaced range dash does not break at all (`1948–1989`).
+  - `links` — web/e-mail addresses in `link()` receive zero-width-space
+    break opportunities at the spots ÚJČ recommends (after `/` but not
+    inside `//`, before `.`, `-` and other special characters, around `@`).
+    The link destination is untouched. Social-media handles (`@SenatCZ`)
+    get no break after the `@`. Works also for bodies that parse as
+    sequences (escaped characters like `\@`) or carry styling.
+  - Initials also cover abbreviated given names (`Fr. Daneš`,
+    `M. Těšitelová` — ÚJČ), and the before-name list gained `kap.`, `obr.`,
+    `odst.`, `tab.` (`obr. 1`, `tab. 3`).
+- **Raw/code blocks are excluded** — code is not Czech running text, so no
+  rule glues anything inside `raw` (inline or block).
+- `examples/stress-test.typ` — a torture sheet covering every rule, edge
+  cases (Unicode, chained runs, narrow columns, URL breaking) and
+  degenerate configurations.
+  - The short-word run's target understands the numeric rules, so
+    `o 2 500 Kč`, `od 21. 6.`, `i s. r. o.` or `zápas o 5 : 3` are glued
+    as one block instead of the preposition stealing the first token.
+
+## [0.2.0] – 2026
+
+Major rewrite of the core.
+
+### Fixed
+- **Jump-to-source preserved.** Feature #1 no longer rebuilds text with
+  `it.text.replace(" ", "~")` (which moved the source position of the affected
+  glyphs to the package). Both short words and titles now wrap the **original**
+  matched content in `#box(..)`, so clicking a glyph in the PDF jumps back to
+  the document, not to the package code.
+- Title alternation is ordered **longest-first**, so multi-word titles match
+  correctly (`Ing. arch.`, `dr. h. c.`, `pplk. gšt.` no longer lose to their
+  shorter prefixes).
+- Typo `plk` → `plk.` in the list of titles.
+- Non-period abbreviations get a trailing word boundary, so `viz` no longer
+  matches inside `vize` and `PhD` no longer matches the start of `PhDr.`.
+
+### Added
+- **Titles after a name** (`Ph.D.`, `PhD.`, `Th.D.`, `CSc.`, `DrSc.`, `DSc.`,
+  `DiS.`, `MBA`, `LL.M.`, `MSc.`) are bound to the preceding word.
+- **Chaining** of short words and titles into a single non-breaking run
+  (`k s bratrem`, `plk. gšt. doc. Mgr. et Mgr. Ing. Libor Kutěj`) — a unified
+  prefix run prevents adjacent rules from competing for the boundary word
+  (e.g. `za tzv. postup`).
+- **Two-letter words** with a lowercase second letter (`na`, `po`, `je`, `se`,
+  …) in addition to single letters.
+- `debug: true` mode that outlines every glued block.
+
+### Changed
+- Public API is unchanged: `#show: apply-vlna` still works. `apply-vlna` now
+  also accepts `debug: false`.
+
+## [0.1.1] – 2025-04-30
+- Short-word regex narrowed to `(\<\p{Lowercase}{1,2}\>)+ `.
+- Experimental list of titles/abbreviations before a name.
+
+## [0.1.0] – 2025-03-03
+- Initial non-breaking spaces after short prepositions/conjunctions.

--- a/packages/preview/vlna/0.3.0/LICENSE
+++ b/packages/preview/vlna/0.3.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 iamanro (formerly ShinoYumi)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/vlna/0.3.0/README.md
+++ b/packages/preview/vlna/0.3.0/README.md
@@ -1,0 +1,225 @@
+# `vlna` package for Typst
+
+In Czech typography, **„vlna"** (literally "wave") is a non-breaking space — the
+tilde `~` in Typst/LaTeX. This package inserts non-breaking spaces
+automatically, so that lines never break in the places where Czech
+typographic rules forbid it: after short prepositions, inside numbers and
+dates, between a number and its unit, in compound abbreviations, and more.
+
+It implements the guideline of the Institute of the Czech Language
+([Internetová jazyková příručka, ?id=880](https://prirucka.ujc.cas.cz/?id=880))
+and mirrors the feature set of `luavlna` (Michal Hoftich) — every rule group
+has its own on/off switch.
+
+## Usage
+
+```typ
+#import "@preview/vlna:0.3.0": apply-vlna
+#show: apply-vlna
+```
+
+That is all — the defaults follow the ÚJČ guideline. Debug mode outlines
+every glued block so you can see exactly what the package did:
+
+```typ
+#show: apply-vlna.with(debug: true)
+```
+
+## What it does
+
+- **One-/two-letter words** — `k`, `s`, `v`, `z`, `a`, `i`, but also `na`,
+  `po`, `je`, `se`, … are bound to the following word. The first letter may
+  be uppercase (a sentence may start with `V lese…`); the optional second
+  letter must be lowercase, so acronyms like `EU`, `AI`, `OSN` are left
+  alone.
+- **Titles / abbreviations before a name** — `Ing. arch. Novák`,
+  `pplk. gšt. Svoboda`, `dr. h. c. Dvořák`, `viz tabulka`, `tzv. postup`,
+  `s. 12`, `obr. 1`, `tab. 3`.
+- **Titles after a name** — `Novák, Ph.D.`, `Malý, CSc.`
+- **Initials and abbreviated given names** — `M. J. Hegel`, `Ž. Zíbrt`,
+  `Fr. Daneš`, `Ch. Novák`.
+- **Numbers** — digit grouping (`2 500`, `25,325 23`), phone numbers
+  (`+420 800 123 987`, `800 11 22 33`), number + symbol (`50 %`, `§ 23`,
+  `* 1921`, `† 2000`), number + unit, abbreviation or currency (`10 kg`,
+  `19 °C`, `5 str.`, `1 000 000 Kč`, `250 €`).
+- **Ratios and scales** — `1 : 50 000`, `5 : 3`, `10 : 2 = 5`.
+- **Dates** — day and month stay together, the year may separate:
+  `21. 6. | 2024`, `16. ledna | 1972`.
+- **Compound abbreviations and codes** — `a. s.`, `s. r. o.`, `př. n. l.`,
+  `T. G. M.`, `PS PČR`, `FF UK`, `ČSN 01 6910`.
+- **Dashes** — a spaced dash stays at the end of the line (`slovo –`);
+  an unspaced range dash never breaks (`1948–1989`).
+- **Web and e-mail addresses** — `link()` URLs get break opportunities
+  exactly where ÚJČ recommends them (after `/`, before `.` and `-`,
+  around `@`); social-media handles (`@SenatCZ`) never break after `@`.
+- **Chaining** — runs like `k s bratrem`, `o 2 500 Kč`, `od 21. 6.` or
+  `plk. gšt. doc. Mgr. et Mgr. Ing. Libor Kutěj` stay together as one block.
+- **Raw/code is skipped** — nothing is glued inside `raw`, inline or block.
+
+## Options
+
+Every rule group can be switched off (or on) independently:
+
+| Parameter | Default | Binds |
+|---|---|---|
+| `bind-two-letter-words` | `true` | two-letter words in addition to one-letter ones |
+| `short-words` | `auto` | which short words are bound (`none` disables them) |
+| `initials` | `true` | `M. J. Hegel`, `Fr. Daneš`, `Ž. Zíbrt` |
+| `compound-initials` | `("Ch",)` | multi-letter initials: `Ch. Novák` |
+| `titles` | `true` | titles/abbreviations before and after a name |
+| `numbers` | `true` | `2 500`, `50 %`, `§ 23`, `10 kg`, `+420 800 123 987` |
+| `units` | `default-units` | units/currencies bound after a number |
+| `ratios` | `true` | `1 : 50 000`, `10 : 2 = 5` |
+| `dates` | `true` | `21. 6. \| 2024`, `16. ledna \| 1972` (year may separate) |
+| `months` | `auto` (Czech) | month names recognised in dates |
+| `number-word` | `false` | `500 lidí`, `strana 2`, `5. pluk`, `Karel IV.` |
+| `abbreviations` | `true` | `a. s.`, `př. n. l.`, `PS PČR`, `ČSN 01 6910` |
+| `dashes` | `true` | `slovo –` at line end; `1948–1989` unbroken |
+| `links` | `true` | ÚJČ break points inside `link()` addresses |
+| `lang` | `auto` | force one language's set (see per-language sets) |
+| `debug` | `false` | outline every glued block |
+
+Notes:
+
+- `units` **replaces** the default list; extend it instead with
+  `units: default-units + ("µm", "dpt")` (`default-units` is exported).
+- `number-word` implements "číslo + název počítaného jevu" literally, which
+  removes a lot of break opportunities — that is why it is off by default.
+- The uppercase branch of `abbreviations` is limited to 2–4 letters per
+  part, so ALL-CAPS headings are not glued word by word.
+- `links` inserts zero-width spaces (U+200B) into the *displayed* address —
+  the technique the ÚJČ note itself recommends. The link target (`dest`)
+  is untouched and stays clickable.
+
+### Which short words are bound
+
+By default, both one- and two-letter words are bound. The strict Czech rule
+requires this only for one-letter prepositions/conjunctions — binding all
+two-letter words is a stronger convention that can hurt line breaking in
+narrow layouts (mobile-friendly pages, multi-column text):
+
+```typ
+// Bind only one-letter words; `na`, `po`, `je`, `se`, … may end a line:
+#show: apply-vlna.with(bind-two-letter-words: false)
+
+// Bind exactly these words and nothing else (case-sensitive).
+// A string is a set of single letters — this example binds one-letter
+// prepositions, their uppercase forms, and uppercase A/I, while allowing
+// lowercase `a`/`i` at the end of a line:
+#show: apply-vlna.with(short-words: "vksuozVKSUOZAI")
+
+// An array lists whole words, so two-letter words can be included:
+#show: apply-vlna.with(short-words: ("v", "k", "s", "z", "a", "i", "na", "Na"))
+```
+
+`short-words` replaces the built-in short-word pattern entirely and takes
+precedence over `bind-two-letter-words`.
+
+### Per-language sets (luavlna `\singlechars`)
+
+`short-words` also accepts a dictionary keyed by language code. The set is
+then chosen by the language of the surrounding text (`text.lang`), and —
+like in luavlna — **languages not listed are not processed at all** (neither
+short words nor title runs; the other rule groups stay language-independent):
+
+```typ
+#set text(lang: "cs")             // required — the default text.lang is "en"!
+#show: apply-vlna.with(short-words: (
+  cs: "AIiVvOoUuSsZzKk",          // luavlna's default set for Czech
+  sk: "AIiVvOoUuSsZzKk",
+))
+```
+
+To force one language's set for the whole document regardless of `text.lang`
+(luavlna `\preventsinglelang`):
+
+```typ
+#show: apply-vlna.with(short-words: (cs: "AIiVvOoUuSsZzKk"), lang: "cs")
+```
+
+### Initials (luavlna `\compoundinitials`)
+
+Initials and abbreviated given names — an uppercase letter, optionally
+followed by a lowercase one, plus a period — are bound to the next word and
+chain with titles: `M. J. Hegel`, `Fr. Daneš`, `Ing. B. Novák`. Compound
+letters that count as one initial default to `Ch` (`Ch. Novák`):
+
+```typ
+#show: apply-vlna.with(compound-initials: ("Ch",))  // default
+#show: apply-vlna.with(initials: false)             // turn initials off
+```
+
+### Mid-document toggles (luavlna `\preventsingleon/off`)
+
+A global `show` rule cannot be cancelled from inside the document, so the
+package provides state-based switches:
+
+```typ
+#import "@preview/vlna:0.3.0": apply-vlna, vlna-on, vlna-off, vlna-debug-on, vlna-debug-off
+#show: apply-vlna
+
+Tady se váže. #vlna-off() Tady ne. #vlna-on() A tady zase.
+#vlna-debug-on() Orámuje zásahy odsud dál. #vlna-debug-off()
+```
+
+### luavlna command mapping
+
+| luavlna | vlna for Typst |
+|---|---|
+| `\singlechars{czech}{AIiVvOoUuSsZzKk}` | `short-words: (cs: "AIiVvOoUuSsZzKk")` |
+| `\compoundinitials{czech}{Ch}` | `compound-initials: ("Ch",)` |
+| `\preventsinglelang{czech}` | `lang: "cs"` |
+| `\preventsingleoff` / `\preventsingleon` | `#vlna-off()` / `#vlna-on()` |
+| `\preventsingledebugon` / `...off` | `#vlna-debug-on()` / `#vlna-debug-off()` (or the `debug: true` parameter) |
+
+## How it works (and why jump-to-source is preserved)
+
+A `show` rule that rebuilds text (`it.text.replace(" ", "~")`) produces
+**new** content whose source position points at the rule itself — so
+clicking a letter in the PDF jumps to the package code, not to your
+document. This package instead wraps the **original matched content** in
+`#box(..)`. The box cannot break internally, yet the glyphs keep their
+original source span, so clicking them jumps to your document.
+
+Compile-time cost is roughly 2–2.5× of the bare document and scales
+linearly (measured: a 300-page all-rules-firing document compiles in
+~2.4 s vs. ~1.0 s without the package).
+
+## Limitations
+
+- Inside a box, spaces do not stretch under justification and words are not
+  hyphenated; a very long word right after a preposition can produce a
+  looser line. In extremely narrow columns, a glued group wider than the
+  line wraps at the column edge instead of gluing.
+- Matches cannot cross styling boundaries: in `k *lesu*` the `k` is not
+  bound, because the bold word is a separate element.
+- Initials are a heuristic — a sentence ending with a bare capital
+  (`… vitamin C. Nový výzkum`) is indistinguishable from an initial and
+  gets bound too. Use `initials: false` if that bothers you.
+- Text copied from a PDF may contain the invisible U+200B characters that
+  `links` inserted, and jump-to-source is not preserved for the rewritten
+  URL text (it is for everything else).
+
+## Implementation status
+
+| # | Feature | 0.1.1 | 0.2.0 | 0.3.0 |
+|---|---------|:-----:|:-----:|:----:|
+| 1 | One-/two-letter words | ✅ (via `~`) | ✅ (box, source-safe) | ✅ configurable |
+| 9 | Abbreviations / titles **before** a name | ⚠️ partial | ✅ | ✅ |
+| — | Titles **after** a name (`Ph.D.`, `CSc.`) | — | ✅ | ✅ |
+| — | Chaining of words / titles | — | ✅ | ✅ |
+| — | Debug visualisation | — | ✅ | ✅ + mid-doc toggle |
+| — | Initials (`M. J. Hegel`), compound `Ch.` | — | — | ✅ |
+| — | Per-language sets, `lang` forcing, on/off | — | — | ✅ |
+| 2–8 | Digit groups, number + symbol/unit, dates, ratios, phone numbers | ❌ | ❌ | ✅ |
+| — | Number + counted noun (`500 lidí`, `strana 2`) | — | — | ✅ opt-in |
+| — | Compound abbreviations (`a. s.`, `ČSN 01 6910`), dashes | — | — | ✅ |
+| — | URL / e-mail break points (ÚJČ, via U+200B) | — | — | ✅ |
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).
+
+## License
+
+MIT — © 2025–2026 iamanro.

--- a/packages/preview/vlna/0.3.0/lib.typ
+++ b/packages/preview/vlna/0.3.0/lib.typ
@@ -1,0 +1,486 @@
+// vlna 0.3.0 — česká sazba: nezlomitelné mezery („vlna").
+// Zachovává „skok do zdroje" (box místo přepisu textu na ~) a pokrývá
+// pravidla ÚJČ (prirucka.ujc.cas.cz/?id=880) i příkazy luavlna.
+//
+// Pravidla:
+//   1. Za jedno- a dvoupísmennými slovy řádek nekončí (k, s, v, z, a, i, …,
+//      ale i „po", „do", „je", „se") — mezera za nimi je nezlomitelná.
+//   2. Tituly a zkratky PŘED jménem/výrazem (Ing., doc., pplk. gšt., např.,
+//      viz, s., …) se váží k následujícímu slovu.
+//   3. Tituly ZA jménem (Ph.D., CSc., …) se váží k předchozímu slovu.
+//   4. Iniciály (M. J. Hegel, Ch. Novák) se váží k následujícímu slovu.
+//   5. Čísla: členění (2 500), značky (50 %, § 23), jednotky a měny
+//      (10 kg, 19 °C, 1 000 000 Kč), telefonní čísla (+420 800 123 987).
+//   6. Poměry a měřítka (1 : 50 000, 10 : 2 = 5), kalendářní data
+//      (21. 6. | 2024, 16. ledna | 1972), pomlčky (slovo –, 1948–1989).
+//   7. Složené zkratky a kódy (a. s., př. n. l., PS PČR, ČSN 01 6910).
+//   8. Webové a e-mailové adresy v link(): zlom jen na místech dle ÚJČ.
+//
+// Volby: `bind-two-letter-words: false` váže jen jednopísmenná slova;
+// `short-words: "vksuozVKSUOZAI"` (či pole slov, či slovník podle jazyka)
+// váže přesně zadaná slova; `initials`/`compound-initials` řídí iniciály;
+// `lang` vynutí jednu jazykovou sadu. Uprostřed dokumentu lze zpracování
+// vypnout/zapnout `#vlna-off()`/`#vlna-on()` (a orámování zásahů
+// `#vlna-debug-on()`/`#vlna-debug-off()`).
+// Ladění: `#show: apply-vlna.with(debug: true)` orámuje všechny zásahy.
+
+// Vzor krátkého slova (1–2 písmena): první písmeno libovolné (věta smí začínat
+// „V lese…"), druhé jen malé — pravidlo se tak nedotkne zkratek typu EU, AI,
+// OSN. Sestavení do běhu s navazujícím slovem je níže (short-run).
+
+// --- Tituly a zkratky PŘED jménem -------------------------------------------
+#let before-list = (
+  // === Oslovení ===
+  "p.", "pan", "Pan", "pí.", "paní", "Paní", "sl.", // Česká
+  "Mr.", "Mrs.", "Ms.", // Anglická
+
+  // === Akademické tituly (před jménem) ===
+  // Bakalářské
+  "bc.", "Bc.", "BcA.",
+  // Magisterské a inženýrské
+  "mgr.", "Mgr.", "mga.", "MgA.",
+  "ing.", "Ing.", "Ing. arch.",
+  // Doktorské (tzv. „malé" a profesní)
+  "dr.", "Dr.", // Obecný doktorát (historický, již se neuděluje)
+  "mudr.", "MUDr.", // Lékařství
+  "mvdr.", "MVDr.", // Veterinární lékařství
+  "MDDr.", // Zubní lékařství
+  "judr.", "JUDr.", // Právo
+  "phdr.", "PhDr.", // Filosofie
+  "rndr.", "RNDr.", // Přírodní vědy
+  "PharmDr.", // Farmacie
+  "thdr.", "ThDr.", // Teologie (starší doktorát)
+  "ThLic.", // Licenciát teologie
+
+  // === Akademické hodnosti (vědecko-pedagogické) ===
+  "doc.", "Doc.", // Docent
+  "prof.", "Prof.", // Profesor
+  "akad.", // akademik (nejvyšší vědecká hodnost ČSAV, již se neuděluje)
+
+  // === Čestné tituly ===
+  "dr. h. c.", // Doctor honoris causa
+
+  // === Vojenské hodnosti ===
+  // Mužstvo
+  "voj.", "svob.",
+  // Poddůstojníci
+  "des.", "čet.", "rtn.",
+  // Praporčíci
+  "rtm.", "nrtm.", "prap.", "nprap.", "šprap.",
+  // Nižší důstojníci
+  "por.", "npor.", "kpt.",
+  // Vyšší důstojníci
+  "mjr.", "pplk.", "pplk. gšt.", "plk.", "plk. gšt.",
+  // Generálové
+  "brig.gen.", "genmjr.", "genpor.", "arm.gen.",
+  // === Policejní hodnosti (mimo již zavedené) ===
+  "stržm.", "nstržm.", "pprap.", "ppor.",
+
+  // === Zkratky ===
+  "aj.", "apod.", "atd.", "atp.", "cca", "č.", "čj.", "kap.", "kupř.",
+  "mj.", "např.", "obr.", "odst.", "popř.", "pozn.", "př.", "příp.",
+  "resp.", "s.", "str.", "sv.", "tab.", "tj.", "tzv.", "tzn.", "viz", "zvl.",
+)
+
+// --- Tituly ZA jménem --------------------------------------------------------
+#let after-list = (
+  "DiS.",
+  "Ph.D.", // Doktor (vědecký, standardní)
+  "PhD.", // zahraniční varianta
+  "PhD", // zahraniční varianta bez teček
+  "Th.D.", // Doktor teologie (vědecký)
+  "CSc.", // Kandidát věd (dobíhá)
+  "DrSc.", // Doktor věd (dobíhá)
+  "DSc.", // Doktor věd (UK a AV ČR)
+  "MBA", "LL.M.", "MSc.",
+)
+
+// --- Jednotky a značky za číslem (ÚJČ: „5 str.", „10 kg", „19 °C", „250 €") --
+// Výchozí seznam; vlastní: `units: vlna.default-units + ("µm",)` nebo úplně
+// jiný. Řadí se nejdelší první, takže „m²" ani „km/h" neprohrají s „m".
+#let default-units = (
+  // procenta, stupně, měny
+  "%", "‰", "°C", "°F", "°", "Kč", "€", "$", "£",
+  // hmotnost, délka, plocha, objem
+  "kg", "dag", "g", "mg", "t", "km", "m", "dm", "cm", "mm", "µm", "nm",
+  "km²", "m²", "ha", "m³", "hl", "l", "dl", "ml",
+  // čas a rychlost
+  "h", "hod.", "min", "s", "ms", "km/h", "m/s",
+  // fyzika a výpočetní technika
+  "Hz", "kHz", "MHz", "GHz", "W", "kW", "MW", "kWh", "MWh",
+  "J", "kJ", "MJ", "V", "mV", "kV", "A", "mA", "µA",
+  "Pa", "hPa", "kPa", "MPa", "N", "kN",
+  "kB", "MB", "GB", "TB", "KiB", "MiB", "GiB",
+  // zkratky počítaného předmětu
+  "str.", "s.", "č.", "obr.", "tab.", "tis.", "mil.", "mld.",
+)
+
+// Měsíce pro kalendářní data („16. ledna"); `months: (...)` je nahradí.
+#let _czech-months = (
+  "ledna", "února", "března", "dubna", "května", "června",
+  "července", "srpna", "září", "října", "listopadu", "prosince",
+)
+
+// --- Sestavení vzorů ---------------------------------------------------------
+#let escape-dot(t) = t.replace(".", "\\.")
+
+// Obecné escapování pro položky, jež mohou nést regexové metaznaky ($, %, /).
+#let escape-regex(t) = {
+  let specials = ("\\", ".", "+", "*", "?", "(", ")", "[", "]", "{", "}", "|", "^", "$")
+  t.clusters().map(c => if c in specials { "\\" + c } else { c }).join("")
+}
+
+// --- Zalomení webových a e-mailových adres ------------------------------------
+// ÚJČ doporučuje vložit mezeru nulové šířky (U+200B) tam, kde adresa smí
+// pokračovat na dalším řádku: za lomítkem (ne mezi znaky „//"), před tečkou,
+// spojovníkem, @ (i za ním) a dalšími speciálními znaky. Znak se nevykresluje,
+// jen dovolí zlom; cíl odkazu (dest) se nemění, odkaz zůstává funkční.
+#let _zwsp = "\u{200B}"
+
+// Vytáhne z těla odkazu prostý text. Tělo nemusí být jediný text element —
+// „jan.novak\@seznam.cz" je SEKVENCE (escape rozdělí textové uzly), styly
+// (kurziva adres) obalují. Cokoli jiného (mezery, obrázky, …) vrátí none
+// a odkaz se nechá být — adresa mezery neobsahuje, takže none = ne-adresa.
+#let _link-text(body) = {
+  // has("text") místo func() == text: escapované znaky („\@") jsou element
+  // `symbol`, jenž má také pole text.
+  if body.has("text") {
+    body.text
+  } else if body.has("children") {
+    let parts = body.children.map(_link-text)
+    if parts.contains(none) { none } else { parts.join("") }
+  } else if body.has("child") {
+    _link-text(body.child)
+  } else if body.has("body") {
+    _link-text(body.body)
+  } else {
+    none
+  }
+}
+
+#let _breakable-url(s) = {
+  let break-before = (".", "-", "‑", "?", ",", "_", "%", "=", "#", "~", "&", "@")
+  let cs = s.clusters()
+  let out = ""
+  for (i, c) in cs.enumerate() {
+    if i > 0 and c in break-before { out += _zwsp }
+    out += c
+    // Za @ jen v e-mailech; účet na sociální síti („@SenatCZ", @ na
+    // začátku) se za zavináčem nezalamuje.
+    if c == "@" and i > 0 { out += _zwsp }
+    if c == "/" and i + 1 < cs.len() and cs.at(i + 1) != "/" { out += _zwsp }
+  }
+  out
+}
+
+// Alternace: delší varianty první (jinak by „pplk." vyhrálo nad „pplk. gšt."
+// a „Ing." nad „Ing. arch."). Položky NEkončící tečkou dostanou koncovou
+// hranici slova, aby „PhD" nechytalo začátek „PhDr." ani „viz" slovo „vize".
+#let alternation(list) = {
+  list
+    .sorted(key: t => -t.len())
+    .map(t => escape-dot(t) + if not t.ends-with(".") { "\\>" } else { "" })
+    .join("|")
+}
+
+// Pravidla matchují CELÝ blok (krátká slova + jejich slovo / titul + jméno),
+// aby ho šlo obalit do #box a tím zamezit zlomu. Klíčové pro zachování
+// „skoku do zdroje": box propouští PŮVODNÍ `it` beze změny, takže glyfy si
+// drží zdrojovou pozici. (Kdybychom místo toho přepisovali `it.text`, nový
+// text by dostal pozici tohoto modulu a klik v PDF by mířil sem, ne do textu.)
+//
+// Kompromis oproti přepisu na ~: uvnitř boxu se mezery při justify nenatahují
+// a slovo v boxu se nezlomí dělením (u velmi dlouhých slov za předložkou proto
+// může vzniknout volnější řádek).
+
+// Předpona = jeden „lepivý" prvek: krátké slovo NEBO titul/zkratka před jménem.
+// Sloučení do jednoho vzoru je nutné kvůli řetězení — jinak by u „za tzv. X"
+// krátké slovo „za" pohltilo titul „tzv." jako své cílové slovo a titul by se
+// pak od „X" oddělil (a stejně u „Mgr. et Mgr. Ing. Novák").
+#let short-word = "\\<\\p{L}\\p{Ll}?\\>"
+
+// Slovo + titul ZA jménem:  „Novák, Ph.D."
+#let after-pattern = regex("\\S+ (?:" + alternation(after-list) + ")")
+
+// --- Přepínače uprostřed dokumentu -------------------------------------------
+// Obdoba luavlna \preventsingleon/off a \preventsingledebugon/off. Globální
+// show pravidlo nejde zevnitř dokumentu „odstínit", proto stavy: glue() je
+// čte a mimo aktivní úsek vrací obsah beze změny.
+#let _vlna-active = state("vlna:active", true)
+#let _vlna-debug = state("vlna:debug", none) // none = řídí parametr debug
+// Čítač potlačení uvnitř raw bloků: kód se typograficky nezpracovává.
+// Čítač (ne bool), aby se po raw bloku obnovil stav bez ohledu na to,
+// kolik jich za sebou následuje.
+#let _vlna-suspend = state("vlna:suspend", 0)
+
+/// Od tohoto místa nezlomitelné mezery nevkládat.
+#let vlna-off() = _vlna-active.update(false)
+/// Od tohoto místa vkládání obnovit.
+#let vlna-on() = _vlna-active.update(true)
+/// Od tohoto místa orámovat slepené bloky (přebíjí parametr debug).
+#let vlna-debug-on() = _vlna-debug.update(true)
+/// Od tohoto místa orámování vypnout.
+#let vlna-debug-off() = _vlna-debug.update(false)
+
+// --- Aplikace ----------------------------------------------------------------
+// Každá skupina pravidel ÚJČ (prirucka.ujc.cas.cz/?id=880) má svůj přepínač:
+//
+//   bind-two-letter-words: false → váže jen jednopísmenná slova (dvoupísmenné
+//     předložky „na", „do", „se" … smí zůstat na konci řádku — v úzké sazbě
+//     dává řádkovému zlomu víc volnosti).
+//   short-words: řetězec písmen ("vksuozVKSUOZAI") nebo pole slov
+//     (("v", "k", "na", "Na")) → váže se PŘESNĚ tato slova (case-sensitive);
+//     má přednost před bind-two-letter-words; `none` krátká slova vypne.
+//   short-words jako slovník (cs: "AIiVvOoUuSsZzKk", sk: "…") → sady podle
+//     jazyka textu (text.lang); obdoba luavlna \singlechars. Jazyky mimo
+//     slovník se NEzpracovávají (krátká slova ani tituly před jménem) —
+//     stejně jako v luavlna. Vyžaduje #set text(lang: "cs")!
+//   lang: "cs" → ignoruje text.lang a všude použije zadanou sadu; obdoba
+//     luavlna \preventsinglelang. Bez slovníku nemá účinek.
+//   initials + compound-initials: iniciály „M. J. Hegel", „Ž. Zíbrt",
+//     „Ch. Novák" (řetězí se s tituly: „Ing. B. Novák").
+//   titles: tituly a zkratky před jménem (Ing., např., viz) i za ním (Ph.D.).
+//   numbers + units: členění čísel (2 500, 25,325 23, +420 800 123 987),
+//     číslo se značkou (50 %, § 23, * 1921, † 2000) a s jednotkou, zkratkou
+//     či měnou (10 kg, 19 °C, 5 str., 1 000 000 Kč, 250 €).
+//   ratios: měřítka, poměry a dělení (1 : 50 000, 10 : 2 = 5).
+//   dates: den + měsíc v datech — „21. 6. | 2024", „16. ledna | 1972";
+//     rok se oddělit smí. months: vlastní seznam názvů měsíců.
+//   number-word: číslo + název počítaného jevu (500 lidí, strana 2, 5. pluk,
+//     Karel IV.) — výrazně ubírá místa zlomu, implicitně vypnuto.
+//   abbreviations: složené zkratky, ustálená spojení a kódy (a. s., s. r. o.,
+//     př. n. l., PS PČR, FF UK, ČSN 01 6910).
+//   dashes: pomlčka s mezerami se neodděluje od předchozího slova (zůstává
+//     na konci řádku); pomlčka bez mezer (1948–1989) se nezalamuje vůbec.
+//   links: do adres v link() vloží mezery nulové šířky na místech, kde ÚJČ
+//     zalomení doporučuje (za lomítkem, před tečkou a spojovníkem, kolem @).
+#let apply-vlna(
+  doc,
+  // krátká slova
+  bind-two-letter-words: true,
+  short-words: auto,
+  // iniciály
+  initials: true,
+  compound-initials: ("Ch",),
+  // tituly a zkratky před/za jménem
+  titles: true,
+  // čísla, jednotky, poměry, data
+  numbers: true,
+  units: default-units,
+  ratios: true,
+  dates: true,
+  months: auto,
+  number-word: false,
+  // složené zkratky a kódy
+  abbreviations: true,
+  // pomlčky
+  dashes: true,
+  // webové a e-mailové adresy
+  links: true,
+  // jazyk a ladění
+  lang: auto,
+  debug: false,
+) = {
+  // -- stavební kameny číselných vzorů --
+  let unit-alt = if units.len() == 0 { none } else {
+    units
+      .sorted(key: u => -u.len())
+      .map(u => {
+        let e = escape-regex(u)
+        // Jednotky končící písmenem/číslicí dostanou hranici slova,
+        // aby „16 h" nechytalo začátek „16 hodin".
+        if u.clusters().last().match(regex("[\\p{L}\\d]")) != none { e + "\\>" } else { e }
+      })
+      .join("|")
+  }
+  // Číslo: celá část, desetinná část a skupiny po 1–3 číslicích
+  // („2 500", „25,325 23", „+420 800 123 987", „100.5").
+  let num-group = " \\d{1,3}(?:[,.]\\d+)?\\>"
+  let num-core = "\\+?\\<\\d+(?:[,.]\\d+)?"
+  let num-any = num-core + "(?:" + num-group + ")*"
+  let num-grouped = num-core + "(?:" + num-group + ")+"
+  let month-alt = {
+    let list = if months == auto { _czech-months } else { months }
+    "\\<(?:" + list.join("|") + ")\\>"
+  }
+
+  // -- krátká slova, iniciály a tituly: společný běh předpon --
+  let short-pattern(spec) = if spec == none { none } else if spec == auto {
+    if bind-two-letter-words { short-word } else { "\\<\\p{L}\\>" }
+  } else {
+    let words = if type(spec) == str { spec.clusters() } else { spec }
+    // Delší slova první — stejný důvod jako u alternation().
+    "\\<(?:" + words.sorted(key: w => -w.len()).map(escape-dot).join("|") + ")\\>"
+  }
+
+  // Iniciála = velké písmeno s tečkou, včetně zkráceného rodného jména
+  // („Fr. Daneš", „M. Těšitelová" — ÚJČ) a složených písmen („Ch").
+  // Vstupuje mezi předpony, takže se řetězí: „M. J. Hegel", „Ing. B. Novák".
+  let initial = if initials {
+    let alts = compound-initials.sorted(key: t => -t.len()).map(escape-dot)
+    "\\<(?:" + (alts + ("\\p{Lu}\\p{Ll}?",)).join("|") + ")\\."
+  } else { none }
+
+  // Cílové slovo běhu: přednostně celé datum, složená zkratka nebo číselný
+  // výraz (i s poměrem a jednotkou), teprve pak obyčejné slovo. Nález běhu
+  // předpon začíná v textu dřív než vzory čísel/dat/zkratek, a protože
+  // dřívější začátek vyhrává, bez tohoto by je běh rozbil („od 21. 6.",
+  // „o 2 500 Kč", „i s. r. o.", „zápas o 5 : 3").
+  let target = {
+    let alts = ()
+    if dates { alts.push("\\d{1,2}\\.(?: \\d{1,2}\\.| " + month-alt + ")?") }
+    if abbreviations {
+      alts.push("(?:\\p{Ll}{1,2}\\. )+\\p{Ll}{1,2}\\.")
+      alts.push("\\p{Lu}{2,4}(?: (?:\\p{Lu}{2,4}\\>|\\d+(?: \\d+)*\\>))+")
+    }
+    if numbers {
+      let numeric = num-any
+      if ratios { numeric += "(?: : " + num-any + ")*(?: = " + num-any + ")?" }
+      if unit-alt != none { numeric += "(?: (?:" + unit-alt + "))?" }
+      if number-word { numeric += "(?: \\p{L}\\S*)?" }
+      alts.push(numeric)
+    }
+    // number-word: i obyčejné cílové slovo smí pokračovat číslem
+    // („viz strana 2").
+    alts.push("\\S+" + if number-word { "(?: \\d+\\>\\.?)?" } else { "" })
+    let t = "(?:" + alts.join("|") + ")"
+    // „s mezerami –" — pomlčka s mezerami drží u předchozího slova.
+    if dashes { t += "(?: [–—])?" }
+    t
+  }
+
+  // Běh předpon + cílové slovo:  „k s bratrem", „V současném", „za tzv. postup",
+  // „prof. Ing. arch. Novák", „M. J. Hegel".
+  let run-of(short) = {
+    let alts = ()
+    if short != none { alts.push(short) }
+    if initial != none { alts.push(initial) }
+    if titles { alts.push("\\<(?:" + alternation(before-list) + ")") }
+    if alts.len() == 0 { none } else {
+      "(?:(?:" + alts.join("|") + ") )+" + target
+    }
+  }
+
+  // Slovník = jazykové sady. Regex neumí větvit podle jazyka, proto jedno
+  // pravidlo se SJEDNOCENÍM všech sad; teprve glue() v místě nálezu zjistí
+  // jazyk (text.lang, příp. vynucený `lang`) a ukotveným vzorem ověří, že
+  // celý nález patří do sady tohoto jazyka — jinak ho nechá být.
+  let (run-pattern, recheck) = if type(short-words) == dictionary {
+    let per-lang = (:)
+    let union = ()
+    for (code, spec) in short-words {
+      let run = run-of(short-pattern(spec))
+      if run != none {
+        per-lang.insert(code, regex("^(?:" + run + ")$"))
+        if run not in union { union.push(run) }
+      }
+    }
+    if union.len() == 0 { (none, none) } else { (regex(union.join("|")), per-lang) }
+  } else {
+    let run = run-of(short-pattern(short-words))
+    (if run == none { none } else { regex(run) }, none)
+  }
+
+  // box(it) = nezlomitelný blok se zachovanou zdrojovou pozicí glyfů.
+  let glue(color, recheck: none) = it => context {
+    let active = _vlna-active.get() and _vlna-suspend.get() == 0
+    if active and recheck != none {
+      let code = if lang == auto { text.lang } else { lang }
+      let pattern = recheck.at(code, default: none)
+      active = pattern != none and it.text.match(pattern) != none
+    }
+    let dbg = _vlna-debug.get()
+    if dbg == none { dbg = debug }
+    if not active { it } else if dbg {
+      box(stroke: .5pt + color, outset: 1.5pt, it)
+    } else {
+      box(it)
+    }
+  }
+
+  // -- pravidla --
+  // Nález s dřívějším začátkem vyhrává vždy; při shodném začátku vyhrává
+  // pravidlo uvedené v tomto poli DŘÍV (obaluje se blíž obsahu). Proto jsou
+  // specifické vzory (poměry, data, složené zkratky) před během předpon.
+  let rules = ()
+  if ratios {
+    rules.push((
+      regex(num-any + "(?: : " + num-any + ")+(?: = " + num-any + ")?"),
+      glue(eastern),
+    ))
+  }
+  if dates {
+    rules.push((
+      regex("\\<\\d{1,2}\\. (?:\\d{1,2}\\.|" + month-alt + ")"),
+      glue(orange),
+    ))
+  }
+  if abbreviations {
+    // a. s., s. r. o., mn. č., př. n. l.  |  PS PČR, FF UK, ČSN 01 6910.
+    // Velká část je omezena na 2–4 písmena, aby se neslepovaly VERZÁLKOVÉ
+    // NADPISY slovo po slovu.
+    rules.push((
+      regex(
+        "(?:\\<(?:\\p{Ll}{1,2}\\. )+\\p{Ll}{1,2}\\."
+          + "|\\<\\p{Lu}{2,4}(?: (?:\\p{Lu}{2,4}\\>|\\d+(?: \\d+)*\\>))+)",
+      ),
+      glue(maroon),
+    ))
+  }
+  if run-pattern != none { rules.push((run-pattern, glue(purple, recheck: recheck))) }
+  if titles { rules.push((after-pattern, glue(blue))) }
+  if numbers {
+    // 50 %, § 23, * 1921 | 10 kg, 19 °C, 1 000 000 Kč | 2 500, 800 11 22 33
+    let alts = ("[§#\\*†] " + num-any,)
+    if unit-alt != none { alts.push(num-any + " (?:" + unit-alt + ")") }
+    alts.push(num-grouped)
+    rules.push((regex("(?:" + alts.join("|") + ")"), glue(green)))
+  }
+  if number-word {
+    // 500 lidí, 5. pluk, II. patro | strana 2, tabulka 3 | Karel IV.
+    // První větev řetězí i „Přišlo 500 lidí" (slovo + číslo + slovo).
+    rules.push((
+      regex(
+        "(?:\\<\\p{L}{2,} \\d+\\>\\.?(?: \\p{L}\\S*)?"
+          + "|\\<\\d+\\.? \\p{L}\\S*"
+          + "|\\<[IVXLCDM]+\\. \\p{L}\\S*"
+          + "|\\<\\p{Lu}\\p{L}+ [IVXLCDM]+\\>\\.?)",
+      ),
+      glue(red),
+    ))
+  }
+  if dashes {
+    // „slovo –" drží pomlčku na konci řádku; „1948–1989" se nezalomí vůbec.
+    rules.push((regex("\\S+ ?[–—]\\S*"), glue(olive)))
+  }
+
+  let out = doc
+  // Raw bloky se nezpracovávají — kód není české souvislé sazby.
+  out = {
+    show raw: it => {
+      _vlna-suspend.update(n => n + 1)
+      it
+      _vlna-suspend.update(n => n - 1)
+    }
+    out
+  }
+  if links {
+    out = {
+      show link: it => context {
+        let plain = _link-text(it.body)
+        let broken = if (
+          _vlna-active.get()
+            and plain != none
+            and not plain.contains(_zwsp)
+            and (plain.contains("/") or plain.contains("@") or plain.contains("."))
+        ) { _breakable-url(plain) } else { none }
+        // broken == plain: beze změny („@SenatCZ") — vrátit `it`, jinak by
+        // pravidlo donekonečna přestavovalo tentýž odkaz.
+        if broken == none or broken == plain { it } else { link(it.dest, broken) }
+      }
+      out
+    }
+  }
+  for (pattern, fn) in rules { out = { show pattern: fn; out } }
+  out
+}

--- a/packages/preview/vlna/0.3.0/typst.toml
+++ b/packages/preview/vlna/0.3.0/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vlna"
+version = "0.3.0"
+entrypoint = "lib.typ"
+authors = ["iamanro"]
+license = "MIT"
+description = "Czech non-breaking spaces (vlna): short words, titles before/after a name and common abbreviations — with jump-to-source preserved."
+repository = "https://github.com/iamanro/typst-vlna"
+keywords = ["czech", "typography", "non-breaking space", "vlna", "luavlna"]
+categories = ["utility"]
+exclude = ["examples"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Description: `vlna` automatically inserts non-breaking spaces for Czech typography (short prepositions, titles, abbreviations), following the guideline of the Institute of the Czech Language ([prirucka.ujc.cas.cz/?id=880](https://prirucka.ujc.cas.cz/?id=880)).

Version 0.3.0 implements the full ÚJČ guideline and the `luavlna` command set, with every rule group individually switchable:

- configurable short words: `bind-two-letter-words: false`, exact sets (`short-words: "vksuozVKSUOZAI"`), per-language dictionaries resolved against `text.lang`, and `lang` forcing ([requested in iamanro/typst-vlna#1](https://github.com/iamanro/typst-vlna/issues/1))
- initials incl. abbreviated given names (`M. J. Hegel`, `Fr. Daneš`, compound `Ch.`)
- digit grouping, phone numbers, number + symbol/unit/currency, ratios (`1 : 50 000`), dates (day + month bound, year may separate), compound abbreviations (`a. s.`, `ČSN 01 6910`), dash rules
- ÚJČ-recommended break points in `link()` web/e-mail addresses via zero-width spaces (link destination untouched)
- mid-document toggles `#vlna-off()` / `#vlna-on()` / `#vlna-debug-on()` / `#vlna-debug-off()`
- raw/code blocks are excluded from processing

Tested locally with Typst 0.15.0 (feature sheet, stress test with edge cases and degenerate configurations, 300-page performance document).
