### PR TITLE
quill:0.8.0

### DIFF
--- a/packages/preview/quill/0.8.0/LICENSE
+++ b/packages/preview/quill/0.8.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/quill/0.8.0/README.md
+++ b/packages/preview/quill/0.8.0/README.md
@@ -1,0 +1,265 @@
+<div align="center">
+  <img alt="Quill logo" src="https://github.com/user-attachments/assets/3cb87ef5-03e0-48a7-b00b-1b8277a03fe1" style="max-width: 100%; width: 300pt">
+</div>
+
+<div align="center">
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fquill%2Fv0.8.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/quill)
+[![Test Status](https://github.com/Mc-Zen/quill/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/quill/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/quill/blob/v0.8.0/LICENSE)
+[![User Manual](https://img.shields.io/badge/manual-.pdf-purple)][guide]
+
+</div>
+
+
+**Quill** is a package for creating quantum circuit diagrams in [Typst](https://typst.app/). 
+It features two distinct creation models:
+- The manual and powerful [grid model](#basic-usage-the-grid-model).
+- The automatic, instruction-driven model [Tequila](#tequila) which is also useful for _composing_ sub-circuits. These circuits are then embedded into the grid model. 
+
+Outline:
+
+
+- [Usage](#basic-usage-the-grid-model): _A quick introduction_
+- [Cheat sheet](#cheat-sheet): _A gallery showcasing various circuit elements_
+- [Tequila](#tequila): _Building circuits similar to QASM or Qiskit_
+- [Examples](#examples)
+- [Changelog](#changelog)
+
+
+## Basic usage (the grid model)
+
+The function `quantum-circuit()` takes any number of positional gates and works similar to the built-in Typst functions `table()` and `grid()`. 
+- A variety of different gate and instruction commands are available for adding elements. 
+- Integers can be used to produce any number of empty cells (filled with the current wire style). 
+- A new wire is started by adding a `[\ ]` item. 
+
+
+```typ
+#{
+  import "@preview/quill:0.8.0": *
+
+  quantum-circuit(
+    lstick($|0〉$), $H$, ctrl(1), rstick($(|00〉+|11〉)/√2$, n: 2), [\ ],
+    lstick($|0〉$), 1, targ(), 1
+  )
+}
+```
+<div align="center">
+  
+  ![Bell state preparation circuit](https://github.com/user-attachments/assets/f80f6041-379e-440c-bcda-95348f066f17)
+  
+</div>
+
+Plain quantum gates — such as a Hadamard gate — can be written with the shorthand notation `$H$` instead of the more lengthy `gate($H$)`. The latter offers additional styling options. 
+
+Refer to the [user guide][guide] for a full documentation of this package. You can also look up the documentation of any function by calling the help module, e.g., `#help("gate")` just where you are currently typing (powered by [tidy][tidy]). 
+
+
+## Cheat Sheet
+
+This gallery quickly showcases a large selection of possible gates and decorations that can be added to any quantum circuit. 
+
+<div align="center">
+  
+  ![Cheatsheet for common quantum gates](https://github.com/user-attachments/assets/c7852e83-6652-4503-a52e-3a658c123a37)
+  
+</div>
+
+
+
+
+
+## Tequila
+
+
+_Tequila_ is a submodule that adds a completely different way of building circuits. 
+
+```typ
+#import "@preview/quill:0.8.0" as quill: tequila as tq
+
+#quill.quantum-circuit(
+  ..tq.build(
+    tq.h(0),
+    tq.cx(0, 1),
+    tq.cx(0, 2),
+  ),
+  quill.gategroup(x: 2, y: 0, 3, 2)
+)
+```
+
+This is similar to how _QASM_ and _Qiskit_ work: gates are successively applied to the circuit which is then laid out automatically by packing gates as tightly as possible. We start by calling the `tq.build()` function and filling it with quantum operations. This returns a collection of gates which we expand into the circuit with the `..` syntax. 
+Now, we still have the option to add annotations, groups, slices, or even more gates via manual placement. 
+
+The syntax works analogously to Qiskit. Available gates are `x`, `y`, `z`, `h`, `s`, `sdg`, `sx`, `sxdg`, `t`, `tdg`, `p`, `rx`, `ry`, `rz`, `u`, `cx`, `cz`, and `swap`. With `barrier`, an invisible barrier can be inserted to prevent gates on different qubits to be packed tightly. Finally, with `tq.gate` and `tq.mqgate`, a generic gate can be created. These two accept the same styling arguments as the normal `gate` (or `mqgate`).
+
+Also like Qiskit, all qubit arguments support ranges, e.g., `tq.h(range(5))` adds a Hadamard gate on the first five qubits and `tq.cx((0, 1), (1, 2))` adds two CX gates: one from qubit 0 to 1 and one from qubit 1 to 2. 
+
+With Tequila, it is easy to build templates for quantum circuits and to compose circuits of various building blocks. For this purpose, `tq.build()` and the built-in templates all feature optional `x` and `y` arguments to allow placing a sub-circuit at an arbitrary position of the circuit. 
+As an example, Tequila provides a `tq.graph-state()` template for quickly drawing graph state preparation circuits. 
+
+The following example demonstrates how to compose multiple sub-circuits. 
+
+
+```typ
+#import tequila as tq
+
+#quantum-circuit(
+  ..tq.graph-state((0, 1), (1, 2)),
+  ..tq.build(y: 3, 
+      tq.p($pi$, 0), 
+      tq.cx(0, (1, 2)), 
+    ),
+  ..tq.graph-state(x: 6, y: 2, invert: true, (0, 1), (0, 2)),
+  gategroup(x: 1, 3, 3),
+  gategroup(x: 1, y: 3, 3, 3),
+  gategroup(x: 6, y: 2, 3, 3),
+  slice(x: 5)
+)
+```
+<div align="center">
+  <img alt="Tequila example for composing circuits" src="https://github.com/user-attachments/assets/3a660b40-923f-4410-838e-322a673604e6" />
+</div>
+
+
+## Examples
+
+Some show-off examples, loosely replicating figures from [Quantum Computation and Quantum Information by M. Nielsen and I. Chuang](https://www.cambridge.org/highereducation/books/quantum-computation-and-quantum-information/01E10196D0A682A6AEFFEA52D53BE9AE#overview). The code for these examples can be found in the [example folder][examples] or in the [user guide][guide]. 
+
+<div align="center">
+  <img alt="Quantum teleportation circuit" src="https://github.com/user-attachments/assets/f371d9b9-e9ab-49a7-a728-7fa94d958a8a">
+</div>
+<div align="center">
+  <img alt="Quantum circuit for phase estimation" src="https://github.com/user-attachments/assets/f1bb6469-bc7e-42a5-83da-9413748506f9">
+</div>
+<div align="center">
+  <img alt="Quantum fourier transformation circuit" src="https://github.com/user-attachments/assets/bdff94ce-f6b8-4d4b-98c1-5eb51d53e3bd">
+</div>
+
+
+## Contribution
+
+If you spot an issue or have a suggestion, you are invited to [post it](https://github.com/Mc-Zen/quill/issues) or to contribute to this package. In [architecture.md][architecture], you can also find a description of the algorithm that forms the base of `quantum-circuit()`. 
+
+## Tests
+This package uses [tytanic](https://github.com/tingerrr/tytanic) for running [tests][tests]. 
+
+
+## Changelog
+
+
+### v0.8.0
+- New repeat annotation `repeat-block`. 
+- Added `targ-y` gate for controlled-Y gates. 
+- New decoration `break-line` for marking the omission of wires.
+- Fixed multi-qubit `lstick`/`rstick` braces that broke with Typst 0.15 (again). 
+- Improved docs for slices and gategroups. 
+
+### v0.7.3
+- ⚠️ Removed the redundant parameter `quantum-circuit.color`. It was not even really used. 
+- Now, no empty `math.lr` are created anymore with `lstick` and `rstick`. 
+- Added styling parameters: `swap.stroke`, `targ.stroke`, `ctrl.stroke`, `phase.stroke`, `meter.stroke`, `lstick.fill`, and `rstick.fill`.
+- Fixed an issue with `permute.x` and `permute.y` being ignored.  
+
+
+### v0.7.2
+- Added a paremter `wire-stroke` to all controlled gates such as `mqgate`, `ctrl`, `targ`, `swap`, and `meter` that gives control over the stroke of the control wire(s). 
+- Added an optional label to `tequila.measure`. 
+- Fixed multiple and manually positioned labels with `meter`. 
+- Allow specifying the right/bottom end of a `gategroup` with two new parameter `gategroup.right` and `gategroup.bottom`. 
+
+### v0.7.1
+- Added the parameter `wires` to `quantum-circuit` that allows defining the number of (qu)bits explicitly. This parameter also accepts an array of wire counts, e.g., `wires: (1,) * qubits + (2,) * clbits` which is useful to avoid having to many `setwire` commands. 
+- Added a `pass-through` parameter to `mqgate` that enables wires to pass through a multi-qubit gate instead of attaching themselves as in- and outputs. 
+- Added the parameters `wire-count` and `stroke` to permute, allowing classical or even mixed permutation gates. 
+- Added more flexibility to meters by allowing the content to be specified. 
+- Fixed circuits with right-to-left text direction
+
+### v0.7.0
+- Improvements to Tequila: 
+  - Exposed a `tequila.ca` gate for arbitrary single-qubit controlled gates. 
+  - Added `tequila.measure` to replace `tequila.meter`. The new gate can also receive an index of a wire to send the result to via a classical wire. 
+  - Addd optional `start` and `end` parameters to `tequila.barrier` that allow local barriers. 
+  - Fixed problems with `multi-controlled-gate`. 
+- `targ` can now take a "target" qubit as in `targ(2)` to produce a vertical wire, just like `ctrl` and `swap`. 
+- Both `ctrl` and `swap` can now be used without target argument like `ctrl()`. This can replace usage like `ctrl(0)` for gates without a control wire. 
+- Added position parameters `x` and `y` to the `phantom` gate. 
+
+### v0.6.1
+- Fixes braces in circuits which were broken in new Typst version 0.13. 
+- Replaces usage of the now deprecated `path` element with the new `curve` element. 
+- ⚠️ Requires Typst 0.13. 
+
+
+### v0.6.0
+- Improved support for Tequila: controlled-gates can now take additional styling parameters.
+- ⚠️ Removed `targX`: use `swap(0)` instead. 
+- Fixed `stroke` for the plain `gate` command. 
+- Big documentation update. 
+
+### v0.5.0
+- Added support for multi-controlled gates with Tequila. 
+- Switched to using `context` instead of the now deprecated `style()` for measurement. 
+Note: Starting with this version, Typst 0.11.0 or higher is required. 
+
+### v0.4.0
+- Alternative model for creating and composing circuits: [Tequila](#tequila). 
+
+### v0.3.0
+- New features
+  - Enable manual placement of gates, `gate($X$, x: 3, y: 1)`, similar to built-in `table()` in addition to automatic placement. This works for most elements, not only gates. 
+  - Add parameter `pad` to `lstick()` and `rstick()`. 
+  - Add parameter `fill-wires` to `quantum-circuit()`. All wires are filled unto the end (determined by the longest wire) by default (breaking change ⚠️). This behavior can be reverted by setting `fill-wires: false`. 
+  - `gategroup()` `slice()` and `annotate()` can now be placed above or below the circuit with `z: "above"` and `z: "below"`.
+  - `help()` command for quickly displaying the documentation of a given function, e.g., `help("gate")`. Powered by [tidy][tidy]. 
+- Improvements:
+  - Complete rework of circuit layout implementation
+    - allows transparent gates since wires are not drawn through gates anymore. The default fill is now `auto` and using `none` sets the background to transparent. 
+    - `midstick` is now transparent by default. 
+  - `setwire()` can now be used to override only partial wire settings, such as wire color `setwire(1, stroke: blue)`, width `setwire(1, stroke: 1pt)` or wire distance, all separately. Before, some settings were reset. 
+- Fixes:
+  - Fixed `lstick`/`rstick` when equation numbering is turned on. 
+- Removed:
+  - The already deprecated `scale-factor` (use `scale` instead)
+
+### v0.2.1
+- Improvements:
+  - Add `fill` parameter to `midstick()`. 
+  - Add `bend` parameter to `permute()`. 
+  - Add `separation` parameter to `permute()`. 
+- Fixes:
+  - With Typst 0.11.0, `scale()` now takes into account outer alignment. This broke the positioning of centered/right-aligned circuits, e.g., ones put into a `figure()`. 
+  - Change wires to be drawn all through `ctrl()`, making it consistent to `swap()` and `targ()`. 
+
+
+### v0.2.0
+- New features:
+  - Add arbitrary labels to any `gate` (also derived gates such as `meter`, `ctrl`, ...), `gategroup` or `slice` that can be anchored to any of the nine 2d alignments. 
+  - Add optional gate inputs and outputs for multi-qubit gates (see gallery).
+  - Implicit gates (breaking change ⚠️): a content item automatically becomes a gate, so you can just type `$H$` instead of `gate($H$)` (of course, the `gate()` function is still important in order to use the many available options). 
+- Other breaking changes ⚠️: 
+  - `slice()` has no `dx` and `dy` parameters anymore. Instead, labels are handled through `label` exactly as in `gate()`. Also the `wires` parameter is replaced with `n` for consistency with other multi-qubit gates. 
+  - Swap order of row and column parameters in `annotate()` to make it consistent with built-in Typst functions. 
+- Improvements: 
+  - Improve layout (allow row/column spacing and min lengths to be specified in em-lengths).
+  - Automatic bounds computation, even for labels. 
+  - Improve meter (allow multi-qubit gate meters and respect global (per-circuit) gate padding).
+- Fixes:
+  - `lstick`/`rstick` braces broke with Typst 0.7.0.
+  - `lstick`/`rstick` bounds.
+- Documentation
+  - Add section on creating custom gates. 
+  - Add section on using labels. 
+  - Explain usage of `slice()` and `gategroup()`.
+
+### v0.1.0
+
+Initial Release
+
+
+[guide]: https://github.com/Mc-Zen/quill/releases/download/v0.8.0/quill-guide.pdf
+[examples]: https://github.com/Mc-Zen/quill/tree/v0.8.0/examples
+[tests]: https://github.com/Mc-Zen/quill/tree/v0.8.0/tests
+[tidy]: https://github.com/Mc-Zen/tidy
+[architecture]: https://github.com/Mc-Zen/quill/blob/v0.8.0/docs/architecture.md
+

--- a/packages/preview/quill/0.8.0/src/arrow.typ
+++ b/packages/preview/quill/0.8.0/src/arrow.typ
@@ -1,0 +1,35 @@
+
+#let draw-arrow(start, end, length: 5pt, width: 2.5pt) = context layout(size => {
+  let convert-ratio(x, y) = {
+    if type(x) == ratio { x *=size.width }
+    if type(y) == ratio { y *= size.height }
+    (x, y)
+  }
+  let start = convert-ratio(..start)
+  let end = convert-ratio(..end)
+  let stroke = line.stroke
+  let arrow-color = stroke.paint
+  if arrow-color == auto { arrow-color = black }
+  place(line(start: start, end: end))
+  let dir = (end.at(0) - start.at(0), end.at(1) - start.at(1))
+  dir = dir.map(x => float(repr(x).slice(0,-2)))
+  // let angle = calc.atan2(dir.at(0), dir.at(1))
+  
+  let len = calc.norm(..dir)
+  dir = dir.map(x => x / len)
+  let normal = (-dir.at(1), dir.at(0))
+
+  let arrow-start = end
+  let arrow-end = (end.at(0) + length*dir.at(0), end.at(1) + length*dir.at(1))
+  let w = width/2
+  let v1 = (arrow-start.at(0) - w*normal.at(0), arrow-start.at(1) - w*normal.at(1))
+  let v2 = (arrow-start.at(0) + w*normal.at(0), arrow-start.at(1) + w*normal.at(1))
+  polygon(arrow-end, v1, v2, fill: arrow-color)
+})
+
+#let test-arrow() = {
+  draw-arrow((0%, 0%), (50%, 10%))
+}
+
+
+#test-arrow()

--- a/packages/preview/quill/0.8.0/src/decorations.typ
+++ b/packages/preview/quill/0.8.0/src/decorations.typ
@@ -1,0 +1,529 @@
+#import "gates.typ": *
+
+
+// align: "left" (for rstick) or "right" (for lstick)
+// brace: auto, none, "{", "}", "|", "[", ...
+#let lrstick(content, n, align, brace, label, pad: 0pt, x: auto, y: auto, fill: auto) = gate(
+  content, 
+  x: x, 
+  y: y,
+  draw-function: draw-functions.draw-lrstick, 
+  size-hint: layout.lrstick-size-hint,
+  box: false, 
+  fill: fill,
+  floating: true,
+  multi: if n == 1 { none } else { 
+   (
+    target: none,
+    num-qubits: n, 
+    wire-count: 0, 
+    label: label,
+    size-all-wires: if n > 1 { none } else { false },
+    pass-through: ()
+  )},
+  data: (
+    brace: brace,
+    align: align,
+    pad: pad
+  ), 
+  label: label
+)
+
+
+
+/// Basic command for labelling a wire at the start. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   lstick($|0〉$), 1
+/// )
+/// ```
+/// It can also span multiple wires
+/// ```example
+/// #quantum-circuit(
+///   lstick($rho$, n: 2), 1, [\ ], 
+///   1
+/// )
+/// ```
+#let lstick(
+
+  /// Label to display, e.g., `$|0〉$`.
+  /// -> content
+  body, 
+
+  /// How many wires the `lstick` should span. 
+  /// -> int
+  n: 1, 
+
+  /// If `brace` is `auto`, then a default `{` brace is shown only if `n > 1`. 
+  /// A brace is always shown when explicitly given, e.g., `"}"`, `"["` or 
+  /// `"|"`. No brace is shown for `brace: none`.
+  /// -> auto | none | str
+  brace: auto, 
+
+  /// Adds a padding between the label and the connected wire to the right. 
+  /// -> length
+  pad: 0pt,
+
+  /// How to color the brace. 
+  /// -> auto | color
+  fill: auto,
+
+  /// One or more labels to add to the gate. See @gate.label. 
+  /// -> none | array | str | content | dictionary
+  label: none, 
+
+  x: auto,
+
+  y: auto
+
+) = lrstick(body, n, right, brace, label, pad: pad, x: x, y: y, fill: fill)
+
+
+
+/// Basic command for labelling a wire at the end. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, rstick($|0〉$)
+/// )
+/// ```
+/// It can also span multiple wires
+/// ```example
+/// #quantum-circuit(
+///   1, rstick($rho$, n: 2), [\ ], 
+/// )
+/// ```
+#let rstick(
+
+  /// Label to display, e.g., `$|0〉$`.
+  /// -> content
+  body, 
+
+  /// How many wires the `rstick` should span. 
+  /// -> int
+  n: 1, 
+
+  /// If `brace` is `auto`, then a default `}` brace is shown only if `n > 1`. 
+  /// A brace is always shown when explicitly given, e.g., `"}"`, `"["` or 
+  /// `"|"`. No brace is shown for `brace: none`. 
+  /// -> auto | none | str
+  brace: auto, 
+
+  /// Adds a padding between the label and the connected wire to the left. 
+  /// -> length
+  pad: 0pt, 
+
+  /// How to color the brace. 
+  /// -> auto | color
+  fill: auto,
+
+  /// One or more labels to add to the gate. See @gate. 
+  /// -> none | array | str | content | dictionary
+  label: none, 
+
+  x: auto,
+
+  y: auto
+
+) = lrstick(body, n, left, brace, label, pad: pad, x: x, y: y, fill: fill)
+
+
+
+/// Create a midstick, i.e., a mid-circuit text. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, midstick($cal(E)$), 1
+/// )
+/// ```
+/// It can also span multiple wires
+/// ```example
+/// #quantum-circuit(
+///   1, midstick($cal(E)^2$, n: 2), 
+///   1, [\ ], 
+/// )
+/// ```
+#let midstick(
+
+  /// Label to display, e.g., `$rho$`.
+  /// -> content
+  body,
+
+  /// How many wires the `midstick` should span. 
+  /// -> content
+  n: 1,
+
+  /// One or more labels to add to the gate. See @gate. 
+  /// -> none | array | str | content | dictionary
+  label: none,
+
+  /// How to fill the midstick.
+  /// -> none color | gradient | tiling
+  fill: none,
+
+  x: auto,
+
+  y: auto
+
+) = {
+  if n == 1 { 
+    gate(body, draw-function: draw-functions.draw-unboxed-gate, label: label, fill: fill, x: x, y: y) 
+  } else {
+    mqgate(body, n: n, draw-function: draw-functions.draw-boxed-multigate, label: label, fill: fill, x: x, y: y, stroke: none) 
+  }
+}
+
+
+
+/// Creates a symbol similar to `\qwbundle` on `quantikz`. Annotates a wire to 
+/// be a bundle of quantum or classical wires. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, nwire($5$), 1
+/// )
+/// ```
+#let nwire(
+
+  /// The label to put on top of the bundle. 
+  /// -> int | content
+  body, 
+
+  x: auto, 
+
+  y: auto
+
+) = gate([#body], draw-function: draw-functions.draw-nwire, box: false, x: x, y: y)
+
+
+
+/// Set current wire mode (0: none, 1 wire: quantum, 2 wires: classical, more  
+/// are possible) and optionally the stroke style. 
+///
+/// The wire style is reset for each row.
+#let setwire(
+
+  /// Number of wires to display. 
+  /// -> int
+  count, 
+
+  /// When given, the stroke is applied to the wire. Otherwise the current stroke is kept. 
+  /// -> auto | none | stroke
+  stroke: auto, 
+
+  /// Distance between wires. 
+  /// -> length
+  wire-distance: auto,
+
+  /// The starting column of the wire change command. 
+  /// -> auto | int
+  x: auto, 
+
+  /// The starting wire of the wire change command. 
+  /// -> auto | int
+  y: auto
+
+) = {
+  let result = (
+    x: x, 
+    y: y,
+    qc-instr: "setwire",
+  )
+  if count != auto { result.count = count }
+  if stroke != auto { result.stroke = stroke }
+  if wire-distance != auto { result.distance = wire-distance }
+  result
+}
+
+
+/// Highlight a group of circuit elements by drawing a rectangular box around
+/// them. 
+/// ```example
+/// #quantum-circuit(
+///   1, gategroup(1, 2), $H$, $S$, 1
+/// )
+/// ```
+#let gategroup(
+
+  /// Number of wires to include. Is ignored if @gategroup.bottom is given. 
+  /// -> int
+  wires, 
+
+  /// Number of columns to include. Is ignored if @gategroup.right is given. 
+  /// -> int
+  steps, 
+
+  /// The starting column of the gategroup. 
+  /// -> auto | int
+  x: auto, 
+
+  /// The starting wire of the gategroup. 
+  /// -> auto | int
+  y: auto, 
+
+  /// The column where the gategroup should end. 
+  /// -> auto | int
+  right: auto,
+
+  /// The row where the gategroup should end. 
+  /// -> auto | int
+  bottom: auto,
+
+  /// The gategroup can be placed `"below"` or `"above"` the circuit. 
+  /// -> "below" | "above"
+  z: "below", 
+
+  /// Padding of rectangle. May be one length for all sides or a dictionary 
+  /// with the keys `left`, `right`, `top`, `bottom` and `default`. Not all 
+  /// keys need to be specified. The value for `default` is used for the 
+  /// omitted sides or `0pt` if no `default` is given. 
+  /// -> length | dictionary
+  padding: 0pt, 
+
+  /// Stroke for rectangle.
+  /// -> stroke
+  stroke: .7pt, 
+
+  /// Fill color for rectangle.
+  /// -> color
+  fill: none, 
+
+  /// Corner radius for rectangle.
+  /// -> length, dictionary
+  radius: 0pt, 
+
+  /// One or more labels to add to the group. See @gate. 
+  /// -> none | array | str | content | dictionary
+  label: none
+
+) = (
+  qc-instr: "gategroup",
+  wires: wires,
+  steps: steps,
+  x: x, 
+  y: y,
+  z: z,
+  right: right, 
+  bottom: bottom,
+  padding: process-args.process-padding-arg(padding),
+  style: (fill: fill, stroke: stroke, radius: radius),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+/// Annotate the repetition of part of the circuit. 
+/// ```example
+/// #quantum-circuit(
+///   1, repeat-block(2, label: $n$), $H$, $X$, meter()
+/// )
+/// ```
+#let repeat-block(
+
+  /// Number of columns to repeat. Is ignored if @repeat-block.right is given. 
+  /// -> int
+  steps, 
+
+  /// Number of wires to include. Is ignored if @repeat-block.bottom is given. 
+  /// -> auto | int
+  wires: auto, 
+  
+  /// The type of the brace to draw. Possible values are `"("`, `"["`, `"{"`, 
+  /// `"|"`, and `"||:"` (the latter displays a musical repetition symbol).
+  /// 
+  /// ```example
+  /// #quantum-circuit(
+  ///   1, repeat-block(2, label: $n$, brace: "||:"), $H$, $X$, 1
+  /// )
+  /// ```
+  /// -> str
+  brace: "[",
+
+  /// The starting column of the repeat block. 
+  /// -> auto | int
+  x: auto, 
+
+  /// The starting wire of the repeat block. 
+  /// -> auto | int
+  y: auto, 
+
+  /// The column where the repeat block should end. 
+  /// -> auto | int
+  right: auto,
+
+  /// The row where the repeat block should end. 
+  /// -> auto | int
+  bottom: auto,
+
+  /// The repeat block can be placed `"below"` or `"above"` the circuit. 
+  /// -> "below" | "above"
+  z: "above", 
+
+  /// Fill color for the brace.
+  /// -> color
+  fill: auto, 
+
+  /// One or more labels to add to the group. See @gate. 
+  /// -> none | array | str | content | dictionary
+  label: none
+
+) = (
+  qc-instr: "repeat-block",
+  wires: wires,
+  steps: steps,
+  x: x, 
+  y: y,
+  z: z,
+  right: right, 
+  bottom: bottom,
+  style: (fill: fill, brace: brace),
+  labels: process-args.process-label-arg(label, default-pos: top+std.right, default-dx: .1em, default-dy:.1em)
+)
+
+
+
+/// Slice the circuit vertically, showing a separation line between columns. 
+/// ```example
+/// #quantum-circuit(
+///   1, $X$, slice(), $H$, 1
+/// )
+/// ```
+#let slice(
+
+  /// Number of wires to slice.
+  /// -> int
+  n: 0, 
+
+  /// The starting column of the slice. 
+  /// -> auto | int
+  x: auto, 
+
+  /// The starting wire of the slice. 
+  /// -> auto | int
+  y: auto,
+
+  /// The slice can be placed `"below"` or `"above"` the circuit. 
+  /// -> "below" | "above"
+  z: "below",
+
+  /// Line style for the slice. 
+  /// -> stroke
+  stroke: (paint: red, thickness: .7pt, dash: "dashed"),
+
+  /// One or more labels to add to the slice. See @gate. 
+  /// -> none | array | str | content | dictionary
+  label: none
+
+) = (
+  qc-instr: "slice",
+  wires: n,
+  x: x,
+  y: y,
+  z: z,
+  style: (stroke: stroke),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+/// Inserts a break line that marks the omission of quantum or classical wires.
+/// ```example
+/// #quantum-circuit(
+///   1, $X$, ctrl(1), 1, [\ ],
+///   break-line(), 
+///   1, $X$, targ(), 1, 
+/// )
+/// ```
+#let break-line(
+
+  /// The wire after which to insert to break line.
+  /// -> auto | int
+  y: auto,
+
+  /// At which column to start the break line.
+  /// -> int
+  start: 0,
+  
+  /// At which column to end the break line.
+  /// -> int
+  end: -1,
+  
+  /// The thickness of the break line.
+  /// -> length
+  thickness: 3pt,
+
+  /// The additional gap to introduce between the two separated wires. 
+  /// -> length
+  gap: 20pt,
+
+  /// How wavy the break lines is drawn.
+  /// ```example
+  /// #quantum-circuit(
+  ///   1, $X$, ctrl(1), 1, [\ ],
+  ///   break-line(wavy: 0%), 
+  ///   1, $X$, targ(), 1, 
+  /// )
+  /// ```
+  /// -> ratio
+  wavy: 40%,
+
+  /// The break line can be placed `"below"` or `"above"` the circuit. 
+  /// -> "below" | "above"
+  z: "above",
+
+  /// Line style of the break-line. If set to `auto`, the stroke is inherited 
+  /// from the wire stroke of the circuit.
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// One or more labels to add to the break-line. See @gate. 
+  /// -> none | array | str | content | dictionary
+  label: none
+
+) = (
+  qc-instr: "break-line",
+  x: 0,
+  y: y,
+  z: z,
+  start: start,
+  end: end,
+  gap: gap,
+  style: (stroke: stroke, thickness: thickness, wavy: wavy),
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+
+
+
+/// Lower-level interface to the cell coordinates to create an arbitrary
+/// annotatation by passing a custom function.
+/// 
+/// This function is passed the coordinates of the specified cell rows 
+/// and columns. 
+#let annotate(
+
+  /// Column indices for which to obtain coordinates.
+  /// -> int | array
+  columns,
+
+  /// Row indices for which to obtain coordinates. 
+  /// -> int | array
+  rows,
+
+  /// Function to call with the obtained coordinates. The signature should
+  /// be with signature `(col-coords, row-coords) => {}`. This function is
+  /// expected to display the content to draw in absolute coordinates within 
+  /// the circuit. 
+  /// -> function
+  callback,
+
+  /// The slice can be placed `"below"` or `"above"` the circuit. 
+  /// -> "below" | "above"
+  z: "below"
+
+) = (
+  qc-instr: "annotate",
+  rows: rows,
+  x: none,
+  y: none,
+  z: z,
+  columns: columns,
+  callback: callback
+)

--- a/packages/preview/quill/0.8.0/src/draw-functions.typ
+++ b/packages/preview/quill/0.8.0/src/draw-functions.typ
@@ -1,0 +1,466 @@
+// INTERNAL GATE DRAW FUNCTIONS
+
+
+#import "utility.typ"
+#import "arrow.typ"
+#import "layout.typ"
+
+
+
+
+
+
+// Default gate draw function. Draws a box with global padding
+// and the gates content. Stroke and default fill are only applied if 
+// gate.box is true
+#let draw-boxed-gate(gate, draw-params) = align(center, box(
+  inset: draw-params.padding, 
+  width: gate.width,
+  radius: gate.radius,
+  stroke: if gate.box { utility.if-auto(gate.stroke, draw-params.wire) }, 
+  fill: utility.if-auto(gate.fill, if gate.box {draw-params.background}),
+  gate.content,
+))
+
+// Same but without displaying a box
+#let draw-unboxed-gate(gate, draw-params) = box(
+  inset: draw-params.padding, 
+  fill: utility.if-auto(gate.fill, draw-params.background),
+  gate.content
+)
+
+// Draw a gate spanning multiple wires
+#let draw-boxed-multigate(gate, draw-params) = {
+  let dy = draw-params.multi.wire-distance
+  let extent = gate.multi.extent
+  if extent == auto { extent = draw-params.x-gate-size.height / 2 }
+  
+  let style-params = (
+      width: gate.width,
+      stroke: utility.if-auto(gate.stroke, draw-params.wire), 
+      radius: gate.radius,
+      fill: utility.if-auto(gate.fill, draw-params.background), 
+      inset: draw-params.padding, 
+  )
+  align(center + horizon, box(
+    ..style-params,
+    height: dy + 2 * extent,
+    gate.content
+  ))
+  
+  
+  let draw-inouts(inouts, alignment) = {
+    
+    if inouts != none and dy != 0pt {
+      let width = measure(line(length: gate.width)).width
+      let y0 = -(dy + extent) - draw-params.center-y-coords.at(0)
+      let get-wire-y(qubit) = { draw-params.center-y-coords.at(qubit) + y0 }
+      
+      set text(size: .8em)
+      context {
+        for inout in inouts {
+          let size = measure(inout.label)
+          let y = get-wire-y(inout.qubit)
+          let label-x = draw-params.padding
+          if "n" in inout and inout.n > 1 {
+            let y2 = get-wire-y(inout.qubit + inout.n - 1)
+            let brace = utility.create-brace(auto, alignment, y2 - y + draw-params.padding)
+            let brace-x = 0pt
+            let size = measure(brace)
+            if alignment == right { brace-x += width - size.width }
+            
+            place(brace, dy: y - 0.5 * draw-params.padding, dx: brace-x)
+            label-x = size.width
+            y += 0.5 * (y2 - y)
+          }
+          place(dy: y - size.height / 2, align(
+            alignment, 
+            box(inout.label, width: width, inset: (x: label-x))
+          ))
+        }
+      }
+      
+    }
+  
+  }
+  draw-inouts(gate.multi.inputs, left)
+  draw-inouts(gate.multi.outputs, right)
+}
+
+#let draw-targ(item, draw-params) = {
+  let size = item.data.size
+  box({
+    set circle(stroke: draw-params.wire)
+    set line(stroke: draw-params.wire)
+    set circle(stroke: item.stroke) if item.stroke != auto
+    set line(stroke: item.stroke) if item.stroke != auto
+    circle(
+      radius: size, 
+      fill: utility.if-auto(item.fill, draw-params.background)
+    )
+    place(line(start: (size, 0pt), length: 2*size, angle: -90deg))
+    place(line(start: (0pt, -size), length: 2*size))
+  })
+}
+
+#let draw-ctrl(gate, draw-params) = {
+  let color = utility.if-auto(gate.fill, draw-params.wire.paint)
+  if "show-dot" in gate.data and not gate.data.show-dot { return none }
+  if gate.data.open {
+    let stroke = utility.update-stroke(draw-params.wire, gate.stroke)
+    let fill = utility.if-auto(gate.fill, draw-params.background)
+    box(circle(stroke: stroke, fill: fill, radius: gate.data.size))
+  } else {
+    box(circle(fill: color, radius: gate.data.size))
+  }
+}
+
+#let draw-swap(gate, draw-params) = {
+  box({
+    let d = gate.data.size
+    set line(stroke: draw-params.wire)
+    set line(stroke: gate.stroke) if gate.stroke != auto
+    box(width: d, height: d, {
+      place(line(start: (-0pt, -0pt), end: (d, d)))
+      place(line(start: (d, 0pt), end: (0pt, d)))
+    })
+  })
+}
+#let draw-targ-y(item, draw-params) = {
+  let size = item.data.size
+  box({
+    rotate(
+      180deg,
+      polygon.regular(
+        fill: item.fill,
+        stroke: draw-params.wire,
+        size: size,
+        vertices: 3,
+      ),
+    )
+  })
+}
+
+
+#let meter-symbol = box(rect(
+  stroke: none, fill: none, 
+  inset: 0pt, outset: 0pt, 
+  {
+    place(curve(
+      curve.move((0%, 110%)),
+      curve.quad((13%, 40%), (50%, 40%)),
+      curve.quad(auto, (100%, 110%)),
+    ))
+    set align(left)
+    arrow.draw-arrow((50%, 120%), (90%, 30%), length: 3.8pt, width: 2.8pt)
+  }
+))
+
+
+
+#let draw-meter(gate, draw-params) = {
+  let height = draw-params.x-gate-size.height 
+  let width = 1.5 * height
+  height -= 2 * draw-params.padding
+  width -= 2 * draw-params.padding
+  
+  gate.content = block({
+    set align(top)
+    set curve(stroke: draw-params.wire)
+    set line(stroke: draw-params.wire)
+    set curve(stroke: gate.stroke) if gate.stroke != auto
+    set line(stroke: gate.stroke) if gate.stroke != auto
+    set rect(width: width, height: height)
+
+    utility.if-auto(gate.content, meter-symbol)
+  })
+
+  if gate.multi != none and gate.multi.num-qubits > 1 {
+    draw-boxed-multigate(gate, draw-params)
+  } else {
+    draw-boxed-gate(gate, draw-params)
+  }
+}
+
+
+#let draw-nwire(gate, draw-params) = {
+  set text(size: .7em)
+  let size = measure(gate.content)
+  let extent = 2.5pt + size.height
+  box(height: 2 * extent, { // box is solely for height hint
+    place(dx: 1pt, dy: 0pt, gate.content)
+    place(dy: extent, line(start: (0pt,-4pt), end: (-5pt,4pt), stroke: draw-params.wire))
+  })
+}
+
+
+
+#let draw-permutation-gate(gate, draw-params) = {
+  let dy = draw-params.multi.wire-distance
+  let width = gate.width
+  if dy == 0pt { return box(width: width, height: 4pt) }
+  
+  let separation = gate.data.separation
+  if separation == auto { separation = draw-params.background }
+  if type(separation) == color { separation += 3pt }
+  if type(separation) == length { separation += draw-params.background }
+
+  let qubits = gate.data.qubits
+  let wire-counts = gate.data.wire-count
+  let stroke = gate.data.stroke
+  
+  box(
+    height: dy + 4pt,
+    inset: (y: 2pt),
+    fill: draw-params.background,
+    width: width, {
+      let y0 = draw-params.center-y-coords.at(gate.qubit)
+      let bend = gate.data.bend * width / 2
+      for (from, wire-count) in wire-counts.enumerate() {
+        let to = qubits.at(from)
+        let y-from = draw-params.center-y-coords.at(from + gate.qubit) - y0
+        let y-to = draw-params.center-y-coords.at(to + gate.qubit) - y0
+        if separation != none {
+          place(curve(
+            curve.move((0pt, y-from)),
+            curve.cubic((bend, y-from), (width - bend, y-to), (width, y-to)),
+            stroke: separation
+          ))
+        }
+        let correction = calc.atan((y-to - y-from) / width) / 1.2rad * calc.sqrt(gate.data.bend / 100%)
+        let pcurve(dy) = place(dy: dy, curve(
+          curve.move((-.1pt, y-from)),
+          curve.cubic((bend - dy*correction, y-from), (width + .1pt - bend - dy*correction, y-to), (width + .1pt, y-to)),
+          stroke: utility.update-stroke(draw-params.wire, stroke.at(from))
+        ))
+        range(wire-count)
+          .map(i => (2*i - (wire-count - 1)) * 1pt)
+          .map(pcurve).join()
+        
+      }
+    }
+  )
+}
+
+// Draw an lstick (align: "right") or rstick (align: "left")
+#let draw-lrstick(gate, draw-params) = {
+
+  assert(gate.data.align in (left, right), message: "`lstick`/`rstick`: Only left and right are allowed for parameter align")
+    
+  let content = box(inset: draw-params.padding, gate.content)
+  let size = measure(content)
+  let brace = none
+  
+  if gate.data.brace != none {
+    let brace-height
+    if gate.multi == none {
+      brace-height = 1em + 2 * draw-params.padding
+    } else {
+      brace-height = draw-params.multi.wire-distance + .5em
+    }
+    let brace-symbol = gate.data.brace
+    if brace-symbol == auto and gate.multi == none {
+      brace-symbol = none
+    }
+    brace = {
+      set text(gate.fill) if gate.fill != auto
+      utility.create-brace(brace-symbol, gate.data.align, brace-height)
+    }
+  }
+  
+  let brace-size = measure(brace)
+  let width = size.width + brace-size.width + gate.data.pad
+  let height = size.height
+  let brace-offset-y
+  let content-offset-y = 0pt
+  
+  if gate.multi == none {
+    brace-offset-y = size.height / 2 - brace-size.height / 2
+  } else {
+    let dy = draw-params.multi.wire-distance
+    // at first (layout) stage:
+    if dy == 0pt { 
+      return box(
+        width: 2 * width, 
+        height: 0pt, 
+        baseline: if sys.version >= version(0, 15) {top} else {0pt},
+        content, 
+      ) 
+    }
+    height = dy
+    content-offset-y = -size.height / 2 + height / 2
+    brace-offset-y = -.25em
+  }
+  
+  let brace-pos-x = if gate.data.align == right { size.width } else { gate.data.pad }
+  let content-pos-x = if gate.data.align == right { 0pt } else { width - size.width }
+
+  box(
+    width: width, 
+    height: height, 
+    {
+      place(brace, dy: brace-offset-y, dx: brace-pos-x)
+      place(content, dy: content-offset-y, dx: content-pos-x)
+    }
+  )
+}
+
+
+
+
+#let draw-gategroup(x1, x2, y1, y2, item, draw-params) = {
+  let p = item.padding
+  let (x1, x2, y1, y2) = (x1 - p.left, x2 + p.right, y1 - p.top, y2 + p.bottom)
+  let size = (width: x2 - x1, height: y2 - y1)
+  layout.place-with-labels(
+    dx: x1, dy: y1, 
+    labels: item.labels, 
+    size: size,
+    draw-params: draw-params, rect(
+      width: size.width, height: size.height,
+      stroke: item.style.stroke,
+      fill: item.style.fill,
+      radius: item.style.radius
+    )
+  )
+}
+
+#let draw-repeat-block(x1, x2, y1, y2, item, draw-params) = {
+  let size = (width: x2 - x1, height: y2 - y1)
+  layout.place-with-labels(
+    dx: x1, dy: y1, 
+    labels: item.labels, 
+    size: size,
+    draw-params: draw-params, box(
+      width: size.width, height: size.height,
+      {
+        set text(item.style.fill) if item.style.fill != auto
+        let l 
+        let r
+        if item.style.brace == "||:" {
+          l = {
+            let color = utility.if-auto(item.style.fill, draw-params.wire.paint)
+            set line(stroke: color)
+            let line = std.line(angle: 90deg, length: size.height)
+            let circle = std.circle(radius: .1em, fill: color)
+            place(line, dx: -1pt)
+            set std.line(stroke: .4pt)
+            place(line, dx: .3pt)
+            let separation = .4em
+            place(horizon, dx: 1.5pt, dy: size.height / 2 - separation,circle)
+            place(horizon, dx: 1.5pt, dy: size.height / 2 + separation,circle)
+          }
+          r = scale(x: -100%, l, reflow: false)
+        } else {
+          l = utility.create-brace(item.style.brace, right, size.height)
+          r = utility.create-brace(item.style.brace, left, size.height)
+        }
+        place(place(center, l))
+        place(right, place(center, r))
+        
+      }
+    )
+  )
+}
+
+#let draw-slice(x, y1, y2, item, draw-params) = layout.place-with-labels(
+  dx: x, dy: y1, 
+  size: (width: 0pt, height: y2 - y1),
+  labels: item.labels, 
+  draw-params: draw-params, 
+  line(angle: 90deg, length: y2 - y1, stroke: item.style.stroke)
+)
+
+#let draw-break-line(y, x1, x2, item, draw-params) = layout.place-with-labels(
+  dx: x1, dy: y - item.gap/2, 
+  size: (width: 0pt, height: 0pt),
+  labels: item.labels, 
+  draw-params: draw-params, {
+    let thickness = item.style.thickness
+    let width = x2 - x1
+    let wavy = item.style.wavy
+    let gap = item.gap*wavy
+    let stroke = utility.if-auto(item.style.stroke, draw-params.wire)
+    let wave(dy) = (
+      curve.move((0pt, dy)),
+      curve.quad((width/8, dy - gap / 2), (width/4, dy - gap / 2)),
+      curve.quad(auto, (width/2, dy)),
+      curve.quad((5*width/8, dy + gap / 2), (3*width/4, dy + gap / 2)),
+      curve.quad(auto, (width, dy)),
+    )
+    place(
+      curve(fill: draw-params.background, 
+        ..wave(thickness/2), 
+        curve.line((width, -thickness/2)),
+        curve.quad((7*width/8, -thickness/2 + gap / 2), (3*width/4, -thickness/2 + gap / 2)),
+        curve.quad(auto, (width/2, -thickness/2)),
+        curve.quad((3 *width/8, -thickness/2 - gap / 2), (width/4, -thickness/2 - gap / 2)),
+        curve.quad(auto, (0pt, -thickness/2)),
+        curve.close(mode: "straight")
+      )
+    )
+    place(curve(stroke: stroke, ..wave(-thickness/2)))
+    place(curve(stroke: stroke, ..wave(thickness/2)))
+  
+  }
+)
+
+
+#let draw-horizontal-wire(x1, x2, y, stroke, wire-count, wire-distance: 1pt) = {
+  if x1 == x2 { return }
+
+  let wire = line(start: (x1, y), end: (x2, y), stroke: stroke)
+  range(wire-count)
+    .map(i => (2*i - (wire-count - 1)) * wire-distance)
+    .map(dy => place(wire, dy: dy))
+    .join()
+}
+
+#let draw-vertical-wire(
+  y1, 
+  y2,
+  x,
+  stroke,
+  wire-count: 1,
+  wire-distance: 1pt,
+) = {
+  let height = y2 - y1
+
+  let wire = line(start: (0pt, 0pt), end: (0pt, height), stroke: stroke)
+  let wires = range(wire-count)
+    .map(i => 2 * i * wire-distance)
+    .map(dx => place(wire, dx: dx))
+
+  place(
+    dx: x - (wire-count - 1) * wire-distance,
+    dy: y1,
+    wires.join()
+  )
+}
+
+#let draw-vertical-wire-with-labels(
+  y1, 
+  y2,
+  x,
+  stroke,
+  wire-count: 1,
+  wire-distance: 1pt,
+  wire-labels: (),
+  draw-params: none,
+) = {
+  let height = y2 - y1
+  
+  let wire = line(start: (0pt, 0pt), end: (0pt, height), stroke: stroke)
+  let wires = range(wire-count)
+    .map(i => 2 * i * wire-distance)
+    .map(dx => place(wire, dx: dx))
+
+  layout.place-with-labels(
+    dx: x - (wire-count - 1) * wire-distance,
+    dy: y1,
+    labels: wire-labels,
+    draw-params: draw-params,
+    size: (width: 2 * (wire-count - 1) * wire-distance, height: height),
+    wires.join()
+  )
+}

--- a/packages/preview/quill/0.8.0/src/gates.typ
+++ b/packages/preview/quill/0.8.0/src/gates.typ
@@ -1,0 +1,781 @@
+#import "layout.typ"
+#import "process-args.typ"
+#import "draw-functions.typ"
+
+
+
+
+/// Creates a quantum (or classical) gate. For special gates, many dedicated 
+/// gate commands like @ctrl, @swap, and more exist. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///  1, gate($H$), 1
+/// )
+/// ```
+///
+/// Note, that most of the parameters listed here are mostly used for derived gate 
+/// functions and do not need to be touched in all but very few cases. 
+#let gate(
+
+  /// The body of the gate (may be none for special gates like @ctrl). 
+  /// -> content
+  body,
+
+  /// The column to put the gate in. 
+  /// -> auto | int
+  x: auto,
+
+  /// The row to put the gate in. 
+  /// -> auto | int
+  y: auto,
+
+  /// How to fill the gate box.
+  /// -> auto | none | color | gradient | tiling
+  fill: auto,
+
+  /// How to stroke the gate box.
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// Border radius for the gate box. Allows the same values as the built-in 
+  /// `rect()` function.
+  /// -> length | dictionary
+  radius: 0pt,
+
+  /// Specifies the width of the gate. 
+  /// -> auto | length
+  width: auto,
+
+  /// Whether this is a boxed gate (determines whether the outgoing wire
+  /// will be drawn all through the gate (`box: false`) or not).
+  /// -> bool
+  box: true,
+
+  /// Whether the content for this gate will be shown floating (i.e. no 
+  /// width is reserved for layout).
+  /// -> bool
+  floating: false,
+
+  /// Information for multi-qubit and controlled gates (see @mqgate).
+  /// -> none | dictionary
+  multi: none,
+
+  /// Size hint function. This function should return a dictionary containing
+  /// the keys `width` and `height`. The result is used to determine the gates
+  /// position and cell sizes of the grid. Signature: `(gate, draw-params) => {}`.
+  /// -> function
+  size-hint: layout.default-size-hint,
+
+  /// Drawing function that produces the displayed content. Signature: 
+  /// `(gate, draw-params) => {}`.
+  /// -> function
+  draw-function: draw-functions.draw-boxed-gate,
+
+  /// Optional additional gate data. This can for example be a dictionary storing 
+  /// extra information that may be used for instance in a custom `draw-function`.
+  /// -> any
+  data: none,
+
+  /// One or more labels to add to the gate. Usually, a label consists of a 
+  /// dictionary with entries for the keys `content` (the label content), `pos` 
+  /// (2d alignment specifying the position of the label) and optionally `dx` 
+  /// and/or `dy` (lengths, ratios or relative lengths). If only a single label 
+  /// is to be added, a plain content or string value can be passed which is then 
+  /// placed at the default position. 
+  /// -> none | array | str | content | dictionary
+  label: none
+
+) = (
+  content: body, 
+  x: x, 
+  y: y,
+  fill: fill,
+  stroke: stroke,
+  radius: radius,
+  width: width,
+  box: box,
+  floating: floating,
+  multi: multi,
+  size-hint: size-hint,
+  draw-function: draw-function,
+  gate-type: "", 
+  data: data,
+  labels: process-args.process-label-arg(label, default-pos: top)
+)
+
+
+
+/// Base command for creating multi-qubit or controlled gates. See also @ctrl and @swap. 
+/// ```example
+/// #quantum-circuit(
+///   1, mqgate($E$, n: 2, target: 2), 1, 
+///   [\ ], [\ ]
+/// )
+/// ```
+#let mqgate(
+
+  /// The body of the gate. 
+  /// -> content
+  body,
+
+  /// The number of wires that the multi-qubit gate spans. 
+  /// -> int
+  n: 1, 
+
+  /// Specifies a control wire to be drawn to a target wire relative to the wire
+  /// that the is placed on. 
+  /// -> none | int
+  target: none,
+
+  /// Which wires to allow to pass through the gate. 
+  /// ```example
+  /// #quantum-circuit(
+  ///   wires: 4,
+  ///   1, mqgate(
+  ///     n: 4, 
+  ///     fill: none, 
+  ///     pass-through: (2,),
+  ///     $E$
+  ///   ), 1
+  /// )
+  /// ```
+  /// Note that it is necessary to set `fill` to none to prevent the gate from 
+  /// drawing over the wires. 
+  /// 
+  /// The indices are given relative to the first wire of the gate. The (relative) first and last wires cannot pass through the gate. 
+  pass-through: (),
+
+
+  /// The column to put the gate in. 
+  /// -> auto | int
+  x: auto,
+
+  /// The row to put the gate in. If $n>1$, this sets the _first_ row of the
+  /// multi-qubit gate. 
+  /// -> auto | int
+  y: auto,
+  
+  /// How to fill the gate box
+  /// -> auto | none | color | gradient | tiling
+  fill: auto, 
+
+  /// How to stroke the gate box. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// Border radius for the gate box. Allows the same values as the built-in 
+  /// `rect()` function.
+  /// -> length | dictionary
+  radius: 0pt,
+
+  /// Specifies the width of the gate. 
+  /// -> auto | length
+  width: auto,
+
+  /// Whether this is a boxed gate (determines whether the outgoing wire will
+  /// be drawn all through the gate (`box: false`) or not).
+  /// -> bool
+  box: true, 
+
+  /// The number of parallel control wires to draw.
+  /// -> int
+  wire-count: 1,
+
+  /// How to stroke the control wire. 
+  /// -> auto | stroke
+  wire-stroke: auto,
+
+  /// You can put labels inside the gate to label the input wires with this
+  /// argument. It accepts a list of labels, each of which has to be a 
+  /// dictionary with the keys `qubit` (denoting the qubit to label, starting 
+  /// at 0) and `content` (containing the label content). Optionally, providing 
+  /// a value for the key `n` allows for labelling multiple qubits spanning 
+  /// over `n` wires. These are then grouped by a brace. 
+  /// -> none | array
+  inputs: none,
+
+  /// Same as @mqgate.inputs but for gate outputs. 
+  /// -> none | array
+  outputs: none,
+
+  /// How much to extent the gate beyond the first and last wire, default is 
+  /// to make it align with an X gate (so [size of x gate] / 2). 
+  /// -> auto | length
+  extent: auto, 
+
+  /// A single-qubit gate affects the height of the row it is being put on. 
+  /// For multi-qubit gate there are different possible behaviours:
+  ///  - `false`: The hight is affected on only the first and last wire.
+  ///  - `true`: The height of all wires is affected.
+  ///  - `none`: The height on no wire is affected.
+  /// -> none | bool
+  size-all-wires: false,
+
+  /// See @gate.draw-function
+  /// -> function
+  draw-function: draw-functions.draw-boxed-multigate, 
+
+  /// One or more labels to add to the gate. See @gate.label. 
+  /// -> none | array | str | content | dictionary
+  label: none,
+
+  /// One or more labels to add to the control wire. Works analogous to 
+  /// `labels` but with default positioning to the right of the wire. 
+  /// -> none | array | str | content | dictionary
+  wire-label: none,
+
+  /// Optional additional gate data. This can for example be a dictionary
+  /// storing extra information that may be used for instance in a custom
+  /// `draw-function`.
+  /// -> any
+  data: none,
+
+) = gate(
+  body, 
+  x: x, 
+  y: y, 
+  fill: fill, 
+  stroke: stroke,
+  box: box, 
+  width: width,
+  radius: radius,
+  draw-function: draw-function,
+  multi: (
+    target: target,
+    num-qubits: n, 
+    wire-count: wire-count, 
+    wire-stroke: wire-stroke,
+    label: label,
+    extent: extent,
+    size-all-wires: size-all-wires,
+    inputs: inputs,
+    outputs: outputs,
+    wire-label: process-args.process-label-arg(wire-label, default-pos: right),
+    pass-through: pass-through
+  ),
+  label: label,
+  data: data,
+)
+
+
+
+// SPECIAL GATES
+
+/// Draws a meter representing a measurement. Meters can stand alone,
+/// ```example
+/// #quantum-circuit(
+///  1, meter(), 1
+/// )
+/// ```
+/// connect to another wire and have a label,
+/// ```example
+/// #quantum-circuit(
+///  1, meter(target: 1, label: $X$), 1, [\ ]
+/// )
+/// ```
+/// and can span multiple qubits.
+/// ```example
+/// #quantum-circuit(
+///  1, meter(n: 2), 1, [\ ]
+/// )
+/// ```
+#let meter(
+
+  /// Optional body to use for the meter. Here you may use the `meter-symbol` and 
+  /// combine it with additional measurement information. 
+  /// ```example
+  /// #quantum-circuit(
+  ///  1, meter[$P_1$ #meter-symbol], 1
+  /// )
+  /// ```
+  /// Superscripts can be used to embed a small basis inset. 
+  /// 
+  /// ```example
+  /// #let basis-meter(basis) = meter[
+  ///   #place(super(baseline: -0.4em, basis)) 
+  ///   #meter-symbol
+  /// ]
+  /// 
+  /// #quantum-circuit(
+  ///  1, basis-meter[X], 1
+  /// )
+  /// ```
+  /// 
+  /// -> any
+  ..body,
+
+  /// If given, draw a control wire to the given target qubit the specified
+  /// number of wires up or down.
+  /// -> none | int
+  target: none, 
+
+  /// How to stroke the meter. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// The number of qubits that the meter spans. 
+  /// -> int
+  n: 1,
+
+  x: auto,
+
+  y: auto,
+
+  /// Wire count for the optional control wire, see @meter.target. 
+  /// -> int
+  wire-count: 2, 
+
+  /// How to stroke the optional control wire. 
+  /// -> auto | stroke
+  wire-stroke: auto,
+
+  /// One or more labels to add to the gate. See @gate.label. 
+  /// -> none | array | str | content | dictionary
+  label: none, 
+
+  fill: auto, 
+
+  radius: 0pt
+
+) = {
+  process-args.assert-no-named(body, fn: "meter")
+  body = body.pos()
+  if body.len() == 1 {
+    body = body.first()
+  } else if body.len() == 0 {
+    body = auto
+  } else {
+    assert(false, message: "Unexpected positional argument `" + repr(body.at(1)) + "` encountered at meter")
+  }
+  label = process-args.process-label-arg(label, default-dy: 0.5em, default-pos: top)
+  if target == none and n == 1 {
+    gate(body, x: x, y: y, fill: fill, stroke: stroke, radius: radius, draw-function: draw-functions.draw-meter, label: label)
+  } else {
+     mqgate(body, x: x, y: y, n: n, target: target, fill: fill, stroke: stroke, radius: radius, box: true, wire-count: wire-count, wire-stroke: wire-stroke, draw-function: draw-functions.draw-meter, label: label)
+  }
+}
+
+
+
+/// Creates a visualized permutation gate which maps the qubits $q_k, q_(k+1), ... $ 
+/// to the qubits $q_(p(k)), q_(p(k+1)), ...$ when placed on the qubit $k$. The 
+/// permutation map is given by the `qubits` argument. Note, that qubit indices 
+/// start with 0. 
+/// 
+/// 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, permute(1, 0), 1, [\ ]
+/// )
+/// ```
+/// The amount of wire bending can be configured:
+/// ```example
+/// #quantum-circuit(
+///   1, permute(2,0,1, bend: 0%), 
+///   1, [\ ], [\ ]
+/// )
+/// ```
+/// Note also, that the wiring is not very sophisticated and will probably look best for 
+/// relatively simple permutations. Furthermore, it only works with quantum wires. 
+#let permute(
+
+  /// Qubit permutation. 
+  /// -> int
+  ..qubits, 
+
+  /// Width of the permutation gate. 
+  /// -> length
+  width: 30pt, 
+
+  /// How much to bend the wires. With `0%`, the wires are straight. 
+  /// -> ratio
+  bend: 100%, 
+
+  /// Overlapping wires are separated by drawing a thicker line below. With 
+  /// this option, this line can be customized in color or thickness. 
+  /// -> auto | none | length | color | stroke
+  separation: auto,
+
+  /// The number of wires to display on each permuted wire. This can be used to
+  /// create a permutation of classical or even mixed wires. 
+  /// -> int | array
+  wire-count: 1,
+
+  /// How to stroke each permuted wire. Wires left at `auto` will inherit the general wire style. 
+  /// -> auto | stroke | array
+  stroke: auto,
+
+  x: auto,
+
+  y: auto,
+
+) = {
+  if qubits.named().len() != 0 {
+    assert(false, message: "Unexpected named argument `" + qubits.named().keys().first() + "` in function `permute()`")
+  }
+  qubits = qubits.pos()
+  if type(wire-count) == array {
+    assert(
+      wire-count.len() == qubits.len(),
+      message: "The number of wire-counts and permuted qubits must match"
+    )
+  } else {
+    wire-count = (wire-count,) * qubits.len()
+  }
+  if type(stroke) == array {
+    assert(
+      stroke.len() == qubits.len(),
+      message: "The number of strokes and permuted qubits must match"
+    )
+  } else {
+    stroke = (stroke,) * qubits.len()
+  }
+  mqgate(none, x: x, y: y, n: qubits.len(), width: width, draw-function: draw-functions.draw-permutation-gate, data: (qubits: qubits, extent: 2pt, separation: separation, bend: bend, wire-count: wire-count, stroke: stroke))
+}
+
+
+
+/// Creates an invisible (phantom) gate for reserving space. If `content` 
+/// is provided, the `height` and `width` parameters are ignored and the gate 
+/// will take the size it would have if `gate(content)` was called. 
+///
+/// Instead specifying width and/or height will create a gate with exactly the
+/// given size (without padding).
+#let phantom(
+
+  /// Content to measure for the phantom gate size. 
+  /// -> content
+  content: none, 
+
+  /// Width of the phantom gate (ignored if `content` is not `none`). 
+  /// -> length
+  width: 0pt, 
+
+  /// Height of the phantom gate (ignored if `content` is not `none`). 
+  /// -> length
+  height: 0pt,
+
+  x: auto,
+
+  y: auto,
+
+) = {
+  let thecontent = if content != none { box(hide(content)) } else { 
+    box(width: width, height: height) 
+  }
+  gate(thecontent, x: x, y: y, box: false, fill: none)
+}
+
+
+
+/// Target element for controlled-$X$ operations. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, targ(), 1, 
+/// )
+/// ```
+#let targ(
+
+  /// How many wires up or down the target wire lives. 
+  /// -> int
+  ..n,
+
+  /// How to fill the target circle. If set to `auto`, the target is 
+  /// filled with the circuits background color.
+  /// -> none | auto | color | gradient | tiling
+  fill: none,
+
+  /// How to stroke the target. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  /// Radius of the target symbol. 
+  /// -> length
+  size: 4.3pt,
+
+  label: none, 
+
+  x: auto,
+
+  y: auto,
+
+  /// Wire count for the control wire.  
+  /// -> int
+  wire-count: 1,
+
+  /// How to stroke the optional control wire. 
+  /// -> auto | stroke
+  wire-stroke: auto,
+
+  /// One or more labels to add to the control wire. See @mqgate.wire-label. 
+  /// -> none | array | str | content | dictionary
+  wire-label: none,
+
+) = {
+  process-args.assert-no-named(n, fn: "targ")
+  n = n.pos()
+  assert(n.len() <= 1, message: "Unexpected second positional argument for `targ`")
+
+  mqgate(
+    none,
+    x: x, 
+    y: y,
+    target: n.at(0, default: 0),
+    box: false,
+    draw-function: draw-functions.draw-targ,
+    wire-count: wire-count,
+    wire-stroke: wire-stroke,
+    fill: if fill == true {auto} else if fill == false {none} else {fill}, 
+    stroke: stroke,
+    data: (size: size), 
+    label: label,
+    wire-label: wire-label
+  )
+}
+
+
+
+/// Creates a phase gate shown as a point on the wire together with a label. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, phase($α$), 1, 
+/// )
+/// ```
+#let phase(
+
+  /// The angle value to display. 
+  /// -> content
+  label,
+  
+  /// Whether to draw an open dot. 
+  /// -> bool
+  open: false,
+
+  /// How to fill the circle. 
+  /// -> auto | none | color
+  fill: auto,
+
+
+  /// How to stroke the circle if `open: true`. 
+  /// -> auto | stroke | color
+  stroke: auto,
+
+  /// The radius of the circle. 
+  /// -> length
+  size: 2.3pt,
+
+  x: auto,
+
+  y: auto
+
+) = gate(
+  none, 
+  x: x, 
+  y: y,
+  box: false,
+  draw-function: (gate, draw-params) => box(
+    inset: (x: .6em), 
+    draw-functions.draw-ctrl(gate, draw-params)
+  ),
+  fill: fill,
+  stroke: stroke,
+  data: (open: open, size: size),
+  label: process-args.process-label-arg(label, default-pos: top + right, default-dx: -.5em)
+)
+
+
+
+/// Creates a #smallcaps("swap") operation with another qubit. 
+/// 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, swap(1), 1, [\ ],
+///   1, swap(), 1
+/// )
+/// ```
+#let swap(
+
+  /// How many wires up or down the target wire lives. 
+  /// -> int
+  ..n, 
+ 
+  /// Wire count for the control wire.  
+  /// -> int
+  wire-count: 1, 
+
+  /// The size of the target symbol. 
+  /// -> length. 
+  size: 7pt, 
+
+  /// How to stroke the swap gate. 
+  /// -> auto | stroke
+  stroke: auto,
+
+  label: none, 
+
+  /// One or more labels to add to the control wire. See @mqgate.wire-label. 
+  /// -> none | array | str | content | dictionary
+  wire-label: none,
+
+  /// How to stroke the control wire. 
+  /// -> auto | stroke
+  wire-stroke: auto,
+
+  x: auto,
+
+  y: auto
+
+) = {
+  process-args.assert-no-named(n, fn: "swap")
+  n = n.pos()
+  assert(n.len() <= 1, message: "Unexpected second positional argument for `swap`")
+
+  mqgate(
+    none,
+    x: x, 
+    y: y,
+    target: n.at(0, default: 0),
+    box: false,
+    draw-function: draw-functions.draw-swap,
+    wire-count: wire-count,
+    wire-stroke: wire-stroke,
+    data: (size: size),
+    label: label,
+    wire-label: wire-label,
+    stroke: stroke
+  )
+}
+
+
+
+/// Creates a control with a vertical wire to another qubit. 
+/// 
+/// ```example
+/// #quantum-circuit(
+///   1, ctrl(1), 1, [\ ],
+///   1, ctrl(), 1
+/// )
+/// ```
+#let ctrl(
+
+  /// How many wires up or down the target wire lives. 
+  /// -> int
+  ..n,
+
+  /// Wire count for the control wire.  
+  /// -> int
+  wire-count: 1,
+
+  /// How to stroke the control wire. 
+  /// -> auto | stroke
+  wire-stroke: auto,
+
+  /// Whether to draw an open dot. 
+  /// -> bool
+  open: false,
+
+  /// How to fill the circle. 
+  /// -> auto | none | color
+  fill: auto,
+
+
+  /// How to stroke the circle if `open: true`. 
+  /// -> auto | stroke | color
+  stroke: auto,
+
+  /// The radius of the control circle. 
+  /// -> length
+  size: 2.3pt,
+
+  /// Whether to show the control dot at all. Set this to false to obtain a 
+  /// vertical wire with no dots at all. 
+  /// -> bool
+  show-dot: true,
+
+  /// One or more labels to add to the control wire. See @mqgate.wire-label. 
+  /// -> none | array | str | content | dictionary
+  wire-label: none,
+
+  label: none,
+
+  x: auto,
+
+  y: auto
+
+) = {
+  process-args.assert-no-named(n, fn: "ctrl")
+  n = n.pos()
+  assert(n.len() <= 1, message: "Unexpected second positional argument for `ctrl`")
+
+  mqgate(
+    none,
+    x: x, 
+    y: y,
+    target: n.at(0, default: 0),
+    box: false,
+    draw-function: draw-functions.draw-ctrl,
+    wire-count: wire-count,
+    fill: fill,
+    stroke: stroke,
+    data: (open: open, size: size, show-dot: show-dot),
+    label: label,
+    wire-label: wire-label, 
+    wire-stroke: wire-stroke
+  )
+}
+
+
+
+#let targ-y(
+
+  /// How many wires up or down the target wire lives. 
+  /// -> int
+  ..n,
+
+  /// How to fill the target triangle. If set to `none`, the target is 
+  /// filled with the 60% lightened wire color.
+  /// -> none | color | gradient | tiling
+  fill: luma(60%),
+
+  /// Radius of the target symbol. 
+  /// -> length
+  size: 10pt,
+
+  label: none, 
+
+  x: auto,
+
+  y: auto,
+
+  /// Wire count for the control wire.  
+  /// -> int
+  wire-count: 1,
+
+  /// One or more labels to add to the control wire. See @mqgate.wire-label. 
+  /// -> none | array | str | content | dictionary
+  wire-label: none,
+
+) = {
+  process-args.assert-no-named(n, fn: "targ-y")
+  n = n.pos()
+  assert(n.len() <= 1, message: "Unexpected second positional argument for `targ`")
+
+  mqgate(
+    none,
+    x: x, 
+    y: y,
+    target: n.at(0, default: 0),
+    box: false,
+    draw-function: draw-functions.draw-targ-y,
+    wire-count: wire-count,
+    fill: fill,
+    data: (size: size), 
+    label: label,
+    wire-label: wire-label
+  )
+}

--- a/packages/preview/quill/0.8.0/src/layout.typ
+++ b/packages/preview/quill/0.8.0/src/layout.typ
@@ -1,0 +1,187 @@
+#import "length-helpers.typ": *
+
+/// Update bounds to contain the given rectangle
+/// - bounds (array): Current bound coordinates x0, y0, x1, y1
+/// - rect (array): Bounds rectangle x0, y0, x1, y1
+#let update-bounds(bounds, rect) = (
+  calc.min(bounds.at(0), rect.at(0).to-absolute()), 
+  calc.min(bounds.at(1), rect.at(1).to-absolute()),
+  calc.max(bounds.at(2), rect.at(2).to-absolute()),
+  calc.max(bounds.at(3), rect.at(3).to-absolute()),
+)
+
+#let offset-bounds(bounds, offset) = (
+  bounds.at(0) + offset.at(0),
+  bounds.at(1) + offset.at(1),
+  bounds.at(2) + offset.at(0),
+  bounds.at(3) + offset.at(1),
+)
+
+#let make-bounds(x0: 0pt, y0: 0pt, width: 0pt, height: 0pt, x1: none, y1: none) = (
+  x0.to-absolute(),
+  y0.to-absolute(),
+  (if x1 != none { x1 } else { x0 + width }).to-absolute(),
+  (if y1 != none { y1 } else { y0 + height }).to-absolute(),
+)
+
+
+/// Take an alignment or 2d alignment and return a 2d alignment with the possibly 
+/// unspecified axis set to a default value. 
+#let make-2d-alignment(alignment, default-vertical: horizon, default-horizontal: center) = {
+  let axis = alignment.axis()
+  if axis == none { return alignment }
+  if alignment.axis() == "horizontal" { return alignment + default-vertical }
+  if alignment.axis() == "vertical" { return alignment + default-horizontal }
+}
+
+
+#let make-2d-alignment-factor(alignment) = {
+  let alignment = make-2d-alignment(alignment)
+  let x = 0
+  let y = 0
+  if alignment.x == left { x = -1 }
+  else if alignment.x == right { x = 1 }
+  if alignment.y == top { y = -1 }
+  else if alignment.y == bottom { y = 1 }
+  return (x, y)
+}
+
+
+
+
+#let default-size-hint(item, draw-params) = {
+  let content = (item.draw-function)(item, draw-params)
+  let hint = measure(content)
+  hint.offset = auto
+  return hint
+}
+
+
+
+
+
+#let lrstick-size-hint(item, draw-params) = {
+  let content = (item.draw-function)(item, draw-params)
+  let hint = measure(content)
+  let dx = 0pt
+  if item.data.align == right { dx = hint.width } 
+  hint.offset = (x: dx, y: auto)
+  return hint
+}
+
+
+
+
+
+/// Place some content along with optional labels while computing bounds. 
+/// 
+/// Returns a pair of the placed content and a bounds array. 
+///
+/// - content (content): The content to place. 
+/// - dx (length): Horizontal displacement.
+/// - dy (length): Vertical displacement.
+/// - size (auto, dictionary): For computing bounds, the size of the placed content
+///           is needed. If `auto` is passed, this function computes the size itself
+///           but if it is already known it can be passed through this parameter. 
+/// - labels (array): An array of labels which in turn are dictionaries that must 
+///           specify values for the keys `content` (content), `pos` (strictly 2d 
+///           alignment), `dx` and `dy` (both length, ratio or relative length).
+/// - draw-params (dictionary): Drawing parameters. 
+/// -> pair
+#let place-with-labels(
+  content, 
+  dx: 0pt, 
+  dy: 0pt,
+  size: auto,
+  labels: (),
+  draw-params: none,
+) = {
+  if size == auto { size = measure(content) }
+  let bounds = make-bounds(
+    x0: dx, y0: dy, width: size.width, height: size.height
+  )
+  if labels.len() == 0 {
+    return (place(content, dx: dx, dy: dy), bounds)    
+  }
+  
+  let placed-labels = place(dx: dx, dy: dy, 
+    box({
+      for label in labels {
+        let label-size = measure(label.content)
+        let ldx = get-length(label.dx, size.width)
+        let ldy = get-length(label.dy, size.height)
+        
+        if label.pos.x == left { ldx -= label-size.width }
+        else if label.pos.x == center { ldx += 0.5 * (size.width - label-size.width) }
+        else if label.pos.x == right { ldx += size.width }
+        if label.pos.y == top { ldy -= label-size.height }
+        else if label.pos.y == horizon { ldy += 0.5 * (size.height - label-size.height) }
+        else if label.pos.y == bottom { ldy += size.height }
+        
+        
+        let placed-label = place(label.content, dx: ldx, dy: ldy)
+        let label-bounds = make-bounds(
+          x0: ldx + dx, y0: ldy + dy, 
+          width: label-size.width, height: label-size.height
+        )
+        bounds = update-bounds(bounds, label-bounds)
+        placed-label
+      }
+    })
+  )
+  return (place(content, dx: dx, dy: dy) + placed-labels, bounds)
+}
+
+
+
+
+// From a list of row heights or col widths, compute the respective
+// cell center coordinates, e.g., (3pt, 3pt, 4pt) -> (1.5pt, 4.5pt, 8pt)
+#let compute-center-coords(cell-lengths, gutter) = {
+  let center-coords = ()
+  let tmpx = 0pt
+  gutter.insert(0, 0pt)
+  // assert.eq(cell-lengths.len(), gutter.len())
+  for (cell-length, gutter) in cell-lengths.zip(gutter) {
+    center-coords.push(tmpx + cell-length / 2 + gutter)
+    tmpx += cell-length + gutter
+  }
+  return center-coords
+} 
+
+
+// Given a list of n center coordinates and n cell sizes along one axis (x or y), retrieve the coordinates for a single cell or a list of cells given by index. 
+// If a cell index is out of bounds, the outer last coordinate is returned
+// center-coords: List of center coordinates for each index
+// cell-sizes: List of cell sizes for each index
+// cells: Indices of cell for which to retrieve coordinates
+// These may also be floats. In this case, the integer part determines the cell index and the fractional part a percentage of the cell width. e.g., passing 2.5 would return the center coordinate of the cell
+#let get-cell-coords(center-coords, cell-sizes, cells) = {
+  let last = center-coords.at(-1) + cell-sizes.at(-1) / 2
+  let get(x) = { 
+    let integral = calc.floor(x)
+    let fractional = x - integral
+    let cell-width = cell-sizes.at(integral, default: 0pt)
+    return center-coords.at(integral, default: last) + cell-width * (fractional - 0.5)
+  }
+  if type(cells) in (int, float) { get(cells)  }
+  else if type(cells) == array { cells.map(x => get(x)) }
+  else { panic("Unsupported coordinate type") }
+}
+
+#let get-cell-coords1(center-coords, cell-sizes, cells) = {
+  let last = center-coords.at(-1) + cell-sizes.at(-1) / 2
+  let get(x) = { 
+    let integral = calc.floor(x)
+    let fractional = x - integral
+    let cell-width = cell-sizes.at(integral, default: 0pt)
+    let c1 = center-coords.at(integral, default: last)
+    let c2 = center-coords.at(integral + 1, default: last)
+    return c1 + (c2 - c1) * (fractional)
+  }
+  if type(cells) in (int, float) { get(cells)  }
+  else if type(cells) == array { cells.map(x => get(x)) }
+  else { panic("Unsupported coordinate type") }
+}
+
+#let std-scale = scale

--- a/packages/preview/quill/0.8.0/src/length-helpers.typ
+++ b/packages/preview/quill/0.8.0/src/length-helpers.typ
@@ -1,0 +1,7 @@
+
+
+#let get-length(len, container-length) = {
+  if type(len) == length { return len }
+  if type(len) == ratio { return len * container-length}
+  if type(len) == relative { return len.length + len.ratio * container-length}
+}

--- a/packages/preview/quill/0.8.0/src/process-args.typ
+++ b/packages/preview/quill/0.8.0/src/process-args.typ
@@ -1,0 +1,73 @@
+// This file contains helper functions to process and normalize special 
+// arguments to functions, especially where multiple formats and types 
+// are allowed.
+
+#import "layout.typ"
+
+
+#let process-padding-arg(padding) = {
+  let type = type(padding)
+  if type == length { 
+    return (left: padding, top: padding, right: padding, bottom: padding)
+  }
+  if type == dictionary {
+    let rest = padding.at("rest", default: 0pt)
+    let x = padding.at("x", default: rest)
+    let y = padding.at("y", default: rest)
+    return (
+      left: padding.at("left", default: x), 
+      right: padding.at("right", default: x), 
+      top: padding.at("top", default: y), 
+      bottom: padding.at("bottom", default: y), 
+    )
+  }
+  assert(false, message: "Unsupported type \"" + str(type) + "\" as argument for padding")
+}
+
+
+/// Process the label argument to `gate`. Allowed input formats are none, array of dictionaries
+/// or a single dictionary/string/content (for just one label). 
+/// 
+/// Each dictionary needs to contain the key content and may optionally have values 
+/// for the  keys `pos` (specifying a 1d or 2d alignment) and `dx` as well as `dy`
+#let process-label-arg(
+  labels, 
+  default-pos: right,
+  default-dx: .4em, 
+  default-dy: .4em
+) = {
+  if labels == none { return () }
+  let type = type(labels)
+  if type == dictionary { labels = (labels,) }
+  else if type in (symbol, content, str) { labels = ((content: labels),) }
+  else if type == dictionary { labels = ((content: labels),) }
+  let processed-labels = ()
+  for label in labels {
+    let alignment = layout.make-2d-alignment(label.at("pos", default: default-pos))
+    let (x, y) = layout.make-2d-alignment-factor(alignment)
+    processed-labels.push((
+      content: label.content,
+      pos: alignment,
+      dx: label.at("dx", default: default-dx * x),
+      dy: label.at("dy", default: default-dy * y)
+    ))
+  }
+  processed-labels
+}
+
+
+/// Assert that there are no additional named arguments in an argument sink. 
+#let assert-no-named(
+  /// Argument sink.
+  args, 
+  /// Function name. This can be used to improve the error message. 
+  fn: ""
+) = {
+  if args.named().len() == 0 { return }
+  
+  assert(false,
+    message: "Unexpected named argument \"" + args.named().keys().first() + "\"" + if fn == "" {""} else {
+      " in function " + fn + "()"
+    }
+  )
+}

--- a/packages/preview/quill/0.8.0/src/quantum-circuit.typ
+++ b/packages/preview/quill/0.8.0/src/quantum-circuit.typ
@@ -1,0 +1,617 @@
+#import "utility.typ" as utility: if-auto
+#import "verifications.typ"
+#import "length-helpers.typ"
+#import "decorations.typ": *
+
+#let signum(x) = if x >= 0. { 1. } else { -1. }
+
+
+
+/// Create a quantum circuit diagram. Children may be
+/// - gates created by one of the many gate commands (@gate, @mqgate, @meter, ...),
+/// - `[\ ]` for creating a new wire/row,
+/// - commands like @setwire, @slice or @gategroup,
+/// - integers for creating cells filled with the current wire setting,
+/// - lengths for creating space between rows or columns,
+/// - plain content or strings to be placed on the wire, and
+/// - @lstick, @midstick or @rstick for placement next to the wire.
+#let quantum-circuit(
+
+  /// Style for drawing the circuit wires. This can take anything 
+  /// that is valid for the stroke of the built-in `line()` function. 
+  /// -> stroke
+  wire: .7pt + black,     
+
+  /// Spacing between rows.
+  /// -> length
+  row-spacing: 12pt,
+
+  /// Spacing between columns.
+  /// -> length
+  column-spacing: 12pt,
+
+  /// Minimum height of a row (e.g., when no gates are given).
+  /// -> length
+  min-row-height: 10pt, 
+
+  /// Minimum width of a column.
+  /// -> length
+  min-column-width: 0pt, 
+
+  /// General padding setting including the inset for gate boxes and 
+  /// the distance of @lstick and co. to the wire. 
+  /// -> length
+  gate-padding: .4em, 
+
+  /// If true, then all rows will have the same height and the wires will
+  /// have equal distances orienting on the highest row. 
+  /// -> bool
+  equal-row-heights: false, 
+
+  /// Default fill color for gates. 
+  /// -> color
+  fill: white,
+
+  /// Default font size for text in the circuit. 
+  /// -> length
+  font-size: 10pt,
+
+  /// Total scale factor applied to the entire circuit without changing proportions.
+  /// -> ratio
+  scale: 100%,
+
+  /// Set the baseline for the circuit. If a content or a string is given, the 
+  /// baseline will be adjusted automatically to align with the center of it. 
+  /// One useful application is `"="` so the circuit aligns with the equals symbol. 
+  /// -> length | content | str
+  baseline: 0pt,
+
+  /// Padding for the circuit (e.g., to accommodate for annotations) in form of 
+  /// a dictionary with possible keys `left`, `right`, `top` and `bottom`. Not 
+  /// all of those need to be  specified. 
+  ///
+  /// This setting basically just changes the size of the bounding box for the
+  /// circuit and can be used to increase it when labels or annotations extend 
+  /// beyond the actual circuit. 
+  /// -> length | dictionary
+  circuit-padding: .4em,
+
+  /// How many wires the circuit has or an array of wire counts, e.g., 
+  /// `(1, 1, 2)` for two quantum wires and one classical wire. 
+  /// -> auto | int | array
+  wires: auto,
+
+  /// Whether to automatically fill up all wires until the end. 
+  /// -> bool
+  fill-wires: true,
+
+  /// Items, gates and circuit commands (see description). 
+  /// -> any
+  ..children
+
+) = { 
+  if children.pos().len() == 0 { return }
+  if children.named().len() > 0 { 
+    panic("Unexpected named argument '" + children.named().keys().at(0) + "' for quantum-circuit()")
+  }
+  if type(wire) == std.color { wire = .7pt }
+  if type(wire) == length { wire += black }
+
+  set text(wire.paint, size: font-size)
+  set math.equation(numbering: none)
+
+  context {
+  
+  // Parameter object to pass to draw-function containing current style info
+  let draw-params = (
+    wire: wire,
+    padding: measure(line(length: gate-padding)).width,
+    background: fill,
+    x-gate-size: none,
+    multi: (wire-distance: 0pt)
+  )
+
+  draw-params.x-gate-size = layout.default-size-hint(gate($X$), draw-params)
+  
+  let items = children.pos().map( x => {
+    if type(x) in (content, str) and x != [\ ] { return gate(x) }
+    return x
+  })
+  
+  /////////// First part: Layout (and spacing)   ///////////
+  
+  let column-spacing = column-spacing.to-absolute()
+  let row-spacing = row-spacing.to-absolute()
+  let min-row-height = min-row-height.to-absolute()
+  let min-column-width = min-column-width.to-absolute()
+  
+  // All these arrays are gonna be filled up in the loop over `items`
+  let matrix = ((),)
+  let row-gutter = (0pt,)
+  let single-qubit-gates = ()
+  let multi-qubit-gates = ()
+  let meta-instructions = ()
+
+  let auto-cell = (empty: true, size: (width: 0pt, height: 0pt), gutter: 0pt)
+
+  let default-wire-style = (
+    count: 1,
+    distance: 1pt, 
+    stroke: wire
+  )
+  let (row, col) = (0, 0)
+  let prev-col = 0
+  let wire-ended = false
+
+  // Wire styles and wire pieces per row. 
+  let wire-instructions = (
+    (default-wire-style, ),
+  )
+  
+ if type(wires) == array {
+    wire-instructions = wires.map(count => (default-wire-style + (count: count),))
+  }
+
+  for item in items {
+    if item == [\ ] {
+      if fill-wires {
+        wire-instructions.at(row).push((prev-col, -1))
+      }
+      row += 1; col = 0; prev-col = 0
+      if row >= wire-instructions.len() {
+        wire-instructions.push((default-wire-style,))
+      }
+
+      if row >= matrix.len() {
+        matrix.push(())
+        row-gutter.push(0pt)
+      }
+      wire-ended = true
+    } else if utility.is-circuit-meta-instruction(item) { 
+      if item.qc-instr == "setwire" {
+        let new-style = (:)
+        if "distance" in item { new-style.distance = item.distance }
+        if "count" in item { new-style.count = item.count }
+        if "stroke" in item { new-style.stroke = item.stroke }
+        wire-instructions.at(row).push(new-style)
+      } else {
+        // Visual meta instructions are handled later
+        let (x, y) = (if-auto(item.x, col), if-auto(item.y, row))
+        meta-instructions.push((x: x, y: y, item: item))
+        if item.qc-instr == "break-line" {
+          if row-gutter.len() < y {
+            row-gutter += ((0pt),) * (y - row-gutter.len())
+          }
+          row-gutter.at(y - 1) = calc.max(row-gutter.at(y - 1), item.gap)
+        }
+      }
+    } else if utility.is-circuit-drawable(item) {
+      let gate = item
+      let (x, y) = (gate.x, gate.y)
+      if x == auto { 
+        x = col 
+        if y == auto {
+          if col != prev-col {
+            wire-instructions.at(row).push((prev-col, col))
+          }
+          prev-col = col 
+          col += 1
+        }
+      }
+      if y == auto { y = row }
+
+      if y >= matrix.len() { matrix += ((),) * (y - matrix.len() + 1) }
+      if x >= matrix.at(y).len() {
+        matrix.at(y) += (auto-cell,) * (x - matrix.at(y).len() + 1)
+      }
+
+      assert(matrix.at(y).at(x).empty, message: "Attempted to place a second gate at column " + str(x) + ", row " + str(y))
+
+      let size-hint = utility.get-size-hint(item, draw-params)
+      let gate-size = size-hint
+      if item.floating { size-hint.width = 0pt } // floating items don't take width in the layout
+
+      matrix.at(y).at(x) = (
+        size: size-hint,
+        gutter: 0pt,
+        box: item.box,
+        empty: gate.data == "placeholder"
+      )
+      let gate-info = (
+        gate: gate,
+        size: gate-size,
+        x: x,
+        y: y
+      )
+      if gate.multi != none { multi-qubit-gates.push(gate-info) } 
+      else { single-qubit-gates.push(gate-info) }
+      wire-ended = false
+    } else if type(item) == int {
+      wire-instructions.at(row).push((prev-col, col + item - 1))
+      col += item
+      prev-col = col - 1
+      if col >= matrix.at(row).len() {
+        matrix.at(row) += (auto-cell,) * (col - matrix.at(row).len())
+      }
+      wire-ended = false
+    } else if type(item) == length {
+      if wire-ended {
+        row-gutter.at(row - 1) = calc.max(row-gutter.at(row - 1), item)
+      } else if col > 0 {
+        matrix.at(row).at(col - 1).gutter = calc.max(matrix.at(row).at(col - 1).gutter, item)
+      }
+    }
+  }
+
+  
+  if wires != auto {
+    let num-wires = if type(wires) == array { wires.len() } else { wires }
+    if matrix.len() < num-wires {
+      let diff = num-wires - matrix.len()
+
+      matrix += ((),) * diff
+      row-gutter +=  (0pt,) * diff
+    } else if type(wires) == int and matrix.len() > num-wires {
+      assert(false, message: "You explicitly specified " + str(wires) + " wires but there are " + str(matrix.len()))
+    }
+  }
+
+  // finish up matrix
+  let num-rows = matrix.len()
+  let num-cols = calc.max(0, ..matrix.map(array.len))
+  if num-rows == 0 or num-cols == 0 { return none }
+
+  
+  for i in range(num-rows) {
+    matrix.at(i) += (auto-cell,) * (num-cols - matrix.at(i).len())
+  }
+  if row-gutter.len() < matrix.len() {
+    row-gutter += (0pt,) * (matrix.len() - row-gutter.len())
+  }
+  if wire-instructions.len() != num-rows {
+    let diff = num-rows - wire-instructions.len()
+    wire-instructions += ((default-wire-style,),) * diff 
+  }
+
+  if fill-wires {
+    wire-instructions.at(row).push((prev-col, -1)) // fill current wire
+    for row in range(row + 1, num-rows) {
+      wire-instructions.at(row).push((0, -1))
+    }
+  }
+
+  let vertical-wires = ()
+  // Treat multi-qubit gates (and controlled gates)
+  // - extract and store all necessary vertical control wires
+  // - Apply same size-hints to all cells that a mqgate spans (without the control wire). 
+  for gate in multi-qubit-gates {
+    let (x, y) = gate
+    let size = matrix.at(y).at(x).size
+    let multi = gate.gate.multi
+    
+    if multi.target != none and multi.target != 0 {
+      verifications.verify-controlled-gate(gate.gate, x, y, num-rows, num-cols)
+
+      let diff = if multi.target > 0 {multi.num-qubits - 1} else {0}
+      vertical-wires.push((
+        x: x, 
+        y: y + diff, 
+        target: multi.target - diff, 
+        wire-style: (count: multi.wire-count, stroke: multi.wire-stroke),
+        labels: multi.wire-label
+      ))
+    }
+    let nq = multi.num-qubits
+    if nq == 1 { continue }
+
+    verifications.verify-mqgate(gate.gate, x, y, num-rows, num-cols)
+
+    for qubit in range(y, y + nq) {
+      if qubit - y in multi.pass-through { continue }
+      matrix.at(qubit).at(x).size.width = size.width
+    }
+    let start = y
+    if multi.size-all-wires != none {
+      if not multi.size-all-wires {
+        start = calc.max(0, y + nq - 1)
+      }
+      for qubit in range(start, y + nq) {
+        matrix.at(qubit).at(x).size = size
+      }
+    }
+  }
+
+
+  let row-heights = matrix.map(row => 
+    calc.max(min-row-height, ..row.map(item => item.size.height)) + row-spacing
+  )
+  if equal-row-heights {
+    let max-row-height = calc.max(..row-heights)
+    row-heights = (max-row-height,) * row-heights.len()
+  }
+
+  let col-widths = range(num-cols).map(j => 
+    calc.max(min-column-width, ..range(num-rows).map(i => {
+        matrix.at(i).at(j).size.width
+    })) + column-spacing 
+  )
+
+  let col-gutter = range(num-cols).map(j => 
+    calc.max(0pt, ..range(num-rows).map(i => {
+        matrix.at(i).at(j).gutter
+    }))
+  )
+
+  let center-x-coords = layout.compute-center-coords(col-widths, col-gutter).map(x => x - 0.5 * column-spacing)
+  let center-y-coords = layout.compute-center-coords(row-heights, row-gutter).map(x => x - 0.5 * row-spacing)
+  draw-params.center-y-coords = center-y-coords
+  
+  let circuit-width = col-widths.sum() + col-gutter.slice(0, -1).sum(default: 0pt) - column-spacing
+  let circuit-height = row-heights.sum() + row-gutter.sum() - row-spacing
+
+
+
+  /////////// Second part: Generation ///////////
+  
+  let bounds = (0pt, 0pt, circuit-width, circuit-height)
+  
+  let circuit = block(
+    width: circuit-width, height: circuit-height, {
+    set align(top + left) // quantum-circuit could be called in a scope where these have been changed which would mess up everything
+    set place(left)
+
+    let layer-below-circuit
+    let layer-above-circuit
+    for (item, x, y) in meta-instructions {
+      let (the-content, decoration-bounds) = (none, none)
+      if item.qc-instr == "gategroup" {
+        if item.right != auto {
+          item.steps = num-cols - x - item.right
+        }
+        if item.bottom != auto {
+          item.wires = num-rows - y - item.bottom
+        }
+        verifications.verify-gategroup(item, x, y, num-rows, num-cols)
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, y + item.wires - 1e-9))
+        let (dx1, dx2) = layout.get-cell-coords(center-x-coords, col-widths, (x, x + item.steps - 1e-9))
+        (the-content, decoration-bounds) = draw-functions.draw-gategroup(dx1, dx2, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "repeat-block" {
+        if item.right != auto {
+          item.steps = num-cols - x - item.right
+        }
+        if item.bottom != auto {
+          item.wires = num-rows - y - item.bottom
+        }
+        
+        if item.wires == auto {
+          item.wires = num-rows - y
+        }
+        verifications.verify-gategroup(item, x, y, num-rows, num-cols)
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, y + item.wires - 1e-9))
+        let (dx1, dx2) = layout.get-cell-coords(center-x-coords, col-widths, (x, x + item.steps - 1e-9))
+        (the-content, decoration-bounds) = draw-functions.draw-repeat-block(dx1, dx2, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "slice" {
+        verifications.verify-slice(item, x, y, num-rows, num-cols)
+        let end = if item.wires == 0 { row-heights.len() } else { y + item.wires }
+        let (dy1, dy2) = layout.get-cell-coords(center-y-coords, row-heights, (y, end))
+        let dx = layout.get-cell-coords(center-x-coords, col-widths, x)
+        (the-content, decoration-bounds) = draw-functions.draw-slice(dx, dy1, dy2, item, draw-params)
+      } else if item.qc-instr == "break-line" {
+        // verifications.verify-slice(item, x, y, num-rows, num-cols)
+        let end = if true { col-widths.len() } else { y + item.wires }
+        let (dx1, dx2) = layout.get-cell-coords(center-x-coords, col-widths, (item.start + .5, item.end + .5))
+        let dy = layout.get-cell-coords(center-y-coords, row-heights, y)
+        (the-content, decoration-bounds) = draw-functions.draw-break-line(dy, dx1, dx2, item, draw-params)
+      } else if item.qc-instr == "annotate" {
+        let rows = layout.get-cell-coords(center-y-coords, row-heights, item.rows)
+        let cols = layout.get-cell-coords(center-x-coords, col-widths, item.columns)
+        let annotation = (item.callback)(cols, rows)
+        verifications.verify-annotation-content(annotation)
+        if type(annotation) == dictionary {
+          (the-content, decoration-bounds) = layout.place-with-labels(
+            annotation.content,
+            dx: annotation.at("dx", default: 0pt),
+            dy: annotation.at("dy", default: 0pt),
+            draw-params: draw-params
+          )
+        } else if type(annotation) in (symbol, content, str) {
+          layer-below-circuit += place(annotation)
+        } 
+      }
+      if decoration-bounds != none {
+        bounds = layout.update-bounds(bounds, decoration-bounds)
+      }
+      if item.at("z", default: "below") == "below" { layer-below-circuit += the-content  }
+      else { layer-above-circuit += the-content  }
+    }
+
+    layer-below-circuit
+
+
+    let get-gate-pos(x, y, size-hint) = {
+      let dx = center-x-coords.at(x)
+      let dy = center-y-coords.at(y)
+      let (width, height) = size-hint
+      let offset = size-hint.at("offset", default: auto)
+
+      if offset == auto { return (dx - width / 2, dy - height / 2) } 
+
+      assert(type(offset) == dictionary, message: "Unexpected type `" + str(type(offset)) + "` for parameter `offset`") 
+      
+      let offset-x = offset.at("x", default: auto)
+      let offset-y = offset.at("y", default: auto)
+      if offset-x == auto { dx -= width / 2}
+      else if type(offset-x) == length { dx -= offset-x }
+      if offset-y == auto { dy -= height / 2}
+      else if type(offset-y) == length { dy -= offset-y }
+      return (dx, dy)
+    }
+
+
+    let get-anchor-width(x, y) = {
+      if x == num-cols { return 0pt }
+      let el = matrix.at(y).at(x)
+      if "box" in el and not el.box { return 0pt }
+      return el.size.width
+    }
+
+    let get-anchor-height(x, y) = {
+      let el = matrix.at(y).at(x)
+      if "box" in el and not el.box { return 0pt }
+      return el.size.height
+    }
+
+    
+    for (x, y, target, wire-style, labels) in vertical-wires {
+      let dx = center-x-coords.at(x)
+      let (dy1, dy2) = (center-y-coords.at(y), center-y-coords.at(y + target))
+      dy1 += get-anchor-height(x, y) / 2 * signum(target)
+      dy2 -= get-anchor-height(x, y + target) / 2 * signum(target)
+      
+      if labels.len() == 0 {
+        draw-functions.draw-vertical-wire(
+          dy1, dy2, dx, 
+          utility.update-stroke(wire, wire-style.stroke),
+          wire-count: wire-style.count,
+        )
+      } else {
+        let (result, gate-bounds) = draw-functions.draw-vertical-wire-with-labels(
+          dy1, dy2, dx, 
+          wire, wire-count: wire-style.count,
+          wire-labels: labels,
+          draw-params: draw-params
+        )
+        result
+        bounds = layout.update-bounds(bounds, gate-bounds)
+      }
+    }
+
+    
+    for (row, wire-in) in wire-instructions.enumerate() {
+      let wire-style = wire-in.at(0)
+      for wire-piece in wire-in {
+        if type(wire-piece) == dictionary {
+          if "stroke" in wire-piece {
+            wire-piece.stroke = utility.update-stroke(wire-style.stroke, wire-piece.stroke)
+          }
+          wire-style += wire-piece
+        } else {
+          if wire-style.count == 0 { continue }
+          let (start-x, end-x) = wire-piece
+          if end-x == -1 {
+            end-x = num-cols - 1
+          }
+          if start-x == end-x { continue }
+
+          let draw-subwire(x1, x2) = {
+            let dx1 = center-x-coords.at(x1)
+            let dx2 = center-x-coords.at(x2, default: circuit-width)
+            let dy = center-y-coords.at(row)
+            dx1 += get-anchor-width(x1, row) / 2
+            dx2 -= get-anchor-width(x2, row) / 2
+            draw-functions.draw-horizontal-wire(dx1, dx2, dy, wire-style.stroke, wire-style.count, wire-distance: wire-style.distance)
+          }
+          // Draw wire pieces and take care not to draw through gates. 
+          for x in range(start-x + 1, end-x) {
+            let anchor-width = get-anchor-width(x, row)
+            if anchor-width == 0pt { continue } // no gate or `box: false` gate. 
+            draw-subwire(start-x, x)
+            start-x = x
+          }
+          draw-subwire(start-x, end-x)
+        }
+      }
+    }
+    
+    
+    
+    for gate-info in single-qubit-gates {
+      let (gate, size, x, y) = gate-info
+      let (dx, dy) = get-gate-pos(x, y, size)
+      let content = utility.get-content(gate, draw-params)
+
+      let (result, gate-bounds) = layout.place-with-labels(
+        content, 
+        size: size,
+        dx: dx, dy: dy, 
+        labels: gate.labels, draw-params: draw-params
+      )
+      bounds = layout.update-bounds(bounds, gate-bounds)
+      result
+    }
+    
+    for gate-info in multi-qubit-gates {
+      let (gate, size, x, y) = gate-info
+      let draw-params = draw-params
+      gate.qubit = y
+      if gate.multi.num-qubits > 1 {
+        let dy1 = center-y-coords.at(y + gate.multi.num-qubits - 1)
+        let dy2 = center-y-coords.at(y)
+        draw-params.multi.wire-distance = dy1 - dy2
+      }
+      
+      // lsticks need their offset/width to be updated again (but don't update the height!)
+      let content = utility.get-content(gate, draw-params)
+      let new-size = utility.get-size-hint(gate, draw-params)
+      size.offset = new-size.offset
+      size.width = new-size.width
+
+      let (dx, dy) = get-gate-pos(x, y, size)
+      let (result, gate-bounds) = layout.place-with-labels(
+        content, 
+        size: if gate.multi != none and gate.multi.num-qubits > 1 {auto} else {size},
+        dx: dx, dy: dy, 
+        labels: gate.labels, draw-params: draw-params
+      )
+      bounds = layout.update-bounds(bounds, gate-bounds)
+      result
+    }
+
+    layer-above-circuit
+
+    // show matrix
+    // for (i, row) in matrix.enumerate() {
+    //   for (j, entry) in row.enumerate() {
+    //     let (dx, dy) = (center-x-coords.at(j), center-y-coords.at(i))
+    //     place(
+    //       dx: dx - entry.size.width / 2, dy: dy - entry.size.height / 2, 
+    //       box(stroke: green, width: entry.size.width, height: entry.size.height)
+    //     )
+    //   }
+    // }
+  
+  }) // end circuit = block(..., {
+    
+  let scale = scale
+  if circuit-padding != none {
+    let circuit-padding = process-args.process-padding-arg(circuit-padding)
+    bounds.at(0) -= circuit-padding.left
+    bounds.at(1) -= circuit-padding.top
+    bounds.at(2) += circuit-padding.right
+    bounds.at(3) += circuit-padding.bottom
+  }
+  let final-height = scale * (bounds.at(3) - bounds.at(1))
+  let final-width = scale * (bounds.at(2) - bounds.at(0))
+  
+  let thebaseline = baseline
+  if type(thebaseline) in (content, str) {
+    thebaseline = height/2 - measure(thebaseline).height/2
+  }
+  if type(thebaseline) == fraction {
+    thebaseline = 100% - layout.get-cell-coords1(center-y-coords, row-heights, thebaseline / 1fr) + bounds.at(1)
+  }
+  box(baseline: thebaseline,
+    width: final-width,
+    height: final-height, 
+    // stroke: 1pt + gray,
+    align(left + top, move(dy: -scale * bounds.at(1), dx: -scale * bounds.at(0), 
+      layout.std-scale(
+        x: scale, 
+        y: scale, 
+        origin: left + top, 
+        circuit
+    )))
+  )
+  
+}
+}

--- a/packages/preview/quill/0.8.0/src/quill.typ
+++ b/packages/preview/quill/0.8.0/src/quill.typ
@@ -1,0 +1,21 @@
+#import "utility.typ"
+#import "decorations.typ": lstick, rstick, midstick, nwire, annotate, slice, setwire, gategroup, repeat-block, break-line
+#import "gates.typ": gate, mqgate, ctrl, swap, targ, targ-y, meter, phantom, permute, phase, draw-functions
+#import draw-functions: meter-symbol
+#import "quantum-circuit.typ": quantum-circuit
+#import "tequila.typ"
+
+
+#let help(..args) = {
+  import "@preview/tidy:0.4.1"
+
+  let namespace = (
+    ".": (
+      read.with("/src/quantum-circuit.typ"), 
+      read.with("/src/gates.typ"),
+      read.with("/src/decorations.typ"),
+    ),
+    "gates": read.with("/src/gates.typ"),
+  )
+  tidy.generate-help(namespace: namespace, package-name: "quill")(..args)
+}

--- a/packages/preview/quill/0.8.0/src/tequila-impl.typ
+++ b/packages/preview/quill/0.8.0/src/tequila-impl.typ
@@ -1,0 +1,468 @@
+#import "gates.typ"
+#import "utility.typ": if-auto
+
+/// Info about one single quantum gate. 
+#let gate-info(
+
+  /// Qubit or first qubit in the case of a multi-qubit gate. 
+  /// -> int
+  qubit, 
+  
+  /// The gate function. 
+  /// -> function
+  constructor, 
+
+  /// Number of qubits. 
+  /// -> int
+  n: 1, 
+
+  /// Additional gates to draw along with the main one given as 
+  /// `(qubit, gate)` tuples. This is used to draw targets or multiple 
+  /// controls. 
+  ///  -> array
+  supplements: (), 
+
+) = (
+  (
+    qubit: qubit,
+    n: n,
+    supplements: supplements,
+    constructor: constructor,
+  ),
+)
+
+
+
+#let construct-single-qubit-gate(
+
+  /// One or more qubits. Named arguments are disallowed. 
+  /// -> int | array
+  qubit, 
+
+  /// Gate function.
+  /// -> function
+  gate
+  
+) = {
+
+  if type(qubit) == arguments {
+    if qubit.named().len() != 0 {
+      assert(false, message: "Unexpected argument `" + qubit.named().keys().first() + "`")
+    }
+    qubit = qubit.pos()
+  } 
+  if type(qubit) == int {
+    qubit = (qubit,)
+  }
+
+  if qubit.len() == 1 { qubit = qubit.first() }
+  if type(qubit) == int { return gate-info(qubit, gate) }
+  qubit.map(qubit => gate-info(qubit, gate))
+}
+
+
+// Generates a two-qubit gate with two qubits connected by a wire. 
+#let construct-two-qubit-gate(
+
+  /// Control qubit(s). 
+  /// -> int | array
+  qubit1, 
+
+  /// Target qubit(s). 
+  /// -> int | array
+  qubit2, 
+
+  /// Gate to put at the control qubit. This gate needs to take a
+  /// single positional argument: the relative target number. 
+  /// -> function
+  gate1, 
+
+  /// Gate to put at the target qubit. 
+  /// -> function
+  gate2
+
+) = {
+  if type(qubit1) == int and type(qubit2) == int { 
+    assert.ne(qubit2, qubit1, message: "Target and control qubit cannot be the same")
+    return gate-info(
+      qubit1,
+      gate1.with(qubit2 - qubit1),
+      n: qubit2 - qubit1 + 1,
+      supplements: ((qubit2, gate2),)
+    ) 
+  }
+  if type(qubit1) == int { qubit1 = (qubit1,) }
+  if type(qubit2) == int { qubit2 = (qubit2,) }
+
+  range(calc.max(qubit1.len(), qubit2.len())).map(i => {
+    let c = qubit1.at(i, default: qubit1.last())
+    let t = qubit2.at(i, default: qubit2.last())
+    assert.ne(t, c, message: "Target and control qubit cannot be the same")
+    gate-info(
+      c, 
+      gate1.with(t - c), 
+      n: t - c + 1, 
+      supplements: ((t, gate2),)
+    )
+  })
+}
+
+
+
+/// Creates a gate with multiple controls. 
+#let construct-multi-controlled-gate(
+
+  /// Control qubits. 
+  /// -> array
+  controls, 
+
+  /// Target qubit. 
+  /// -> int
+  qubit, 
+
+  /// Gate to put at the target. 
+  /// -> function
+  gate,
+
+  /// Additional arguments to apply to the `ctrl` gate. 
+  /// -> any
+  ..args
+
+) = {
+  let ctrl = gates.ctrl.with(..args)
+
+  controls = controls.map(c => if type(c) == int { (c,) } else { c })
+  if type(qubit) == int { qubit = (qubit,) }
+
+  range(calc.max(qubit.len(), ..controls.map(array.len))).map(i => {
+    let target = qubit.at(i, default: qubit.last())
+    let cs = controls.map(c => c.at(i, default: c.last()))
+
+    assert((cs + (target,)).dedup().len() == cs.len() + 1, message: "Target and control qubits need to be all different (were " + str(target) + " and " + repr(cs) + ")")
+
+
+
+
+    let (first, ..rest) = (cs + (target,)).sorted()
+    let n = rest.last() - first
+
+    if first == target {
+      let (..rest, last) = rest
+      gate-info(
+        target, gate,
+        n: n + 1, 
+        supplements: rest.map(q => (q, ctrl.with(0))) +  ((last, ctrl.with(-n)),)
+      )
+    } else {
+      
+      gate-info(
+        first, ctrl.with(n), 
+        n: n + 1, 
+        supplements: rest.map(q => 
+          (q, if q == target { gate } else { ctrl.with(0) })
+        )
+      )
+    }
+
+  })
+}
+
+
+#let gate(qubit, ..args) = gate-info(qubit, gates.gate.with(..args))
+
+#let mqgate(qubit, n: 1, ..args) = {
+  gate-info(qubit, n: n, gates.mqgate.with(..args, n: n))
+}
+
+#let barrier(start: 0, end: auto) = gate-info(
+  start, 
+  n: if end == auto { auto } else { end - start },
+  barrier
+)
+
+#let x(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($X$, ..args))
+#let y(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($Y$, ..args))
+#let z(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($Z$, ..args))
+
+#let h(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($H$, ..args))
+#let s(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($S$, ..args))
+#let sdg(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($S^dagger$, ..args))
+#let sx(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($sqrt(X)$, ..args))
+#let sxdg(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($sqrt(X)^dagger$, ..args))
+#let t(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($T$, ..args))
+#let tdg(qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($T^dagger$, ..args))
+#let p(theta, qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($P (#theta)$, ..args))
+
+#let rx(theta, qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($R_x (#theta)$, ..args))
+#let ry(theta, qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($R_y (#theta)$, ..args))
+#let rz(theta, qubit, ..args) = construct-single-qubit-gate(qubit, gates.gate.with($R_z (#theta)$, ..args))
+
+#let u(theta, phi, lambda, qubit, ..args) = construct-single-qubit-gate(
+  qubit, gates.gate.with($U (#theta, #phi, #lambda)$, ..args)
+)
+
+#let meter(qubit, ..args) = construct-single-qubit-gate(qubit, gates.meter.with(..args))
+
+#let measure(label: none, ..args) = {
+  let qubits = args.pos()
+  assert(qubits.len() > 0, message: "Missing argument `qubit`")
+
+  if type(label) == content {
+    label = (content: label, pos: bottom)
+  }
+
+  if qubits.len() == 1 {
+    construct-single-qubit-gate(qubits.first(), gates.meter.with(..args.named()))
+  } else {
+    assert(qubits.len() == 2, message: "Expected a qubit and a classical, got more than three positional arguments")
+    construct-two-qubit-gate(
+      qubits.last(), 
+      qubits.first(), 
+      gates.ctrl.with(open: true, wire-count: 2, label: label), 
+      gates.meter.with(..args.named())
+    )
+  }
+}
+
+
+#let cx(control, target, ..args) = construct-two-qubit-gate(
+  control, target, gates.ctrl.with(..args), gates.targ
+)
+#let cz(control, target, ..args) = construct-two-qubit-gate(
+  control, target, gates.ctrl.with(..args), gates.ctrl.with(0)
+)
+#let swap(control, target, ..args) = construct-two-qubit-gate(
+  control, target, gates.swap.with(..args), gates.swap.with(0)
+)
+#let ccx(control1, control2, target, ..args) = construct-multi-controlled-gate(
+  (control1, control2), target, gates.targ, ..args
+)
+#let ccz(control1, control2, target, ..args) = construct-multi-controlled-gate(
+  (control1, control2), target, gates.ctrl.with(0), ..args
+)
+#let cca(control1, control2, target, content, ..args) = construct-multi-controlled-gate(
+  (control1, control2), target, gates.gate.with(content), ..args
+)
+#let cccx(control1, control2, control3, target, ..args) = construct-multi-controlled-gate(
+  (control1, control2, control3), target, gates.targ, ..args
+)
+
+
+#let ca(control, target, ..args) = construct-two-qubit-gate(
+  control, target, gates.ctrl, gates.gate.with(..args)
+)
+
+#let multi-controlled-gate(controls, target, gate, ..args) = construct-multi-controlled-gate(
+  controls, target, gate, ..args
+)
+
+
+/// Constructs a circuit from operation instructions. 
+/// 
+/// ```example
+/// #import tequila as tq
+/// 
+/// #quantum-circuit(
+///   ..tq.build(
+///     tq.h(0),
+///     tq.cx(0, 1),
+///     tq.sdg(1)
+///   )
+/// )
+/// ```
+#let build(
+
+  /// Number of qubits. Can be inferred automatically. 
+  /// -> auto | int 
+  n: auto, 
+
+  /// Determines at which column the subcircuit will be put in the circuit. 
+  /// -> int 
+  x: 1, 
+
+  /// Determines at which row the subcircuit will be put in the circuit. 
+  /// -> int 
+  y: 0,
+
+  /// If set to `true`, the a last column of outgoing wires will be added. 
+  /// -> bool
+  append-wire: true,
+  
+  /// Sequence of instructions. 
+  /// -> any
+  ..children
+
+) = {
+  let operations = children.pos().flatten().filter(x => x != none)
+
+  let num-qubits = n
+  if num-qubits == auto {
+    num-qubits = calc.max(..operations.map(x => x.qubit + calc.max(0, if-auto(x.n, 1) - 1))) + 1
+  }
+
+  let tracks = ((),) * num-qubits
+  
+  // now we doin some Tetris
+  for op in operations {
+    let start = op.qubit
+    let end = start + if-auto(op.n, 2) - 1
+
+    assert(start >= 0 and start < num-qubits, message: "The qubit `" + str(start) + "` is out of range. Leave `n` at `auto` if you want to automatically resize the circuit. ")
+    assert(end >= 0 and end < num-qubits, message: "The qubit `" + str(end) + "` is out of range. Leave `n` at `auto` if you want to automatically resize the circuit. " + repr((start, end, num-qubits, op)))
+
+    // Special case: barriers
+    let (q1, q2) = (start, end).sorted()
+    if op.constructor == barrier {
+      if op.n == auto { end = num-qubits - 1}
+      (q1, q2) = (start, end)
+    }
+
+
+    // Find how "high" the tracks in interval [q1, q2] are stacked so far. 
+    let max-track-len = calc.max(..tracks.slice(q1, q2 + 1).map(array.len))
+    let h = (start,) + op.supplements.map(supplement => supplement.first())
+
+    // Even up the "height" of the tracks in interval [q1, q2].
+    for q in range(q1, q2 + 1) {
+      let dif = max-track-len - tracks.at(q).len()
+      if op.constructor != barrier and q not in h {
+         dif += 1
+      }
+      tracks.at(q) += (1,) * dif
+    }
+
+    // Place gate and supplementary gates. 
+    if op.constructor != barrier {
+      tracks.at(start).push((op.constructor)(x: x + tracks.at(start).len(), y: y + start))
+      for (qubit, supplement) in op.supplements {
+        tracks.at(qubit).push((supplement)(x: x + tracks.at(end).len(), y: y + qubit))
+      }
+    }
+  }
+  
+  // Fill up all tracks
+  let max-track-len = calc.max(..tracks.map(array.len)) + 1
+  for q in range(tracks.len()) {
+    tracks.at(q) += (1,) * (max-track-len - tracks.at(q).len())
+  }
+  
+  let num-cols = x + calc.max(..tracks.map(array.len)) - 2
+  if append-wire { num-cols += 1 }
+  
+  // A special placeholder guarantees that 
+  // - the last wire is shown even if there are no gates on it
+  // - all wires go to the last column correctly. 
+  let placeholder = gates.gate(
+    none, 
+    x: num-cols, y: y + num-qubits - 1, 
+    data: "placeholder", box: false, floating: true, 
+    size-hint: (it, i) => (width: 0pt, height: 0pt)
+  )
+
+  (placeholder,) + tracks.join().filter(x => x != 1) 
+}
+
+
+
+/// Constructs a graph state preparation circuit. 
+/// 
+/// ```example
+/// #import tequila as tq
+/// 
+/// #quantum-circuit(
+///   ..tq.graph-state(
+///     (1, 2), (2,0)
+///   )
+/// )
+/// ```
+#let graph-state(
+
+  /// Number of qubits. Can be inferred automatically. 
+  /// -> auto | int
+  n: auto,
+
+  /// Determines at which column the subcircuit will be put in the circuit. 
+  /// -> int 
+  x: 1,
+
+  /// Determines at which row the subcircuit will be put in the circuit. 
+  /// -> int 
+  y: 0,
+
+  /// If set to `true`, the circuit will be inverted, i.e., a circuit for
+  /// "uncomputing" the corresponding graph state. 
+  /// -> bool
+  invert: false,
+
+  /// -> array
+  ..edges
+
+) = {
+  edges = edges.pos()
+  let max-qubit = 0
+
+  for edge in edges {
+    assert(type(edge) == array, message: "Edges need to be pairs of vertices")
+    assert(edge.len() == 2, message: "Every edge needs to have exactly two vertices")
+    max-qubit = calc.max(max-qubit, ..edge)
+  }
+
+  let num-qubits = max-qubit + 1
+  if n != auto {
+    num-qubits = n
+    assert(n > max-qubit, message: "")
+  }
+
+  let gates = (
+    h(range(num-qubits)),
+    barrier(),
+    edges.map(edge => cz(..edge))
+  )
+
+  if invert {
+    gates = gates.rev()
+  }
+
+  build(
+    x: x, y: y, 
+    ..gates
+  )
+}
+
+
+/// Template for the quantum fourier transform (QFT). 
+/// ```example
+/// #import tequila as tq
+/// 
+/// #quantum-circuit(
+///   ..tq.qft(2)
+/// )
+/// ```
+#let qft(
+
+  /// Number of qubits. 
+  /// -> auto | int
+  n, 
+
+  /// Determines at which column the QFT routine will be placed in the circuit. 
+  /// -> int 
+  x: 1, 
+
+  /// Determines at which row the QFT routine will be placed in the circuit. 
+  /// -> int 
+  y: 0
+
+) = {
+  let gates = ()
+
+  for i in range(n - 1) {
+    gates.push(h(i))
+    for j in range(2, n - i + 1) {
+      gates.push(ca(i + j - 1, i, $R_#j$))
+    }
+    gates.push(barrier())
+  }
+
+  gates.push(h(n - 1))
+  build(n: n, x: x, y: y, ..gates)
+}

--- a/packages/preview/quill/0.8.0/src/tequila.typ
+++ b/packages/preview/quill/0.8.0/src/tequila.typ
@@ -1,0 +1,1 @@
+#import "tequila-impl.typ": build, h, gate, mqgate, x, y, z, cx, cz, ca, s, sdg, sx, sxdg, t, tdg, p, rx, ry, rz, u, barrier, swap, meter, graph-state, qft, ccx, ccz, cca, cccx, multi-controlled-gate, measure

--- a/packages/preview/quill/0.8.0/src/utility.typ
+++ b/packages/preview/quill/0.8.0/src/utility.typ
@@ -1,0 +1,71 @@
+
+#let if-none(a, b) = { if a != none { a } else { b } }
+#let if-auto(a, b) = { if a != auto { a } else { b } }
+#let is-gate(item) = { type(item) == dictionary and "gate-type" in item }
+#let is-circuit-drawable(item) = { is-gate(item) or type(item) in (str, content) }
+#let is-circuit-meta-instruction(item) = { type(item) == dictionary and "qc-instr" in item }
+
+
+
+// Get content from a gate or plain content item
+#let get-content(item, draw-params) = {
+  if is-gate(item) { 
+    if item.draw-function != none {
+      return (item.draw-function)(item, draw-params)
+    }
+  } else { return item }
+}
+
+// Get size hint for a gate or plain content item
+#let get-size-hint(item, draw-params) = {
+  if is-gate(item) { 
+    return (item.size-hint)(item, draw-params) 
+  } 
+  measure(item)
+}
+
+
+// Creates a sized brace with given length. 
+// `brace` can be auto, defaulting to "{" if alignment is right
+// and "}" if alignment is left. Other possible values are 
+// "[", "]", "|", "{", and "}".
+#let create-brace(brace, alignment, length) = {
+  if brace == none { 
+    return none
+  }
+  let lookup = (
+    "{": (${$, $}$),
+    "}": (${$, $}$),
+    "|": ($|$, $|$),
+    "[": ($[$, $]$),
+    "]": ($[$, $]$),
+    "(": ($($, $)$),
+    ")": ($($, $)$),
+  )
+  if brace == auto {
+    brace = if alignment == right {${$} else {$}$} 
+  } else if brace != none {
+    assert(brace in lookup, message: "Unsupported brace " + repr(brace))
+    brace = lookup.at(brace).at(if alignment == right { 0 } else { 1 })
+  }
+  return $ lr(#brace, size: length) $
+}
+
+/// Updates the first stroke with the second, i.e., returns the second stroke but all 
+/// fields that are auto are inherited from the first stroke. 
+/// If the second stroke is none, returns none. 
+#let update-stroke(stroke1, stroke2) = {
+  let if-not-auto(a, b) = if b == auto {a} else {b}
+  if stroke2 == none { return none }
+  if stroke2 == auto { return stroke1 }
+  if stroke1 == none { stroke1 = stroke() }
+  let s1 = stroke(stroke1)
+  let s2 = stroke(stroke2)
+  let paint = if-not-auto(s1.paint, s2.paint)
+  let thickness = if-not-auto(s1.thickness, s2.thickness)
+  let cap = if-not-auto(s1.cap, s2.cap)
+  let join = if-not-auto(s1.join, s2.join)
+  let dash = if-not-auto(s1.dash, s2.dash)
+  let miter-limit = if-not-auto(s1.miter-limit, s2.miter-limit)
+  return stroke(paint: paint, thickness: thickness, cap: cap, join: join, dash: dash, miter-limit: miter-limit)
+}

--- a/packages/preview/quill/0.8.0/src/verifications.typ
+++ b/packages/preview/quill/0.8.0/src/verifications.typ
@@ -1,0 +1,81 @@
+#let plural-s(n) = if n == 1 { "" } else { "s" }
+
+#let verify-controlled-gate(gate, x, y, circuit-rows, circuit-cols) = {
+  let multi = gate.multi
+  if y + multi.target >= circuit-rows or y + multi.target < 0 {
+    assert(false, message: 
+      "A controlled gate starting at qubit " + str(y) + 
+      " with relative target " + str(multi.target) + 
+      " exceeds the circuit which has only " + str(circuit-rows) + 
+      " qubit" + plural-s(circuit-rows)
+    )
+  }
+}
+
+
+#let verify-mqgate(gate, x, y, circuit-rows, circuit-cols) = {
+  let nq = gate.multi.num-qubits
+  if y + nq - 1 >= circuit-rows {
+    assert(false, message: 
+      "A " + str(nq) + "-qubit gate starting at qubit " + 
+      str(y) + " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubits"
+    )
+  }
+}
+
+#let verify-slice(slice, x, y, circuit-rows, circuit-cols) = {
+  if slice.wires < 0 {
+    assert(false, message: "`slice`: The number of wires needs to be > 0 (is " + str(slice.wires) + ")")
+  }
+  if y + slice.wires > circuit-rows {
+    assert(false, message: 
+      "A `slice` starting at qubit " + str(y) + 
+      " spanning " + str(slice.wires) + 
+      " qubit" + plural-s(slice.wires) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubit" + plural-s(circuit-rows)
+    )
+  }
+}
+
+
+#let verify-gategroup(gategroup, x, y, circuit-rows, circuit-cols) = {
+  if gategroup.wires <= 0 {
+    assert(false, message: "`gategroup`: The number of wires needs to be > 0 (is " + str(gategroup.wires) + ")")
+  }
+  if gategroup.steps <= 0 {
+    assert(false, message: "`gategroup`: The number of steps needs to be > 0 (is " + str(gategroup.steps) + ")")
+  }
+  if y + gategroup.wires > circuit-rows {
+    assert(false, message: 
+      "A `gategroup` at qubit " + str(y) + 
+      " spanning " + str(gategroup.wires) + 
+      " qubit" + plural-s(gategroup.wires) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-rows) + " qubit" + plural-s(circuit-rows)
+    )
+  }
+  if x + gategroup.steps > circuit-cols {
+    assert(false, message: 
+      "A `gategroup` at column " + str(x) + 
+      " spanning " + str(gategroup.steps) + 
+      " column" + plural-s(gategroup.steps) + 
+      " exceeds the circuit which has only " + 
+      str(circuit-cols) + " column" + plural-s(circuit-cols)
+    )
+  }
+}
+
+#let verify-annotation-content(annotation-content) = {
+  let content-type = type(annotation-content)
+  assert(content-type in (symbol, content, str, dictionary), message: "`annotate`: Unsupported callback return type `" + str(content-type) + "` (can be `dictionary` or `content`")
+
+  if content-type == dictionary {
+    assert("content" in annotation-content, message: "`annotate`: Missing field `content` in annotation. If the callback returns a dictionary, it must contain the key `content` and may specify coordinates with `dx` and `dy`.")
+    if "z" in annotation-content {
+      let z = annotation-content.z
+      assert(z in ("below", "above"), message: "`annotate`: The parameter `z` can take the values `\"above\"` and `\"below\"`")
+    }
+  }
+}

--- a/packages/preview/quill/0.8.0/typst.toml
+++ b/packages/preview/quill/0.8.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quill"
+version = "0.8.0"
+entrypoint = "src/quill.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Effortlessly create quantum circuit diagrams."
+compiler = "0.13.0"
+
+repository = "https://github.com/Mc-Zen/quill"
+keywords = ["quantum circuit diagram", "quantikz", "qcircuit"]
+categories = ["visualization"]
+disciplines = ["physics", "computer-science"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] an update for a package



## Changelog

- New repeat annotation `repeat-block`. 
- Added `targ-y` gate for controlled-Y gates. 
- New decoration `break-line` for marking the omission of wires.
- Fixed multi-qubit `lstick`/`rstick` braces that broke with Typst 0.15 (again). 
- Improved docs for slices and gategroups. 
