### PR TITLE
zero:0.7.0

### DIFF
--- a/packages/preview/zero/0.7.0/LICENSE
+++ b/packages/preview/zero/0.7.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Mc-Zen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/zero/0.7.0/README.md
+++ b/packages/preview/zero/0.7.0/README.md
@@ -1,0 +1,617 @@
+# $Z\cdot e^{ro}$
+
+_Precise scientific number and unit formatting for Typst._
+
+[![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fzero%2Fv0.7.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/zero)
+[![Test Status](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/zero/blob/main/LICENSE)
+
+
+- [Introduction](#introduction)
+- [Quick Demo](#demo)
+- [**Number Formatting**](#number-formatting)
+- [**Table Number Alignment**](#table-alignment)
+- [**Units and Quantities**](#units-and-quantities)
+- [Accessibility](#accessibility)
+- [Zero for Third-Party Packages](#zero-for-third-party-packages)
+- [Changelog](#changelog)
+
+---
+
+## Introduction
+
+Proper number formatting is essential for clear and readable scientific documents. **Zero** provides tools for consistent formatting and simplifies adherence to established publication standards. Key features include:
+
+- Standardized formatting
+- [**Unit and quantity formatting**](#units-and-quantities)
+- Plug-and-play number [**alignment in tables**](#table-alignment)
+- Symmetric and asymmetric [**uncertainties**](#specifying-uncertainties)
+- Quick scientific notation, e.g., `"2e4"` becomes $2\times10^4$
+- [**Rounding**](#rounding) in various modes
+- Digit [**grouping**](#grouping), e.g., $`299\,792\,458`$ instead of $299792458$
+- [**Accessibility**](#accessibility) through auto-generated alt descriptions for numbers and units
+
+A number in scientific notation consists of three parts: the _mantissa_, an optional _uncertainty_, and an optional _power_ (exponent). The following figure illustrates the anatomy of a formatted number:
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/a78ff9a4-eb90-44b4-9168-37d100452363">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/feb578b1-9c8b-43e6-a825-fe0f57fd2d9b">
+    <img alt="Anatomy of a formatted number" src="https://github.com/user-attachments/assets/a78ff9a4-eb90-44b4-9168-37d100452363">
+  </picture>
+</p>
+
+<!-- For generating formatted numbers, *Zero* provides the `num` type along with the types `coefficient`, `uncertainty`, and `power` that allow for fine-grained customization with `show` and `set` rules.  -->
+
+---
+
+## Demo
+
+```typ
+#import "@preview/zero:0.7.0": num, format-table, zi
+
+Physicists estimate a number of #num[1e80] particles in the observable universe. 
+
+#figure({
+  show: format-table(none, auto)
+  table(
+    columns: 2,
+    [1], [1.2], 
+    [2], [2], 
+    [3], [300]
+  )
+})
+
+#let Js = zi.declare("J s")
+Plancks constant is roughly #Js[6.626e-34]. 
+```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/43d6e3e2-339c-44ba-bc5a-3985be6488a5">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/e9668164-d476-4f9d-ac1d-5ed5bd2c85fe">
+    <img alt="Quick demo" src="https://github.com/user-attachments/assets/43d6e3e2-339c-44ba-bc5a-3985be6488a5">
+  </picture>
+</p>
+
+See below for a few examples of the syntax that can be used with `num`. 
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/1331bf62-530d-423e-9052-2483cb641718">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/eebc2676-ad22-4a97-a21b-09517251f14e">
+    <img alt="num syntax overview" src="https://github.com/user-attachments/assets/1331bf62-530d-423e-9052-2483cb641718">
+  </picture>
+</p>
+
+---
+
+## Number Formatting
+
+- [Function `num`](#num)
+- [Grouping](#grouping)
+- [Rounding](#rounding)
+- [Uncertainties](#specifying-uncertainties)
+
+### `num`
+
+Zero's core is the `num()` function, which provides flexible number formatting. Its defaults can be configured via `set-num()`. 
+
+```typ
+#num(
+  number:                 str | content | int | float | dictionary | array,
+  digits:                 auto | int = auto,
+  exponent:               auto | str = auto,
+
+  decimal-separator:      str = ".",
+  product:                content = sym.times,
+  tight:                  bool = false,
+  breakable:              bool | dict = false,
+  math:                   bool = true,
+
+  omit-unity-mantissa:    bool = false,
+  omit-zero-exponent:     bool = false,
+  positive-sign:          bool = false,
+  positive-sign-exponent: bool = false,
+  trim-zeros:             bool = false,
+
+  base:                   int | content = 10,
+  uncertainty-mode:       str = "separate",
+  round:                  dictionary,
+  group:                  dictionary,
+
+  alt:                    auto | dictionary | string | none = auto,
+)
+```
+- `number: str | content | int | float | array` : Number input; `str` is preferred. If the input is `content`, it may only contain text nodes. Numeric types `int` and `float` are supported but not encouraged because of information loss (e.g., the number of trailing "0" digits or the exponent). The remaining types `dictionary` and `array` are intended for advanced use, see [below](#zero-for-third-party-packages).
+- `digits: auto | int = auto` : Truncates the number at a given (positive) number of decimal places or pads the number with zeros if necessary. This is independent of [rounding](#rounding).
+- `exponent: auto | str = auto` : Controls the value of the exponent. Possible values are
+  - `auto` : The exponent is taken to be the _input exponent_, e.g., `5` for `num[1e5]`. 
+  - `"sci"` : The exponent is chosen according to scientific notation. Use `(sci: n)` to activate scientific notation only when the absolute of the exponent is at least `n` or `(sci: (min, max))` to activate scientific notation only when the exponent is less or equal to `min` or greater or equal to `max`. 
+  - `"eng"` : The exponent chosen according to engineering notation, that is the exponent is a multiple of three and the integer part is never zero. 
+  - `(fixed: n)` : The exponent is fixed to the given integer. 
+- `decimal-separator: str = "."` : Specifies the marker that is used for separating integer and decimal part.
+- `product: content = sym.times` : Specifies the multiplication symbol used for scientific notation. 
+- `tight: bool = false` : If true, tight spacing is applied between operands (applies to $\times$ and $\pm$). 
+- `breakable: bool | dict` : Whether numbers and quantities can be broken across paragraph lines. Setting this to `true`/`false` entirely enables/disables breaking. For more fine-grained control, a dictionary with the keys `uncertainty`, `power`, and `unit` (all booleans) can be passed for specifying whether breaks are allowed after the ± symbol, the × symbol, or before the unit, respectively. 
+- `math: bool = true` : If set to `false`, the parts of the number won't be wrapped in a `math.equation`. This makes it possible to use `num()` with non-math fonts.
+- `omit-unity-mantissa: bool = false` : Determines whether a mantissa of 1 is omitted in scientific notation, e.g., $10^4$ instead of $1\cdot 10^4$. 
+- `omit-zero-exponent: bool = false` : Determines whether a power with an exponent of 0 is omitted.  
+- `positive-sign: bool = false` : If set to `true`, positive coefficients are shown with a $+$ sign. 
+- `positive-sign-exponent: bool = false` : If set to `true`, positive exponents are shown with a $+$ sign. 
+- `trim-zeros: bool = false` : If set to `true`, trailing zeros are trimmed from the fractional part of the number. By default, they are kept in order to preserve the given input precision but especially for `float` input and automatic exponents, such as scientific notation, it can be useful to trim any trailing zeros. [Rounding](#rounding) is applied after trimming.
+- `base: int | content = 10` : The base used for scientific power notation. 
+- `uncertainty-mode: str = "separate"` : Selects one of the modes `"separate"`, `"compact"`, or `"compact-separator"` for displaying uncertainties. The different behaviors are shown below:
+
+  <p align="center">
+    <picture>
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/b7f5b106-efd5-477a-8299-c8daacdbd6e4">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/9afc2776-b9a2-4c2a-abc7-c453727f36ea">
+      <img alt="Uncertainty modes" src="https://github.com/user-attachments/assets/b7f5b106-efd5-477a-8299-c8daacdbd6e4">
+    </picture>
+  </p>
+
+- `round: dictionary` : You can provide one or more rounding options in a dictionary. Also see [rounding](#rounding). 
+- `group: dictionary` : You can provide one or more grouping options in a dictionary. Also see [grouping](#grouping). 
+- `alt: auto | dictionary | str | none` : The alt description for the number, as read by a screen reader. If set to `auto` and if the document language is supported, the description is generated automatically. By passing a dictionary with the keys `plus`, `minus`, `times`, `power`, and `decimal-separator` you can override the translations for these parts (the meaning of these keys is explained in the [language contribution guide][language contribution guide]). The alt description can also be set manually per number instance. Also see [accessibility](#accessibility). 
+
+Configuration example: 
+```typ
+#set-num(product: math.dot, tight: true)
+```
+
+### Grouping
+
+
+Digit grouping is important for keeping large figures readable. It is customary to separate thousands with a thin space, a period, comma, or an apostrophe (however, we do not recommend using a period or a comma to avoid confusion since both are used for decimal separators in various countries). 
+
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f900e134-b1d9-482f-b2c2-3100cad38793">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/67e8516f-98d5-4678-8af0-b2a8786da507">
+    <img alt="Digit grouping" src="https://github.com/user-attachments/assets/f900e134-b1d9-482f-b2c2-3100cad38793">
+  </picture>
+</p>
+
+
+Digit grouping can be configured with the `set-group()` function. 
+
+
+```typ
+#set-group(
+  size:       int = 3, 
+  separator:  content = sym.space.thin,
+  threshold:  int | dictionary = 5
+)
+```
+- `size: int = 3` : Determines the size of the groups. 
+- `separator: content = sym.space.thin` : Separator between groups. 
+- `threshold: int | dictionary = 5` : Necessary number of digits needed for digit grouping to kick in. Four-digit numbers for example are usually not grouped at all since they can still be read easily. This parameter also accepts dictionary arguments of the form `(integer: int, fractional: int)` to allow turning on grouping for only the integer or fractional part, for example `(integer: 5, fractional: calc.inf)`. 
+
+
+
+Configuration example: 
+```typ
+#set-group(separator: "'", threshold: 4)
+```
+
+Set `threshold: calc.inf` to disable grouping.
+
+
+
+### Rounding
+
+Rounding can be configured with the `set-round()` function. 
+
+Numbers with an uncertainty are by default (`round.follow-uncertainty: true`) rounded to the precision of the uncertainty − we call this _automatic rounding_. If no uncertainty is present or `round.follow-uncertainty: false`, _manually rounding_ is applied according to the options `mode` and `precision`.
+
+In the second case, there is no guarantee that value and uncertainty have the same number of digits.
+
+```typ
+#set-round(
+  follow-uncertainty:    bool = true,
+  uncertainty-precision: auto | int | dictionary = auto,
+  mode:                  str = "places",
+  precision:             int | auto = auto,
+  pad:                   bool = true,
+  direction:             str = "nearest",
+  ties:                  str = "away-from-zero"
+)
+```
+- `follow-uncertainty: bool = true` : If `true`, round to match the uncertainty (if present) instead of rounding to a fixed precision.
+- `uncertainty-precision: auto | int | dictionary = auto` : 
+  - `auto` : The uncertainty is left as-is. 
+  - `int` : The number of significant figures to round the uncertainty to. 
+  - `(places: int)` : The number of decimal places to round the uncertainty to.
+- `mode: str = "places"` : Sets the fixed appendrounding mode. The possible options are
+  - `"places"` : The number is rounded to the number of decimal places given by the `precision` parameter. 
+  - `"figures"` : The number is rounded to a number of significant figures given by the `precision` parameter.
+- `precision: int | auto = auto` : The precision to round to. Also see parameter `mode`. When set to `auto`, no rounding is applied. 
+- `pad: bool | int = true` : Whether to pad the number with zeros if the 
+   number has fewer digits than the rounding precision. When an integer is passed, it defines the minimum number of decimal digits to display 
+   for `mode: "places"` and the minimum number of significant figures for `mode: "figures"`. 
+- `direction: str = "nearest"` : Sets the rounding direction. 
+  - `"nearest"`: Rounding takes place in the usual fashion, rounding to the nearer 
+    number, e.g., 2.3 → 2 and 2.6 → 3. 
+  - `"towards-infinity"`: Always round up, e.g., 2.3 → 3 and −2.3 → -2. 
+  - `"towards-negative-infinity"`: Always round down, e.g., 2.8 → 2 and −2.8 → −3. 
+  - `"towards-zero"`: Round towards zero, e.g., 2.8 → 2 and −2.8 → −2. 
+  - `"away-from-zero"`: Round away from zero, e.g., 2.3 → 3 and −2.3 → −3. 
+- `ties: str = "away-from-zero"` : How to round ties, i.e., when the digit at the rounding position is 5. 
+  - `"away-from-zero"`: Always round ties away from zero. This is also the behavior of `calc.round`. 
+  - `"towards-zero"`: The opposite of `"away-from-zero"`, always round ties towards zero. 
+  - `"towards-infinity"`: Always round ties up, towards infinity, e.g., 12.5 → 13 and −12.5 → −12. 
+  - `"towards-negative-infinity"`: Always round ties down, towards negative infinity, e.g., 12.5 → 12 and −12.5 → −13. 
+  - `"to-even"`: Round to the nearest even number, e.g., 12.5 → 12 and 13.5 → 14. This is the default rounding mode used in IEEE 754 floating point operations. 
+  - `"to-odd"`: Round to the nearest odd number, e.g., 12.5 → 13 and 13.5 → 13. 
+
+
+### Specifying Uncertainties
+
+There are two ways of specifying uncertainties:
+- Applying an uncertainty to the least significant digits using parentheses, e.g., `2.3(4)`,
+- Denoting an absolute uncertainty, e.g., `2.3+-0.4` becomes $2.3\pm0.4$. 
+
+Zero supports both and can convert between these two, so that you can pick the displayed style (configured via `uncertainty-mode`, see above) independently of the input style. 
+
+How do uncertainties interplay with exponents? The uncertainty needs to come first, and the exponent applies to both the mantissa and the uncertainty, e.g., `num("1.23+-.04e2")` becomes
+
+$$ (1.23\pm0.04)\times 10^2. $$
+
+Note that the mantissa is now put in parentheses to disambiguate the application of the power. 
+
+In some cases, the uncertainty is asymmetric which can be expressed via `num("1.23+0.02-0.01")`
+
+$$ 1.23^{+0.02}_{-0.01}. $$
+
+---
+
+## Table Alignment
+
+In scientific publication, presenting many numbers in a readable fashion can be a difficult discipline. A good starting point is to align numbers in a table at the decimal separator. With Zero, this can be easily accomplished by simply applying a show-rule to `table`. 
+
+
+```typ
+#{
+  show table: zero.format-table(none, auto, auto)
+  table(
+    columns: 3,
+    align: center,
+    $n$, $α$, $β$,
+    [1], [3.45], [-11.1],
+    ..
+  )
+}
+```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f964e693-b65a-43c5-81ce-e37a3122bea8">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/cf708395-ecea-49d4-bf67-d1acad0261ec">
+    <img alt="Number alignment in tables" src="https://github.com/user-attachments/assets/f964e693-b65a-43c5-81ce-e37a3122bea8">
+  </picture>
+</p>
+
+Arguments to `format-table` are `none`, `auto`, or dictionaries (see [below](#advanced-table-options)) that turn on or off number alignment for individual columns. In the example above, we activate number alignment for the second and third column. 
+
+Be careful to scope the show-rule with curly `{}` or square `[]` brackets to avoid applying the rule twice when changing format for the next table. You can use this in your figures in the following way:
+```typ
+#figure(
+  {
+    show table: zero.format-table(..)
+    table(..)
+  },
+  caption: []
+)
+```
+Through this show-rule, Zero can interoperate seamlessly with many other table packages for Typst. 
+
+Nevertheless, Zero also provides the function `ztable` that you can use as a drop-in replacement for the standard table function. It features an additional parameter `format` which takes an array of `none`, `auto`, or `dictionary` values to turn on number alignment for specific columns. With `ztable` the above example can be recreated like this:
+```typ
+#ztable(
+  columns: 3,
+  align: center,
+  format: (none, auto, auto),
+  $n$, $α$, $β$,
+  [1], [3.45], [-11.1],
+  ..
+)
+```
+
+### Protect Non-Numerical Content
+
+Non-number entries (e.g., in the header) are automatically recognized in some cases and will not be aligned. In ambiguous cases, adding a leading or trailing space tells Zero not to apply alignment to this cell, e.g., `[Angle ]` instead of `[Angle]`. 
+
+
+In addition, you can prefix or suffix a numeral with content wrapped by the function `nonum[]` to mark it as _not belonging to the number_. The remaining content may still be recognized as a number and formatted/aligned accordingly. 
+```typ
+#ztable(
+  format: (auto,),
+  [#nonum[€]123.0#nonum(footnote[A special number])],
+  [12.111],
+)
+```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/337054ef-c7e6-4feb-b5fd-f50e36eb043a">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a1692f23-a8fa-40d0-a7e9-85ad6b74d020">
+    <img alt="Avoid number recognition in tables" src="https://github.com/user-attachments/assets/337054ef-c7e6-4feb-b5fd-f50e36eb043a">
+  </picture>
+</p>
+
+
+### Advanced Table Options
+
+Zero not only aligns numbers at the decimal point but also at the uncertainty and exponent part. Moreover, by passing a `dictionary` instead of `auto`, a set of `num()` arguments to apply to all numbers in a column can be specified. 
+
+```typ
+#ztable(
+  columns: 4,
+  align: center,
+  format: (none, auto, auto, (digits: 1)),
+  $n$, $α$, $β$, $γ$,
+  [1], [3.45e2], [-11.1+-3], [0],
+  ..
+)
+```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/f91004fe-d7ca-4db8-81a1-b65236c72cac">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/e1c8abfe-b59c-4789-a356-df2e545a99c5">
+    <img alt="Advanced number alignment in tables" src="https://github.com/user-attachments/assets/f91004fe-d7ca-4db8-81a1-b65236c72cac">
+  </picture>
+</p>
+---
+
+## Units and Quantities
+
+Numbers are frequently displayed together with a (physical) unit forming a so-called _quantity_. Zero has built-in support for formatting quantities through two different philosophies.
+<!-- the `zi` module.  -->
+
+<!-- Zero takes a different approach to units than other packages: -->
+### 1. The `quan` function
+The function `quan` 
+Similar to `num`, the function `quan` takes one argument, specifying a value and a unit − or just one of them. A few examples:
+- `quan[1.2 m/s]` - the space is optional
+- `quan[-2.0+-.4e3 m/s]` - the value works just like `num`
+- `quan[GHz]` - units can also go without a value
+- `quan[600us]` - "u" is changed to "µ"
+
+The precise syntax for specifying units is explained in the next section.
+Units of the SI system and units that may be used in compliance with the SI system are automatically recognized and annotated with alt descriptions, see also [accessibility](#accessibility) below.
+
+
+### 2. Predefined units
+
+In order to avoid repetition ([DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)) and to avoid accidental errors, every unit can be
+- first _declared_ (or already predefined)
+- and then used as a function to produce a quantity. 
+
+Take a look at the example below:
+```typ
+#import "@preview/zero:0.7.0": zi
+
+#let kgm-s2 = zi.declare("kg m/s^2")
+
+- The current world record for the 100 meters is held by Usain Bolt with #zi.s[9.58]. 
+- The velocity of light is #zi.m-s[299792458].
+- A Newton is defined as #kgm-s2[1]. 
+- The unit of a frequency is #zi.Hz(). 
+```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/45597707-323a-4cc2-b331-07daf5ec64c4">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/06768121-e130-40e6-87b3-14a3f1f0372d">
+    <img alt="Units and quantities" src="https://github.com/user-attachments/assets/45597707-323a-4cc2-b331-07daf5ec64c4">
+  </picture>
+</p>
+
+
+#### Declaring a New Unit
+
+All common single units as well as a few frequent combinations are already predefined in the `zi` module (e.g., `zi.m`, `zi.V`, `zi.m-s`). 
+
+You can create a new unit through the `zi.declare` function. We recommend the following naming convention to uniquely assign a variable name to the unit. 
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/c0c6b280-d53e-4b4f-a719-5f86001c326e">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/761fe5c4-ee2c-49e1-b438-f0589104b06c">
+    <img alt="Declaring new units" src="https://github.com/user-attachments/assets/c0c6b280-d53e-4b4f-a719-5f86001c326e">
+  </picture>
+</p>
+
+For most units, it will suffice to use the string unit syntax shown above because mostly Latin letters are used. For the µ symbol, you can write "mu", as in `zi.declare("mus")` for microseconds. 
+
+If you need to build more complex units, consisting of symbols, math, or other content, you can use the alternative construction method. Here, each base unit is passed as a positional argument to `zi.declare`: either just the content if (the exponent is 1) or a pair of content and exponent. 
+```typ
+#zi.declare($M_dot.o$, ("s", -2))
+```
+
+
+### Configuring Units
+The appearance of units can be configured via `set-unit`:
+```typ
+#set-unit(
+  unit-separator:  content = sym.space.thin,
+  fraction:        str = "power",
+  prefix:          auto | none = auto
+)
+```
+- `unit-separator: content` : Configures the separator between consecutive unit parts in a composite unit. 
+- `fraction: str` : Configures the appearance of fractions when there are units present in the denominator. Possible options are
+  - `"power"` : Units with negative exponents are shown as powers. 
+  - `"fraction"` : When units with negative exponents are present, a fraction is created and the concerned units are put in the denominator. 
+  - `"inline"` : An inline fraction is created. 
+- `prefix: auto | none` : When set to `auto` and `num.exponent` is set to `"eng"`, a metric prefix is displayed along with the unit, replacing the exponent, e.g., `zi.m[2e4]` will render as 20km. 
+
+These options are also available when instancing a quantity, e.g., `#zi.m(fraction: "inline")[2.5]`. 
+
+Note that the configuration made through `set-num` also affects the numeral of a quantity. 
+
+For supported languages, an automatic alt description is generated for accessibility. A manual description can be specified per unit/quantity through the `alt` parameter, e.g., `zi.m(alt: "meter")`. This is especially necessary for custom units that are not part of the SI system or recommended to be used in compliance with the SI system, e.g., `(zi.declare("yard", alt: "yard"))`.
+
+
+### Lower and upper case liter
+
+By default, the symbol for liter is an uppercase L. In order to display a lowercase l, use the unit option `lowercase-liter`.
+```typ
+#set-unit(lowercase-liter: true)
+```
+
+
+---
+
+## Accessibility
+
+Zero generates accessible output! Numbers, units, and quantities that are formatted with Zero have automatically generated alt descriptions that specify how a screen reader should read them.
+
+This is supported for a selection of languages (currently: English, German, French, Spanish, Italian, Finnish, and Slovenian) and you can extend this selection by opening a PR and providing the necessary translations for the new language. When opening a PR, please read the [language contribution guide][language contribution guide] first.
+
+
+
+---
+
+## Zero for Third-party Packages
+
+This package provides some useful extras for third-party packages that generate formatted numbers (for example graphics libraries). 
+
+Instead of passing a `str` to `num()`, it is also possible to pass a dictionary of the form
+```typ
+(
+  mantissa:  str | int | float,
+  e:         none | str,
+  pm:        none | array
+)
+```
+This way, parsing the number can be avoided which makes especially sense for packages that generate numbers (e.g., tick labels for a diagram axis) with independent mantissa and exponent. 
+
+Furthermore, `num()` also allows `array` arguments for `number` which allows for more efficient batch-processing of numbers with the same setup. In this case, the caller of the function needs to provide `context`. 
+
+To accept `num` or `qty` as arguments for package functions, the underlying raw data can be accessed by calling the `impl.utility.retrieve-metadata` function. Manipulating this data will not change what content is drawn, but allows reasoning about the values and units. The info dictionary contains all the relevant information for the numeral and `impl.utility.info-to-float` converts these values to float numbers.
+
+Creating _Zero_-equivalent number and quantity metadata should only be done when the content is contextually equivalent to the outputs from the num and qty functions, this can be done using the `impl.utility.create-qty-metadata` and `create-num-metadata` functions.
+
+_Zero_ features powerful accessibility descriptions for numbers. If your package displays numbers in any way, even if not using the _Zero_ package it may still be useful to generate description strings from numbers. `impl.accessibility.generate-num-alt-description` accepts a number info dictionary which can be created manually or from `impl.parsing.parse-numeral`.
+
+Lastly, the function `align-columns` can be used to format and align an array of numerals into a single column. The returned array of items can be used to fill a column of a `table` or `stack`. Also, here the caller of the function needs to provide `context`. 
+
+
+## Changelog
+
+### Version 0.7.0
+
+Features:
+- The new `quan` function provides a new way of defining quantities and units.
+- Zero now adds alt descriptions for all numbers and units for supported languages, see [Accessibility](#accessibility). New translations are work, see the [language contribution guide][language contribution guide].
+
+Rounding:
+- ⚠️ Breaking change: the rounding API was changed to a more comprehensible model and to better reflect common applications. Numbers with an uncertainty are by default (`round.follow-uncertainty: true`) rounded to the precision of the uncertainty − we call this _automatic rounding_. If no uncertainty is present or `round.follow-uncertainty: false`, _manually rounding_ is applied according to the options `mode` and `precision`. The `mode: "uncertainty"` has been removed.
+- ⚠️ Breaking change: zeros are now trimmed after rounding and padding is independent. This leads to the following effect of change:
+  - Before: `num(round: (precision: 2, pad: false)[0.299]` -> 0.30
+  - Now: `num(round: (precision: 2, pad: false)[0.299]` -> 0.3 
+- Fixed a bug where rounding to zero were for negative precision led to multiple zeros being displayed in the integer part.
+- Fixed rounding to negative (integer) places.
+- Fixed rounding of 0 to a positive number of significant figures: now no trailing zeros are displayed anymore.
+
+Input:
+- Added support for capital E in exponent notation.
+
+Formatting:
+- New option `num.trim-zeros` for trimming trailing zeros.
+- New option `num.omit-zero-exponent`.
+- Fixed: Automatic exponents with scientific or engineering notation are now omitted when the mantissa is 0 and no explicit exponent is given.
+- Fixed prevention of line breaks and add more fine-grained line break control: after the ×, after the ± and before the unit.
+- ⚠️ Breaking change: moved the parameter `breakable` from `set-unit` to `set-num` since it now also affects numbers.
+- Fixed `num.use-sqrt` with inline fraction mode.
+- Fixed formatting of exponents with custom decimal separators.
+- Fixed an error with scientific mode with asymmetric uncertainties.
+- Fixed a tiny detail when formatting the decimal separator.
+
+
+API:
+- Added queryable metadata to numbers and units, see [here](#zero-for-third-party-packages).
+- Moved the internal `num-state` to the impl module.
+
+### Version 0.6.1
+- Fixed dictionary input for 3rd-party packages. 
+- Fixed `math` parameter in unit arguments. 
+- Added more common combined units like `zi.m-s2`, `zi.g-cm^3`, `zi.kg-m^3`, `zi.J-K` and many more. 
+
+### Version 0.6.0
+_Exponent modes and rounding improvements_
+
+Exponents:
+- ⚠️ Breaking Change: Removes the parameter `num.fixed` which is now replaced by the exponent mode `fixed` (see below). 
+- Adds new exponent modes: 
+  - `auto` for standard formatting, 
+  - `"sci"` for automatic scientific notation, 
+  - `(fixed: n)` for fixing the exponent to a specific value, and 
+  - `"eng"` for automatic engineering notation. 
+- Improves rendering of exponents for `math: true` to guarantee a look just like the number was generated by hand with an equation.
+
+Rounding:
+- ⚠️ Breaking Change: Renames rounding modes `"down"` to `"towards-negative-infinity"` and `"up"` to `"towards-infinity"`. 
+- Adds an option `round.ties` to configure the behavior for rounding the digit 5. 
+- Adds two new rounding directions `"towards-zero"` and `"away-from-zero"`. 
+- Adds support for padding with a minimum number of digits when rounding. 
+- Fixes rounding when no integer part is given (like `num[.5]`). 
+
+Units:
+- Fixes spacing with angle units (there should be no space between the number and an angle unit). 
+- ⚠️ Breaking Change: The unit alternatives with British spelling `zi.metre` and `zi.litre` have been removed for consistency and to avoid confusion. 
+- Adds an option `unit.lowercase-liter` that enables a lower case symbol for the unit liter. 
+
+Miscellaneous:
+- Fixes parsing of `[#""]` values in formatted tables. 
+
+
+### Version 0.5.0
+_Unit and rounding improvements_
+- Adds a new unit construction method that allows for more complex units involving math, symbols or basically anything. 
+- ⚠️ Breaking Change: The rounding setup has been streamlined. The `mode` can no longer be `none`, instead it defaults to `"places"` while the default precision is `none` meaning that no rounding is applied. This is more convenient when rounding single numbers (e.g., `num(round: (precision: 2))[9.80665]`) because the mode does not have to be set repeatedly. 
+- Fixes an issue with non-breakable units and quantities.
+
+### Version 0.4.0
+_Units and quantities_
+- Adds the `zi` module for unit and quantity formatting. 
+- Adds new way of applying table alignment via show-rules for seamless interoperability with other table packages. 
+- Adds option to configure the group threshold individually for the integer and fractional part. 
+- Fixes numbers in RTL direction context. 
+- Fixes `figure.kind` detection of`ztable`. 
+- Fixes direct usage of `nonum` in `ztable`. 
+- Fixes uncertainties in combination with a `fixed` exponent. 
+
+### Version 0.3.3
+_Fix_
+- Fixes an issue with negative numbers in parentheses due to a change in Typst 0.13. 
+
+### Version 0.3.2
+_Fixes and more helpers for third-party package developers_
+- Adds `align-columns` for package developers. 
+- Fixes issues arising for Typst 0.13.
+
+### Version 0.3.1 
+_Improvements for tables and math-less mode_
+- Fixes `show` rules with `table.cell` for number-aligned cells. 
+- Improves `math: false` mode: Formatting can now be handled entirely without equations which makes it possible to use Zero with fonts without math support. 
+- Improves number recognition in tables. A number now needs to start with one of `0123456789+-,.`. This gets rid of many false positives (mostly encountered in header cells). 
+
+### Version 0.3.0
+_Support for non-numerical content in number cells_
+- Adds `nonum[]` function that can be used to mark content in cells as _not belonging to the number_. The remaining content may still be recognized as a number and formatted/aligned accordingly. The content wrapped by `nonum[]` is preserved. 
+- Fixes number alignment tables with new version Typst 0.12. 
+
+### Version 0.2.0 
+_Performance and math-less mode_
+- Adds support for using non-math fonts for `num` via the option `math`. This can be activated by calling `#set-num(math: false)`. 
+- Performance improvements for both `num()` and `ztable(9)`.
+
+### Version 0.1.0
+_Initial release_
+
+
+[language contribution guide]: https://github.com/Mc-Zen/zero/blob/v0.7.0/docs/language-contribution-guide.md

--- a/packages/preview/zero/0.7.0/README.md
+++ b/packages/preview/zero/0.7.0/README.md
@@ -1,6 +1,3 @@
-# $Z\cdot e^{ro}$
-
-_Precise scientific number and unit formatting for Typst._
 
 [![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fzero%2Fv0.7.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/zero)
 [![Test Status](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml)
@@ -26,18 +23,19 @@ Proper number formatting is essential for clear and readable scientific document
 - [**Unit and quantity formatting**](#units-and-quantities)
 - Plug-and-play number [**alignment in tables**](#table-alignment)
 - Symmetric and asymmetric [**uncertainties**](#specifying-uncertainties)
-- Quick scientific notation, e.g., `"2e4"` becomes $2\times10^4$
+- Quick scientific notation, e.g., `"2e4"` becomes 2×10²
 - [**Rounding**](#rounding) in various modes
-- Digit [**grouping**](#grouping), e.g., $`299\,792\,458`$ instead of $299792458$
+- Digit [**grouping**](#grouping), e.g., 299 792 458 instead of 299792458
 - [**Accessibility**](#accessibility) through auto-generated alt descriptions for numbers and units
 
-A number in scientific notation consists of three parts: the _mantissa_, an optional _uncertainty_, and an optional _power_ (exponent). The following figure illustrates the anatomy of a formatted number:
+
+A number in scientific notation consists of three parts: the _mantissa_, an optional _uncertainty_, and an optional _power_ (exponent). Additionally, the number can be followed by a unit. This figure illustrates the anatomy of a formatted quantity:
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/a78ff9a4-eb90-44b4-9168-37d100452363">
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/feb578b1-9c8b-43e6-a825-fe0f57fd2d9b">
-    <img alt="Anatomy of a formatted number" src="https://github.com/user-attachments/assets/a78ff9a4-eb90-44b4-9168-37d100452363">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/5c5572a6-f163-4581-863a-e73335e2b373">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/2ac4f172-4564-4c50-abe7-90889379f80e">
+    <img alt="Anatomy of a formatted number" src="https://github.com/user-attachments/assets/5c5572a6-f163-4581-863a-e73335e2b373">
   </picture>
 </p>
 
@@ -132,13 +130,13 @@ Zero's core is the `num()` function, which provides flexible number formatting. 
   - `(fixed: n)` : The exponent is fixed to the given integer. 
 - `decimal-separator: str = "."` : Specifies the marker that is used for separating integer and decimal part.
 - `product: content = sym.times` : Specifies the multiplication symbol used for scientific notation. 
-- `tight: bool = false` : If true, tight spacing is applied between operands (applies to $\times$ and $\pm$). 
+- `tight: bool = false` : If true, tight spacing is applied between operands (applies to × and ±). 
 - `breakable: bool | dict` : Whether numbers and quantities can be broken across paragraph lines. Setting this to `true`/`false` entirely enables/disables breaking. For more fine-grained control, a dictionary with the keys `uncertainty`, `power`, and `unit` (all booleans) can be passed for specifying whether breaks are allowed after the ± symbol, the × symbol, or before the unit, respectively. 
 - `math: bool = true` : If set to `false`, the parts of the number won't be wrapped in a `math.equation`. This makes it possible to use `num()` with non-math fonts.
-- `omit-unity-mantissa: bool = false` : Determines whether a mantissa of 1 is omitted in scientific notation, e.g., $10^4$ instead of $1\cdot 10^4$. 
+- `omit-unity-mantissa: bool = false` : Determines whether a mantissa of 1 is omitted in scientific notation, e.g., 10⁴ instead of 1·10⁴. 
 - `omit-zero-exponent: bool = false` : Determines whether a power with an exponent of 0 is omitted.  
-- `positive-sign: bool = false` : If set to `true`, positive coefficients are shown with a $+$ sign. 
-- `positive-sign-exponent: bool = false` : If set to `true`, positive exponents are shown with a $+$ sign. 
+- `positive-sign: bool = false` : If set to `true`, positive coefficients are shown with a + sign. 
+- `positive-sign-exponent: bool = false` : If set to `true`, positive exponents are shown with a + sign. 
 - `trim-zeros: bool = false` : If set to `true`, trailing zeros are trimmed from the fractional part of the number. By default, they are kept in order to preserve the given input precision but especially for `float` input and automatic exponents, such as scientific notation, it can be useful to trim any trailing zeros. [Rounding](#rounding) is applied after trimming.
 - `base: int | content = 10` : The base used for scientific power notation. 
 - `uncertainty-mode: str = "separate"` : Selects one of the modes `"separate"`, `"compact"`, or `"compact-separator"` for displaying uncertainties. The different behaviors are shown below:
@@ -251,13 +249,13 @@ In the second case, there is no guarantee that value and uncertainty have the sa
 
 There are two ways of specifying uncertainties:
 - Applying an uncertainty to the least significant digits using parentheses, e.g., `2.3(4)`,
-- Denoting an absolute uncertainty, e.g., `2.3+-0.4` becomes $2.3\pm0.4$. 
+- Denoting an absolute uncertainty, e.g., `2.3+-0.4` becomes 2.3±0.4. 
 
 Zero supports both and can convert between these two, so that you can pick the displayed style (configured via `uncertainty-mode`, see above) independently of the input style. 
 
 How do uncertainties interplay with exponents? The uncertainty needs to come first, and the exponent applies to both the mantissa and the uncertainty, e.g., `num("1.23+-.04e2")` becomes
 
-$$ (1.23\pm0.04)\times 10^2. $$
+ (1.23±0.04)×10².
 
 Note that the mantissa is now put in parentheses to disambiguate the application of the power. 
 
@@ -364,6 +362,8 @@ Zero not only aligns numbers at the decimal point but also at the uncertainty an
     <img alt="Advanced number alignment in tables" src="https://github.com/user-attachments/assets/f91004fe-d7ca-4db8-81a1-b65236c72cac">
   </picture>
 </p>
+
+
 ---
 
 ## Units and Quantities

--- a/packages/preview/zero/0.7.0/README.md
+++ b/packages/preview/zero/0.7.0/README.md
@@ -1,7 +1,7 @@
 
 [![Typst Package](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMc-Zen%2Fzero%2Fv0.7.0%2Ftypst.toml&query=%24.package.version&prefix=v&logo=typst&label=package&color=239DAD)](https://typst.app/universe/package/zero)
 [![Test Status](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml/badge.svg)](https://github.com/Mc-Zen/zero/actions/workflows/run_tests.yml)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/zero/blob/main/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Mc-Zen/zero/blob/0.7.0/LICENSE)
 
 
 - [Introduction](#introduction)

--- a/packages/preview/zero/0.7.0/src/accessibility.typ
+++ b/packages/preview/zero/0.7.0/src/accessibility.typ
@@ -1,0 +1,999 @@
+#import "parsing.typ": content-to-string
+
+#let phrases = (
+  "fallback": (
+    "times": "×",
+    "power": "^",
+    "plus": "+",
+    "minus": "−",
+    "per": "/",
+    "decimal-separator": ".",
+  ),
+  "en": (
+    "times": "times",
+    "power": "to the power of",
+    "plus": "plus",
+    "minus": "minus",
+    "per": "per",
+    "decimal-separator": ".",
+  ),
+  "de": (
+    "times": "mal",
+    "power": "hoch",
+    "plus": "plus",
+    "minus": "minus",
+    "per": "pro",
+    "decimal-separator": ",",
+  ),
+  "fr": (
+    "times": "fois",
+    "power": "à la puissance",
+    "plus": "plus",
+    "minus": "moins",
+    "per": "par",
+    "decimal-separator": ",",
+  ),
+  "es": (
+    "times": "veces",
+    "power": "elevado a",
+    "plus": "más",
+    "minus": "menos",
+    "per": "por",
+    "decimal-separator": ",",
+  ),
+  "it": (
+    "times": "per",
+    "power": "alla potenza di",
+    "plus": "più",
+    "minus": "meno",
+    "per": "per",
+    "decimal-separator": ",",
+  ),
+  "ru": (
+    "times": "на",
+    "power": "в степени",
+    "plus": "плюс",
+    "minus": "минус",
+    "per": "в",
+    "decimal-separator": ",",
+  ),
+  "fi": (
+    "times": "kertaa",
+    "power": "potenssiin",
+    "plus": "plus",
+    "minus": "miinus",
+    "per": "jaettuna",
+    "decimal-separator": ",",
+  ),
+  "sl": (
+    "times": "krat",
+    "power": "na stopnjo",
+    "plus": "plus",
+    "minus": "minus",
+    "per": "na",
+    "decimal-separator": ",",
+  ),
+)
+
+#let prefixes = (
+  en: (
+    a: "atto",
+    f: "femto",
+    p: "pico",
+    n: "nano",
+    µ: "micro",
+    m: "milli",
+    c: "centi",
+    d: "deci",
+    da: "deca",
+    h: "hecto",
+    k: "kilo",
+    M: "mega",
+    G: "giga",
+    T: "tera",
+    P: "peta",
+    E: "exa",
+  ),
+  // identical prefixes are inherited from English
+  de: (
+    a: "Atto",
+    f: "Femto",
+    p: "Piko",
+    n: "Nano",
+    µ: "Mikro",
+    m: "Milli",
+    c: "Zenti",
+    d: "Dezi",
+    da: "Deka",
+    h: "Hekto",
+    k: "Kilo",
+    M: "Mega",
+    G: "Giga",
+    T: "Tera",
+    P: "Peta",
+    E: "Exa",
+  ),
+  fr: (
+    d: "déci",
+    da: "déca",
+    M: "méga",
+    T: "téra",
+    P: "péta",
+  ),
+  es: (:),
+  ru: (
+    a: "атто",
+    f: "фемто",
+    p: "пико",
+    n: "нано",
+    µ: "микро",
+    m: "милли",
+    c: "санти",
+    d: "деци",
+    da: "дека",
+    h: "гекто",
+    k: "кило",
+    M: "мега",
+    G: "гига",
+    T: "тера",
+    P: "пета",
+    E: "экса",
+  ),
+  it: (
+    k: "chilo",
+    h: "etto",
+  ),
+  fi: (
+    a: "atto",
+    f: "femto",
+    p: "piko",
+    n: "nano",
+    µ: "mikro",
+    m: "milli",
+    c: "sentti",
+    d: "desi",
+    da: "deka",
+    h: "hehto",
+    k: "kilo",
+    M: "mega",
+    G: "giga",
+    T: "tera",
+    P: "peta",
+    E: "eksa",
+  ),
+  sl: (
+    /* inherits femto, nano,
+    centi, deci, kilo, mega,
+    giga, tera, and peta */
+    a: "ato",
+    p: "piko",
+    µ: "mikro",
+    m: "mili",
+    da: "deka",
+    h: "hekto",
+    E: "eksa",
+  ),
+)
+
+#let units = (
+  en: (
+    A: "ampere",
+    au: "astronomical unit",
+    B: "bel",
+    Bq: "becquerel",
+    C: "coulomb",
+    cd: "candela",
+    d: "day",
+    Da: "dalton",
+    dB: "decibel",
+    sym.degree: "degree",
+    sym.degree + "C": "degree Celsius",
+    eV: "electronvolt",
+    F: "farad",
+    g: "gram",
+    Gy: "gray",
+    H: "henry",
+    h: "hour",
+    ha: "hectare",
+    Hz: "hertz",
+    J: "joule",
+    K: "kelvin",
+    kat: "katal",
+    kg: "kilogram",
+    L: "liter",
+    lm: "lumen",
+    lx: "lux",
+    m: "meter",
+    sym.prime: "arc minute",
+    min: "minute",
+    mol: "mole",
+    sym.prime.double: "arc second",
+    N: "newton",
+    Np: "neper",
+    sym.Omega: "ohm",
+    Pa: "pascal",
+    rad: "radian",
+    s: "second",
+    S: "siemens",
+    sr: "steradian",
+    Sv: "sievert",
+    t: "tonne",
+    T: "tesla",
+    V: "volt",
+    W: "watt",
+    Wb: "weber",
+    "%": "percent",
+    "‰": "permille",
+  ),
+  de: (
+    // identical/similar units are inherited from English
+    ha: "Hektar",
+    sym.degree: "Grad",
+    sym.degree + "C": "Grad Celsius",
+    h: "Stunde",
+    min: "Minute",
+    s: "Sekunde",
+    d: "Tag",
+    kg: "Kilogramm",
+    g: "Gramm",
+    dB: "Dezibel",
+    eV: "Elektronvolt",
+    au: "astronomische Einheit",
+    sym.prime.double: "Bogensekunde",
+    sym.prime: "Bogenminute",
+    mol: "Mol",
+    A: "Ampère",
+    B: "Bel",
+    Bq: "Becquerel",
+    C: "Coulomb",
+    cd: "Candela",
+    Da: "Dalton",
+    F: "Farad",
+    Gy: "Gray",
+    H: "Henry",
+    Hz: "Hertz",
+    J: "Joule",
+    K: "Kelvin",
+    kat: "Katal",
+    L: "Liter",
+    lm: "Lumen",
+    lx: "Lux",
+    m: "Meter",
+    N: "Newton",
+    Np: "Neper",
+    sym.Omega: "Ohm",
+    Pa: "Pascal",
+    rad: "Radian",
+    S: "Siemens",
+    sr: "Steradian",
+    Sv: "Sievert",
+    t: "Tonne",
+    T: "Tesla",
+    V: "Volt",
+    W: "Watt",
+    Wb: "Weber",
+    "%": "Prozent",
+    "‰": "Promille",
+  ),
+  fr: (
+    A: "ampère",
+    sym.degree: "degré",
+    sym.degree + "C": "degré Celsius",
+    h: "heure",
+    m: "mètre",
+    min: "minute",
+    s: "seconde",
+    d: "jour",
+    au: "unité astronomique",
+    sym.prime.double: "seconde d'arc",
+    sym.prime: "minute d'arc",
+    decibel: "décibel",
+    eV: "électronvolt",
+    g: "gramme",
+    kg: "kilogramme",
+    l: "litre",
+    Np: "néper",
+    sr: "stéradian",
+    "%": "pour cent",
+    "‰": "pour mille",
+  ),
+  es: (
+    A: "amperio",
+    C: "culombio",
+    sym.degree: "grado sexagesimal",
+    sym.degree + "C": "grado Celsius",
+    eV: "electronvoltio",
+    F: "faradio",
+    g: "gramo",
+    kg: "kilogramo",
+    l: "litro",
+    m: "metro",
+    ha: "hectárea",
+    J: "julio",
+    H: "henrio",
+    Hz: "hercio",
+    mol: "mol",
+    sym.Omega: "ohmio",
+    rad: "radián",
+    sr: "esterorradián",
+    t: "tonelada",
+    V: "voltio",
+    W: "vatio",
+    h: "hora",
+    min: "minuto",
+    s: "segundo",
+    d: "día",
+    au: "unidad astronómica",
+    sym.prime.double: "segundo de arco",
+    sym.prime: "minuto de arco",
+    "%": "por ciento",
+    "‰": "por mil",
+  ),
+  it: (
+    m: "metro",
+    kg: "kilogrammo",
+    g: "grammo",
+    eV: "elettronvolt",
+    sym.degree: "grado",
+    sym.degree + "C": "grado Celsius",
+    h: "ora",
+    min: "minuto",
+    s: "secondo",
+    d: "giorno",
+    rad: "radiante",
+    sr: "steradiante",
+    au: "unità astronomica",
+    sym.prime.double: "secondo d'arco",
+    sym.prime: "minuto d'arco",
+    "%": "per cento",
+    "‰": "per mille",
+  ),
+  fi: (
+    A: "ampeeri",
+    au: "astronominen yksikkö",
+    B: "bel",
+    Bq: "becquerel",
+    C: "coulombi",
+    cd: "kandela",
+    d: "päivä",
+    Da: "dalton",
+    dB: "desibeli",
+    sym.degree: "aste",
+    sym.degree + "C": "Celsiusaste",
+    eV: "elektronivoltti",
+    F: "faradi",
+    g: "gramma",
+    Gy: "gray",
+    H: "henry",
+    h: "tunti",
+    ha: "hehtaari",
+    Hz: "hertsi",
+    J: "joule",
+    K: "kelvin",
+    kat: "katal",
+    kg: "kilogramma",
+    L: "litra",
+    lm: "luumen",
+    lx: "luksi",
+    m: "metri",
+    sym.prime: "kaariminuutti",
+    min: "minuuti",
+    mol: "mooli",
+    sym.prime.double: "kaarisekunti",
+    N: "newton",
+    Np: "neper",
+    sym.Omega: "ohmi",
+    Pa: "pascal",
+    rad: "radiaani",
+    s: "sekunti",
+    S: "siemens",
+    sr: "steradiaani",
+    Sv: "sievertti",
+    t: "tonni",
+    T: "tesla",
+    V: "voltti",
+    W: "watti",
+    Wb: "weber",
+    "%": "prosentti",
+    "‰": "promille",
+  ),
+  sl: (
+    /* inherits bel, dalton,
+    decibel, farad, gram,
+    kelvin, katal, kilogram,
+    liter, lumen, meter,
+    newton, neper, radian,
+    steradian, tesla,
+    and volt */
+    A: "amper",
+    au: "astronomska enota",
+    Bq: "bekerel",
+    C: "kulon",
+    cd: "kandela",
+    d: "dan",
+    sym.degree: "stopinja",
+    sym.degree + "C": "stopinja Celzija",
+    eV: "elektronvolt",
+    Gy: "grej",
+    H: "henri",
+    h: "ura",
+    ha: "hektar",
+    Hz: "herc",
+    J: "džul",
+    lx: "luks",
+    sym.prime: "kotna minuta",
+    min: "minuta",
+    mol: "mol",
+    sym.prime.double: "kotna sekunda",
+    sym.Omega: "om",
+    Pa: "paskal",
+    s: "sekunda",
+    S: "simens",
+    Sv: "sivert",
+    t: "tona",
+    W: "vat",
+    Wb: "veber",
+    "%": "odstotek",
+    "‰": "odtisoček",
+  ),
+)
+
+// Register of the shorthands for special powers that a language has. This
+// can be a string that is appended to the constituent unit (with a space)
+// or a function that takes the translated constituent unit.
+#let power-shorthands = (
+  en: (
+    "2": "squared",
+    "3": "cubed",
+  ),
+  de: (
+    "2": unit => "Quadrat" + lower(unit),
+    "3": unit => "Kubik" + lower(unit),
+  ),
+  fr: (
+    "2": "carré",
+    "3": "cube",
+  ),
+  es: (
+    "2": "al cuadrado",
+    "3": "al cubo",
+  ),
+  it: (
+    "2": "al quadrato",
+    "3": "al cubo",
+  ),
+  fi: (
+    "2": "toiseen",
+    "3": "kolmanteen",
+  ),
+  sl: (
+    "2": "na kvadrat",
+    "3": "na kub",
+  ),
+)
+
+#let finnish-plural-units = (
+  A: "ampeeria",
+  au: "astronomista yksikköä",
+  B: "beliä",
+  Bq: "becquereliä",
+  C: "coulombia",
+  cd: "kandelaa",
+  d: "päivää",
+  Da: "daltonia",
+  dB: "desibeliä",
+  sym.degree: "astetta",
+  sym.degree + "C": "Celsiusastetta",
+  eV: "elektronivolttia",
+  F: "faradia",
+  g: "grammaa",
+  Gy: "graytä",
+  H: "henryä",
+  h: "tuntia",
+  ha: "hehtaaria",
+  Hz: "hertsiä",
+  J: "joulea",
+  K: "kelviniä",
+  kat: "katalia",
+  kg: "kilogrammaa",
+  L: "litraa",
+  lm: "luumenia",
+  lx: "luksia",
+  m: "metriä",
+  sym.prime: "kaariminuuttia",
+  min: "minuuttia",
+  mol: "moolia",
+  sym.prime.double: "kaarisekuntia",
+  N: "newtonia",
+  Np: "neperiä",
+  sym.Omega: "ohmia",
+  Pa: "pascalia",
+  rad: "radiaania",
+  s: "sekuntia",
+  S: "siemensiä",
+  sr: "steradiaania",
+  Sv: "sieverttiä",
+  t: "tonnia",
+  T: "teslaa",
+  V: "volttia",
+  W: "wattia",
+  Wb: "weberiä",
+  "%": "prosentti",
+  "‰": "promille",
+)
+
+// Needed by pluralize when a unit is in a denominator.
+// The unit suffixes are in a form where each word would be preceded by the word "jaettuna" or "divided by".
+#let finnish-denom-units = (
+  A: "ampeerilla",
+  au: "astronomisella yksikköllä",
+  B: "belillä",
+  Bq: "becquerelillä",
+  C: "coulombilla",
+  cd: "kandelalla",
+  d: "päivällä",
+  Da: "daltonilla",
+  dB: "desibelillä",
+  sym.degree: "asteella",
+  sym.degree + "C": "Celsiusasteella",
+  eV: "elektronivoltilla",
+  F: "faradilla",
+  g: "grammalla",
+  Gy: "grayllä",
+  H: "henryllä",
+  h: "tunnilla",
+  ha: "hehtaarilla",
+  Hz: "hertsillä",
+  J: "joulella",
+  K: "kelvinillä",
+  kat: "katalilla",
+  kg: "kilogrammalla",
+  L: "litralla",
+  lm: "luumenilla",
+  lx: "luksilla",
+  m: "metrillä",
+  sym.prime: "kaariminuuttilla",
+  min: "minuutilla",
+  mol: "moolilla",
+  sym.prime.double: "kaarisekunnilla",
+  N: "newtonilla",
+  Np: "neperillä",
+  sym.Omega: "ohmilla",
+  Pa: "pascalilla",
+  rad: "radiaanilla",
+  s: "sekunnilla",
+  S: "siemensillä",
+  sr: "steradiaanilla",
+  Sv: "sievertillä",
+  t: "tonnilla",
+  T: "teslalla",
+  V: "voltilla",
+  W: "watilla",
+  Wb: "weberillä",
+  "%": "prosentilla",
+  "‰": "promillella",
+)
+
+// How to form the plural of a constituent unit. For each language, this should
+// be a function that takes a unit symbol string, e.g. "Hz",
+// and a float `count` which is assumed to be of some plural amount,
+// and a bool `is-in-denom` that specifies whether the unit is placed in the denominator.
+#let pluralize = (
+  en: (unit, count, is-in-denom) => {
+    let singular = units.en.at(unit)
+    if unit in ("lx", "Hz", "S", "%", "‰") {
+      return singular
+    }
+    if unit == sym.degree + "C" {
+      return "degrees Celsius"
+    }
+    if unit == "H" {
+      return "henries"
+    }
+    return singular + "s"
+  },
+
+  de: (unit, count, is-in-denom) => {
+    let singular = units.de.at(unit)
+    if unit in ("h", "min", "s", sym.prime.double, sym.prime, "t", "%", "‰") {
+      return singular + "n"
+    }
+    if unit == "au" {
+      return singular + "en"
+    }
+    if unit == "d" {
+      return singular + "e"
+    }
+
+    return singular
+  },
+
+  fi: (unit, count, is-in-denom) => {
+    if is-in-denom {
+      // Things get more complex here since when in a denominator we need a form of each word where things happen IN something.
+      // Like literally IN one second, or IN one meter. And of course Finnish has a specific suffix for each word for this.
+      // Often this just means adding a "ss" before the last letter of the quantity form of each word but not always.
+      // For example "metriä sekunnissa" means "meters per second" or "meters in one second".
+      return finnish-denom-units.at(unit)
+    } else {
+      return finnish-plural-units.at(unit)
+    }
+  },
+
+  fr: (unit, count, is-in-denom) => {
+    let singular = units.fr.at(unit, default: units.en.at(unit))
+    if unit in ("lx", "Hz", "S", "%", "‰") {
+      return singular
+    }
+    if unit == sym.degree + "C" { return "degrés Celsius" }
+    if unit == sym.prime.double { return "secondes d'arc" }
+    if unit == sym.prime { return "minutes d'arc" }
+    if unit == "au" { return "unités astronomique" }
+    return singular + "s"
+  },
+
+  es: (unit, count, is-in-denom) => {
+    let singular = units.es.at(unit, default: units.en.at(unit))
+    if unit in ("lx", "Hz", "S", "%", "‰") {
+      return singular
+    }
+    if unit == sym.degree + "C" { return "grados Celsius" }
+    if unit == "rad" { return "radianes" }
+    if unit == "sr" { return "esterorradianes" }
+    if (
+      singular.ends-with("o") or singular.ends-with("y") or singular.ends-with("a")
+    ) {
+      return singular + "s"
+    } else {
+      return singular + "es"
+    }
+  },
+
+  it: (unit, count, is-in-denom) => {
+    let singular = units.it.at(unit, default: units.en.at(unit))
+    if unit in ("J", "A", "T", "%", "‰") { return singular }
+    if unit == sym.degree + "C" { return "gradi Celsius" }
+    if unit.ends-with("o") or unit.ends-with("e") {
+      return singular.slice(0, -1) + "i"
+    }
+    if unit.ends-with("a") { return singular.slice(0, -1) + "e" }
+    return singular
+  },
+
+  sl: (unit, count, is-in-denom) => {
+    let singular = units.sl.at(unit, default: units.en.at(unit))
+
+    // This doesn't ruin 1 000, 10 000, 100 000, 1 000 000 ...
+    // Because 0 is plural in the same way as them
+    count = calc.abs(calc.rem(count, 100))
+
+    // Easier keywords
+    let (dual, plural-3-4, is-float) = (
+      count == 2, // Dual
+      count in (3, 4), // Plural for 3 and 4
+
+      // A would-be `plural-5` for 5+ and 0
+      // Is simply an `else` branch instead
+      // count >= 5 or count == 0,
+
+      float == type(count), // Singular genitive for floats
+    )
+
+    // Checks the need for plural despite already supposedly done via `needs-plural()`
+    if calc.abs(count) == 1 and not is-float and not is-in-denom {
+      panic("Attempt to use plural for an integer count of 1")
+    }
+
+    let feminine(word) = {
+      // Denominator rule with a hardcoded `return`
+      if is-in-denom { return word.slice(0, -1) + "o" }
+
+      // When the word is a feminine adjective, so to a feminine noun
+      let adj-role = if word in ("astronomska", "kotna") { "ih" }
+
+      if dual {
+        word.slice(0, -1) + "i"
+      } else if plural-3-4 or is-float {
+        word.slice(0, -1) + "e"
+      } else {
+        word.slice(0, -1) + adj-role
+      }
+    }
+
+    let masculine(word) = {
+      // Denominator rule with a hardcoded `return`
+      if is-in-denom and word == "tesla" { return word.slice(0, -1) + "o" } else if is-in-denom { return word }
+
+      // Different float rule with a hardcoded `return`
+      if word == "tesla" and is-float {
+        return "tesle"
+      }
+
+      if dual or is-float {
+        if word == "dan" {
+          "dneva"
+        } else if word == "henri" {
+          "henrija"
+        } else if word == "lumen" {
+          "lumna"
+        } else if word == "tesla" {
+          "tesli"
+        } else if word.ends-with("ek") {
+          word.slice(0, -2) + "ka"
+        } else if word.ends-with(regex("ber|ter")) {
+          word.slice(0, -2) + "ra"
+        } else {
+          word + "a"
+        }
+      } else if plural-3-4 {
+        if word == "dan" {
+          "dnevi"
+        } else if word == "henri" {
+          "henriji"
+        } else if word == "lumen" {
+          "lumni"
+        } else if word == "tesla" {
+          "tesle"
+        } else if word.ends-with("ek") {
+          word.slice(0, -2) + "ki"
+        } else if word.ends-with(regex("ber|ter")) {
+          word.slice(0, -2) + "ri"
+        } else {
+          word + "i"
+        }
+      } else {
+        if word == "dan" {
+          "dni"
+        } else if word == "henri" {
+          "henrijev"
+        } else if word == "lumen" {
+          "lumnov"
+        } else if word == "tesla" {
+          "tesel"
+        } else if word.ends-with("ek") {
+          word.slice(0, -2) + "kov"
+        } else if word.ends-with(regex("ber|ter")) {
+          word.slice(0, -2) + "rov"
+        } else if word.ends-with(regex("c|j")) {
+          word + "ev"
+        } else {
+          word + "ov"
+        }
+      }
+    }
+
+    // Feminine
+    if unit in ("cd", str(sym.degree), "h", "min", "s", "t") {
+      return feminine(singular)
+    }
+
+    // Masculine
+    if (
+      unit in (
+        "A", "B", "Bq", "C", "d", "Da", "dB", "eV", "F", "g", "Gy", "H", "ha",
+        "Hz", "J", "K", "kat", "kg", "L", "lm", "lx", "m", "mol", "N", "Np",
+        str(sym.Omega), "Pa", "rad", "S", "sr", "Sv", "T", "V", "W", "Wb",
+        "%", "‰",
+      )
+    ) {
+      return masculine(singular)
+    }
+
+    // More, all of which are so far feminine, apart from the C-noun
+    if unit in ("au", str(sym.degree) + "C", str(sym.prime), str(sym.prime.double)) {
+      return singular
+        .split(" ")
+        .map(word => {
+          if word == "Celzija" { word } else { feminine(word) }
+        })
+        .join(" ")
+    }
+
+    // Beware that this error can also appear because `sym.___` or `symbol(sym.___)` isn't the same as the symbol string itself
+    panic("Slovenian translation not updated to support '" + singular + "'?")
+  },
+)
+
+
+// How to join a prefix to a unit. This can be overridden for individual languages.
+#let join-prefix-unit(
+  /// The translated prefix, e.g. "milli"
+  /// -> str
+  prefix,
+
+  /// The translated unit, e.g. "meter".
+  /// -> str
+  unit,
+
+  /// The language code.
+  /// -> str
+  lang,
+) = {
+  if lang == "de" {
+    prefix + lower(unit)
+  } else {
+    prefix + unit
+  }
+}
+
+
+// Check whether a quantity requires the (composed) unit to be in plural. This
+// can be overridden for individual languages.
+#let needs-plural(
+  /// The value of the quantity, e.g. `1.5`.
+  /// -> float
+  value,
+
+  /// The language code.
+  /// -> str
+  lang,
+) = {
+  if lang == "fr" {
+    calc.abs(value) >= 2
+  } else {
+    calc.abs(value) != 1 or type(value) == float
+  }
+}
+
+
+#let base-to-string(base) = {
+  if type(base) == str {
+    return base
+  } else if type(base) in (int, float, symbol) {
+    return str(base)
+  } else if type(base) == content {
+    if base.func() == math.equation {
+      let result = content-to-string(base.body)
+      if result != none {
+        return result
+      }
+    }
+  }
+
+  assert(
+    false,
+    message: "Failed to convert base to string. Please provide a manual alt text for this numeral.",
+  )
+}
+
+#let generate-num-alt-description(info, translation: auto) = {
+  let lang = text.lang
+  if translation == auto {
+    translation = phrases.at(lang, default: phrases.fallback)
+  }
+  let format-comma-number(int, frac) = {
+    if int.len() == 0 {
+      int = "0"
+    }
+    int + if frac.len() > 0 { translation.decimal-separator + frac }
+  }
+
+  let alt = ""
+  alt += if info.sign == "-" { translation.minus + " " }
+  alt += format-comma-number(info.int, info.frac)
+
+  if info.pm != none {
+    if type(info.pm.first()) == array {
+      alt += (
+        " " + translation.plus + " " + format-comma-number(..info.pm.first())
+      )
+      alt += (
+        " " + translation.minus + " " + format-comma-number(..info.pm.last())
+      )
+    } else {
+      alt += (
+        " " + translation.plus + " " + translation.minus + " " + format-comma-number(..info.pm)
+      )
+    }
+  }
+  if info.e != none {
+    alt += (
+      " " + translation.times + " " + base-to-string(info.base) + " " + translation.power + " " + info.e
+    )
+  }
+
+  alt
+}
+
+
+
+
+#let unit-component-description(
+  component,
+  plural: false,
+  count: auto,
+  is-in-denom: false,
+) = {
+  if count == auto {
+    if not plural { count = 1 } else { count = 99 }
+  }
+
+  let lang = text.lang
+  let units = units.en + units.at(lang, default: units.en)
+  let get-unit(unit-code) = {
+    if plural { (pluralize.at(lang))(unit-code, count, is-in-denom) } // Add your language here to `pluralize` the denominator
+    else if is-in-denom and lang in ("sl", "fi") {
+      (pluralize.at(lang))(unit-code, count, is-in-denom)
+    } else { units.at(unit-code) }
+  }
+
+  if type(component) in (symbol, str) {
+    component = str(component)
+    if component in units {
+      return get-unit(component)
+    }
+    if component.len() > 1 {
+      let prefixes = prefixes.en + prefixes.at(lang, default: prefixes.en)
+      let clusters = component.clusters()
+      let prefix = clusters.at(0)
+      let unit = clusters.slice(1).join()
+      if prefix in prefixes and unit in units {
+        return join-prefix-unit(prefixes.at(prefix), get-unit(unit), text.lang)
+      }
+    }
+  }
+  assert(
+    false,
+    message: "Failed to auto-generate alt description for unit component "
+      + repr(component)
+      + ". Please provide a manual alt text for this unit.",
+  )
+}
+
+#let generate-unit-alt-description(
+  numerator,
+  denominator,
+  translation: auto,
+  value: 1,
+) = {
+  let lang = text.lang
+  if translation == auto {
+    translation = phrases.at(lang, default: phrases.fallback)
+    if lang not in phrases {
+      return none
+    }
+    // assert(
+    //   lang in phrases,
+    //   message: "Unsupported language "
+    //     + lang
+    //     + " for alt text generation. Please provide a manual alt text for this unit. Supported languages are: "
+    //     + repr(phrases.keys())
+    //     + ". If you want to contribute a translation for your language, please open a pull request.",
+    // )
+  }
+
+  let alt = ""
+  let power-shorthands = power-shorthands.at(lang, default: (:))
+
+  let power-of-unit-component-description((unit-component, exponent), plural: false, is-in-denom: false) = {
+    let unit = unit-component-description(unit-component, plural: plural, count: value, is-in-denom: is-in-denom)
+    if exponent == "1" { return unit }
+    if exponent in power-shorthands {
+      let power-shorthand = power-shorthands.at(exponent)
+      if type(power-shorthand) == function {
+        unit = power-shorthand(unit)
+      } else {
+        unit += " " + power-shorthand
+      }
+    } else {
+      unit += " " + translation.power + " " + exponent
+    }
+    unit
+  }
+
+  let plural = needs-plural(value, lang)
+  if numerator.len() > 0 {
+    alt += (
+      numerator.slice(0, -1).map(power-of-unit-component-description)
+        + (power-of-unit-component-description(numerator.at(-1), plural: plural),)
+    ).join(" ")
+  }
+  if denominator.len() > 0 {
+    alt += " " + translation.per + " "
+    alt += denominator
+      .map(power-of-unit-component-description.with(is-in-denom: true))
+      .join(" " + translation.per + " ")
+  }
+
+  alt
+}

--- a/packages/preview/zero/0.7.0/src/align-column.typ
+++ b/packages/preview/zero/0.7.0/src/align-column.typ
@@ -1,0 +1,35 @@
+
+#import "num.typ": num
+#import "state.typ": num-state
+
+/// Turns a series of numeral strings into an array of aligned numbers.
+/// This can be used to generate cells for a column in a `table` or `stack`.
+///
+/// This function requires context from the caller.
+///
+/// -> array
+#let align-column(
+  /// Numerals and named options to pass on to `num`.
+  /// -> str | int | float | content
+  ..args,
+) = {
+  let num = num.with(
+    align: "components",
+    state: num-state.get(),
+    ..args.named(),
+  )
+
+  let numbers = args.pos().map(num)
+
+  let widths = numbers.map(components => components.map(x => measure(x).width))
+
+  let max-widths = array.zip(..widths).map(col => calc.max(..col))
+
+  return numbers.map(components => components
+    .zip(max-widths, (right, right, left, left, left))
+    .map(((body, width, alignment)) => box(width: width, align(
+      alignment,
+      body,
+    )))
+    .join())
+}

--- a/packages/preview/zero/0.7.0/src/assertions.typ
+++ b/packages/preview/zero/0.7.0/src/assertions.typ
@@ -1,0 +1,81 @@
+
+/// Check that a given value is one of the given string options
+/// and prints a suitable error message suggesting the possible
+/// values.
+#let assert-option(
+  /// Value to check -> any
+  value,
+  /// Name of the parameter -> str
+  name,
+  /// Possible options -> array
+  options,
+) = {
+  if value not in options {
+    options = options.map(option => "\"" + option + "\"")
+    if options.len() == 2 {
+      options = options.join(" or ")
+    } else {
+      options = options.slice(0, -1).join(", ") + ", or " + options.last()
+    }
+    assert(
+      false,
+      message: "Expected "
+        + options
+        + " for `"
+        + name
+        + "`, got "
+        + "\""
+        + value
+        + "\"",
+    )
+  }
+}
+
+
+/// Checks that a given set of `arguments` contains only named
+/// arguments contained in `possible-names`. Otherwise, the function panics
+/// with a suitable error message.
+#let assert-settable-args(
+  /// Arguments to test.
+  /// -> argument
+  args,
+  /// Supported argument names as an array or strings or keys of a dictionary.
+  /// -> array | dictionary
+  possible-names,
+  /// Enhances the error message with a suitable name of the calling function.
+  /// -> str
+  name: none,
+) = {
+  if args.pos().len() != 0 {
+    assert(
+      false,
+      message: "Unexpected positional argument: "
+        + repr(args.pos().first())
+        + if name != none { " in `" + name + "`" },
+    )
+  }
+  for (arg-name, _) in args.named() {
+    if arg-name in possible-names { continue }
+    let message = "Unexpected named argument: \"" + arg-name + "\""
+    if name != none {
+      message += " in `" + name + "`"
+    }
+    assert(false, message: message)
+  }
+}
+
+
+#let assert-no-fixed(args) = {
+  return
+  if "fixed" in args.named() {
+    let value = str(args.at("fixed"))
+    assert(
+      false,
+      message: "The parameter `fixed` has been removed. Instead use `exponent (fixed: "
+        + value
+        + "`) instead of `fixed: "
+        + value
+        + "`",
+    )
+  }
+}

--- a/packages/preview/zero/0.7.0/src/formatting.typ
+++ b/packages/preview/zero/0.7.0/src/formatting.typ
@@ -1,0 +1,407 @@
+#import "state.typ": num-state
+#import "parsing.typ": *
+
+
+#let sequence = [].func()
+
+/// Creates an equation from an array of content items. This function leaves
+/// the `block` attribute unset.
+#let equation-from-items(
+  /// An array of content items.
+  /// -> array
+  items,
+  alt: none
+) = {
+  math.equation(sequence(items), alt: alt)
+}
+
+
+
+
+/// Formats a sign. If the sign is the ASCII character "-", the minus
+/// unicode symbol "−" is returned. Otherwise, "+" is returned but only
+/// if `positive-sign` is set to true. In all other cases, the result is
+/// `none`.
+/// -> content | none
+#let format-sign(sign, positive-sign: false) = {
+  if sign == "-" {
+    math.class("unary", sym.minus)
+  } else if sign == "+" and positive-sign {
+    return math.class("unary", sym.plus)
+  }
+}
+
+
+
+
+
+/// Inserts group separators (e.g., thousand separators if `group-size` is 3)
+/// into a sequence of digits.
+/// -> content
+#let insert-group-separators(
+  /// Input string.
+  /// -> str
+  x,
+  /// If `false`, the separators are inserted counting from right-to-left (as
+  /// customary for integers), if `true`, they are inserted from left-to-right
+  /// (for fractionals).
+  /// -> bool
+  invert: false,
+  /// If the number of digits is below this threshold, the string is left unchanged,
+  /// -> int
+  threshold: 5,
+  /// The size of the groups.
+  /// -> int
+  size: 3,
+  /// The group separator to use.
+  /// -> str | symbol | content
+  separator: sym.space.thin,
+) = {
+  if type(threshold) == dictionary {
+    assert(
+      threshold.keys().sorted() == ("fractional", "integer"),
+      message: "group.threshold expects either an int or a dictionary with the keys \"fractional\" and \"integer\"",
+    )
+    if invert {
+      threshold = threshold.fractional
+    } else {
+      threshold = threshold.integer
+    }
+  }
+  if x.len() < threshold {
+    return x
+  }
+
+  if not invert {
+    x = x.rev()
+  }
+  let chunks = x.codepoints().chunks(size)
+  if not invert {
+    chunks = chunks.rev().map(array.rev)
+  }
+  chunks.intersperse(separator).flatten().join()
+}
+
+
+
+/// Attaches sub-/super-script values using text mode, while allowing for
+/// stacking of a combined sub-script and super-script.
+/// -> content
+#let non-math-attach(
+  /// Content to attach to -> content
+  body,
+  /// Superscript content -> content
+  t: none,
+  /// Subscript content -> content
+  b: none,
+) = {
+  if t != none {
+    t = super(typographic: false, t)
+  }
+  if b != none {
+    b = sub(typographic: false, b)
+  }
+
+  if t != none and b != none {
+    let width = calc.max(measure(t).width, measure(b).width)
+    let attachments = (
+      sym.zws + place(top, sym.zws + t) + place(top, sym.zws + b)
+    )
+    body + box(width: width, attachments)
+  } else {
+    body + t + b
+  }
+}
+
+
+/// Takes a string of digits and truncates or pads it to a length of @digits.
+/// -> str
+#let pad-or-truncate(
+  /// Input string -> str
+  x,
+  /// Number of digits -> str
+  digits,
+) = {
+  let len = x.len()
+  if len == digits or digits == auto { return x }
+  if len < digits { return x + "0" * (digits - len) }
+  if len > digits { return x.slice(0, digits) }
+}
+
+
+
+
+
+#let format-integer = it => {
+  // int, group
+  if type(it.group) == dictionary and it.int != none {
+    it.int = insert-group-separators(it.int, ..it.group)
+  }
+  if it.int == "" { it.int = "0" }
+  it.int
+}
+
+
+
+#let format-fractional = it => {
+  // frac, group, digits, decimal-separator
+  let frac = pad-or-truncate(it.frac, it.digits)
+  if frac.len() == 0 {
+    return none
+  }
+  if type(it.group) == dictionary {
+    frac = insert-group-separators(frac, invert: true, ..it.group)
+  }
+  it.decimal-separator + frac
+}
+
+
+
+#let format-comma-number = it => {
+  // sign, int, frac, digits, group, positive-sign
+  let frac = format-fractional((
+    frac: it.frac,
+    group: it.group,
+    digits: it.digits,
+    decimal-separator: [#it.decimal-separator],
+  ))
+
+  return sequence((
+    format-sign(it.sign, positive-sign: it.positive-sign),
+    format-integer((int: it.int, group: it.group)),
+    frac,
+  ))
+}
+
+
+#let nonbreaking-binary-class(body, tight: false, breakable: true) = {
+  let space = if tight { 0pt } else { 2em/9 }
+  
+  if breakable {
+    math.class("binary", body)
+  } else {
+    // Recover spacing of binary relations but without breakability
+    h(space) + math.class("normal", body) + h(space)
+  }
+}
+
+#let format-uncertainty = it => {
+  /// pm, digits, mode, concise, tight, math, breakable
+  let pm = it.pm
+  if pm == none { return () }
+  let is-symmetric = type(pm.first()) != array
+  if is-symmetric { pm = (pm,) }
+
+  if it.concise {
+    let compact-pm = (
+      it.mode == "compact"
+        or (
+          it.mode == "compact-separator"
+            and pm.map(x => x.first().trim("0")).all(x => x.len() == 0)
+        )
+    )
+
+    if compact-pm {
+      pm = pm.map(x => utility.shift-decimal-left(..x, digits: -it.digits))
+      it.digits = auto
+    }
+  }
+
+  pm = pm.map(((int, frac)) => format-comma-number((
+    sign: none,
+    int: int,
+    frac: frac,
+    digits: auto,
+    group: false,
+    positive-sign: false,
+    decimal-separator: it.decimal-separator,
+  )))
+  if is-symmetric {
+    if it.concise {
+      ("(", pm.first(), ")")
+    } else if it.math {
+      (
+        math.class("normal", none),
+        nonbreaking-binary-class(
+          sym.plus.minus, 
+          tight: it.tight, 
+          breakable: it.breakable.uncertainty
+        ),
+        pm.first(),
+      )
+    } else {
+      let space = if it.tight { sym.space.hair } else { sym.space.thin }
+      (
+        space,
+        sym.wj,
+        sym.plus.minus,
+        space,
+        if not it.breakable.uncertainty { sym.wj },
+        pm.first(),
+      )
+    }
+  } else if it.math {
+    (
+      math.attach(
+        none,
+        t: $+#pm.at(0)$,
+        b: $-#pm.at(1)$,
+      ),
+    )
+  } else {
+    (
+      sym.wj,
+      non-math-attach(
+        none,
+        t: "+" + pm.at(0),
+        b: "−" + pm.at(1),
+      ),
+    )
+  }
+}
+
+
+
+#let format-power = it => {
+  /// x, base, product, positive-sign-exponent, tight, math, breakable
+  if it.exponent == none { return () }
+
+  let (sign, integer, fractional) = decompose-signed-float-numeral(it.exponent)
+  let exponent = format-comma-number((
+    sign: sign,
+    int: integer,
+    frac: fractional,
+    digits: auto,
+    group: false,
+    positive-sign: it.positive-sign-exponent,
+    decimal-separator: it.decimal-separator,
+  ))
+
+  if it.math {
+    let power = math.attach([#it.base], t: [#exponent])
+    if it.product == none { (power,) } else {
+      (
+        box(),
+        nonbreaking-binary-class(
+          it.product, 
+          tight: it.tight, 
+          breakable: it.breakable.power
+        ),
+        power,
+      )
+    }
+  } else {
+    let power = non-math-attach([#it.base], t: [#exponent])
+    if it.product == none { (power,) } else {
+      let space = if it.tight { sym.space.hair } else { sym.space.thin }
+      (
+        space,
+        sym.wj,
+        it.product,
+        space,
+        if not it.breakable.power { sym.wj },
+        power,
+      )
+    }
+  }
+}
+
+
+
+#let show-num-impl = it => {
+  let breakable = utility.process-breakable(it.breakable)
+  /// sign, int, frac, e, pm,
+  /// digits
+  /// omit-unity-mantissa, uncertainty-mode, positive-sign
+
+  let decimal-separator = it.decimal-separator
+  if decimal-separator == "." {
+    decimal-separator = sym.dot.basic
+  } 
+  
+  let omit-mantissa = (
+    it.omit-unity-mantissa
+      and it.int == "1"
+      and it.frac == ""
+      and it.e != none
+      and it.pm == none
+      and it.digits == 0
+  )
+
+  assert(
+    it.uncertainty-mode in ("separate", "compact", "compact-separator"),
+    message: "The uncertainty-mode can be one of \"separate\", \"compact\", \"compact-separator\", got "
+      + repr(it.uncertainty-mode),
+  )
+  let concise-uncertainty = it.uncertainty-mode != "separate"
+
+
+  let integer = (
+    sign: it.sign,
+    int: if omit-mantissa { none } else { it.int },
+    decimal-separator: decimal-separator,
+    group: it.group,
+  )
+
+
+  let uncertainty = (
+    pm: it.pm,
+    digits: it.digits,
+    concise: concise-uncertainty,
+    tight: it.tight,
+    math: it.math,
+    mode: it.uncertainty-mode,
+    decimal-separator: decimal-separator,
+    breakable: breakable
+  )
+
+
+  let power = (
+    exponent: it.e,
+    base: it.base,
+    product: if omit-mantissa { none } else { it.product },
+    positive-sign-exponent: it.positive-sign-exponent,
+    tight: it.tight,
+    math: it.math,
+    decimal-separator: decimal-separator,
+    breakable: breakable
+  )
+
+  let integer-part = (
+    format-sign(it.sign, positive-sign: it.positive-sign),
+    format-integer(integer),
+  )
+
+  let fractional-part = (
+    format-fractional((
+      frac: it.frac,
+      group: it.group,
+      digits: it.digits,
+      decimal-separator: decimal-separator,
+    )),
+  )
+
+  let uncertainty-part = format-uncertainty(uncertainty)
+  if not breakable.uncertainty and uncertainty-part.len() != 0{
+    // uncertainty-part = (std.box(equation-from-items(uncertainty-part)),)
+  }
+
+  if concise-uncertainty {
+    fractional-part += uncertainty-part
+    uncertainty-part = ()
+  }
+
+
+  if it.pm != none and (it.e != none or it.fpau) and not concise-uncertainty {
+    integer-part = ("(",) + integer-part
+    uncertainty-part.push(")")
+  }
+
+  let result = (
+    integer-part,
+    fractional-part,
+    uncertainty-part,
+    format-power(power),
+  )
+  return result
+}

--- a/packages/preview/zero/0.7.0/src/impl.typ
+++ b/packages/preview/zero/0.7.0/src/impl.typ
@@ -1,0 +1,7 @@
+// Access to implementation for third-party packages. Note: this API may be unstable.
+#import "formatting.typ"
+#import "parsing.typ"
+#import "utility.typ"
+#import "rounding.typ"
+#import "accessibility.typ"
+#import "state.typ": default-state, num-state

--- a/packages/preview/zero/0.7.0/src/num.typ
+++ b/packages/preview/zero/0.7.0/src/num.typ
@@ -1,0 +1,348 @@
+#import "state.typ": num-state, update-num-state
+#import "formatting.typ": *
+#import "rounding.typ": *
+#import "assertions.typ": *
+#import "parsing.typ" as parsing: nonum
+#import "accessibility.typ": generate-num-alt-description
+#let update-state(state, args, name: none) = {
+  assert-no-fixed(args)
+  state.update(s => {
+    assert-settable-args(args, s, name: name)
+    s + args.named()
+  })
+}
+
+
+#let set-num(..args) = update-state(num-state, args, name: "set-num")
+
+#let set-group(..args) = {
+  num-state.update(s => {
+    assert-settable-args(args, s.group, name: "set-group")
+    s.group += args.named()
+    s
+  })
+}
+
+#let set-round(..args) = {
+  num-state.update(s => {
+    assert-settable-args(args, s.round, name: "set-round")
+    s.round += args.named()
+    s
+  })
+}
+
+
+// Process the exponent with its various modes mode
+#let process-exponent(info, exponent) = {
+  if (info.int + info.frac).trim("0") == "" {
+    // Add no exponent if number is 0
+    return info
+  }
+
+  let new-exponent = if type(exponent) == dictionary {
+    assert(
+      "fixed" in exponent or "sci" in exponent,
+      message: "Expected key \"fixed\" or \"sci\", got " + repr(exponent),
+    )
+
+    if "fixed" in exponent {
+      exponent.fixed
+    } else {
+      let threshold = exponent.sci
+      if type(threshold) == int {
+        threshold = (-threshold, threshold)
+      }
+      let e = parsing.compute-sci-digits(info)
+      if e > threshold.at(0) and e < threshold.at(1) {
+        return info
+      }
+      e
+    }
+  } else if exponent == "eng" {
+    parsing.compute-eng-digits(info)
+  } else if exponent == "sci" {
+    parsing.compute-sci-digits(info)
+  }
+
+  let e = if info.e == none { 0 } else { int(info.e) }
+
+  let shift = utility.shift-decimal-left.with(digits: new-exponent - e)
+
+  info.e = str(new-exponent).replace("−", "-")
+  (info.int, info.frac) = shift(info.int, info.frac)
+
+  if info.pm != none {
+    if type(info.pm.first()) != array {
+      info.pm = shift(..info.pm)
+    } else {
+      info.pm = info.pm.map(x => shift(..x))
+    }
+  }
+
+  info
+}
+
+
+#let process-input(number) = {
+  let info
+  if type(number) == dictionary {
+    info = number
+    if "mantissa" in info {
+      let mantissa = info.mantissa
+      if type(mantissa) in (int, float) {
+        mantissa = str(mantissa).replace("−", "-")
+      }
+      let (sign, int, frac) = parsing.decompose-signed-float-numeral(mantissa)
+      info += (sign: sign, int: int, frac: frac)
+    }
+    if "sign" not in info { info.sign = "" }
+  } else {
+    info = parse-numeral(number)
+  }
+  return info
+}
+
+#let show-num(it) = {
+  // Process input
+  let info = it.info
+
+  if it.exponent != auto {
+    info = process-exponent(info, it.exponent)
+    if "prefixed-eng" in it {
+      info.e = none
+    }
+  }
+  if info.e in (0, "0") and it.omit-zero-exponent {
+    info.e = none
+  }
+  if it.trim-zeros {
+    info.frac = info.frac.trim("0", at: end)
+  }
+
+  /// Round number and uncertainty
+  if info.pm != none and it.round.follow-uncertainty {
+    (info.int, info.frac, info.pm) = round-to-uncertainty(
+      info.int,
+      info.frac,
+      info.pm,
+      sign: info.sign,
+      ..it.round,
+      precision: it.round.uncertainty-precision,
+    )
+  } else {
+    if it.round.precision != none {
+      (info.int, info.frac) = round(
+        info.int,
+        info.frac,
+        sign: info.sign,
+        ..it.round,
+      )
+    }
+  }
+
+  let digits = if it.digits == auto { info.frac.len() } else { it.digits }
+  if digits < 0 {
+    assert(false, message: "`digits` needs to be positive, got " + str(digits))
+  }
+  it.digits = digits
+
+  // Format number
+  let components = show-num-impl(info + it)
+
+  let description
+  if it.alt == auto {
+    it.alt = generate-num-alt-description
+  }
+  if type(it.alt) == dictionary {
+    assert(
+      "times" in it.alt
+        and "power" in it.alt
+        and "plus" in it.alt
+        and "minus" in it.alt
+        and "decimal-separator" in it.alt,
+      message: "Expected keys \"times\", \"power\", \"plus\", \"minus\", and \"decimal-marker\" got " + repr(it.alt),
+    )
+    it.alt = generate-num-alt-description.with(translation: it.alt)
+  }
+  if type(it.alt) == function {
+    description = (it.alt)(
+      (
+        sign: info.sign,
+        int: info.int,
+        frac: info.frac,
+        pm: info.pm,
+        e: info.e,
+        base: it.base,
+      ),
+    )
+  } else {
+    description = it.alt
+  }
+  let collect = if it.math { equation-from-items.with(alt: description) } else { it => it.join() }
+
+  if it.align == none {
+    set text(dir: ltr)
+    it.prefix + collect(components.join()) + it.suffix
+  } else if it.align == "components" {
+    components.map(c => {
+      set text(dir: ltr)
+      collect(c)
+    })
+  } else {
+    set text(dir: ltr)
+
+    let (col-widths, col) = it.align
+    let components = components.map(x => if x == () { none } else {
+      collect(x)
+    })
+    components.at(0) = it.prefix + components.at(0)
+    if it.suffix != none {
+      if components.at(2) == none and components.at(3) == none {
+        components.at(1) += it.suffix
+      } else {
+        components.at(3) += it.suffix
+      }
+    }
+    let widths = components.map(x => if x == none { 0pt } else {
+      measure(x).width
+    })
+
+    if col-widths != auto {
+      for i in range(4) {
+        let alignment = if i == 0 { right } else { left }
+        let content = align(alignment, components.at(i))
+        components.at(i) = box(width: col-widths.at(i), content)
+      }
+    }
+
+    [#components.join()#metadata((col,) + widths)<__pillar-num__>]
+  }
+}
+
+
+#let num(
+  number,
+  align: none,
+  state: auto,
+  prefix: none,
+  suffix: none,
+  force-parentheses-around-uncertainty: false,
+  ..args,
+) = {
+  assert-no-fixed(args)
+
+  let inline-args = (
+    align: align,
+    prefix: prefix,
+    suffix: suffix,
+    fpau: force-parentheses-around-uncertainty,
+  )
+
+  if type(number) == array {
+    let named = args.named()
+    let num-state = if state == auto { num-state.get() } else { state }
+    let it = num-state + inline-args + args.named()
+
+    return number.map(n => {
+      let info = process-input(n)
+      utility.create-num-metadata(info, n, args)
+      show-num(it + (info: info))
+    })
+  }
+
+  let info = process-input(number)
+  let metadata = utility.create-num-metadata(info, number, args)
+
+  if state != auto {
+    let it = (
+      update-num-state(state, args.named()) + inline-args + (info: info)
+    )
+    if align == "components" {
+      (metadata,) + show-num(it)
+    } else {
+      metadata
+      show-num(it)
+    }
+  } else {
+    metadata
+    context {
+      let it = (
+        update-num-state(num-state.get(), args.named()) + inline-args + (info: info)
+      )
+      show-num(it)
+    }
+  }
+}
+
+
+
+
+
+
+
+
+
+/*
+
+- Mantissa (value or uncertainty): Doesn't really need a show rule?
+- Power: A rule would be beneficial. Does the multiplier need to be included?
+
+
+Question: How to pass values on to the nested types
+
+#set num.power(base: [5])
+and then
+#num(power: (base: [4]), "1.23e4")
+
+
+show num.power: it => {
+  - it.exponent [2.3]
+  - it.base [10]
+  - it.multiplier [×] ??
+
+  math.attach([#it.base], t: [#it.exponent])
+
+  or
+
+  (
+    box(),
+    it.multiplier,
+    math.attach([#it.base], t: [#it.exponent])
+  )
+}
+
+
+show num.exponent: it => {
+  - it.sign
+  - it.integer
+  - it.fractional
+
+  it.sign + format-integer(it.integer) + format-fractional(it.fractional).join()
+}
+
+
+show num.uncertainty: it => {
+  - it.value ([0.2, 0.4])
+  - it.mode
+  - it.symmetric false
+  if it.mode == ...
+
+  if it.symmetric {
+    return (
+      math.class("normal", none),
+      math.class(if state.tight {"normal"} else {"binary"}, sym.plus.minus),
+      it.value
+    )
+  } else {
+    math.attach(none, t: sym.plus + it.value.at(0), b: sym.minus + it.value.at(1)),
+  }
+}
+
+show num.num: it => {
+
+}
+
+
+
+*/
+

--- a/packages/preview/zero/0.7.0/src/parsing.typ
+++ b/packages/preview/zero/0.7.0/src/parsing.typ
@@ -1,0 +1,294 @@
+#import "utility.typ"
+
+/// Converts a content value into a string if it contains only text nodes.
+/// Otherwise, `none` is returned.
+/// -> str | none
+#let content-to-string(
+  /// -> content
+  body,
+) = {
+  if body.has("text") {
+    return body.text
+  }
+
+  if (
+    body.has("children")
+      and body.children.len() != 0
+      and body.children.all(child => child.has("text") or child == [ ])
+  ) {
+    body.children.map(child => if child == [ ] { " " } else { child.text }).join()
+  }
+}
+
+
+
+/// Same as @content-to-string but also extract special prefix and suffix elements.
+/// Returns `none`, if the content does not only contain text nodes and a tuple
+/// `(text: str, prefix: content, suffix: content)` otherwise
+#let content-to-string-table(body) = {
+  if body.has("text") {
+    return (body.text, none, none)
+  }
+
+  if body.has("children") and body.children.len() != 0 {
+    if body.children.all(child => child.has("text")) {
+      return (body.children.map(child => child.text).join(), none, none)
+    }
+
+    let main = none
+    let prefix = none
+    let suffix = none
+    for child in body.children {
+      if child.has("text") { main += child.text } else if (
+        child.func() == highlight
+      ) {
+        if main == none { prefix = child.body } else { suffix = child.body }
+      } else { return none }
+    }
+    return (main, prefix, suffix)
+  }
+}
+
+
+/// The nonum element makes it possible to add _protected_ content before and
+/// after a numeral in a table cell.
+#let nonum = highlight
+
+
+
+/// Converts the input into a numeral string if the input is of type `int`,
+/// `float`, `str`, or `content` that contains only text nodes but does not
+/// start or end with a space.
+///
+/// In case of a conversion failure, `none` is returned.
+///
+/// The output is normalized, meaning that both decimals separators "," and
+/// "." are unified to "." and the minus symbol "−" is replaced by the
+/// ASCII "-" character.
+///
+/// -> str | none
+#let to-normalized-numeral(
+  /// The input
+  /// -> int | float | str | content
+  number,
+) = {
+  let result = if type(number) == str {
+    number
+  } else if type(number) in (int, float) {
+    str(number)
+  } else if type(number) == content {
+    content-to-string(number)
+  }
+
+  if result in (none, "") { return none }
+
+  result.replace(",", ".").replace("−", "-")
+}
+
+
+/// Same as @to-normalized-numeral but for table cell contents.
+#let to-normalized-numeral-table(number) = {
+  let result = if type(number) == str {
+    number
+  } else if type(number) in (int, float) {
+    str(number)
+  } else if type(number) == content {
+    content-to-string-table(number)
+  }
+  if result == none { return none }
+
+  if type(result) != array {
+    result = (result, none, none)
+  }
+
+  if result.at(0) == "" { return none }
+
+  result.at(0) = result.at(0).replace(",", ".").replace("−", "-")
+
+  if result.len() == 0 or result.at(0).at(0) not in "0123456789+-." {
+    return none
+  }
+
+  result
+}
+
+
+
+
+/// Decomposes a string representing an unsigned floating point into
+/// integer and fractional part. If either part is not present, it is
+/// returned as an empty string. Returns `(integer, fractional)`.
+/// Expects a normalized input string (see @number-to-string).
+///
+/// *Example:*
+/// #example(`decompose-unsigned-float-numeral("9.81")`
+///
+/// -> (str, str)
+#let decompose-unsigned-float-numeral(
+  /// The numeral to decompose.
+  /// -> str
+  numeral,
+) = {
+  let components = numeral.split(".")
+  if components.len() == 1 {
+    components.push("")
+  } else if components.len() > 2 {
+    assert(false, message: "unparsable number `" + numeral + "`")
+  }
+  components
+}
+
+
+
+
+/// Decomposes a string representing a (possibly signed) floating point
+/// into integer and fractional part. If either part is not present, it
+/// is returned as an empty string. Returns `(sign, integer, fractional)`
+/// where the sign is either `"+"` or `"-"`.
+/// Expects a normalized input string (see @number-to-string).
+///
+/// *Example:*
+/// #example(`decompose-signed-float-numeral("-9.81")`
+///
+/// -> ("+" | "-", str, str)
+#let decompose-signed-float-numeral(
+  /// The numeral to decompose.
+  /// -> str
+  numeral,
+) = {
+  let sign = "+"
+  if numeral.starts-with("-") {
+    sign = "-"
+    numeral = numeral.slice(1)
+  } else if numeral.starts-with("+") {
+    numeral = numeral.slice(1)
+  }
+
+  (sign,) + decompose-unsigned-float-numeral(numeral)
+}
+
+
+
+/// Parses a normalized compound numeral string into sign, integer,
+/// fractional, uncertainty and exponent.
+///
+/// Here, normalized means that the decimal separator is `"."`, and
+/// `"+"`, `"-"` is used for all signs (as opposed to `"−"`).
+///
+/// Sign, integer and fractional part are guaranteed to be valid (however,
+/// the latter two may be empty strings) while the uncertainty and the
+/// exponent may be none if not present.
+///
+///
+/// *Example:*
+/// #example(`parse-normalized-compound-numeral("-10.2+-.3e3")`)
+///
+/// -> (int: str, frac: str, sign: str, pm: array | str, e: str)
+#let parse-normalized-compound-numeral(numeral) = {
+  numeral = numeral.replace("E", "e")
+  let original-numeral = numeral
+  let e
+  let pm
+  let sign = "+"
+  if "e" in numeral {
+    let components = numeral.split("e")
+    if components.len() > 2 {
+      assert(
+        false,
+        message: "Error while parsing `"
+          + original-numeral
+          + "`: Asymmetric uncertainties must be specified on both sides",
+      )
+    }
+    (numeral, e) = components
+  }
+  if numeral.starts-with("-") {
+    sign = "-"
+    numeral = numeral.slice(1)
+  } else if numeral.starts-with("+") { numeral = numeral.slice(1) }
+
+  let normalize-pm = false
+  let pm-count = int("+" in numeral) + int("-" in numeral)
+  if pm-count == 2 {
+    if "+-" in numeral { (numeral, pm) = numeral.split("+-") } else {
+      let p
+      let m
+      (numeral, m) = numeral.split("-")
+      assert(
+        "+" in numeral,
+        message: "Error while parsing `"
+          + original-numeral
+          + "`: Asymmetric uncertainties must start with the positive component",
+      )
+      (numeral, p) = numeral.split("+")
+      pm = (p, m)
+    }
+  } else if pm-count == 1 {
+    assert(
+      false,
+      message: "Error while parsing `"
+        + original-numeral
+        + "`: Asymmetric uncertainties must be specified on both sides",
+    )
+  } else if "(" in numeral {
+    (numeral, pm) = numeral.split("(")
+    assert(
+      pm.ends-with(")"),
+      message: "Error while parsing `"
+        + original-numeral
+        + "`: Unclosed parenthesized uncertainty",
+    )
+    pm = pm.trim(")")
+    normalize-pm = true
+  }
+  let (integer, fractional) = decompose-unsigned-float-numeral(numeral)
+  if pm != none {
+    if type(pm) == array {
+      pm = pm.map(decompose-unsigned-float-numeral)
+    } else {
+      pm = decompose-unsigned-float-numeral(pm)
+    }
+
+    if normalize-pm {
+      pm = utility.shift-decimal-left(..pm, digits: fractional.len())
+    }
+  }
+  if integer == "" {
+    integer = "0"
+  }
+
+  (int: integer, frac: fractional, sign: sign, pm: pm, e: e)
+}
+
+
+
+
+/// Like @parse-normalized-compound-numeral but also normalizes the input.
+#let parse-numeral(numeral) = {
+  let numeral = to-normalized-numeral(numeral)
+  if numeral == none {
+    assert(false, message: "Cannot parse the numeral `" + repr(numeral) + "`")
+  }
+  parse-normalized-compound-numeral(numeral)
+}
+
+
+#let compute-sci-digits(num-info) = {
+  let integer = num-info.int
+  let fractional = num-info.frac
+  let e = if num-info.e == none { 0 } else { int(num-info.e) }
+
+  let exponent = 0
+  if integer == "0" {
+    let leading-zeros = fractional.len() - fractional.trim("0", at: start).len()
+
+    exponent = -leading-zeros - 1
+  } else {
+    exponent = integer.len() - 1
+  }
+  exponent + e
+}
+
+#let compute-eng-digits(num-info) = {
+  calc.floor(compute-sci-digits(num-info) / 3) * 3
+}

--- a/packages/preview/zero/0.7.0/src/quan.typ
+++ b/packages/preview/zero/0.7.0/src/quan.typ
@@ -1,0 +1,40 @@
+#import "num.typ": num
+#import "parsing.typ": content-to-string
+#import "units.typ": parse-unit, qty, unit
+
+#let quan(input) = {
+  if type(input) == content {
+    input = content-to-string(input)
+    assert(input != none, message: "")
+  }
+  
+  let regex-beginning-of-unit = regex("[ a-zA-Zµ/]")
+
+  
+  // We need to protect against detecting the e/E exponent notation as a unit
+  let e-position = lower(input).position("e")
+  let pos = if (
+    e-position != none
+      and input.at(e-position + 1, default: ".") in "+-1234567890.,"
+  ) {
+    let pos = input.slice(e-position + 1).position(regex-beginning-of-unit)
+    if pos != none {
+      pos += e-position + 1
+    }
+    pos
+  } else {
+    input.position(regex-beginning-of-unit)
+  }
+
+  if pos == none {
+    num(input)
+  } else if pos == 0 {
+    unit(parse-unit(input))
+  } else {
+    qty(
+      input.slice(0, pos),
+      parse-unit(input.slice(pos)),
+    )
+  }
+}
+

--- a/packages/preview/zero/0.7.0/src/rounding.typ
+++ b/packages/preview/zero/0.7.0/src/rounding.typ
@@ -1,0 +1,390 @@
+#import "assertions.typ": *
+
+
+/// Count the leading zeros in a string of digits
+#let count-leading-zeros(
+  /// A string of digits
+  /// -> str
+  string,
+) = {
+  string.len() - string.trim("0", at: start).len()
+}
+
+
+/// Rounds an integer given as a string of digits to a given digit place.
+#let round-integer(
+
+  /// The integer string to round.
+  /// -> str
+  integer,
+
+  /// The digit place to round to.
+  place,
+
+  /// The rounding direction.
+  /// -> "nearest" | "towards-infinity" | "towards-negative-infinity" | "towards-zero" | "away-from-zero"
+  dir: "nearest",
+
+  /// How to round ties.
+  /// -> "away-from-zero" | "towards-zero" | "to-odd" | "to-even" | "towards-infinity" | "towards-negative-infinity"
+  ties: "away-from-zero",
+
+  /// The sign of the number.
+  /// -> "+" | "-"
+  sign: "+"
+
+) = {
+  if place == 0 { panic("") }
+
+  if dir == "towards-infinity" {
+    if sign == "+" { dir = "away-from-zero" } else { dir = "towards-zero" }
+  }
+  if dir == "towards-negative-infinity" {
+    if sign == "-" { dir = "away-from-zero" } else { dir = "towards-zero" }
+  }
+
+  if dir == "towards-zero" {
+    return integer.slice(0, place)
+  } else if dir == "away-from-zero" {
+    let x = float(integer.slice(0, place) + "." + integer.slice(place))
+    integer = str(int(calc.ceil(x)))
+  } else if dir == "nearest" {
+    let fractional = integer.slice(place)
+    if fractional.trim("0", at: end) == "5" {
+      if ties == "away-from-zero" {} else if ties == "towards-zero" {
+        fractional = "4"
+      } else if ties == "to-even" {
+        let ls-integer-digit = integer.slice(place - 1, place)
+        if calc.even(int(ls-integer-digit)) {
+          fractional = "4"
+        }
+      } else if ties == "to-odd" {
+        let ls-integer-digit = integer.slice(place - 1, place)
+        if calc.odd(int(ls-integer-digit)) {
+          fractional = "4"
+        }
+      } else if ties == "towards-infinity" {
+        let ls-integer-digit = integer.slice(place - 1, place)
+        if sign == "-" {
+          fractional = "4"
+        }
+      } else if ties == "towards-negative-infinity" {
+        let ls-integer-digit = integer.slice(place - 1, place)
+        if sign == "+" {
+          fractional = "4"
+        }
+      }
+    }
+    let x = float(integer.slice(0, place) + "." + fractional)
+    integer = str(int(calc.round(x)))
+  }
+  if place > integer.len() {
+    integer = "0" * (place - integer.len()) + integer
+  }
+  return integer
+}
+
+
+/// Compute the absolute digit to round to, given a decimal from two strings, 
+/// a precision and a rounding mode of either `"places"` or `"figures"`. 
+/// 
+/// Examples:
+/// - `2.123` (`"2", "123"`), `mode: "places", precision: 2`
+///       ↑ 
+///       round to second place, i.e., third digit in total
+/// - `2.123` (`"2", "123"`), `mode: "figures", precision: 2`
+///      ↑ 
+///      round to second figure, i.e., second digit in total
+/// 
+#let get-rounding-digit(int, frac, mode, precision) = {
+  if mode == "places" {
+    precision + int.len()
+  } else if mode == "figures" {
+    if (int + frac).trim("0") == "" {
+      int.len()
+    } else {
+      precision + count-leading-zeros(int + frac)
+    }
+  }
+}
+
+
+/// Pads a decimal number to given precision with given rounding mode. 
+/// Examples with `pad: true`:
+/// - `62.1` (`"62", "1"`), `mode: "places", precision: 2`
+///    → `"62.10` 
+/// - `0.003` (`"0", "003"`), `mode: "figures", precision: 4`
+///    → `"0.003000` 
+#let pad-decimal(int, frac, pad, mode, precision) = {
+  let rounding-digit = get-rounding-digit(int, frac, mode, precision)
+
+  rounding-digit = calc.max(0, rounding-digit)
+  let number = int + frac
+
+  if rounding-digit > number.len() {
+    if type(pad) == std.int {
+      let max-pad = rounding-digit - number.len()
+      frac += "0" * calc.clamp(pad - precision + max-pad, 0, max-pad)
+    } else if pad {
+      frac += "0" * (rounding-digit - number.len())
+    }
+  }
+  
+  (int, frac)
+}
+
+
+/// Rounds a decimal number to given precision with given rounding mode. 
+/// 
+/// If rounding is applied, the returned fractional part is stripped from
+/// trailing zeros. 
+#let round-decimal(
+
+  /// Integer part of a decimal number. 
+  /// -> str
+  int,
+
+  /// Fractional part of a decimal number. 
+  /// -> str
+  frac,
+
+  /// The sign of the number. 
+  /// -> "+" | "-"
+  sign: "+",
+
+  /// -> int
+  precision: 2,
+
+  /// -> "nearest" | "towards-infinity" | "towards-negative-infinity"
+  dir: "nearest",
+
+  ties: "away-from-zero",
+
+  /// -> "places" | "figures"
+  mode: "places",
+
+) = {
+  let rounding-digit = get-rounding-digit(int, frac, mode, precision)
+  if rounding-digit < 0 { return ("", "")}
+
+  let number = int + frac
+
+  if rounding-digit < number.len() {
+    number = round-integer(
+      "0" + number, // prevent errors when rounding-digit is 0
+      1 + rounding-digit,
+      dir: dir,
+      ties: ties,
+      sign: sign,
+    )
+
+    // We ALWAYS need to pad the integer part, e.g. when rounding
+    // 123 to the hundreds, round-integer gives 1 but we want 100. 
+    if rounding-digit < int.len() {
+      number += "0" * (int.len() - rounding-digit)
+    }
+
+    let new-int-digits = int.len() + 1
+    int = number.slice(0, new-int-digits)
+    frac = number.slice(new-int-digits).trim("0", at: end)
+  }
+
+  (int.trim("0", at: start), frac)
+}
+
+
+
+
+
+/// Rounds (and/or pads) a number given by an integer part and a fractional 
+/// part. 
+#let round(
+
+  /// Integer part. 
+  /// -> str
+  int,
+
+  /// Fractional part. 
+  /// -> str
+  frac,
+
+  /// The sign of the number. 
+  /// -> "+" | "-"
+  sign: "+",
+
+  /// Rounding mode.
+  /// - `"places"`: The number is rounded to the number of places after the
+  ///   decimal point given by the `precision` parameter.
+  /// - `"figures"`: The number is rounded to a number of significant figures.
+  mode: "places",
+
+  /// The precision to round to. See parameter `mode` for the different modes. 
+  /// If set to `auto` or `none`, no rounding is performed. 
+  /// -> int | auto | none
+  precision: 2,
+
+  /// Rounding direction.
+  /// -> str
+  direction: "nearest",
+
+  /// How to round ties.
+  /// -> "away-from-zero" | "towards-zero" | "to-odd" | "to-even" | "towards-infinity" | "towards-negative-infinity"
+  ties: "away-from-zero",
+
+  /// Determines whether the number should be padded with zeros if the number 
+  /// has less digits than the rounding precision. If an integer is given, 
+  /// determines the minimum number of decimal digits (`mode: "places"`) or 
+  /// significant figures (`mode: "figures"`) to display. 
+  /// -> bool | int
+  pad: true,
+
+  ..
+
+) = {
+  if precision in (auto, none) {
+    return (int, frac)
+  }
+
+
+  assert-option(mode, "round-mode", ("places", "figures"))
+
+  // Removal hint
+  if direction == "down" {
+    assert(
+      false,
+      message: "In zero:0.5.0, the rounding direction \"down\" has been renamed to \"towards-negative-infinity\"",
+    )
+  } else if direction == "up" {
+    assert(
+      false,
+      message: "In zero:0.5.0, the rounding direction \"up\" has been renamed to \"towards-infinity\"",
+    )
+  }
+  assert-option(direction, "round-direction", (
+    "nearest",
+    "towards-infinity",
+    "towards-negative-infinity",
+    "away-from-zero",
+    "towards-zero",
+  ))
+
+
+  pad-decimal(
+    ..round-decimal(
+      int, frac, 
+      precision: precision,
+      mode: mode,
+      dir: direction,
+      sign: sign,
+      ties: ties,
+    ),
+    pad, mode, precision
+  )
+}
+
+
+/// Rounds a number to the same decimal place as its uncertainty. 
+#let round-to-uncertainty(
+  
+  /// Integer part. 
+  /// -> str
+  int,
+
+  /// Fractional part. 
+  /// -> str
+  frac,
+
+  /// Uncertainty, given as a tuple of integer and fractional part. Can also be a tuple of two tuples, in the case of asymmetric uncertainty.
+  /// -> (str, str) | ((str, str), (str, str))
+  uncertainty,
+
+  /// The sign of the number. 
+  /// -> "+" | "-"
+  sign: "+",
+
+  /// The precision to round the uncertainty to. If `auto`, the uncertainty
+  /// left as is. If given as an int, the precision is interpreted in terms 
+  /// of number of significant figures. Alternatively, a dictionary of the form
+  /// `(places: int)` can be passed to specify the precision in terms of decimal 
+  /// places.
+  /// -> auto | int | dictionary
+  precision: auto,
+
+  /// Rounding direction.
+  /// -> str
+  direction: "nearest",
+
+  /// How to round ties.
+  /// -> "away-from-zero" | "towards-zero" | "to-odd" | "to-even" | "towards-infinity" | "towards-negative-infinity"
+  ties: "away-from-zero",
+
+  /// Determines whether the number should be padded with zeros if the number 
+  /// has less digits than the rounding precision. If an integer is given, 
+  /// determines the minimum number of decimal digits (`mode: "places"`) or 
+  /// significant figures (`mode: "figures"`) to display. 
+  /// -> bool | int
+  pad: true,
+  ..
+
+) = {
+  let is-symmetric = type(uncertainty.first()) != array
+  if is-symmetric {
+    uncertainty = (uncertainty,)
+  }
+  
+  /// Find the (fractional) place of the smallest uncertainty
+  let places = if precision == auto {
+    calc.max(
+      ..uncertainty.map(((i, f)) => f.len())
+    )
+  } else if type(precision) == std.int {
+    precision + calc.max(
+      ..uncertainty.map(((i, f)) => count-leading-zeros(i + f) - i.len())
+    )
+  } else if type(precision) == dictionary {
+    assert(
+      precision.keys() == ("places",), 
+      message: "Expected a dictionary with the key \"places\""
+    )
+    precision.places
+  } else {
+    assert(
+      false,
+      message: "Unexpected argument " + repr(precision) + " for uncertainty-precision"
+    )
+  }
+
+  uncertainty = uncertainty
+    .map(((i, f)) => round-decimal(
+      i, f,
+      dir: direction,
+      precision: places, 
+      mode: "places"
+    ))
+    .map(((i, f)) => pad-decimal(
+      i, f,
+      pad, 
+      "places",
+      places 
+    ))
+
+  if is-symmetric {
+    uncertainty = uncertainty.first()
+  }
+  
+  // Then, round number to the same number of places as the uncertainty. 
+  (
+    ..pad-decimal(
+      ..round-decimal(
+        int, frac, 
+        precision: places,
+        mode: "places",
+        dir: direction,
+        sign: sign,
+        ties: ties,
+      ),
+      pad, "places", places
+    ),
+    uncertainty
+  )
+}

--- a/packages/preview/zero/0.7.0/src/state.typ
+++ b/packages/preview/zero/0.7.0/src/state.typ
@@ -1,0 +1,60 @@
+#let default-state = (
+  // Mantissa and uncertainty:
+  digits: auto,
+  decimal-separator: ".",
+  omit-unity-mantissa: false,
+  omit-zero-exponent: false,
+  uncertainty-mode: "separate",
+  positive-sign: false,
+  tight: false,
+  math: true,
+  alt: auto,
+  // Power:
+  product: sym.times,
+  positive-sign-exponent: false,
+  base: 10,
+  fixed: none,
+  exponent: auto,
+  trim-zeros: false,
+  breakable: false,
+  group: (
+    size: 3,
+    separator: sym.space.thin,
+    threshold: 5,
+  ),
+  round: (
+    mode: "places",
+    precision: auto,
+    follow-uncertainty: true,
+    uncertainty-precision: auto,
+    pad: true,
+    direction: "nearest",
+    ties: "away-from-zero",
+  ),
+  unit: (
+    unit-separator: sym.space.thin,
+    fraction: "power",
+    use-sqrt: true,
+    prefix: auto,
+    lowercase-liter: false,
+  ),
+)
+
+#let num-state = state("num-state", default-state)
+
+
+#let update-num-state(state, args) = {
+  if "round" in args {
+    state.round += args.round
+    args.remove("round")
+  }
+  if "group" in args {
+    state.group += args.group
+    args.remove("group")
+  }
+  if "unit" in args {
+    state.unit += args.unit
+    args.remove("unit")
+  }
+  return state + args
+}

--- a/packages/preview/zero/0.7.0/src/units.typ
+++ b/packages/preview/zero/0.7.0/src/units.typ
@@ -1,0 +1,395 @@
+#import "num.typ": num, process-input
+#import "state.typ": num-state, update-num-state
+#import "assertions.typ": assert-settable-args
+#import "parsing.typ": compute-eng-digits, parse-numeral
+#import "accessibility.typ": generate-unit-alt-description
+#import "utility.typ"
+
+/// [internal function]
+/// Parse a text-based unit specification.
+/// - Consecutive units can be separated by a space.
+///   (Why is this necessary? in "kg m" the "kg" needs to be close
+///    but distinguishable from the "m")
+/// - Exponents are allowed as in "m^2"
+/// - A unit in the fraction can be specified either with a negative
+///   exponent "s^-1" or by adding a slash before "/s"
+/// - Prefixes are allowed and should be prepended to the
+/// constituent unit without
+///   a space in between. Example: `"/mm^2"`. Occurrences of "mu" will be replaced
+///   by the greek mu symbol.
+/// Returns: a dictionary with the keys "numerator" and "denominator",
+/// both containing a list where each entry is a tuple with the unit symbol
+/// as the first element and the exponent as the second element. The exponent
+/// is always positive.
+#let parse-unit-str(str) = {
+  str += " "
+  str = str.replace("mu", "µ")
+
+  let numerator = ()
+  let denominator = ()
+  let unit = ""
+  let per = false
+
+  let get-symbol-and-exponent(str, per) = {
+    let pow-index = str.position("^")
+    if pow-index == none { return (str, "1") }
+
+    let exponent = str.slice(pow-index + 1)
+    assert(
+      exponent.len() > 0,
+      message: "Invalid unit: missing exponent after \"^\"",
+    )
+    exponent = exponent.trim("(").trim(")")
+    let symbol = str.slice(0, pow-index)
+    assert(
+      symbol.len() != 0,
+      message: "Invalid unit: an exponent needs to be preceded by a unit",
+    )
+    return (symbol, exponent)
+  }
+
+  for c in str {
+    if c in "/ " {
+      // both "/" and " " terminate the current unit
+      if unit.len() == 0 {
+        if c == "/" { per = true }
+        continue
+      }
+
+      let (symbol, exponent) = get-symbol-and-exponent(unit, per)
+      if symbol.starts-with("u") {
+        symbol = "µ" + symbol.slice(1)
+      }
+      if exponent.starts-with("-") {
+        per = not per
+        exponent = exponent.slice(1)
+      }
+      // exponent = [#exponent]
+      if unit != "1" {
+        // make calls like "1/s" possible in addition to "/s"
+        if per { denominator.push((symbol, exponent)) } else {
+          numerator.push((symbol, exponent))
+        }
+      }
+      per = false
+      unit = ""
+
+      if c == "/" { per = true }
+    } else {
+      unit += c
+    }
+  }
+
+  (numerator: numerator, denominator: denominator)
+}
+
+#let parse-unit(..children) = {
+  children = children.pos()
+  if children.len() == 1 and type(children.first()) == str {
+    return parse-unit-str(children.first())
+  }
+
+  let numerator = ()
+  let denominator = ()
+
+  for child in children {
+    if type(child) in (str, content, symbol) {
+      numerator.push((child, "1"))
+    } else if type(child) == array {
+      assert(
+        child.len() == 2,
+        message: "Unit entries need to be a tuple of a unit and an exponent, got " + repr(child),
+      )
+      let (unit, exponent) = child
+      assert(
+        type(exponent) in (int, float, str),
+        message: "The exponent of a unit entry needs to be an int, float, or str, got " + repr(exponent),
+      )
+      if type(exponent) in (int, float) {
+        exponent = str(exponent).replace("−", "-")
+      }
+      if exponent.starts-with("-") {
+        exponent = exponent.slice(1)
+        denominator.push((unit, exponent))
+      } else {
+        numerator.push((unit, exponent))
+      }
+    } else {
+      assert(
+        false,
+        message: "Expected str, content, symbol or a unit-exponent pair, got " + repr(child),
+      )
+    }
+  }
+
+  (numerator: numerator, denominator: denominator)
+}
+
+
+
+
+#let liter-impl = context {
+  if not num-state.get().unit.lowercase-liter {
+    "L"
+  } else {
+    "l"
+  }
+}
+
+#let format-unit-power(unit, exponent, math: true, negative: false) = {
+  if type(exponent) in (int, float) {
+    exponent = str(exponent)
+  }
+
+  exponent = [#exponent]
+  if negative {
+    exponent = sym.minus + exponent
+  }
+
+  if type(unit) == str and unit.ends-with("L") {
+    unit = unit.replace("L", "") + liter-impl
+  }
+
+  if exponent in (1, [1], "1") {
+    unit
+  } else {
+    if math {
+      std.math.attach(unit, t: exponent)
+    } else {
+      unit + super(typographic: false, exponent)
+    }
+  }
+}
+
+#let fold-units(
+  ..units,
+  exp-multiplier,
+  math: true,
+  unit-separator: sym.space.thin,
+  use-sqrt: true,
+) = {
+  let units = units
+    .pos()
+    .map(((unit, exponent)) => {
+      if use-sqrt and exponent == "0.5" and exp-multiplier == 1 and math {
+        return std.math.sqrt(unit)
+      }
+      format-unit-power(
+        unit,
+        exponent,
+        math: math,
+        negative: exp-multiplier == -1,
+      )
+    })
+
+  let folded-units = units.join(unit-separator)
+  if math {
+    std.math.upright(folded-units)
+  } else {
+    folded-units
+  }
+}
+
+/// Show a unit that has been parsed with @parse-unit-str.
+#let show-unit(
+  /// The unit elements in the numerator.
+  /// -> array
+  numerator,
+
+  /// The unit elements in the denominator.
+  /// -> array
+  denominator,
+
+  /// Mode for displaying fractions.
+  /// -> "power" | "fraction" | "inline"
+  fraction: "power",
+
+  /// Whether to use an equation or plain text elements.
+  math: true,
+
+  /// Symbol to use between constituent units.
+  /// -> content
+  unit-separator: sym.space.thin,
+
+  /// Whether to display a square root symbol when the exponent is 1/2.
+  use-sqrt: true,
+
+  /// The alt description for the unit.
+  /// -> auto | str
+  alt: auto,
+
+  /// Value of the mantissa, if part of quantity
+  /// -> float
+  value: 1,
+
+  /// Unprocessed arguments.
+  ..args,
+) = {
+  assert(
+    fraction in ("power", "fraction", "inline"),
+    message: "Invalid fraction: " + fraction + ". Expected \"power\", \"fraction\", or \"inline\"",
+  )
+  if alt == auto {
+    alt = generate-unit-alt-description(numerator, denominator, value: value)
+  }
+
+  let equation = std.math.equation.with(alt: alt)
+
+  let fold-units = fold-units.with(
+    unit-separator: unit-separator + sym.wj,
+    math: math,
+    use-sqrt: use-sqrt,
+  )
+
+  let numerator-content = fold-units(..numerator, 1)
+  if denominator.len() == 0 {
+    return if math { equation($#numerator-content$) } else { numerator-content }
+  }
+
+  let denom-exp-multiplier = if fraction == "power" { -1 } else { 1 }
+  let denominator-content = fold-units(..denominator, denom-exp-multiplier)
+
+  if fraction == "power" {
+    // Numerator could be empty!
+    let result = denominator-content
+    if numerator.len() != 0 {
+      result = numerator-content + unit-separator + sym.wj + result
+    }
+    return if math { equation($result$) } else { result }
+  }
+
+  // For the two fractional modes, the numerator shall not be empty.
+  if numerator.len() == 0 { numerator-content = $1$ }
+
+  if math {
+    if denominator.len() > 1 and fraction == "inline" {
+      denominator-content = $(#denominator-content)$
+    }
+    set std.math.frac(style: "horizontal") if fraction == "inline"
+    equation($#numerator-content/#denominator-content$)
+  } else {
+    if denominator.len() > 1 {
+      denominator-content = [(#denominator-content)]
+    }
+    numerator-content + "/" + denominator-content
+  }
+}
+
+
+#let unit(
+  unit,
+  alt: auto,
+  ..args,
+) = {
+  utility.create-unit-metadata(unit, alt: alt, ..args)
+  context {
+    let args = (unit: args.named())
+    if "math" in args.unit {
+      args.math = args.unit.math
+    }
+    let num-state = update-num-state(num-state.get(), args)
+
+    let result = (
+      show-unit(
+        unit.numerator,
+        unit.denominator,
+        ..num-state.unit,
+        math: num-state.math,
+        alt: alt,
+      )
+    )
+    result
+  }
+}
+
+
+
+
+#let qty(
+  value,
+  unit,
+  alt: auto,
+  ..args,
+) = {
+  let info = process-input(value)
+  utility.create-qty-metadata(info, value, unit, alt: alt, ..args)
+  context {
+    let unit = unit
+
+    let num-state = update-num-state(
+      num-state.get(),
+      (unit: args.named()) + args.named(),
+    )
+
+    let separator = sym.space.thin
+    if num-state.math {
+      separator = math.equation($separator$, alt: sym.zws)
+    }
+
+    let angles = ("°", "′", "″", sym.degree, sym.prime, sym.prime.double)
+    if unit.numerator.len() > 0 and unit.numerator.at(0).at(0) in angles {
+      separator = none
+    }
+
+    if num-state.unit.prefix == auto and num-state.exponent == "eng" {
+      num-state.prefixed-eng = true
+
+      let e = if info.e == none { 0 } else { int(info.e) }
+      let eng = compute-eng-digits(info)
+
+      if eng != 0 {
+        let prefixes = (
+          "3": "k",
+          "6": "M",
+          "9": "G",
+          "12": "T",
+          "15": "P",
+          "18": "E",
+          "−3": "m",
+          "−6": "µ",
+          "−9": "n",
+          "−12": "p",
+          "−15": "f",
+          "−18": "a",
+        )
+
+        let prefix = prefixes.at(str(eng))
+        assert(unit.numerator.len() != 0)
+        unit.numerator.first().first() = prefix + unit.numerator.first().first()
+      }
+    }
+    let breakable = utility.process-breakable(num-state.breakable)
+
+    let result = {
+      num(value, state: num-state, force-parentheses-around-uncertainty: true)
+      sym.wj
+      separator
+      if not breakable.unit { sym.wj }
+      show-unit(
+        unit.numerator,
+        unit.denominator,
+        fraction: num-state.unit.fraction,
+        unit-separator: num-state.unit.unit-separator,
+        math: num-state.math,
+        use-sqrt: num-state.unit.use-sqrt,
+        alt: alt,
+        value: if info.frac == "" {
+          int(info.int)
+        } else {
+          float(info.int + "." + info.frac)
+        },
+      )
+    }
+
+    result
+  }
+}
+
+
+#let set-unit(..args) = {
+  num-state.update(s => {
+    assert-settable-args(args, s.unit, name: "set-unit")
+    s.unit += args.named()
+    s
+  })
+}

--- a/packages/preview/zero/0.7.0/src/utility.typ
+++ b/packages/preview/zero/0.7.0/src/utility.typ
@@ -1,0 +1,118 @@
+
+/// Takes a number by integer and fractional part and
+/// shifts specified number of digits left. Negative values
+/// for `digits` produce a right-shift. Numbers are automatically
+/// padded with zeros but both integer and fractional parts
+/// may become "empty" when they are zero.
+/// -> (str, str)
+#let shift-decimal-left(
+  /// The integer part of a number as a string of digits.
+  /// -> str
+  integer,
+  /// The fractional part of a number as a string of digits.
+  /// -> str
+  fractional,
+  /// By how many digits to shift the number.
+  /// -> int
+  digits: 0,
+) = {
+  if digits < 0 {
+    let available-digits = calc.min(-digits, fractional.len())
+    integer += fractional.slice(0, available-digits)
+    integer += "0" * (-digits - available-digits)
+    fractional = fractional.slice(available-digits)
+    if integer.starts-with("0") {
+      integer = (integer + ";").trim("0").slice(0, -1)
+    }
+  } else {
+    let available-digits = calc.min(digits, integer.len())
+    fractional = integer.slice(integer.len() - available-digits) + fractional
+    fractional = "0" * (digits - available-digits) + fractional
+    integer = integer.slice(0, integer.len() - available-digits)
+  }
+  if integer == "" {
+    integer = "0"
+  }
+  return (integer, fractional)
+}
+
+#assert.eq(shift-decimal-left("123", "456", digits: 0), ("123", "456"))
+#assert.eq(shift-decimal-left("123", "456", digits: 2), ("1", "23456"))
+#assert.eq(shift-decimal-left("123", "456", digits: 5), ("0", "00123456"))
+#assert.eq(shift-decimal-left("123", "456", digits: -2), ("12345", "6"))
+#assert.eq(shift-decimal-left("123", "456", digits: -5), ("12345600", ""))
+#assert.eq(shift-decimal-left("0", "0012", digits: -4), ("12", ""))
+#assert.eq(shift-decimal-left("0", "0012", digits: -2), ("0", "12"))
+
+
+#let process-breakable(breakable) = {
+  let default = (
+    uncertainty: false,
+    power: false,
+    unit: false,
+  )
+
+  if breakable == false {
+    return default
+  }
+  if breakable == true {
+    return (
+      uncertainty: true,
+      power: true,
+      unit: true,
+    )
+  }
+  if type(breakable) == dictionary {
+    return default + breakable
+  }
+  assert(false)
+}
+
+#let info-to-float(value) = {
+  let f = float(
+    value.sign
+      + value.int
+      + if value.frac != "" { "." + value.frac }
+      + if value.e != none and not value.e.contains(".") { "e" + value.e },
+  )
+
+  if value.e != none and value.e.contains(".") {
+    f *= calc.pow(10, float(value.e))
+  }
+  return f
+}
+
+#let info-to-uncertainty(value) = if value.pm != none {
+  if type(value.pm.first()) == array {
+    value.pm.map(x => float(x.at(0) + "." + x.at(1) + if value.e != none { "e" + value.e }))
+  } else {
+    float(value.pm.at(0) + "." + value.pm.at(1) + if value.e != none { "e" + value.e })
+  }
+}
+
+#let create-num-metadata(info, raw, args) = [#metadata((
+  info: info,
+  raw: raw,
+  args: args,
+))<zero-num>]
+
+#let create-qty-metadata(info, raw, unit, ..args) = [#metadata((
+  info: info,
+  unit: unit,
+  raw: raw,
+  args: args,
+))<zero-qty>]
+
+#let create-unit-metadata(unit, ..args) = [#metadata((
+  unit: unit,
+  args: args,
+))<zero-unit>]
+
+#let _sequence = ([A] + [B]).func()
+#let retrieve-metadata(it) = {
+  if type(it) == content and it.func() == _sequence {
+    if it.children.first().func() == metadata {
+      return it.children.first().value
+    }
+  }
+}

--- a/packages/preview/zero/0.7.0/src/zero.typ
+++ b/packages/preview/zero/0.7.0/src/zero.typ
@@ -1,0 +1,7 @@
+#import "impl.typ"
+#import "num.typ": nonum, num, set-group, set-num, set-round
+#import "ztable.typ": format-table, ztable
+#import "align-column.typ": align-column
+#import "zi.typ"
+#import "units.typ": set-unit
+#import "quan.typ": quan

--- a/packages/preview/zero/0.7.0/src/zi.typ
+++ b/packages/preview/zero/0.7.0/src/zi.typ
@@ -1,0 +1,201 @@
+#import "units.typ"
+
+#let declare(alt: auto, ..unit) = {
+  assert(unit.named().len() == 0, )
+
+  (..value) => if value.pos().len() == 0 { 
+    units.unit(units.parse-unit(..unit.pos()), ..value, alt: alt)
+  } else { 
+    units.qty(..value, units.parse-unit(..unit.pos()), alt: alt)
+  }
+}
+
+// SI base units ..
+#let ampere = declare("A")
+#let candela = declare("cd")
+#let kelvin = declare("K")
+#let kilogram = declare("kg")
+#let meter = declare("m")
+#let mole = declare("mol")
+#let second = declare("s")
+
+// .. and shorthands
+#let A = ampere
+#let cd = candela
+#let K = kelvin
+#let kg = kilogram
+#let m = meter
+#let mol = mole
+#let s = second
+
+
+// Derived units ..
+#let becquerel = declare("Bq")
+#let degreeCelsius = declare(sym.degree + "C")
+#let coulomb = declare("C")
+#let farad = declare("F")
+#let gray = declare("Gy")
+#let hertz = declare("Hz")
+#let henry = declare("H")
+#let joule = declare("J")
+#let lumen = declare("lm")
+#let katal = declare("kat")
+#let lux = declare("lx")
+#let newton = declare("N")
+#let ohm = declare(sym.Omega)
+#let pascal = declare("Pa")
+#let radian = declare("rad")
+#let degree = declare(sym.degree)
+#let percent = declare("%")
+#let promille = declare("‰")
+#let siemens = declare("S")
+#let sievert = declare("Sv")
+#let steradian = declare("sr")
+#let tesla = declare("T")
+#let volt = declare("V")
+#let watt = declare("W")
+#let weber = declare("Wb")
+
+// .. and shorthands
+#let Bq = becquerel
+#let C = coulomb
+#let F = farad
+#let Gy = gray
+#let Hz = hertz
+#let H = henry
+#let J = joule
+#let lm = lumen
+#let kat = katal
+#let lx = lux
+#let N = newton
+#let Ω = ohm
+#let Pa = pascal
+#let rad = radian
+#let S = siemens
+#let Sv = sievert
+#let sr = steradian
+#let T = tesla
+#let V = volt
+#let W = watt
+#let Wb = weber
+
+#let astronomicalunit = declare("au")
+#let bel = declare("B")
+#let dalton = declare("Da")
+#let day = declare("d")
+#let decibel = declare("dB")
+#let electronvolt = declare("eV")
+#let hectare = declare("ha")
+#let liter = declare("L")
+#let arcminute = declare(sym.prime)
+#let arcsecond = declare(sym.prime.double)
+#let hour = declare("h")
+#let minute = declare("min")
+#let neper = declare("Np")
+#let tonne = declare("t")
+#let gram = declare("g")
+
+// Common units with prefixes
+#let mm = declare("mm")
+#let km = declare("km")
+#let cm = declare("cm")
+#let µm = declare("µm")
+#let um = µm
+#let nm = declare("nm")
+#let pm = declare("pm")
+#let ms = declare("ms")
+#let µs = declare("µs")
+#let us = µs
+#let ns = declare("ns")
+#let ps = declare("ps")
+#let mK = declare("mK")
+#let nK = declare("nK")
+#let mF = declare("mF")
+#let µF = declare("µF")
+#let uF = µF
+#let nF = declare("nF")
+#let pF = declare("pF")
+#let mH = declare("mH")
+#let µH = declare("µH")
+#let uH = µH
+#let nH = declare("nH")
+#let mC = declare("mC")
+#let nC = declare("nC")
+#let µC = declare("µC")
+#let uC = µC
+#let THz = declare("THz")
+#let GHz = declare("GHz")
+#let MHz = declare("MHz")
+#let kHz = declare("kHz")
+#let mHz = declare("mHz")
+#let MJ = declare("MJ")
+#let kJ = declare("kJ")
+#let mJ = declare("mJ")
+#let GPa = declare("GPa")
+#let MPa = declare("MPa")
+#let kPa = declare("kPa")
+#let mPa = declare("mPa")
+#let MN = declare("MN")
+#let kN = declare("kN")
+#let mN = declare("mN")
+#let kT = declare("kT")
+#let mT = declare("mT")
+#let µT = declare("µT")
+#let uT = µT
+#let nT = declare("nT")
+#let GV = declare("GV")
+#let MV = declare("MV")
+#let kV = declare("kV")
+#let mV = declare("mV")
+#let µV = declare("µV")
+#let uV = µV
+#let nV = declare("nV")
+#let kA = declare("kA")
+#let mA = declare("mA")
+#let µA = declare("µA")
+#let uA = µA
+#let nA = declare("nA")
+#let TW = declare("TW")
+#let GW = declare("GW")
+#let kW = declare("kW")
+#let mW = declare("mW")
+#let mSv = declare("mSv")
+#let hL = declare("h" + "L")
+#let mL = declare("m" + "L")
+#let µL = declare("µ" + "L")
+#let uL = µL
+#let meV = declare("meV")
+#let keV = declare("keV")
+#let MeV = declare("MeV")
+#let GeV = declare("GeV")
+#let TeV = declare("TeV")
+#let mohm = declare("m" + sym.Omega)
+#let kohm = declare("k" + sym.Omega)
+#let Mohm = declare("M" + sym.Omega)
+
+
+// Some common combined units
+#let m-s = declare("m/s")
+#let m-s2 = declare("m/s^2")
+#let km-h = declare("km/h")
+#let Js = declare("J s")
+#let J-K = declare("J/K")
+#let m2 = declare("m^2")
+#let m3 = declare("m^3")
+#let g-cm3 = declare("g/cm^3")
+#let kg-m3 = declare("kg/m^3")
+#let kg-m2 = declare("kg/m^2")
+#let As = declare("A s")
+#let W-m2 = declare("W/m^2")
+#let J-kg = declare("J/kg")
+#let W-K = declare("W/K")
+#let N-m = declare("N/m")
+#let C-m2 = declare("C/m^2")
+#let V-m = declare("V/m")
+#let A-m = declare("A/m")
+#let Gy-s = declare("Gy/s")
+#let kg-mol = declare("kg/mol")
+#let J-T = declare("J/T")
+#let N-A2 = declare("N/A^2")
+#let F-m = declare("F/m")
+#let kWh = declare("kW h")

--- a/packages/preview/zero/0.7.0/src/ztable.typ
+++ b/packages/preview/zero/0.7.0/src/ztable.typ
@@ -1,0 +1,118 @@
+#import "num.typ": num, to-normalized-numeral-table
+#import "state.typ": num-state
+#import "parsing.typ": nonum
+
+// #let ptable-counter = counter("__pillar-table__")
+
+#let is-normal-cell(cell, format, default: none) = {
+  (
+    (
+      format.at(cell.x, default: default) == none
+        or to-normalized-numeral-table(cell.body) == none
+    )
+      and cell.body.func() != nonum
+  )
+}
+
+#let call-num(
+  cell,
+  format,
+  col-widths: auto,
+  default: none,
+  state: auto,
+) = context {
+  if cell.body.func() == nonum {
+    return cell.body.body
+  }
+  
+  let (numeral, prefix, suffix) = to-normalized-numeral-table(cell.body)
+  let cell-fmt = format.at(cell.x, default: default)
+  let args = if type(cell-fmt) == dictionary { cell-fmt } else { () }
+
+  num(
+    numeral,
+    prefix: prefix,
+    suffix: suffix,
+    state: state,
+    align: (col-widths: col-widths, col: cell.x),
+    ..args,
+  )
+}
+
+
+
+
+
+#let show-ztable(it, format: none) = {
+  if format == none or it.children.len() == 0 { return it }
+  assert.eq(
+    type(format),
+    array,
+    message: "The parameter `format` requires an array argument, got "
+      + repr(format),
+  )
+
+
+  let table = context {
+    let state = num-state.get()
+
+    let table-end = query(selector(<__pillar-table__>).after(here()))
+      .first()
+      .location()
+
+    let number-infos = query(
+      selector(<__pillar-num__>).after(here()).before(table-end),
+    ).map(x => x.value)
+
+
+    // let debug-info = (counter: ptable-counter.get(), d: number-infos)
+
+
+    if number-infos.len() == 0 {
+      // first layout pass
+      return {
+        show table.cell: it => {
+          if is-normal-cell(it, format) { it } else {
+            call-num(it, format, state: state)
+          }
+        }
+        it
+      }
+    }
+
+    // second layout pass
+    let aligned-columns = range(format.len()).filter(x => format.at(x) != none)
+    let col-widths = (none,) * format.len()
+    for col in aligned-columns {
+      let filtered-cells = number-infos.filter(x => x.at(0) == col)
+      col-widths.at(col) = range(1, 5).map(i => calc.max(
+        0pt,
+        ..filtered-cells.map(x => x.at(i)),
+      ))
+    }
+
+    show table.cell: it => {
+      if is-normal-cell(it, format) { it } else {
+        table.cell(
+          call-num(it, format, col-widths: col-widths.at(it.x), state: state),
+          align: it.align,
+          x: it.x,
+          y: it.y,
+          inset: it.inset,
+        )
+      }
+    }
+    it
+  }
+  table + [#metadata(none)<__pillar-table__>] + place(hide(std.table()))
+}
+
+
+#let ztable(..children, format: none) = {
+  show-ztable(table(..children), format: format)
+}
+
+
+#let format-table(..format) = {
+  show-ztable.with(format: format.pos())
+}

--- a/packages/preview/zero/0.7.0/typst.toml
+++ b/packages/preview/zero/0.7.0/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zero"
+version = "0.7.0"
+entrypoint = "src/zero.typ"
+authors = ["Mc-Zen <https://github.com/Mc-Zen>"]
+license = "MIT"
+description = "Precise scientific number and unit formatting."
+compiler = "0.12.0"
+
+repository = "https://github.com/Mc-Zen/zero"
+keywords = ["number", "table", "siunitx", "numeral", "alignment", "formatting", "num", "ztable"]
+categories = ["visualization", "layout"]
+disciplines = ["physics", "chemistry", "engineering", "mathematics", "economics", "computer-science"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Description: Explain what the package does and why it's useful.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

## Changelog


Features:
- The new `quan` function provides a new way of defining quantities and units.
- Zero now adds alt descriptions for all numbers and units for supported languages. 

Rounding:
- ⚠️ Breaking change: the rounding API was changed to a more comprehensible model and to better reflect common applications. Numbers with an uncertainty are by default (`round.follow-uncertainty: true`) rounded to the precision of the uncertainty − we call this _automatic rounding_. If no uncertainty is present or `round.follow-uncertainty: false`, _manually rounding_ is applied according to the options `mode` and `precision`. The `mode: "uncertainty"` has been removed.
- ⚠️ Breaking change: zeros are now trimmed after rounding and padding is independent. This leads to the following effect of change:
  - Before: `num(round: (precision: 2, pad: false)[0.299]` -> 0.30
  - Now: `num(round: (precision: 2, pad: false)[0.299]` -> 0.3 
- Fixed a bug where rounding to zero were for negative precision led to multiple zeros being displayed in the integer part.
- Fixed rounding to negative (integer) places.
- Fixed rounding of 0 to a positive number of significant figures: now no trailing zeros are displayed anymore.

Input:
- Added support for capital E in exponent notation.

Formatting:
- New option `num.trim-zeros` for trimming trailing zeros.
- New option `num.omit-zero-exponent`.
- Fixed: Automatic exponents with scientific or engineering notation are now omitted when the mantissa is 0 and no explicit exponent is given.
- Fixed prevention of line breaks and add more fine-grained line break control: after the ×, after the ± and before the unit.
- ⚠️ Breaking change: moved the parameter `breakable` from `set-unit` to `set-num` since it now also affects numbers.
- Fixed `num.use-sqrt` with inline fraction mode.
- Fixed formatting of exponents with custom decimal separators.
- Fixed an error with scientific mode with asymmetric uncertainties.
- Fixed a tiny detail when formatting the decimal separator.


API:
- Added queryable metadata to numbers and units.
- Moved the internal `num-state` to the impl module.
