### PR TITLE
Clarify LICENSE and allowed Markdown

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -37,7 +37,8 @@ page should only have a single `<h1>` tag for accessibility and SEO reasons, and
 Typst Universe already shows the name of the package in such a heading.
 
 Also note that some Markdown extensions that are present on GitHub, like
-[alert blocks] or [emoji shortcodes] are not available on Typst Universe.
+[alert blocks], [emoji shortcodes], or [task lists] are not available on
+Typst Universe.
 
 ## Theme-responsive images
 
@@ -56,3 +57,4 @@ using the following snippet:
 [what to exclude]: tips.md#what-to-commit-what-to-exclude
 [alert blocks]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
 [emoji shortcodes]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#using-emojis
+[task lists]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -10,7 +10,8 @@ licenses, it should be stated clearly (in your README for example) which license
 applies to which file.
 
 In addition to specifying the license in the TOML manifest, a package must
-either contain a `LICENSE` file or link to one in its `README.md`.
+either contain a `LICENSE` file (not `LICENSE.txt` or other names) or link
+to one in its `README.md`.
 
 *Additional details for template packages:* If you expect the package
 license's provisions to apply to the contents of the template directory (used


### PR DESCRIPTION
From https://github.com/typst/packages/pull/5533#pullrequestreview-4897810736:

> Regarding the `.txt` or `.md` extensions for license files and the lack of support for GFM tasks lists, do you think adding this information in the docs would have helped you to avoid these mistakes? If so, feel free to make a PR to add that :) Otherwise, what would have helped?