### PR TITLE
nexus-tools:0.2.0

### DIFF
--- a/packages/preview/nexus-tools/0.2.0/LICENSE
+++ b/packages/preview/nexus-tools/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Maycon F. Melo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/nexus-tools/0.2.0/README.md
+++ b/packages/preview/nexus-tools/0.2.0/README.md
@@ -8,25 +8,25 @@
 
 <p class="hidden">
   <a href="https://typst.app/universe/package/nexus-tools">
-    <img src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fnexus-tools&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&labelColor=%23353c44" /></a>
+    <img alt="Typst Universe version" src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fnexus-tools&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&labelColor=%23353c44" /></a>
   <a href="https://github.com/mayconfmelo/nexus-tools/tree/dev/">
-    <img src="https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmayconfmelo%2Fnexus-tools%2Frefs%2Fheads%2Fdev%2Ftypst.toml&query=%24.package.version&logo=github&label=Development&logoColor=%2397978e&color=%23239DAE&labelColor=%23353c44" /></a>
+    <img alt="GitHub development branch version" src="https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmayconfmelo%2Fnexus-tools%2Frefs%2Fheads%2Fdev%2Ftypst.toml&query=%24.package.version&logo=github&label=Development&logoColor=%2397978e&color=%23239DAE&labelColor=%23353c44" /></a>
 </p>
 
-[![Manual](https://img.shields.io/badge/Manual-%23353c44)](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/tags/0.2.0/docs/manual.pdf)
+[![Read the manual](https://img.shields.io/badge/Manual-%23353c44)](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/tags/0.2.0/docs/manual.pdf)
 [![Example PDF](https://img.shields.io/badge/Example-.pdf-%23777?labelColor=%23353c44)](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/tags/0.2.0/docs/example.pdf)
-[![Example SRC](https://img.shields.io/badge/Example-.typ-%23777?labelColor=%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/0.2.0/docs/assets/example.typ)
-[![Changelog](https://img.shields.io/badge/Changelog-%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/main/docs/changelog.md)
-[![Contribute](https://img.shields.io/badge/Contribute-%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/main/docs/contributing.md)
+[![Example source code](https://img.shields.io/badge/Example-.typ-%23777?labelColor=%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/0.2.0/docs/assets/example.typ)
+[![Changelog file](https://img.shields.io/badge/Changelog-%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/0.2.0/docs/changelog.md)
+[![Contribute with development](https://img.shields.io/badge/Contribute-%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/0.2.0/docs/contributing.md)
 
 
 <p class="hidden">
   <a href="https://github.com/mayconfmelo/nexus-tools/actions/workflows/tests.yml">
-    <img alt="Tests" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/tests.yml/badge.svg" /></a>
+    <img alt="General tests badge" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/tests.yml/badge.svg" /></a>
   <a href="https://github.com/mayconfmelo/nexus-tools/actions/workflows/build.yml">
-    <img alt="Build" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/build.yml/badge.svg" /></a>
+    <img alt="Build test badge" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/build.yml/badge.svg" /></a>
   <a href="https://github.com/mayconfmelo/nexus-tools/actions/workflows/spellcheck.yml">
-    <img alt="Spellcheck" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/spellcheck.yml/badge.svg" /></a>
+    <img alt="Spellcheck test badge" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/spellcheck.yml/badge.svg" /></a>
 </p>
 </div>
 
@@ -68,7 +68,7 @@ for packages.
   - Null value
   - Replacement of auto values
   - Relative luminance of a color
-  - Dynamic foreground/background colors
+  - Dynamic colors based on relative luminance
 - Attribute checks
   - Content fields
   - Dictionary keys
@@ -87,7 +87,7 @@ for packages.
 
 ### Internal Structure
 
-![YAML structure](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/heads/main/tests/representation/out/1.png)
+![YAML module structure](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/tags/0.2.0/tests/representation/out/1.png)
 
 This is a YAML representation of the package internal structure and all its
 features.

--- a/packages/preview/nexus-tools/0.2.0/README.md
+++ b/packages/preview/nexus-tools/0.2.0/README.md
@@ -1,0 +1,93 @@
+# Nexus Tools
+
+<div align="center">
+
+<p class="hidden">
+  Easily implement and reuse tools and components across projects.
+</p>
+
+<p class="hidden">
+  <a href="https://typst.app/universe/package/nexus-tools">
+    <img src="https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Ftypst.app%2Funiverse%2Fpackage%2Fnexus-tools&query=%2Fhtml%2Fbody%2Fdiv%2Fmain%2Fdiv%5B2%5D%2Faside%2Fsection%5B2%5D%2Fdl%2Fdd%5B3%5D&logo=typst&label=Universe&color=%23239DAE&labelColor=%23353c44" /></a>
+  <a href="https://github.com/mayconfmelo/nexus-tools/tree/dev/">
+    <img src="https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmayconfmelo%2Fnexus-tools%2Frefs%2Fheads%2Fdev%2Ftypst.toml&query=%24.package.version&logo=github&label=Development&logoColor=%2397978e&color=%23239DAE&labelColor=%23353c44" /></a>
+</p>
+
+[![Manual](https://img.shields.io/badge/Manual-%23353c44)](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/tags/0.2.0/docs/manual.pdf)
+[![Example PDF](https://img.shields.io/badge/Example-.pdf-%23777?labelColor=%23353c44)](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/tags/0.2.0/docs/example.pdf)
+[![Example SRC](https://img.shields.io/badge/Example-.typ-%23777?labelColor=%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/0.2.0/docs/assets/example.typ)
+[![Changelog](https://img.shields.io/badge/Changelog-%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/main/docs/changelog.md)
+[![Contribute](https://img.shields.io/badge/Contribute-%23353c44)](https://github.com/mayconfmelo/nexus-tools/blob/main/docs/contributing.md)
+
+
+<p class="hidden">
+  <a href="https://github.com/mayconfmelo/nexus-tools/actions/workflows/tests.yml">
+    <img alt="Tests" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/tests.yml/badge.svg" /></a>
+  <a href="https://github.com/mayconfmelo/nexus-tools/actions/workflows/build.yml">
+    <img alt="Build" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/build.yml/badge.svg" /></a>
+  <a href="https://github.com/mayconfmelo/nexus-tools/actions/workflows/spellcheck.yml">
+    <img alt="Spellcheck" src="https://github.com/mayconfmelo/nexus-tools/actions/workflows/spellcheck.yml/badge.svg" /></a>
+</p>
+</div>
+
+
+## Quick Start
+
+```typ
+#import "@preview/nexus-tools:0.2.0": *
+```
+
+## Description
+
+Easily implement handy features from a curated collection of frequently used
+package functionality, such as data storage or custom defaults. This library was
+created as part of the development of [my other Typst projects](https://typst.app/universe/search/?q=author%3A%22Maycon%20F.%20Melo%22);
+it contains functionality shared across multiple projects that would otherwise
+need to be maintained and updated individually, but is now centralized in a
+single place. This is not intended to be a full-fledged development toolset, but
+rather a compartmentalization of shared resources.
+
+You can use this library without restrictions as a development aid, especially
+for packages.
+
+
+## Feature List
+
+- Custom defaults that can be overridden by _set_ rules
+- General data storage
+  - Storage compartmentalization (namespaces)
+  - Add, append, and remove data
+  - Retrieve individual data or whole namespaces
+  - Reset namespaces
+- Visual components
+  - Paper-friendly links (attached to footnotes)
+  - General package URLs
+  - Customizable callout box
+- Get Typst values
+  - Generate datetime using positional and/or named arguments
+  - Null value
+  - Replacement of auto values
+  - Relative luminance of a color
+  - Dynamic foreground/background colors
+- Attribute checks
+  - Content fields
+  - Dictionary keys
+  - Dictionary values
+  - Array items
+- Specific tests
+  - None values
+  - Null values
+  - Empty values
+  - Context values
+  - Content sequences
+  - Content spaces
+  - Content functions
+  - Any value types
+
+
+### Internal Structure
+
+![YAML structure](https://raw.githubusercontent.com/mayconfmelo/nexus-tools/refs/heads/main/tests/representation/out/1.png)
+
+This is a YAML representation of the package internal structure and all its
+features.

--- a/packages/preview/nexus-tools/0.2.0/src/lib.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/lib.typ
@@ -1,0 +1,23 @@
+#import "sub/storage.typ"
+#import "sub/comp.typ"
+#import "sub/get.typ"
+#import "sub/has.typ"
+#import "sub/its.typ"
+
+#import "sub/main.typ": *
+
+/**#outline()
+= Description
+
+Easily implement handy features from a curated collection of frequently used
+package functionality, such as data storage or custom defaults. This library was
+created as part of the development of #url(
+"https://typst.app/universe/search/?q=author%3A%22Maycon%20F.%20Melo%22")[my
+other Typst projects;] it contains functionality shared across multiple projects
+that would otherwise need to be maintained and updated individually, but is now
+centralized in a single place. This is not intended to be a full-fledged
+development toolset, but rather a compartmentalization of shared resources.
+
+You can use this library without restrictions as a development aid, especially
+for packages.
+**/

--- a/packages/preview/nexus-tools/0.2.0/src/sub/assets/orig.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/assets/orig.typ
@@ -1,0 +1,2 @@
+#let type = type
+#let text = text

--- a/packages/preview/nexus-tools/0.2.0/src/sub/comp.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/comp.typ
@@ -1,0 +1,157 @@
+/**
+= Components
+```typ
+#import "@preview/nexus-tools: 0.1.0": comp
+```
+
+== Paper-friendly URLs
+```typ
+#comp.url(target, id, text)
+```
+
+Creates a paper-friendly link, attached to a footnote containing the URL itself
+to ensure readability when printed.
+
+target <- string | label <required>
+  URL used as link and footnote, or label referencing a previous `#url` command.
+
+id <- label
+  Optional label for further reference.
+  
+text <- string | content
+  Text shown as link (fallback to the URL).
+**/
+#let url(target, ..args) = {
+  assert(args.pos().len() <= 2, message: "#url(target, id, name) only")
+  assert(args.named() == (:), message: "#url(target, id, name) only")
+  
+  let note = if type(target) == str {link(target)} else {target}
+  let id = args.pos().first(default: none)
+  let text = args.pos().last(default: target)
+  let hash
+  
+  
+  // Store text under hash label
+  if type(id) == label {
+    import "@preview/digestify:0.1.0": md5, bytes-to-hex
+    
+    // When #url(target, id) the text = id (first and last of ..args)
+    if text == id {text = target}
+    
+    hash = bytes-to-hex( md5(bytes(repr(id))) )
+    
+    [ #metadata(text)#label(hash) ]
+  }
+  else {id = none}
+  
+  // Retrieve hash label to obtain text
+  if type(target) == label {
+    import "@preview/digestify:0.1.0": md5, bytes-to-hex
+    hash = bytes-to-hex( md5(bytes(repr(target))) )
+    text = context {
+      let data = query(label(hash))
+      
+      if data == () {panic("Label not found: " + repr(target))}
+      
+      data.first().value
+    }
+  }
+  
+  link(target, emph(text))
+  
+  [ #footnote(note)#id ]
+}
+
+
+/**
+== Package URLs
+```typ
+#comp.pkg(target, id)
+```
+Generates paper-friendly links for general package/library repositories.
+
+target <- string | label
+  `"https://example.com/name"`\ `"https://example.com/{name}/slug/"`\
+  Package URL, or label referencing a previous `#pkg` command. The package name
+  is inferred from the last URL slug or retrieved from curly brackets.
+  
+id <- label
+  Optional label for further reference.
+**/
+#let pkg(target, ..args) = {
+  assert(args.pos().len() <= 1, message: "#pkg(target, id) only")
+  assert(args.named() == (:), message: "#pkg(target, id) only")
+  
+  let id = args.pos().at(0, default: none)
+  let target = target
+  let text
+  
+  if type(target) == label {text = target}
+  else {
+    assert.eq(type(target), str, message: "pkg(url) must be string")
+    
+    // Extract text from target
+    text = target.match(regex("\{.*?\}|/[^/]*/?$"))
+    text = if text != none {text.text.trim(regex("[/{}]"))} else {target}
+    target = target.replace(regex("[{}]"), "")
+  }
+  
+  url(target, id, text)
+}
+
+
+/**
+== Callout
+:callout: => #comp.<name>(<capt>)
+
+Creates a highly customizable callout box.
+**/
+#let callout(
+  icon: "information-circle", /// <- string
+    /// Icon name, as set by #url("https://heroicons.com/")[Heroicons]. |
+  title: none, /// <- string | content | none
+    /// Title, if any. |
+  text: (:), /// <- color | dictionary
+    /// `#text` options (the special `#text.title` is used for title). |
+  background: (:), /// <- color | dictionary
+    /// `#block` options. |
+  body,
+) = {
+  import "@preview/heroic:0.1.0": hi
+  import "assets/orig.typ"
+  
+  if type(text) == color {text = (fill: text)}
+  if type(background) == color {background = (fill: background)}
+  
+  let title-styling = text.remove("title", default: (:))
+  
+  assert.eq(
+    type(text), dictionary,
+    message: "#callout(text) must be dictionary"
+  )
+  assert.eq(
+    type(title-styling), dictionary,
+    message: "#callout(text.title) must be dictionary"
+  )
+  assert.eq(
+    type(background), dictionary,
+    message: "#callout(background) must be dictionary"
+  )
+  
+  set orig.text(..text)
+  
+  title = hi(icon, solid: false) + " " + if title != none {title + linebreak()}
+  title = orig.text(title, ..title-styling)
+  
+  pad(
+    x: 1em,
+    block(
+      strong(title) + body,
+      fill: gray.lighten(85%),
+      width: 100%,
+      outset: (x: 0.45em),
+      inset: (y: 0.45em),
+      ..background,
+    )
+  )
+}

--- a/packages/preview/nexus-tools/0.2.0/src/sub/get.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/get.typ
@@ -1,0 +1,170 @@
+/**
+= Get
+```typ
+#import "@preview/nexus-tools: 0.1.0": get
+```
+
+== Null Value
+```typ
+#get.null
+```
+A null value that matches only itself. Useful as substitute for `none` default
+values, as it is truly unique and not naturally returned by anything in Typst.
+**/
+#let null() = [#sym.zws#sym.zwnj#sym.zws#sym.zwnj#sym.zws]
+
+
+/**
+== Automatic Values
+:auto-val: => #get.<name>(<capt>)
+
+Sets a meaningful value to `auto` values: if a value is automatic, returns the
+replacement; otherwise, returns the value unchanged.
+**/
+#let auto-val(
+  origin, /// <- auto | any
+    /// Value to be checked. |
+  replace, /// <- any
+    /// Replacement for the value if `auto`. |
+) = {if origin == auto {return replace} else {return origin}}
+
+
+/**
+== Date
+:date: => #get.<name>(<capt>)
+
+Create a `#datetime` date from named and/or positional arguments, combined or not.
+Panics if two values are set for the same data component — like a positional and
+also a named value for the year.
+
+..date <- arguments | array | dictionary | string <required>
+  `(year, month, day)`\
+  Components of the data, as positional/named arguments, array, dictionary, or
+  string; fallback to current year, month 1, and day 1 when these components are
+  not set.
+
+pattern: <- string
+  Pattern used to parse datetime from string.
+**/
+#let date(..date, pattern: "mm/dd/yyyy") = {
+  if type(date.pos().at(0, default: "")) == datetime {return date.pos().at(0)}
+  
+  let pos = date.pos()
+  let named = date.named()
+  let first-type = type(pos.first(default: 0))
+  let named-keys
+  
+  if first-type == array {pos = pos.first()}
+  else if first-type == dictionary {
+    named = pos.first()
+    
+    let _ = pos.remove(0)
+  }
+  else if first-type == str {
+    let re = lower(pattern).replace(regex("(?:y+|m+|d+)"), "(\d+)")
+    let results = pos.first().match(regex(re))
+      
+    if results != none {results = results.captures.map(item => int(item))}
+    else {panic("Date '" + pos.first() + "' not in '" + pattern + "' pattern")}
+    
+    pattern = pattern
+      .replace(regex("[^ymd]"), "")
+      .replace(regex("y+"), "year|")
+      .replace(regex("m+"), "month|")
+      .replace(regex("d+"), "day|")
+      .split("|")
+    
+    for (i, value) in pattern.enumerate() {
+      if value == "" {continue}
+      
+      named.insert(value, results.at(i, default: none))
+    }
+    
+    let _ = pos.remove(0)
+  }
+  
+  named-keys = named.keys()
+  
+  if named-keys.contains("year") and pos.len() > 0 {
+    panic("Duplicated positional and named year defined")
+  }
+  if named-keys.contains("month") and pos.len() > 1 {
+    panic("Duplicated positional and named month defined")
+  }
+  if named-keys.contains("day") and pos.len() > 2 {
+    panic("Duplicated positional and named day defined")
+  }
+  
+  let values = (
+    year: named.at("year",
+      default: pos.at(0,
+        default: datetime.today().year()
+      )
+    ),
+    month: named.at("month",
+      default: pos.at(1,
+        default: 1
+      )
+    ),
+    day: named.at("day",
+      default: pos.at(2,
+        default: 1
+      )
+    ),
+  )
+  
+  datetime(
+    year: values.year,
+    month: values.month,
+    day: values.day
+  )
+}
+
+
+/**
+== Relative Luminance
+:relative-luminance:
+Calculates the relative relative luminance of a color (0 is lighter and 1 is darker)
+
+colour <- color
+  Color to be evaluated.
+
+`#relative-luminance()` -> float
+  The relative luminance is expressed as a floating-point number (0 is lighter and 1 is darker).
+**/
+#let relative-luminance(colour) = {
+  assert.eq(type(colour), color, message: "Argument must be a color")
+  
+  let components = rgb(colour).components().map(c => c / 100%)
+  let luminance = 0
+  
+  luminance += 0.2126 * components.at(0)
+  luminance += 0.7152 * components.at(1)
+  luminance += 0.0722 * components.at(2)
+  
+  return luminance
+}
+
+
+/**
+== Dynamic colors
+:dynamic-color: => #get.<name>(<capt>)
+
+Return a foreground color based on a background color luminance: lighter color when dark and darker color when light.
+**/
+#let dynamic-color(
+  background, /// <- color
+    /// Background color evaluated. |
+  dark: white, /// <- color
+    /// Foreground color when background is darker. |
+  light: black, /// <- color
+    /// Foreground color when background is lighter. |
+  limit: 0.55 /// <- float
+    /// Luminance limit (0 is light and 1 is dark). |
+) = {
+  assert.eq(type(background), color, message: "Argument must be a color")
+  assert.eq(type(dark), color, message: "Dark must be a color")
+  assert.eq(type(light), color, message: "Light must be a color")
+  
+  if relative-luminance(background) < limit {dark} else {light}
+}

--- a/packages/preview/nexus-tools/0.2.0/src/sub/get.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/get.typ
@@ -44,7 +44,7 @@ also a named value for the year.
   not set.
 
 pattern: <- string
-  Pattern used to parse datetime from string.
+  Pattern used to parse datetime from string (basic `dd`, `mm`, and `yyyy` support).
 **/
 #let date(..date, pattern: "mm/dd/yyyy") = {
   if type(date.pos().at(0, default: "")) == datetime {return date.pos().at(0)}
@@ -124,13 +124,13 @@ pattern: <- string
 /**
 == Relative Luminance
 :relative-luminance:
-Calculates the relative relative luminance of a color (0 is lighter and 1 is darker)
+Returns the relative relative luminance --- something like the "amount of light" --- of a color, ranging from 0 (darkest) to 1 (lightest).
 
 colour <- color
   Color to be evaluated.
 
 `#relative-luminance()` -> float
-  The relative luminance is expressed as a floating-point number (0 is lighter and 1 is darker).
+  The relative luminance obtained, as a floating-point number.
 **/
 #let relative-luminance(colour) = {
   assert.eq(type(colour), color, message: "Argument must be a color")
@@ -150,17 +150,18 @@ colour <- color
 == Dynamic colors
 :dynamic-color: => #get.<name>(<capt>)
 
-Return a foreground color based on a background color luminance: lighter color when dark and darker color when light.
+Derive different colors based on the relative luminance of a color.
+This is ideal to set optimal foreground colors that contrasts with background colors (e.g.: texts).
 **/
 #let dynamic-color(
   background, /// <- color
-    /// Background color evaluated. |
+    /// Color evaluated. |
   dark: white, /// <- color
-    /// Foreground color when background is darker. |
+    /// Color returned when the relative luminance evaluated is low (darker color). |
   light: black, /// <- color
-    /// Foreground color when background is lighter. |
+    /// Color returned when the relative luminance evaluated is high (lighter color). |
   limit: 0.55 /// <- float
-    /// Luminance limit (0 is light and 1 is dark). |
+    /// Relative luminance limit (0--1). |
 ) = {
   assert.eq(type(background), color, message: "Argument must be a color")
   assert.eq(type(dark), color, message: "Dark must be a color")

--- a/packages/preview/nexus-tools/0.2.0/src/sub/has.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/has.typ
@@ -1,0 +1,108 @@
+/**
+= Has
+```typ
+#import "@preview/nexus-tools: 0.1.0": has
+```
+
+== Field
+:field: => #has.<name>(<capt>)
+
+Check if content has a given field.
+ 
+data <- content
+  The content itself.
+
+values <- string | array of strings
+  One or more field names.
+**/
+#let field(data, values) = {
+  assert.eq(type(data), content, message: repr(data) + " is not content")
+  
+  if type(values) != array {values = (values,)}
+  
+  for value in values {
+    assert.eq(type(value), str, message: repr(value) + " is not string")
+    
+    if data.at(value, default: "") != "" {return true}
+  }
+  return false
+}
+
+
+/**
+== Key
+:key: => #has.<name>(<capt>)
+
+Check if dictionary or module has a given key.
+
+data <- dictionary | module
+  The dictionary or module itself.
+
+values <- string | array of strings
+  One or more key names.
+**/
+#let key(data, values) = {
+  assert(
+    type(data) == dictionary or type(data) == module,
+    message: repr(data) + " is not dictionary nor module"
+  )
+  
+  if type(data) == module {data = dictionary(data)}
+  if type(values) != array {values = (values,)}
+  
+  for value in values {
+    if data.keys().contains(value) {return true}
+  }
+  return false
+}
+
+/**
+== Value
+:value: => #has.<name>(<capt>)
+
+Check if dictionary or module has a given value.
+
+data <- dictionary | module
+  The dictionary or module itself.
+
+values <- string | array
+  One or more values.
+**/
+#let value(data, values) = {
+  assert(
+    type(data) == dictionary or type(data) == module,
+    message: repr(data) + " is not dictionary nor module"
+  )
+  
+  if type(data) == module {data = dictionary(data)}
+  if type(values) != array {values = (values,)}
+  
+  for value in values {
+    if data.values().contains(value) {return true}
+  }
+  return false
+}
+
+
+/**
+== Item
+:item: => #has.<name>(<capt>)
+
+Check if an array has one or more given items.
+
+data <- string
+  The array itself.
+
+values <- string | array of strings
+  One or more items.
+**/
+#let item(data, values) = {
+  assert.eq(type(data), array, message: repr(data) + " is not array")
+  
+  if type(values) != array {values = (values,)}
+  
+  for value in values {
+    if data.contains(value) {return true}
+  }
+  return false
+}

--- a/packages/preview/nexus-tools/0.2.0/src/sub/its.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/its.typ
@@ -1,0 +1,127 @@
+/**
+= It's
+```typ
+#import "@preview/nexus-tools: 0.1.0": its
+```
+
+== None
+:none-val: => #its.<name>(<capt>)
+
+Check whether a value is `none`.
+
+data <- none | any
+  Value to be checked. 
+**/
+#let none-val(data) = {return data == none}
+
+
+/**
+== Null
+:null: => #its.<name>(<capt>)
+
+Check whether a value is `#get.null`.
+
+data <- any
+  Value to be checked. 
+**/
+#let null(data) = {
+  import "get.typ": null
+  
+  return data == null
+}
+
+
+/**
+== Empty
+:empty: => #its.<name>(<capt>)
+
+Check whether a value is empty: `""` or `[]` or `()` or `(:)`.
+
+data <- any
+  Value to be checked. 
+**/
+#let empty(data) = {return ("", [], (), (:)).contains(data)}
+
+
+/**
+== Context
+:context-val: => #its.<name>(<capt>)
+
+Check whether a value is a `#context()`.
+
+data <- any
+  Value to be checked.
+**/
+#let context-val(data) = { return data.func() == [#context()].func() }
+
+
+/**
+== Sequence of Contents
+:sequence: => #its.<name>(<capt>)
+
+Check whether a value is a sequence of contents.
+
+data <- any
+  Value to be checked.
+**/
+#let sequence(data) = { return data.func() == [*A* _B_].func() }
+
+
+/**
+== Space Content
+:space: => #its.<name>(<capt>)
+
+Check whether a value is a content with just a space.
+
+data <- any
+  Value to be checked. 
+**/
+#let space(data) = { return data.func() == [ ].func() }
+
+
+/**
+== Function
+:func: => #its.<name>(<capt>)
+
+Check whether a value function is one of the given ones.
+
+data <- any
+  Value to be checked.
+
+values <- function | array of functions
+  One or more functions.
+**/
+#let func(data, values) = {
+  assert.eq(type(data), content, message: repr(data) + " is not content")
+  
+  if type(values) != array {values = (values,)}
+  
+  for value in values {
+    if data.func() == value {return true}
+  }
+  return false
+}
+
+
+/**
+== Type
+:type: => #its.<name>(<capt>)
+
+Check whether a value type is one of the given ones.
+
+data <- any
+  Value to be checked.
+
+values <- type | array of types
+  One or more types.
+**/
+#let type(data, values) = {
+  import "assets/orig.typ"
+  
+  if orig.type(values) != array {values = (values,)}
+  
+  for value in values {
+    if orig.type(data) == value {return true}
+  }
+  return false
+}

--- a/packages/preview/nexus-tools/0.2.0/src/sub/main.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/main.typ
@@ -1,0 +1,53 @@
+/**
+= Main
+```typ
+#import "@preview/nexus-tools:0.2.0"
+```
+
+== Custom Defaults
+:default:
+
+Substitutes Typst defaults for custom ones, allowing to set new defaults that
+can be easily changed using `#set` rules; it works by mapping custom defaults to
+the originals, replacing them when in use.
+**/
+#let default(
+  when: false, /// <- boolean
+    /// Condition to apply custom default. |
+  value: (:), /// <- dictionary | any
+    /// Custom default value (condition is `true`). |
+  otherwise: (:), /// <- dictionary | any
+    /// Alternative value when default is not being used (condition is `false`). |
+  disabled, /// <- boolean
+    /// Disable custom default when `true`. |
+) = {
+  if disabled {return}
+  /**
+  This command is commonly used inside `#set` rules.
+  **/
+  if when {return value}
+  else {return otherwise}
+}
+
+
+/**
+== Content to String
+:content2str:
+Converts content to string.
+
+data <- content
+  Content data
+**/
+#let content2str(data) = {
+  if type(data) != content {data = [#data]}
+  
+  if data.has("text") {
+    if type(data.text) == str {data.text}
+    else {content2str(data.text)}
+  }
+  else if data.has("children") {data.children.map(content2str).join("")}
+  else if data.has("body") {content2str(data.body)}
+  else if data == [ ] {" "}
+  else if data == linebreak() {"\n"}
+  else if data == parbreak() {"\n\n"}
+}

--- a/packages/preview/nexus-tools/0.2.0/src/sub/storage.typ
+++ b/packages/preview/nexus-tools/0.2.0/src/sub/storage.typ
@@ -1,0 +1,183 @@
+#let this = state("nexus-tools:general-data-storage", (:))
+
+/**
+= Storage
+```typ
+#import "preview/nexus-tools:0.2.0": storage
+```
+
+== Set Namespace
+```typ
+#storage.namespace(name)
+```
+Set the namespace used as storage. Namespaces allows multiple packages/templates
+to use `#storage` at the same time, each accessing its own proper space. This
+changes where data is stored *globally*, use it with caution.
+
+name <- string <required>
+  Namespace name.
+**/
+#let namespace(name) = {
+  assert.ne(
+    name, "namespace",
+    message: "Cannot use reserved 'namespace' name"
+  )
+  
+  this.update(curr => {
+    curr.insert("namespace", name)
+    curr
+  })
+}
+
+
+/**
+== Add Data
+:add: => #storage.<name>(<capt>)
+
+Insert a new entry in the storage.
+**/
+#let add(
+  key, /// <- string
+    /// Storage entry name. |
+  value, /// <- ant
+    /// Value to be stored. |
+  append: false, /// <- boolean
+    /// If entry already exists, append value when `true`; replaces it when `false`. |
+  namespace: auto, /// <- string
+    /// Add to the given namespace. |
+) = {
+  this.update(curr => {
+    if curr == none {curr = (:)}
+    
+    let value = value
+    let ns = namespace
+    
+    if ns == auto {ns = curr.at("namespace", default: "std")}
+    
+    if curr.at(ns, default: none) == none {curr.insert(ns, (:))}
+    
+    if append {
+      let stored = curr
+        .at(ns)
+        .at(key, default: if type(value) == dictionary {(:)} else {()})
+      
+      if not (dictionary, array).contains(type(stored)) {stored = (stored,)}
+      if not (dictionary, array).contains(type(value)) {value = (value,)}
+      
+      value = stored + value
+    }
+    
+    curr.at(ns).insert(str(key), value)
+    
+    return curr
+  })
+}
+
+
+/**
+== Remove Data
+:remove: => #storage.<name>(<capt>)
+
+Removes an existing entry from storage.
+**/
+#let remove(
+  key, /// <- string
+    /// Storage entry name. |
+  namespace: auto, /// <- string
+    /// Remove from the given namespace. |
+) = {
+  this.update(curr => {
+    if curr == none {curr = (:)}
+    
+    let ns = namespace
+    
+    if ns == auto {ns = curr.at("namespace", default: "std")}
+    
+    let _ = curr.at(ns).remove(str(key), default: none)
+    
+    return curr
+  })
+}
+
+/**
+== Get Data
+:get: => #storage.<name>(<capt>)
+
+Retrieves a value from storage, or the entire namespace itself.
+
+args.pos().at(0) <- string
+  Storage entry name; if not set, returns the whole namespace.
+
+args.pos().at(1) <- any
+  Default value returned when the storage entry is not found; otherwise returns `none`.
+**/
+#let get(
+  ..args,
+  namespace: auto, /// <- string
+    /// Get from the given namespace. |
+) = {
+  let key = args.pos().at(0, default: none)
+  let default = args.pos().at(1, default: none)
+  let ns = namespace
+  
+  if ns == auto {ns = this.get().at("namespace", default: "std")}
+  
+  let stored = this.get().at(ns, default: (:))
+  
+  if key != none {stored = stored.at(str(key), default: default)}
+  
+  return stored
+}
+
+/**
+== Get Final Data
+:final: => #storage.<name>(<capt>)
+
+Retrieves the final value (or namespace) state from storage.
+
+args.pos().at(0) <- string
+  Storage entry name; if not set, returns the final state for the whole namespace.
+
+args.pos().at(1) <- any
+  Default value returned when the storage entry is not found; otherwise returns `none`.
+**/
+#let final(
+    ..args,
+  namespace: auto, /// <- string
+    /// Final state from the given namespace. |
+) = {
+  let key = args.pos().at(0, default: none)
+  let default = args.pos().at(1, default: none)
+  let ns = namespace
+  
+  if ns == auto {ns = this.get().at("namespace", default: "std")}
+  
+  let stored = this.final().at(ns, default: (:))
+  
+  if key != none {stored = stored.at(str(key), default: default)}
+  
+  return stored
+}
+
+/**
+== Reset Database
+:reset: => #storage.<name>(<capt>)
+
+Set a new value for the entire storage namespace. While the new value can be of
+any type, the other storage commands can only work with `dictionary` values.
+**/
+#let reset(
+  data, /// <- dictionary | any
+    /// New namespace value. |
+  namespace: auto, /// <- string
+    /// Reset the given namespace. |
+) = {
+  this.update(curr => {
+    let ns = namespace
+    
+    if ns == auto {ns = curr.at("namespace", default: "std")}
+    
+    curr.at(ns) = data
+    curr
+  })
+}

--- a/packages/preview/nexus-tools/0.2.0/typst.toml
+++ b/packages/preview/nexus-tools/0.2.0/typst.toml
@@ -1,0 +1,17 @@
+[package]
+name = "nexus-tools"
+version = "0.2.0"
+description = "Easily implement and reuse tools and components across projects"
+authors = ["Maycon F. Melo <@mayconfmelo>"]
+license = "MIT-0"
+repository = "https://github.com/mayconfmelo/nexus-tools"
+entrypoint = "src/lib.typ"
+categories = ["scripting", "utility", "components"]
+keywords = [
+  "development", "dev", "storage", "database", "components", "callout", "null",
+  "testing", "defaults", "content2str", "date"
+]
+exclude = [
+  "dev/", "tests/", "docs/", "scripts/", ".git", ".github", ".gitignore",
+  "justfile", "manual.typ"
+]


### PR DESCRIPTION

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

This version adds the ability to determine the "amount of light" in a color—ranging from 0 (darkest) to 1 (lightest)—and to derive different colors based on relative luminance, which is ideal for determining an optimal text color that contrasts with the background. It is now also possible to generate a `#datetime` object from an array, dictionary, or string.

- Added: `#get.relative-luminance()` of a color
- Added: `#get.dynamic-color()` to get different colors based on the relative luminance of a color
- Updated: `#date` support for arrays, dictionaries, and strings