### PR TITLE
jurlstify:0.3.1

### DIFF
--- a/packages/preview/jurlstify/0.3.1/LICENSE
+++ b/packages/preview/jurlstify/0.3.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SchrodingerBlume
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/jurlstify/0.3.1/README.md
+++ b/packages/preview/jurlstify/0.3.1/README.md
@@ -1,0 +1,152 @@
+<p align="center">
+  <strong>jurlstify</strong><br>
+  <em>URL typesetting with line-break opportunities — the url package port for Typst</em>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-0.3.1-blue" alt="version: 0.3.1">
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="license: MIT">
+  <img src="https://img.shields.io/badge/typst-0.13.0+-orange" alt="minimum typst version: 0.13.0">
+  <a href="https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.pdf"><img src="https://img.shields.io/badge/📖_manual-PDF-blueviolet" alt="manual (PDF)"></a>
+</p>
+
+<p align="center">
+  <a href="#english">English</a> | <a href="#中文">中文</a>
+</p>
+
+---
+
+## English
+
+A Typst package that ports the line-breaking logic of LaTeX's [`url` package](https://ctan.org/pkg/url) to Typst. Typst breaks bare URLs only at a fixed, non-configurable set of characters: a URL that contains none of them overflows the margin, and the available break points can produce uneven word spacing in justified paragraphs. This package inserts break opportunities at a configurable set of characters, and can add further breaks at a fixed interval inside long runs.
+
+By default it breaks only at delimiter characters and shows no hyphen, matching the `url` package — the copy-safe default (a shown hyphen could be mistaken for part of the URL).
+
+📖 **Full API reference:** the [manual (PDF)](https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.pdf), rendered from [`manual/manual.typ`](https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.typ).
+
+### Features
+
+- **Configurable break classes** — `url`-package-compatible defaults (`/`, `?`, `&`, `.`, `#`, …), overridable per call
+- **Literal-hyphen & long-run control** — `break-at-literal-hyphens`, plus `extra-break-every` for runs with no delimiter
+- **Two hyphen-display switches** — show a `-` at delimiter breaks and/or at the extra breaks, independently (both off by default)
+- **Space handling** — `show-spaces-as`: `"nbsp"` / `"normal"` / `none`
+- **Font inheritance & stretch** — `font: auto` inherits the body font; `stretch` aligns URL-only lines to the right margin
+- **Reaches generated content** — `jurlstify-text()` matches URL-shaped *text* anywhere, including `#bibliography` output, third-party templates, and bare URLs that were never links; it leaves code (`raw`) alone
+- **Four usage modes** — `jurlstify()`, the `jurl()` link wrapper, and the `jurlstify-links()` / `jurlstify-text()` show rules
+
+### Quick Start
+
+```typ
+#import "@preview/jurlstify:0.3.1": jurlstify, jurl, jurlstify-links
+
+// Render a URL string with break opportunities
+#jurlstify("https://example.com/very/long/path?query=value&more=stuff")
+
+// Clickable link — same breaking, wrapped in link()
+#jurl("https://example.com/very/long/path?query=value")
+
+// Apply automatically to every link() in the document
+#show: jurlstify-links.with()
+#link("https://example.com/automatically/handled")
+
+// Reach content you cannot touch at the source — bibliography, templates,
+// bare URLs. Code blocks are left alone.
+#show: jurlstify-text.with()
+#bibliography("refs.bib")
+```
+
+### Options at a glance
+
+| Group | Parameters |
+|---|---|
+| Where a line may break | `break-chars`, `big-break-chars`, `no-break-chars`, `break-at-literal-hyphens`, `extra-break-every` |
+| Show a hyphen at a break | `show-hyphens-after-delimiters`, `show-hyphens-at-extra-breaks` |
+| Other | `show-spaces-as`, `stretch`, `font`, `size`, `fill` |
+| `jurlstify-text` detection | `schemes`, `pattern`, `match-in-raw`, `linkify` |
+
+See the [manual](https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.pdf) for every parameter's type, default, and description. The three default character sets are exported as `break-chars-default` / `big-break-chars-default` / `no-break-chars-default` for extending.
+
+### Migration (0.2.x → 0.3.x)
+
+| 0.2.x | 0.3.x |
+|---|---|
+| `hyphens` | `break-at-literal-hyphens` |
+| `every` | `extra-break-every` |
+| `breaks` / `big-breaks` / `no-breaks` | `break-chars` / `big-break-chars` / `no-break-chars` |
+| `show-hyphen` (global) | `show-hyphens-after-delimiters` + `show-hyphens-at-extra-breaks` |
+| `spaces: "nobreak"/"break"/"strip"` | `show-spaces-as: "nbsp"/"normal"/none` |
+| `stretch` `font` `size` `fill` | unchanged |
+
+Old code keeps working by pinning `@preview/jurlstify:0.2.1`.
+
+### License
+
+MIT — see [LICENSE](LICENSE).
+
+---
+
+## 中文
+
+一个把 LaTeX [`url` 宏包](https://ctan.org/pkg/url) 的换行逻辑移植到 Typst 的包。Typst 只在一组固定、不可配置的字符处断开裸 URL:不含这些字符的 URL 会溢出页边距,而可用的断点在两端对齐段落中可能导致词间距不均。本包在一组可配置的字符处插入换行机会,并可在长串内部按固定间隔补充断点。
+
+默认情况下,本包只在分隔符处断行、不显示连字符,与 `url` 宏包一致——这是可安全复制的默认行为(显示连字符可能被误认为是 URL 的一部分)。
+
+📖 **完整 API 参考:** 见[手册 PDF](https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.pdf),由 [`manual/manual.typ`](https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.typ) 渲染。
+
+### 功能特性
+
+- **可配置断点类** — 与 `url` 宏包兼容的默认值(`/`、`?`、`&`、`.`、`#` 等),每次调用可覆盖
+- **真实连字符与长串控制** — `break-at-literal-hyphens`,以及给无分隔符长串兜底的 `extra-break-every`
+- **两个连字符显示开关** — 独立控制分隔符断点和额外断点换行时是否显示 `-`(默认都关)
+- **空格处理** — `show-spaces-as`:`"nbsp"` / `"normal"` / `none`
+- **字体继承与拉伸** — `font: auto` 继承正文字体;`stretch` 让纯 URL 行对齐右边距
+- **能触达生成内容** — `jurlstify-text()` 匹配任意位置**长得像 URL 的文本**,包括 `#bibliography` 的输出、第三方模板、以及从来不是 link 的裸 URL;默认不动代码块(`raw`)
+- **四种使用方式** — `jurlstify()`、超链接包装器 `jurl()`、`jurlstify-links()` / `jurlstify-text()` show rule
+
+### 快速上手
+
+```typ
+#import "@preview/jurlstify:0.3.1": jurlstify, jurl, jurlstify-links
+
+// 渲染带换行机会的 URL 字符串
+#jurlstify("https://example.com/very/long/path?query=value&more=stuff")
+
+// 可点击超链接,同样支持换行
+#jurl("https://example.com/very/long/path?query=value")
+
+// 全局 show rule:让文档中所有 link() 自动使用
+#show: jurlstify-links.with()
+#link("https://example.com/automatically/handled")
+
+// 触达源头够不着的内容 —— bibliography、模板、裸 URL。代码块不受影响。
+#show: jurlstify-text.with()
+#bibliography("refs.bib")
+```
+
+### 参数一览
+
+| 分组 | 参数 |
+|---|---|
+| 哪里允许断行 | `break-chars`、`big-break-chars`、`no-break-chars`、`break-at-literal-hyphens`、`extra-break-every` |
+| 断点处显不显 `-` | `show-hyphens-after-delimiters`、`show-hyphens-at-extra-breaks` |
+| 其余 | `show-spaces-as`、`stretch`、`font`、`size`、`fill` |
+| `jurlstify-text` 的判定 | `schemes`、`pattern`、`match-in-raw`、`linkify` |
+
+每个参数的类型、默认值、说明见[手册](https://github.com/SchrodingerBlume/typst-jurlstify/blob/90de29846d45c5e402c05ed49e9af80e6b966274/0.3.1/manual/manual.pdf)。三个默认字符集导出为 `break-chars-default` / `big-break-chars-default` / `no-break-chars-default`,可用于扩展。
+
+### 迁移(0.2.x → 0.3.x)
+
+| 0.2.x | 0.3.x |
+|---|---|
+| `hyphens` | `break-at-literal-hyphens` |
+| `every` | `extra-break-every` |
+| `breaks` / `big-breaks` / `no-breaks` | `break-chars` / `big-break-chars` / `no-break-chars` |
+| `show-hyphen`(全局) | `show-hyphens-after-delimiters` + `show-hyphens-at-extra-breaks` |
+| `spaces: "nobreak"/"break"/"strip"` | `show-spaces-as: "nbsp"/"normal"/none` |
+| `stretch` `font` `size` `fill` | 不变 |
+
+旧代码只要锁定 `@preview/jurlstify:0.2.1` 即可继续使用。
+
+### 许可
+
+MIT —— 详见 [LICENSE](LICENSE)。

--- a/packages/preview/jurlstify/0.3.1/lib.typ
+++ b/packages/preview/jurlstify/0.3.1/lib.typ
@@ -1,0 +1,252 @@
+// jurlstify — URL typesetting with line-break opportunities.
+// Ported from Donald Arseneau's LaTeX `url` package. MIT-licensed.
+//
+// Two independent axes control the output:
+//   • where a line may break  — `break-chars` / `big-break-chars` /
+//     `no-break-chars`, `break-at-literal-hyphens`, `extra-break-every`.
+//   • whether a visible "-" is shown at a break — `show-hyphens-after-delimiters`
+//     for the natural breaks, `show-hyphens-at-extra-breaks` for the extra ones.
+// Every option defaults to the copy-safe behaviour of the url package: break
+// only at the delimiter characters and never show a hyphen.
+
+// The internal break characters are defined locally inside `jurlstify` so a
+// wildcard `import` of this module never exposes them.
+
+// Default normal break characters, identical to the url package's \UrlBreaks.
+#let break-chars-default = (
+  ".", "@", "\\", "/", "!", "_", "|", ";", ">", "]",
+  ")", ",", "?", "&", "'", "+", "=", "#",
+)
+
+// Default high-priority break characters (the url package's \UrlBigBreaks).
+#let big-break-chars-default = (":",)
+
+// Default characters that suppress a break landing right before them
+// (the url package's \UrlNoBreaks, the \mathopen class).
+#let no-break-chars-default = ("(", "[", "{", "<")
+
+/// Render a URL string as inline content, with line-break opportunities at
+/// positions compatible with LaTeX's `url` package. Automatic hyphenation and
+/// ligatures are disabled inside the URL, matching that package's behaviour.
+///
+/// With no options set, only the delimiter breaks are active and no hyphen is
+/// shown — the copy-safe default. Opt into extra breaks and visible hyphens
+/// with the options below.
+///
+/// - url (str): The URL string to render.
+/// - break-chars (array): Characters after which a normal break may occur.
+///   Defaults to `. @ \ / ! _ | ; > ] ) , ? & ' + = #`.
+/// - big-break-chars (array): Higher-priority break characters. Defaults to
+///   `(":",)`.
+/// - no-break-chars (array): Characters that drop a break landing immediately
+///   before them. Defaults to `("(", "[", "{", "<")`.
+/// - break-at-literal-hyphens (bool): Allow a break after a literal `-` already
+///   present in the URL. Defaults to `false`, so `my-domain.com` never breaks
+///   mid-word.
+/// - extra-break-every (none, int): Insert one extra break opportunity every N
+///   consecutive non-break characters, for long unbroken runs. Defaults to
+///   `none` (disabled).
+/// - show-hyphens-after-delimiters (bool): Show a `-` at a delimiter break when
+///   the line breaks there. Defaults to `false`. Also places a `-` after
+///   punctuation, e.g. a line ending in `com/-`.
+/// - show-hyphens-at-extra-breaks (bool): Show a `-` at an `extra-break-every`
+///   break when the line breaks there. Defaults to `false`.
+/// - show-spaces-as (str, none): How to render a literal space in the URL:
+///   `"nbsp"` (non-breaking space), `"normal"` (ordinary breakable space), or
+///   `none` (remove it). Defaults to `"nbsp"`.
+/// - stretch (bool): Make break points stretchable so URL-internal lines reach
+///   the right margin in justified paragraphs, at the cost of small gaps at
+///   breaks. Defaults to `false`.
+/// - font (auto, str, array): URL font; `auto` inherits the body font. Defaults
+///   to `auto`.
+/// - size (auto, length): Font size; `auto` inherits from context. Defaults to
+///   `auto`.
+/// - fill (auto, color): Text colour; `auto` inherits from context. Defaults to
+///   `auto`.
+/// -> content
+#let jurlstify(
+  url,
+  break-chars: break-chars-default,
+  big-break-chars: big-break-chars-default,
+  no-break-chars: no-break-chars-default,
+  break-at-literal-hyphens: false,
+  extra-break-every: none,
+  show-hyphens-after-delimiters: false,
+  show-hyphens-at-extra-breaks: false,
+  show-spaces-as: "nbsp",
+  stretch: false,
+  font: auto,
+  size: auto,
+  fill: auto,
+) = {
+  assert(
+    type(url) == str,
+    message: "jurlstify: expected a string, got " + str(type(url)),
+  )
+  assert(
+    show-spaces-as in ("nbsp", "normal", none),
+    message: "jurlstify: `show-spaces-as` must be \"nbsp\", \"normal\", or none",
+  )
+  assert(
+    extra-break-every == none
+      or (type(extra-break-every) == int and extra-break-every >= 1),
+    message: "jurlstify: `extra-break-every` must be none or a positive integer",
+  )
+
+  let big = if break-at-literal-hyphens { big-break-chars + ("-",) } else { big-break-chars }
+  let all-breaks = break-chars + big
+
+  // url.sty runs in math mode, which suppresses hyphenation and ligatures;
+  // disable them directly so Typst adds no fake hyphens or ligatures in URLs.
+  set text(hyphenate: false, historical-ligatures: false, discretionary-ligatures: false)
+  set text(font: font) if font != auto
+  set text(size: size) if size != auto
+  set text(fill: fill) if fill != auto
+
+  // Internal characters, kept local so a wildcard `import` never exposes them.
+  let _zwsp = "\u{200B}"  // ZERO WIDTH SPACE — breakable, zero width, no stretch
+  let _wj   = "\u{2060}"  // WORD JOINER      — forbids a line break
+  let _nbsp = "\u{00A0}"  // NO-BREAK SPACE
+  let _shy  = "\u{00AD}"  // SOFT HYPHEN      — shows "-" only if broken here
+  // Stretchable invisible break: a space with negative tracking, so it is
+  // invisible yet still stretches under justification (used when `stretch`).
+  let _stretch-break = text(tracking: -1em, " ")
+
+  let plain-break = if stretch { _stretch-break } else { _zwsp }
+
+  // Emit content incrementally: text runs punctuated by break markers.
+  let chars = url.clusters()
+  let n = chars.len()
+  let i = 0
+  let run = 0  // consecutive non-break chars since the last break
+  while i < n {
+    let c = chars.at(i)
+
+    if c == " " {
+      run = 0
+      if show-spaces-as == "nbsp" { _nbsp } else if show-spaces-as == "normal" { c }
+      // none: drop the space
+      i += 1
+      continue
+    }
+
+    c
+
+    if c in all-breaks {
+      run = 0
+      let nxt = if i + 1 < n { chars.at(i + 1) } else { none }
+      if nxt not in no-break-chars {
+        // A literal "-" is already its own visible hyphen — never stack a soft
+        // one on top, which would render an ugly "--" at the line end.
+        if show-hyphens-after-delimiters and c != "-" { _shy } else { plain-break }
+      }
+    } else if c == "-" and not break-at-literal-hyphens {
+      run = 0
+      _wj
+    } else {
+      run += 1
+      if extra-break-every != none and run >= extra-break-every and i + 1 < n {
+        if show-hyphens-at-extra-breaks { _shy } else { plain-break }
+        run = 0
+      }
+    }
+
+    i += 1
+  }
+}
+
+/// A clickable hyperlink whose visible text is formatted by `jurlstify`.
+/// Accepts every `jurlstify` option as a trailing keyword argument.
+///
+/// - dest (str): Link destination (the URL).
+/// - display (none, str, content): Visible content. `none` shows `dest` itself
+///   (formatted by `jurlstify`); a string is likewise formatted; content is
+///   used verbatim. Defaults to `none`.
+/// -> content
+#let jurl(dest, display: none, ..opts) = {
+  let shown = if display == none { dest } else { display }
+  let body = if type(shown) == str { jurlstify(shown, ..opts.named()) } else { shown }
+  link(dest, body)
+}
+
+/// A document-level show rule that routes every `link("http://…")` whose body
+/// equals its destination through `jurlstify`. Links with explicit display
+/// content are left untouched. All `jurlstify` options are forwarded.
+///
+/// - body (content): The content the rule applies to.
+/// -> content
+#let jurlstify-links(..opts, body) = {
+  let kwargs = opts.named()
+  show link: it => {
+    if (
+      type(it.dest) == str
+        and it.body.func() == text
+        and type(it.body.text) == str
+        and it.body.text == it.dest
+    ) {
+      link(it.dest, jurlstify(it.body.text, ..kwargs))
+    } else {
+      it
+    }
+  }
+  body
+}
+
+/// Apply `jurlstify` to every URL-shaped run of text, including content this
+/// package cannot reach at the source: `#bibliography` output, third-party
+/// templates, and bare URLs that were never wrapped in a `link`.
+///
+/// Because the text is already rendered, detection is necessarily by shape.
+/// `schemes` covers the common case; `pattern` hands you full control.
+///
+/// Composes with `jurlstify-links`: text that already carries this package's
+/// break markers is left alone, so applying both rules — in either order —
+/// processes each URL exactly once.
+///
+/// - schemes (array): URL schemes to detect. A pattern is built from them, and
+///   this is ignored when `pattern` is given. Defaults to `("http", "https")`.
+/// - pattern (auto, regex): Detection pattern, overriding `schemes`. Defaults
+///   to `auto`.
+/// - match-in-raw (bool): Also rewrite URLs inside `raw` (code). Defaults to
+///   `false`, so code stays exact when copied.
+/// - linkify (bool): Wrap a matched URL in `link()`, making bare URLs
+///   clickable. Defaults to `false`.
+/// - body (content): The content the rule applies to.
+/// -> content
+#let jurlstify-text(
+  schemes: ("http", "https"),
+  pattern: auto,
+  match-in-raw: false,
+  linkify: false,
+  ..opts,
+  body,
+) = {
+  let kwargs = opts.named()
+  let pat = if pattern != auto { pattern } else {
+    regex("(?:" + schemes.join("|") + ")://[^\\s]+")
+  }
+  // Text already carrying one of our markers has been processed — by an earlier
+  // rule or by this one. Skipping it keeps the rules idempotent, so applying
+  // `jurlstify-links` and `jurlstify-text` together (in any order) is safe.
+  let processed = regex("[\u{200B}\u{00AD}\u{2060}]")
+
+  let render(t) = {
+    let out = jurlstify(t, ..kwargs)
+    if linkify { link(t, out) } else { out }
+  }
+
+  if match-in-raw {
+    show pat: it => if it.text.contains(processed) { it } else { render(it.text) }
+    body
+  } else {
+    // A regex show rule also fires inside `raw`, and an inner show rule cannot
+    // suppress an outer one. So flag raw content with a state and read it back
+    // in the handler.
+    let in-raw = state("jurlstify-in-raw", false)
+    show raw: it => { in-raw.update(true); it; in-raw.update(false) }
+    show pat: it => context {
+      if in-raw.get() or it.text.contains(processed) { it } else { render(it.text) }
+    }
+    body
+  }
+}

--- a/packages/preview/jurlstify/0.3.1/typst.toml
+++ b/packages/preview/jurlstify/0.3.1/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "jurlstify"
+version = "0.3.1"
+entrypoint = "lib.typ"
+authors = ["SchrodingerBlume <https://github.com/SchrodingerBlume>"]
+license = "MIT"
+description = "URL typesetting with line-break opportunities, inspired by LaTeX's url package."
+repository = "https://github.com/SchrodingerBlume/typst-jurlstify"
+keywords = ["url", "linebreak", "justify", "hyperref"]
+categories = ["text", "utility", "layout"]
+compiler = "0.13.0"
+exclude = ["*.pdf"]


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Description:

`jurlstify-text`: a show rule that gives URL-shaped text line breaks anywhere - `#bibliography()` output, templates, bare URLs - leaving raw/code alone (state-based detection) and staying idempotent with `jurlstify-links` via break-marker probing. `"schemes"|"pattern"|"match-in-raw"|"linkify"` options.

Manual: vendor min-manual (MIT, LICENSE kept) and render the Reference via tidy with a min-manual-flavoured `#arg` style.