### PR TITLE
tidymind:0.2.0

### DIFF
--- a/packages/preview/tidymind/0.2.0/LICENSE
+++ b/packages/preview/tidymind/0.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Elitus, Pierry A. Pereira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/tidymind/0.2.0/README.md
+++ b/packages/preview/tidymind/0.2.0/README.md
@@ -1,0 +1,137 @@
+# tidymind
+
+Horizontal mind map diagrams for [Typst](https://typst.app), built on
+[CeTZ](https://typst.app/universe/package/cetz/). Every node is measured before
+the layout runs, so long labels never overlap — the common failure of
+fixed-spacing tree drawers.
+
+![A mind map with a filled root and rounded, colored nodes](https://raw.githubusercontent.com/pierryangelo/tidymind/v0.2.0/img/shallow.png)
+
+## Usage
+
+````typ
+#import "@preview/tidymind:0.2.0": mindmap, node
+
+#mindmap(node([Root],
+  node([Branch A], node([A1]), node([A2])),
+  node([Branch B]),
+))
+````
+
+`node(content, ..children)` builds a tree node; `content` is the label and the
+remaining positional arguments are its children (each one another `node(...)` or
+raw content). A raw dictionary `(content: .., children: (..))` is also accepted.
+
+## Long labels
+
+This is the case that pushed the package into existence. Node sizes come from
+Typst's `measure`, so a label that wraps reserves the vertical band it actually
+needs — at any depth, with no manual offsets.
+
+![Two long labels wrapped at node-max-width, neither overlapping the other](https://raw.githubusercontent.com/pierryangelo/tidymind/v0.2.0/img/long_labels.png)
+
+## Styles
+
+`style: "boxed"` (the default) draws every node as a rounded box, the root
+filled with its branch color.
+
+`style: "outline"` drops the boxes entirely: the root becomes a heading over a
+baseline rule, each first-level branch a label resting on a rule in its own
+color, and everything deeper is plain text. Hierarchy comes from size, weight
+and color instead of from frames — useful when the map sits inside a document
+and boxes would fight with the surrounding text.
+
+![The same tree in the outline style, with no boxes around any node](https://raw.githubusercontent.com/pierryangelo/tidymind/v0.2.0/img/outline.png)
+
+## Roles and branch colors
+
+A node can carry an `emphasis` — its role — and a `branch` index that overrides
+the color it would inherit from its position. Both are given by **name**: the
+document says what a node *means*, and the package resolves the color.
+
+````typ
+#mindmap(
+  node([SQL privileges],
+    node([GRANT],
+      node([Idempotent], emphasis: "definition"),
+      node([Cascades to dependents], emphasis: "warning"),
+    ),
+    node([REVOKE], branch: 5,
+      node([RESTRICT is the default], emphasis: "highlight"),
+    ),
+  ),
+  style: "outline",
+)
+````
+
+![A map whose leaves are colored by role: definition, warning, highlight and example](https://raw.githubusercontent.com/pierryangelo/tidymind/v0.2.0/img/emphasis.png)
+
+## Options
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `style` | `"boxed"` | `"boxed"` or `"outline"` (see above) |
+| `palette` | 6 colors | color per first-level branch, cycled |
+| `font` | `"Inter"` | label font, or a fallback list |
+| `text-size` | `9pt` | base label size; the root and first level scale up from it |
+| `node-max-width` | `6cm` | max width before a label wraps |
+| `max-depth` | `6` | prune nodes deeper than this |
+| `h-gap` | `40pt` | horizontal gap between levels |
+| `v-gap` | `10pt` | minimum vertical gap between siblings |
+| `ink` | `(strong, soft)` | label colors; partial dictionaries merge over the defaults |
+| `emphasis-colors` | 4 roles | `highlight`, `warning`, `definition`, `example` |
+
+Labels take arbitrary Typst content, so markup and emoji work — pass a color
+emoji font in the `font` fallback list to get the second one:
+
+````typ
+#mindmap(node([Git: #strong[what gets graded]], node([🥇 #strong[Remote sync] (35%)])),
+  font: ("Inter", "Noto Color Emoji"))
+````
+
+## How it works
+
+The layout is a tidy tree by subtree extent: every subtree reserves a vertical
+band equal to the sum of its children's bands (or its own height, if a leaf), and
+the parent is centered within that band. Because sibling subtrees occupy disjoint
+bands, nodes never overlap — at any depth. It runs in O(n), in two passes: one
+up the tree to size the bands, one down to place the nodes.
+
+Node sizes come from Typst's `measure`, so a band accounts for the real rendered
+size of each (possibly wrapped) label. Measuring and drawing go through a single
+description of the node body (`src/style.typ`), which is what keeps an edge
+landing exactly on the node it points at.
+
+## Examples
+
+Every file under [`examples/`](examples) compiles on its own. Files named
+`visual_*` produce the images above; files named `_assert_*` exercise the logic
+through `#assert`, so compiling them **is** the test suite.
+
+```sh
+sh examples/render.sh    # runs the asserts, then regenerates img/
+```
+
+| Example | What it covers |
+|---------|----------------|
+| [`visual_shallow`](examples/visual_shallow.typ) | a root with three leaves |
+| [`visual_deep`](examples/visual_deep.typ) | several levels of nesting |
+| [`visual_many_siblings`](examples/visual_many_siblings.typ) | vertical spacing under pressure |
+| [`visual_long_labels`](examples/visual_long_labels.typ) | labels wrapping at `node-max-width` |
+| [`visual_outline`](examples/visual_outline.typ) | the `"outline"` style |
+| [`visual_emphasis`](examples/visual_emphasis.typ) | roles and branch overrides |
+| [`visual_markdown_emoji`](examples/visual_markdown_emoji.typ) | markup and emoji in labels |
+| [`visual_single`](examples/visual_single.typ) | a lone root |
+| [`visual_empty`](examples/visual_empty.typ) | empty labels |
+
+## Changelog
+
+**0.2.0** — adds `style: "outline"`, the `branch` and `emphasis` attributes on
+`node`, and the `ink` / `emphasis-colors` options. The default output is
+unchanged: `style: "boxed"` renders exactly what 0.1.1 rendered.
+
+**0.1.1** — long labels wrap instead of overflowing their measured width.
+
+## License
+
+MIT

--- a/packages/preview/tidymind/0.2.0/examples/_assert_emphasis_branch.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_emphasis_branch.typ
@@ -1,0 +1,29 @@
+// Branch and emphasis must survive normalization and pruning: the caller speaks
+// by NAME (branch index, node role) and the package resolves the color. If
+// `normalize` drops either one, the drawing silently loses the author's intent.
+#import "../src/tree.typ": normalize, prune
+#set page(width: auto, height: auto)
+
+#context {
+  let t = normalize((
+    content: [Root],
+    children: (
+      (content: [Branch], branch: 5, children: (
+        (content: [Leaf], emphasis: "warning", children: ()),
+      )),
+    ),
+  ))
+
+  assert(t.branch == none, message: "the root declares no branch")
+  assert(t.children.at(0).branch == 5, message: "an explicit branch must survive")
+  assert(
+    t.children.at(0).children.at(0).emphasis == "warning",
+    message: "emphasis must survive normalization",
+  )
+
+  // Pruning cuts children, not attributes.
+  let p = prune(t, 1)
+  assert(p.children.len() == 1)
+  assert(p.children.at(0).branch == 5, message: "pruning must not erase the branch")
+  assert(p.children.at(0).children.len() == 0)
+}

--- a/packages/preview/tidymind/0.2.0/examples/_assert_layout.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_layout.typ
@@ -1,0 +1,26 @@
+#import "../src/tree.typ": normalize
+#import "../src/layout.typ": measure-tree, layout-tree
+#set page(width: auto, height: auto)
+
+#context {
+  let t = normalize((content: [Root], children: (
+    (content: [Child 1],), (content: [Child 2],), (content: [Child 3],),
+  )))
+  let m = measure-tree(t, 6cm, "Inter", 9pt, "boxed")
+  let l = layout-tree(m, 40pt, 10pt)
+
+  // the root sits to the left of its children
+  assert(l.x < l.children.at(0).x)
+  // siblings share one column
+  assert(l.children.at(0).x == l.children.at(2).x)
+  // siblings never overlap vertically: the gap between centers is at least the
+  // average of their heights
+  let y0 = l.children.at(0).y
+  let y1 = l.children.at(1).y
+  assert(calc.abs(y1 - y0) >= (l.children.at(0).h + l.children.at(1).h) / 2)
+  // first-level branches are marked by position; the root is -1
+  assert(l.branch-index == -1)
+  assert(l.children.at(0).branch-index == 0)
+  assert(l.children.at(2).branch-index == 2)
+}
+#[OK]

--- a/packages/preview/tidymind/0.2.0/examples/_assert_long_label_wraps.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_long_label_wraps.typ
@@ -1,0 +1,21 @@
+// A long label is capped at node-max-width (it wraps) instead of growing as a
+// single line. `draw.typ` draws the box with `width: n.w`, so the drawing obeys
+// exactly this measurement — without it the node overflowed its slot and ran
+// off the page.
+#import "../src/tree.typ": normalize
+#import "../src/layout.typ": measure-tree
+#set page(width: auto, height: auto)
+
+#context {
+  let long = [CASCADE — revokes, in a chain, every privilege handed down to dependent users and roles]
+  let short = [GRANT]
+  let mw = 6cm
+  let ml = measure-tree(normalize((content: long, children: ())), mw, "Inter", 9pt, "boxed")
+  let ms = measure-tree(normalize((content: short, children: ())), mw, "Inter", 9pt, "boxed")
+  // long: capped at the maximum width, and taller (it wrapped onto 2+ lines)
+  assert(ml.w <= mw.pt() + 0.1, message: "a long label should be capped at node-max-width")
+  assert(ml.h > ms.h, message: "a wrapped label should be taller than a short one")
+  // short: natural width, below the cap
+  assert(ms.w < mw.pt(), message: "a short label should keep its natural width")
+}
+#[OK]

--- a/packages/preview/tidymind/0.2.0/examples/_assert_measure.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_measure.typ
@@ -1,0 +1,12 @@
+#import "../src/tree.typ": normalize
+#import "../src/layout.typ": measure-tree
+#set page(width: auto, height: auto)
+
+#context {
+  let t = normalize((content: [A fairly long sample label], children: ((content: [x],),)))
+  let m = measure-tree(t, 6cm, "Inter", 9pt, "boxed")
+  assert(m.w > 0)
+  assert(m.h > 0)
+  assert(m.w > m.children.at(0).w)
+}
+#[OK]

--- a/packages/preview/tidymind/0.2.0/examples/_assert_normalize.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_normalize.typ
@@ -1,0 +1,26 @@
+#import "../src/tree.typ": normalize
+#set page(width: auto, height: auto)
+
+// a plain dictionary keeps its shape
+#let a = normalize((content: [R], children: ()))
+#assert.eq(a.children.len(), 0)
+#assert(a.content == [R])
+
+// a missing `children` becomes an empty list
+#let b = normalize((content: [R],))
+#assert.eq(b.children.len(), 0)
+
+// raw content becomes a leaf
+#let c = normalize([Loose leaf])
+#assert.eq(c.children.len(), 0)
+#assert(c.content == [Loose leaf])
+
+// recursion: children are normalized too
+#let d = normalize((content: [R], children: ((content: [F],),)))
+#assert.eq(d.children.len(), 1)
+#assert.eq(d.children.at(0).children.len(), 0)
+
+// an empty label never yields a null node
+#assert(normalize([]).content == [—])
+
+#[OK]

--- a/packages/preview/tidymind/0.2.0/examples/_assert_prune.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_prune.typ
@@ -1,0 +1,18 @@
+#import "../src/tree.typ": normalize, prune
+#set page(width: auto, height: auto)
+
+// a three-level tree
+#let t = normalize((content: [A], children: (
+  (content: [B], children: ((content: [C], children: ()),)),
+)))
+
+// max-depth 1 → grandchildren (C) are cut, B stays
+#let p = prune(t, 1)
+#assert.eq(p.children.len(), 1)
+#assert.eq(p.children.at(0).children.len(), 0)
+
+// max-depth 0 → the root alone
+#let p0 = prune(t, 0)
+#assert.eq(p0.children.len(), 0)
+
+#[OK]

--- a/packages/preview/tidymind/0.2.0/examples/_assert_style.typ
+++ b/packages/preview/tidymind/0.2.0/examples/_assert_style.typ
@@ -1,0 +1,70 @@
+// The box the layout RESERVES must be the box the drawing EMITS.
+//
+// These were once two hand-mirrored functions in two files, and every time one
+// of them changed an inset or a font weight, the edge stopped touching the node
+// in the other. Both now go through `node-body`, and this file is what keeps
+// them honest: what `measure-node` reserves has to match, to the point, the
+// fully painted body that `draw.typ` puts on the canvas — at every depth, in
+// every style.
+#import "../src/style.typ": default-emphasis-colors, default-ink, node-body, node-paint, node-spec
+#import "../src/tree.typ": normalize
+#import "../src/layout.typ": measure-node, measure-tree
+#set page(width: auto, height: auto)
+
+#context {
+  let label = [Sample label]
+
+  for style in ("boxed", "outline") {
+    for depth in (0, 1, 2) {
+      // An emphasized node is the case that used to break: it was measured in
+      // regular and drawn in semibold, so the label outgrew its own box and
+      // hyphenated. Both plain and emphasized have to agree.
+      for emphasized in (false, true) {
+        // What the layout pass reserves for this node...
+        let reserved = measure-node(
+          label, 6cm, "Inter", 9pt, style, depth, emphasized: emphasized,
+        )
+        // ...against the fully painted body the drawing pass actually emits.
+        let spec = node-spec(style, depth, emphasized: emphasized)
+        let role = if emphasized { default-emphasis-colors.warning } else { none }
+        let painted = node-paint(spec, depth, red, default-ink, role)
+        let drawn = measure(node-body(label, spec, painted, "Inter", 9pt))
+
+        assert(
+          calc.abs(reserved.w - drawn.width.pt()) < 0.001
+            and calc.abs(reserved.h - drawn.height.pt()) < 0.001,
+          message: "the layout reserves a different box than the one drawn ("
+            + style + ", depth " + str(depth) + ", emphasized "
+            + (if emphasized { "yes" } else { "no" }) + "): reserved " + str(reserved.w) + "×"
+            + str(reserved.h) + ", drawn " + str(drawn.width.pt()) + "×"
+            + str(drawn.height.pt()),
+        )
+      }
+    }
+  }
+
+  // An emphasized leaf really is wider than a plain one — if this ever stops
+  // holding, the assert above would pass for the wrong reason.
+  let plain = measure-node(label, 6cm, "Inter", 9pt, "outline", 2)
+  let heavy = measure-node(label, 6cm, "Inter", 9pt, "outline", 2, emphasized: true)
+  assert(heavy.w > plain.w, message: "an emphasized label should measure wider")
+
+  // The two styles are genuinely different shapes, not the same one renamed.
+  assert(node-spec("boxed", 0).frame == "box")
+  assert(node-spec("boxed", 3).frame == "box")
+  assert(node-spec("outline", 0).frame == "underline")
+  assert(node-spec("outline", 1).frame == "side-rule")
+  assert(node-spec("outline", 3).frame == "none")
+
+  // In "outline" the root is typographically larger, so it must also measure
+  // larger — if it did not, the layout would reserve the wrong band for it.
+  let t = normalize((content: [Root], children: ((content: [Child],),)))
+  let boxed = measure-tree(t, 6cm, "Inter", 9pt, "boxed")
+  let outline = measure-tree(t, 6cm, "Inter", 9pt, "outline")
+  assert(
+    outline.h > outline.children.at(0).h,
+    message: "an outline root should be taller than its leaf",
+  )
+  assert(boxed.h == boxed.children.at(0).h, message: "boxed nodes share one height")
+}
+#[OK]

--- a/packages/preview/tidymind/0.2.0/examples/render.sh
+++ b/packages/preview/tidymind/0.2.0/examples/render.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Regenerates img/*.png from examples/visual_*.typ, and runs examples/_assert_*.typ.
+#
+# The README points at these images by absolute URL, so they must be regenerated
+# and committed whenever the drawing changes — otherwise the package page shows
+# a version of the output that no longer exists.
+#
+# Usage, from the repository root:
+#   sh examples/render.sh              # render + assert
+#   FONT_PATH=/path/to/fonts sh examples/render.sh
+#
+# Inter and Noto Color Emoji are what the examples ask for. Without them Typst
+# falls back to another family and the images stop matching the real output.
+set -eu
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+version=$(sed -n 's/^version *= *"\(.*\)"/\1/p' "$root/typst.toml")
+: "${FONT_PATH:=$root/fonts}"
+
+# Typst resolves `@preview/tidymind:<version>` through a package path, so point
+# one at this very working copy instead of at the published package.
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/preview/tidymind"
+ln -s "$root" "$work/preview/tidymind/$version"
+
+fonts=""
+[ -d "$FONT_PATH" ] && fonts="--font-path $FONT_PATH"
+
+mkdir -p "$root/img"
+
+for f in "$root"/examples/_assert_*.typ; do
+  name=$(basename "$f" .typ)
+  # A file that compiles is a file whose #assert calls all held.
+  # shellcheck disable=SC2086
+  typst compile --package-path "$work" --root "$root" $fonts "$f" "$work/out.pdf" \
+    && echo "assert  $name" \
+    || { echo "FAILED  $name"; exit 1; }
+done
+
+for f in "$root"/examples/visual_*.typ; do
+  name=$(basename "$f" .typ | sed 's/^visual_//')
+  # shellcheck disable=SC2086
+  typst compile --package-path "$work" --root "$root" $fonts \
+    --format png --ppi 192 "$f" "$root/img/$name.png" \
+    && echo "render  img/$name.png" \
+    || { echo "FAILED  $name"; exit 1; }
+done

--- a/packages/preview/tidymind/0.2.0/examples/visual_deep.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_deep.typ
@@ -1,0 +1,6 @@
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(node([System],
+  node([Layer A], node([A1], node([A1a]), node([A1b])), node([A2])),
+  node([Layer B], node([B1], node([B1a]))),
+))

--- a/packages/preview/tidymind/0.2.0/examples/visual_emphasis.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_emphasis.typ
@@ -1,0 +1,17 @@
+// Roles and branch colors travel by NAME. The document says "this is a warning"
+// and "put this branch on color 5"; the package resolves both.
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(
+  node([SQL privileges],
+    node([GRANT],
+      node([Idempotent], emphasis: "definition"),
+      node([Cascades to dependents], emphasis: "warning"),
+    ),
+    node([REVOKE], branch: 5,
+      node([RESTRICT is the default], emphasis: "highlight"),
+      node([`REVOKE ALL ON t FROM u`], emphasis: "example"),
+    ),
+  ),
+  style: "outline",
+)

--- a/packages/preview/tidymind/0.2.0/examples/visual_empty.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_empty.typ
@@ -1,0 +1,4 @@
+// An empty label still yields a node, marked with an em dash.
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(node([], node([])))

--- a/packages/preview/tidymind/0.2.0/examples/visual_long_labels.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_long_labels.typ
@@ -1,0 +1,6 @@
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(node([Principles of distributed software architecture],
+  node([Eventual consistency and the CAP theorem applied to real systems]),
+  node([Network partition tolerance in geographically distributed clusters]),
+))

--- a/packages/preview/tidymind/0.2.0/examples/visual_many_siblings.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_many_siblings.typ
@@ -1,0 +1,6 @@
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(node([Root],
+  node([1]), node([2]), node([3]), node([4]),
+  node([5]), node([6]), node([7]), node([8]),
+))

--- a/packages/preview/tidymind/0.2.0/examples/visual_markdown_emoji.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_markdown_emoji.typ
@@ -1,0 +1,13 @@
+// Labels carry markup and emoji — the emoji needs a color font in the `font`
+// fallback list, which the caller provides.
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(
+  node([Git: #strong[what gets graded]],
+    node([🥇 #strong[Remote sync] (35%)]),
+    node([🥈 #strong[Merging branches] (30%)]),
+    node([🥉 #strong[The three areas] (20%)]),
+    node([⚪ #strong[Pointers (HEAD)] (15%)]),
+  ),
+  font: ("Inter", "Noto Color Emoji"),
+)

--- a/packages/preview/tidymind/0.2.0/examples/visual_outline.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_outline.typ
@@ -1,0 +1,22 @@
+// The "outline" style: no boxes at all. The root is a heading over a baseline
+// rule, first-level branches rest on a rule in their own color, and everything
+// deeper is plain text.
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(
+  node([Cell biology],
+    node([Membrane],
+      node([Phospholipid bilayer]),
+      node([Transport proteins]),
+    ),
+    node([Nucleus],
+      node([Chromatin]),
+      node([Nucleolus]),
+    ),
+    node([Organelles],
+      node([Mitochondria]),
+      node([Ribosomes]),
+    ),
+  ),
+  style: "outline",
+)

--- a/packages/preview/tidymind/0.2.0/examples/visual_shallow.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_shallow.typ
@@ -1,0 +1,5 @@
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(node([Networks],
+  node([TCP/IP]), node([Routing]), node([Security]),
+))

--- a/packages/preview/tidymind/0.2.0/examples/visual_single.typ
+++ b/packages/preview/tidymind/0.2.0/examples/visual_single.typ
@@ -1,0 +1,4 @@
+// A lone root: no edges, nothing to lay out.
+#import "@preview/tidymind:0.2.0": mindmap, node
+#set page(width: auto, height: auto, margin: 10pt)
+#mindmap(node([Just the root]))

--- a/packages/preview/tidymind/0.2.0/lib.typ
+++ b/packages/preview/tidymind/0.2.0/lib.typ
@@ -1,0 +1,67 @@
+#import "@preview/cetz:0.5.2"
+#import "src/tree.typ": normalize, prune
+#import "src/layout.typ": measure-tree, layout-tree
+#import "src/draw.typ": draw-mindmap
+#import "src/style.typ": default-emphasis-colors, default-ink
+
+#let default-palette = (
+  rgb("#2563eb"), rgb("#16a34a"), rgb("#dc2626"),
+  rgb("#9333ea"), rgb("#ea580c"), rgb("#0891b2"),
+)
+
+#let styles = ("boxed", "outline")
+
+/// Builds a tree node. `content` is the label and the remaining positional
+/// arguments are its children.
+///
+/// - `branch`: index (1..n) into the palette, overriding the color the node
+///   would inherit from its position.
+/// - `emphasis`: the role of the node — a key of `emphasis-colors`, by default
+///   `highlight`, `warning`, `definition` or `example`.
+///
+/// Both are given by NAME: the map resolves the color, so a document never has
+/// to carry a hex value to say what a node means.
+#let node(content, ..children, branch: none, emphasis: none) = normalize((
+  content: content,
+  children: children.pos(),
+  branch: branch,
+  emphasis: emphasis,
+))
+
+/// Draws a complete mind map: measure, tidy layout, then CeTZ drawing.
+///
+/// - `style`: `"boxed"` (default) draws every node as a rounded box;
+///   `"outline"` drops the boxes and builds hierarchy out of type — a root over
+///   a baseline rule, branches on a side rule in their color, plain-text leaves.
+/// - `palette`: one color per first-level branch, cycled.
+/// - `ink` / `emphasis-colors`: overridable color roles; partial dictionaries
+///   are merged over the defaults.
+#let mindmap(
+  root,
+  style: "boxed",
+  palette: default-palette,
+  font: "Inter",
+  text-size: 9pt,
+  node-max-width: 6cm,
+  max-depth: 6,
+  h-gap: 40pt,
+  v-gap: 10pt,
+  ink: (:),
+  emphasis-colors: (:),
+) = context {
+  assert(
+    style in styles,
+    message: "tidymind: unknown style \"" + style + "\", expected one of "
+      + styles.join(", "),
+  )
+  let ink = default-ink + ink
+  let emphasis-colors = default-emphasis-colors + emphasis-colors
+
+  let t = prune(normalize(root), max-depth)
+  let measured = measure-tree(t, node-max-width, font, text-size, style)
+  let placed = layout-tree(measured, h-gap, v-gap)
+  cetz.canvas(
+    length: 1pt,
+    draw-mindmap(placed, palette, style, font, text-size, ink, emphasis-colors),
+  )
+}

--- a/packages/preview/tidymind/0.2.0/src/draw.typ
+++ b/packages/preview/tidymind/0.2.0/src/draw.typ
@@ -1,0 +1,62 @@
+#import "@preview/cetz:0.5.2"
+#import "style.typ": edge-width, node-body, node-paint, node-spec
+
+// Cor do ramo. O `branch` explícito do chamador (1..n) vence a posição natural,
+// e a raiz — que não pertence a ramo nenhum — usa a primeira cor da paleta.
+#let _branch-color(n, palette) = {
+  let idx = if n.at("branch", default: none) != none {
+    n.branch - 1
+  } else if n.branch-index < 0 {
+    0
+  } else {
+    n.branch-index
+  }
+  palette.at(calc.rem(idx, palette.len()))
+}
+
+#let _emphasis-color(n, emphasis-colors) = {
+  let role = n.at("emphasis", default: none)
+  if role == none { none } else { emphasis-colors.at(role, default: none) }
+}
+
+// Arestas pai→filho (bezier horizontal). Recursivo.
+#let _draw-edges(n, palette, style, depth) = {
+  import cetz.draw: *
+  let w = edge-width(style, depth)
+  for c in n.children {
+    let col = _branch-color(c, palette)
+    let px = n.x + n.w // borda direita do pai
+    let py = -n.y
+    let cx = c.x // borda esquerda do filho
+    let cy = -c.y
+    let mid = (px + cx) / 2
+    bezier((px, py), (cx, cy), (mid, py), (mid, cy), stroke: w + col)
+  }
+  for c in n.children { _draw-edges(c, palette, style, depth + 1) }
+}
+
+// Nós. Recursivo. A caixa vem de `style.typ` — a MESMA que foi medida.
+#let _draw-nodes(n, palette, style, font, text-size, ink, emphasis-colors, depth) = {
+  import cetz.draw: *
+  let emphasis = _emphasis-color(n, emphasis-colors)
+  // Mesmo spec que `layout.typ` mediu — inclusive o peso que a ênfase impõe.
+  let spec = node-spec(style, depth, emphasized: emphasis != none)
+  let paint = node-paint(spec, depth, _branch-color(n, palette), ink, emphasis)
+  // Âncora à esquerda do nó (x é a borda esquerda); centro vertical em -y.
+  // `width: n.w` casa o desenho com a medição: rótulos longos quebram em
+  // node-max-width em vez de vazar em linha única para fora da página.
+  content(
+    (n.x, -n.y),
+    anchor: "west",
+    node-body(n.content, spec, paint, font, text-size, width: n.w * 1pt),
+  )
+  for c in n.children {
+    _draw-nodes(c, palette, style, font, text-size, ink, emphasis-colors, depth + 1)
+  }
+}
+
+/// Draws the already positioned mind map (the output of `layout-tree`).
+#let draw-mindmap(n, palette, style, font, text-size, ink, emphasis-colors) = {
+  _draw-edges(n, palette, style, 0)
+  _draw-nodes(n, palette, style, font, text-size, ink, emphasis-colors, 0)
+}

--- a/packages/preview/tidymind/0.2.0/src/layout.typ
+++ b/packages/preview/tidymind/0.2.0/src/layout.typ
@@ -1,0 +1,106 @@
+#import "style.typ": node-body, node-paint, node-spec
+
+// Cores neutras para a passada de medição: a geometria é a mesma do desenho,
+// e é só ela que interessa aqui.
+#let _neutral-ink = (strong: black, soft: black)
+
+/// Measures one node, honoring `node-max-width` (the label wraps past it).
+/// Returns `(w, h)` in points. MUST be called inside `context`.
+///
+/// `emphasized` must match what the drawing pass will do with this node: an
+/// emphasized label is heavier, therefore wider.
+#let measure-node(
+  content,
+  node-max-width,
+  font,
+  text-size,
+  style,
+  depth,
+  emphasized: false,
+) = {
+  let spec = node-spec(style, depth, emphasized: emphasized)
+  let paint = node-paint(spec, depth, black, _neutral-ink, none, neutral: true)
+  let natural = measure(node-body(content, spec, paint, font, text-size))
+  if natural.width <= node-max-width {
+    return (w: natural.width.pt(), h: natural.height.pt())
+  }
+  // A largura entra na PRÓPRIA caixa do nó (não numa caixa em volta): assim o
+  // texto quebra dentro do inset, e a caixa desenhada tem exatamente esta
+  // largura. Medir por fora era o que deixava o rótulo vazar para fora dela.
+  let wrapped = measure(
+    node-body(content, spec, paint, font, text-size, width: node-max-width),
+  )
+  (w: node-max-width.pt(), h: wrapped.height.pt())
+}
+
+/// Annotates every node of the tree with `w`/`h` (in points).
+/// MUST be called inside `context`. `depth` picks the measured style, which is
+/// what keeps the measuring and the drawing passes in agreement.
+#let measure-tree(n, node-max-width, font, text-size, style, depth: 0) = {
+  let m = measure-node(
+    n.content,
+    node-max-width,
+    font,
+    text-size,
+    style,
+    depth,
+    emphasized: n.at("emphasis", default: none) != none,
+  )
+  (
+    ..n,
+    children: n.children.map(c => measure-tree(
+      c,
+      node-max-width,
+      font,
+      text-size,
+      style,
+      depth: depth + 1,
+    )),
+    w: m.w,
+    h: m.h,
+  )
+}
+
+// Pós-ordem: anota cada nó com `ext` (faixa vertical da subárvore, pt).
+#let _assign-extent(n, v-gap) = {
+  if n.children.len() == 0 {
+    return (..n, ext: n.h)
+  }
+  let kids = n.children.map(c => _assign-extent(c, v-gap))
+  let kids-ext = kids.fold(0.0, (a, c) => a + c.ext) + v-gap * (kids.len() - 1)
+  (..n, children: kids, ext: calc.max(n.h, kids-ext))
+}
+
+// Pré-ordem: atribui x/y/branch-index. `branch-index` é a POSIÇÃO do ramo
+// (0..n-1), herdada por toda a descendência; o `branch` que o chamador pediu,
+// quando existe, vence no desenho.
+#let _place(n, x, top, h-gap, v-gap, branch) = {
+  let y = top + n.ext / 2 // centro vertical do nó na sua faixa
+  let child-x = x + n.w + h-gap
+  // span vertical ocupado pelos filhos (com v-gaps entre eles)
+  let kids-span = if n.children.len() == 0 { 0.0 } else {
+    n.children.fold(0.0, (a, c) => a + c.ext) + v-gap * (n.children.len() - 1)
+  }
+  // centra o bloco de filhos dentro da faixa do nó → pai alinhado ao centro deles
+  let cursor = top + (n.ext - kids-span) / 2
+  let kids = ()
+  let i = 0
+  for c in n.children {
+    let b = if branch == -1 { i } else { branch }
+    kids.push(_place(c, child-x, cursor, h-gap, v-gap, b))
+    cursor = cursor + c.ext + v-gap
+    i = i + 1
+  }
+  (..n, children: kids, x: x, y: y, branch-index: branch)
+}
+
+/// Annotates the (already measured) tree with `x`/`y`/`branch-index`/`ext`.
+/// The root gets `branch-index: -1`. Coordinates are floats in points, and `y`
+/// grows downwards.
+#let layout-tree(n, h-gap, v-gap) = {
+  // Aceita length (ex.: 40pt) ou float; trabalha internamente em float pt.
+  let hg = if type(h-gap) == length { h-gap.pt() } else { h-gap }
+  let vg = if type(v-gap) == length { v-gap.pt() } else { v-gap }
+  let e = _assign-extent(n, vg)
+  _place(e, 0.0, 0.0, hg, vg, -1)
+}

--- a/packages/preview/tidymind/0.2.0/src/style.typ
+++ b/packages/preview/tidymind/0.2.0/src/style.typ
@@ -1,0 +1,119 @@
+// Fonte ÚNICA da aparência de um nó.
+//
+// Medir e desenhar precisam produzir exatamente a mesma caixa. Enquanto isso
+// viveu em dois arquivos "espelhados à mão", qualquer ajuste de inset ou de
+// peso de fonte num deles desalinhava o traço no outro. Aqui a geometria é
+// declarada uma vez: `layout.typ` mede este corpo e `draw.typ` desenha ESTE
+// mesmo corpo, com as cores por cima.
+
+/// Text colors. `strong` is the label ink, `soft` the ink of deeper labels in
+/// the `"outline"` style.
+#let default-ink = (
+  strong: rgb("#1e293b"),
+  soft: rgb("#475569"),
+)
+
+/// Role → color. Roles are named by the caller and resolved here, so a document
+/// never has to hardcode a hex value to say "this node is a warning".
+#let default-emphasis-colors = (
+  highlight: rgb("#2a72ae"),
+  warning: rgb("#b45309"),
+  definition: rgb("#2e7d32"),
+  example: rgb("#1769aa"),
+)
+
+/// Geometry and typography of a node, by style and depth.
+///
+/// - `"boxed"`: every node is a rounded box, the root filled with its color.
+/// - `"outline"`: no boxes at all. The root is a heading over a baseline rule,
+///   a first-level branch is a label resting on a rule in its branch color, and
+///   deeper nodes are plain text. Hierarchy comes from size, weight and color.
+///
+/// `emphasized` belongs HERE, not in the painting step: a role makes the label
+/// heavier as well as colored, and weight changes how wide the label is. Left
+/// out of the spec, a node would be measured light and drawn heavy — and then
+/// the label no longer fits the box the layout reserved for it.
+#let node-spec(style, depth, emphasized: false) = {
+  let emph(weight) = if emphasized and weight == "regular" { "semibold" } else { weight }
+
+  if style == "outline" {
+    if depth == 0 {
+      (scale: 1.5, weight: "bold", inset: (x: 2pt, y: 3pt), frame: "underline")
+    } else if depth == 1 {
+      (scale: 1.1, weight: "semibold", inset: (left: 6pt, rest: 3pt), frame: "side-rule")
+    } else {
+      (scale: 1.0, weight: emph("regular"), inset: (x: 2pt, y: 2pt), frame: "none")
+    }
+  } else {
+    (
+      scale: 1.0,
+      weight: emph(if depth == 0 { "bold" } else { "regular" }),
+      inset: (x: 8pt, y: 4pt),
+      radius: 4pt,
+      frame: "box",
+    )
+  }
+}
+
+/// Colors for a node: `(fill, stroke, text)`.
+///
+/// `color` is the resolved branch color and `emphasis` the resolved role color
+/// (`none` when the node has no role). Pass `neutral: true` to get the same
+/// shapes with no color — that is how the measuring pass runs, so it produces
+/// the exact geometry of the drawing pass.
+#let node-paint(spec, depth, color, ink, emphasis, neutral: false) = {
+  let frame = spec.frame
+
+  if frame == "box" {
+    let root = depth == 0
+    return (
+      fill: if neutral { none } else if root { color } else { white },
+      stroke: if root { none } else { 0.8pt + (if neutral { black } else { color }) },
+      text: if neutral { black } else if root { white } else { ink.strong },
+    )
+  }
+  if frame == "underline" {
+    return (
+      fill: none,
+      stroke: (bottom: 1.2pt + (if neutral { black } else { ink.strong })),
+      text: if neutral { black } else { ink.strong },
+    )
+  }
+  if frame == "side-rule" {
+    return (
+      fill: none,
+      stroke: (left: 2pt + (if neutral { black } else { color })),
+      text: if neutral { black } else if emphasis == none { ink.strong } else { emphasis },
+    )
+  }
+  (
+    fill: none,
+    stroke: none,
+    text: if neutral { black } else if emphasis == none { ink.soft } else { emphasis },
+  )
+}
+
+/// Thickness of the edge leaving a node at `depth`. In `"outline"` the stroke
+/// thins out with depth, which reads as a branch tapering into twigs; in
+/// `"boxed"` every edge keeps the same weight.
+#let edge-width(style, depth) = {
+  if style != "outline" { return 1pt }
+  if depth == 0 { 1.4pt } else if depth == 1 { 0.9pt } else { 0.6pt }
+}
+
+/// The node body itself — the one box that gets both measured and drawn.
+/// `width` is `auto` while measuring the natural size, and a fixed length once
+/// the layout knows how wide the node ended up.
+#let node-body(content, spec, paint, font, text-size, width: auto) = box(
+  width: width,
+  fill: paint.fill,
+  stroke: paint.stroke,
+  radius: spec.at("radius", default: 0pt),
+  inset: spec.inset,
+  text(
+    font: font,
+    size: text-size * spec.scale,
+    weight: spec.weight,
+    fill: paint.text,
+  )[#content],
+)

--- a/packages/preview/tidymind/0.2.0/src/tree.typ
+++ b/packages/preview/tidymind/0.2.0/src/tree.typ
@@ -1,0 +1,34 @@
+/// Substitui rótulo vazio por um marcador para não gerar nó nulo.
+#let _nonempty(c) = {
+  if c == [] or c == "" or c == none { [—] } else { c }
+}
+
+/// Normalizes any input into `(content, children, branch, emphasis)`.
+/// Accepts a dictionary carrying `content` (plus optional attributes), or raw
+/// content, which becomes a leaf.
+///
+/// `branch` is the INDEX of a branch color (1..n), for when the caller wants to
+/// override the natural position; `emphasis` is the ROLE of the node. Both
+/// arrive by NAME — the package is never handed a color, it resolves one.
+#let normalize(n) = {
+  if type(n) == dictionary and "content" in n {
+    let children = n.at("children", default: ())
+    return (
+      content: _nonempty(n.content),
+      children: children.map(normalize),
+      branch: n.at("branch", default: none),
+      emphasis: n.at("emphasis", default: none),
+    )
+  }
+  // conteúdo cru → folha
+  (content: _nonempty(n), children: (), branch: none, emphasis: none)
+}
+
+/// Prunes the tree at `max-depth` (root = depth 0). Past the limit, children
+/// are dropped — this is what keeps a runaway tree from growing a huge canvas.
+#let prune(n, max-depth, depth: 0) = {
+  if depth >= max-depth {
+    return (..n, children: ())
+  }
+  (..n, children: n.children.map(c => prune(c, max-depth, depth: depth + 1)))
+}

--- a/packages/preview/tidymind/0.2.0/typst.toml
+++ b/packages/preview/tidymind/0.2.0/typst.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tidymind"
+version = "0.2.0"
+entrypoint = "lib.typ"
+authors = ["Elitus <https://elitus.com.br>", "Pierry A. Pereira <@pierryangelo>"]
+license = "MIT"
+description = "Draw tidy horizontal mind maps with CeTZ"
+repository = "https://github.com/pierryangelo/tidymind"
+keywords = ["mindmap", "mind-map", "diagram", "tree", "cetz"]
+categories = ["visualization"]
+compiler = "0.14.0"
+# Documentation files: kept in the repo and linked from the README, but excluded
+# from the published archive (see docs/tips.md "What to commit? What to exclude?").
+exclude = ["examples", "img"]


### PR DESCRIPTION
Adds tidymind 0.2.0. The package draws horizontal, tidy mind maps on CeTZ, measuring every node before layout so long labels never overlap.

## What is new

- **`style: "outline"`** — an alternative that drops the boxes: the root becomes a heading over a baseline rule, first-level branches rest on a rule in their own color, and deeper nodes are plain text. Useful when the map sits inside a document and frames would fight with the surrounding text.
- **`branch` and `emphasis` on `node`** — a caller marks a node's role (`highlight`, `warning`, `definition`, `example`) or overrides its branch color *by name*, and the package resolves the color. `ink` and `emphasis-colors` on `mindmap` make those names configurable.
- **A measurement that matches the drawing.** Measuring and drawing were two hand-mirrored functions in two files, and an emphasized node ended up measured in `regular` but drawn in `semibold` — the label outgrew the box the layout had reserved for it and hyphenated inside it. Both passes now go through a single `node-body` in `src/style.typ`, and `examples/_assert_style.typ` asserts that what the layout reserves equals what the drawing emits, for every style, depth and emphasis.

## Compatibility

The default is unchanged: `style: "boxed"` renders exactly what 0.1.1 renders. I verified this by compiling the four examples published with 0.1.1 against both versions and comparing the rendered PNGs — they are byte-for-byte identical.

## Notes for review

- The `authors` field changes from "Fora da Curva" to "Elitus". This is a rebrand of the same entity, not a change of maintainer; `Pierry A. Pereira <@pierryangelo>`, the author of 0.1.1, is unchanged and is submitting this version.
- README images are served from the package repository over absolute URLs pinned to the `v0.2.0` tag, so they add nothing to the archive.
- `examples/` is committed but excluded from the archive. Files named `visual_*` produce the README images; files named `_assert_*` exercise the logic through `#assert`, so compiling them is the test suite. All 16 compile.