### PR TITLE
datehog:0.1.1

### DIFF
--- a/packages/preview/datehog/0.1.1/CHANGELOG.md
+++ b/packages/preview/datehog/0.1.1/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog of all Changes to Datehog
+
+## v0.1.1
+
+No functional changes. The `v0.1.0` was prematurely created without this changelog and the release pipeline.
+
+## v0.1.0
+
+Initial release. Parses date strings and epoch milliseconds into a plain
+*moment* dictionary (`from-ms`, `parse`, `parse-ms`, ...), converts back to
+epoch ms/seconds/days or ISO 8601, interops with Typst's native `datetime`,
+and adds calendar arithmetic (`add-days`, `add-months`, `is-leap-year`,
+`days-in-month`, ...). Nothing panics: unparseable input returns `none`.
+
+Parsing tracks JavaScript's `Date.parse` order and is calibrated against
+flint-py, the reference implementation datehog exists to stay compatible
+with. Basically on par with V8's own parsing, and bug-for-bug compatible with
+the mismatches flint-py also makes -- except where flint-py's mismatch is
+simply a flint-py bug, in which case datehog follows V8 instead:
+
+- Strings V8 sloppily accepts as dates but flint-py rejects, so datehog does
+  too: invalid calendar dates (`2020-02-30`, `2019-02-29`), and short
+  fragments V8 parses through a loose heuristic (`Wk 01`, `Round 1`..`Round 6`,
+  `Stage 1`..`Stage 12`).
+- `2018 FY` goes the other way: flint-py (and datehog) parse the trailing
+  year out of it; V8 does not.
+- Month-name formats flint-py mishandles even though V8 parses them
+  correctly -- a genuine flint-py bug, not a deliberate JS leniency, so
+  datehog matches V8 here instead of replicating it: bare `"Month Year"` and
+  `"Month D Year"` in their various spellings (`Feb 2020`, `February 2020`,
+  `Feb 15 2020`, `Feb 15, 2020`, `February 15, 2020`, `15 Feb 2020`,
+  `15 February 2020`, `Sept 2020`, `Jan. 2020`, plus RFC 2822 forms like
+  `Tue, 15 Feb 2020 08:30:00 GMT` and `15 Feb 2020 08:30:00 +0200`), and the
+  bare year-month `2020-03`.
+
+Verified against 29,031/29,031 calendar dates (1600-2400) vs. Python's
+`datetime`, and 445/445 parser cases vs. flint-py or, on the cases just
+above, vs. V8. See [Testing](README.md#testing) for how the suite is run.

--- a/packages/preview/datehog/0.1.1/LICENSE
+++ b/packages/preview/datehog/0.1.1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zral0kh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/datehog/0.1.1/README.md
+++ b/packages/preview/datehog/0.1.1/README.md
@@ -1,0 +1,311 @@
+# datehog
+
+Date parsing and epoch arithmetic for Typst. \
+For the changes see the [Changelog](./CHANGELOG.md).
+
+Typst's built-in `datetime` can be constructed from calendar parts and
+formatted, but it cannot parse a string and has no epoch conversion:
+
+```typst
+#datetime("2020-03-14")   // error: unexpected argument
+#d.timestamp()            // error: type datetime has no method `timestamp`
+```
+
+datehog fills exactly that gap. Strings and epoch milliseconds in, a plain
+dictionary out, everything in UTC, everything a pure function.
+
+Status: unit tests pass; **29 031/29 031** calendar dates from 1600–2400 match
+Python's `datetime`; **445/445** parser cases match the reference implementation
+it is calibrated against. Details under [Testing](#testing).
+
+```typst
+#import "@preview/datehog:0.1.1" as dh
+
+#dh.parse("2020-03-14T08:30:00Z").day        // 14
+#dh.parse("Feb 2020").month                  // 2
+#dh.parse-ms("15 February 2020")             // 1581724800000
+#dh.to-iso(dh.from-ms(1584174600000))        // "2020-03-14T08:30:00.000Z"
+#dh.to-iso-date(dh.add-months(dh.parse("2020-01-31"), 1))   // "2020-02-29"
+```
+
+## The moment type
+
+Everything resolves to a *moment*: an instant in UTC as an ordinary
+dictionary, so it prints under `repr`, compares with `==`, and is memoised by
+Typst like any other value.
+
+```typst
+#dh.from-ms(1584174600250)
+// (datehog: "moment", ms: 1584174600250,
+//  year: 2020, month: 3, day: 14,
+//  hour: 8, minute: 30, second: 0, millisecond: 250,
+//  weekday: 6, ordinal: 74)
+```
+
+`weekday` is ISO (Monday = 1, Sunday = 7); `ordinal` is the day of the year.
+
+## API
+
+**Parsing** — all return a moment, or `none` for unparseable input. Nothing
+ever panics: a bad cell in a data table must not take down the document.
+
+| | |
+|---|---|
+| `parse(value, assume-offset: 0)` | every strategy, in JavaScript's order |
+| `parse-ms(value, assume-offset: 0)` | the same, as epoch milliseconds |
+| `is-parseable(value)` | would parsing succeed? |
+| `parse-iso(s, assume-offset: 0)` | strict ISO 8601 / ECMAScript only |
+| `parse-numeric(s, assume-offset: 0)` | `M/D/YYYY`, `YYYY-M-D` and dot/dash variants |
+| `parse-loose(s, assume-offset: 0)` | month names and RFC 2822 |
+| `is-iso-date-only(s)`, `is-numeric-date-shape(s)` | shape predicates |
+| `year-from-words(s)` | the year in `"FY 2018"` |
+| `offset-from-string(s)` | `"+02:00"` → `120` minutes east of UTC |
+| `local-offset(key: "tz", default: 0)` | that offset from `sys.inputs` — see [Timezones](#timezones-utc-by-default-deliberately) |
+| `expand-two-digit-year(s)` | `"99"` → `"1999"`, `"20"` → `"2020"` |
+
+**Construction and conversion**
+
+| | |
+|---|---|
+| `from-ms(ms)`, `to-ms(m)` | epoch milliseconds |
+| `from-parts(y, m, d, hour: .., minute: .., second: .., millisecond: ..)` | UTC calendar parts |
+| `to-seconds(m)`, `to-days(m)` | floored epoch seconds / days |
+| `to-iso(m)` | `2020-03-14T08:30:00.000Z` |
+| `to-iso-date(m)` | `2020-03-14` |
+| `from-typst-datetime(d)`, `to-typst-datetime(m)` | interop (lossy: no milliseconds) |
+| `is-moment(v)`, `pad(n, width)` | |
+
+**Arithmetic** — `add-ms`, `add-days`, `add-months` (clamps: Jan 31 + 1 month
+is Feb 29, not Mar 2).
+
+**Calendar** — `is-leap-year`, `days-in-month`, `is-valid-date`,
+`days-from-civil`, `civil-from-days`, `weekday-from-days`,
+`ordinal-from-civil`.
+
+**Names** — `month-name`, `month-from-name`, `weekday-name`, plus the
+`MONTH-NAMES` / `MONTH-ABBR` / `WEEKDAY-NAMES` / `WEEKDAY-ABBR` tables.
+
+## Timezones: UTC by default, deliberately
+
+**Zoneless input is read as UTC.** An explicit zone in the string always wins;
+`assume-offset` (minutes east of UTC) applies when there is none.
+
+```typst
+#dh.to-iso(dh.parse-iso("2020-03-14T08:30:00"))                    // 08:30 Z
+#dh.to-iso(dh.parse-iso("2020-03-14T08:30:00", assume-offset: 120)) // 06:30 Z
+#dh.to-iso(dh.parse-iso("2020-03-14T08:30:00Z", assume-offset: 120))// 08:30 Z
+```
+
+ECMAScript reads a zoneless date-*time* string in the host's local zone. datehog
+cannot, because **Typst cannot discover the host's timezone at all**. This is
+worth spelling out, because two plausible workarounds both fail.
+
+*Deriving it from `datetime.today()`* does not work. It returns a local date but
+no time of day, so there is nothing to compare against UTC at better than
+one-day resolution, and `datetime.today(offset: n)` requires you to supply the
+offset rather than reporting it. Scanning does not recover it either — at the
+time of writing, 14 different offsets all reproduce `datetime.today()`'s date:
+
+```typst
+#let local = datetime.today().display("[year]-[month]-[day]")
+#range(-12, 15).filter(n => datetime.today(offset: n).display("[year]-[month]-[day]") == local)
+// (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+```
+
+*Shipping a wasm plugin to read it* does not work either. Typst plugins run in
+`wasmi` with no WASI and exactly one host import —
+`typst_env.wasm_minimal_protocol_send_result_to_host`, the result callback. A
+plugin is a pure function over the bytes Typst hands it. Compiling
+`std::env::var("TZ")` or `SystemTime::now()` into a plugin succeeds, and both
+then trap at runtime with `plugin panicked: wasm 'unreachable' instruction
+executed`, because neither has an implementation on `wasm32-unknown-unknown`.
+There is no clock and no environment inside the sandbox to reach.
+
+### Passing the offset in
+
+Since the offset cannot be discovered, it has to be supplied. `local-offset`
+reads it from `sys.inputs`:
+
+```sh
+typst compile --input tz="$(date +%z)" doc.typ
+```
+
+```typst
+#let tz = dh.local-offset()                      // +0200 -> 120
+#dh.parse("2020-03-14T08:30:00", assume-offset: tz)
+```
+
+`offset-from-string` accepts `Z`, `+02:00`, `+0200`, `-05`, `UTC+02:00` or a
+bare minute count. IANA names like `Europe/Berlin` are **not** supported —
+resolving those needs the tzdata database, which does not belong in a date
+package — and `local-offset` falls back to its default rather than failing, so a
+document still compiles either way.
+
+One caveat worth stating: `date +%z` is the offset *now*. For data spanning a
+DST boundary it is wrong for half the rows. Where that matters, prefer input
+that carries its own zone — a string with an explicit offset always wins over
+`assume-offset`.
+
+### Why UTC is the right default anyway
+
+Local-time parsing makes a document render differently depending on the machine
+that compiled it — a chart axis shifting by a day between a laptop in Berlin and
+CI in UTC is a bug, not a feature. Defaulting to UTC means a document that says
+nothing about timezones is reproducible; a document that cares says so
+explicitly.
+
+## JavaScript compatibility
+
+`dh.js` reproduces V8's `Date.parse` closely enough to port JavaScript code
+that depends on it. The ordering — strict ISO, then numeric forms, then
+month-name forms, then the trailing-year heuristic — matches V8's, including
+two behaviours strict parsers get differently:
+
+- **V8 accepts** `"FY 2018"`, `"hello world 2018"` — words plus exactly one
+  four-digit year — as January 1 of that year. Real spreadsheet columns look
+  like this, so it matters.
+- **V8 rejects** `"15.01.2020"` and `"15/01/2020"`: it reads the first
+  component as a month, and 15 is not a month. Lenient parsers read these as
+  15 January. datehog rejects them, as V8 does.
+
+Also in `dh.js`: `is-likely-timestamp(n)` and `timestamp-to-ms(n)`, for the
+common case of a numeric column that is really seconds or milliseconds since
+the epoch.
+
+### Known divergences from V8
+
+datehog is bug-for-bug compatible with [flint-chart]'s Python port of these
+semantics, which is stricter than V8 in three places. Where V8 is more
+permissive, datehog follows the stricter reading:
+
+| input | V8 | datehog |
+|---|---|---|
+| `"Stage 1"`, `"Round 2"`, `"Wk 01"` | parses (reads the trailing digit as a month) | `none` |
+| `"2020-02-30"`, `"2019-02-29"` | overflows into the next month | `none` |
+| `"1/2/3"` (no four-digit component) | parses | `none` |
+| `"2018 FY"` (year first) | `none` | parses |
+
+The first row is worth knowing about if you are porting: V8 will happily treat
+a column of `"Stage 1"`, `"Stage 2"` … as *dates*, which is almost never what
+the data means.
+
+[flint-chart]: https://github.com/microsoft/flint-chart
+
+## Performance
+
+Every parser is a pure top-level function and every regex is bound at module
+level, so Typst memoises parses and compiles each pattern once. Real data
+re-presents the same handful of dates thousands of times, and that is where
+this pays:
+
+| 50 000 `parse-ms` calls | time |
+|---|---|
+| 500 distinct values | **278 ms** |
+| all distinct | 857 ms |
+
+About 3.1× at a realistic redundancy ratio, for free. If you are building your
+own helpers on top, keep them top-level and pure for the same reason — but
+don't wrap trivial checks in functions, where the call plus cache lookup costs
+more than the check.
+
+The calendar conversions go through Typst's native `datetime` and `duration`
+rather than a reimplemented calendar: subtracting two datetimes gives a
+duration, adding one back gives a datetime, and that covers every conversion
+between a date and a day count. One definition of the Gregorian calendar is in
+play, not two — and it is faster, since the built-in is Rust and hand-rolled
+arithmetic would be interpreted (measured: ~13 % quicker on the cold path).
+
+Milliseconds are the exception. Native datetimes have second resolution, so a
+moment tracks the day count and intraday milliseconds itself and only reaches
+for `datetime` at the date boundary.
+
+## Implementation notes
+
+Three constraints shaped the code, all of them worth knowing if you extend it.
+
+**Typst's regex engine has no backreferences.** It is Rust's `regex` crate,
+which is finite-automaton based. A pattern like
+
+```regex
+^\s*(\d{1,4})\s*([./-])\s*(\d{1,2})\s*\2\s*(\d{1,4})\s*$
+```
+
+— requiring the two separators in `01/15/2020` to be the *same* character — is
+rejected outright rather than silently misbehaving. `parse-numeric` captures
+both separators and compares them in code instead. Expect this anywhere you
+port a pattern from a PCRE-family engine.
+
+**Integer division must be `calc.div-euclid`, never `/`.** In Typst `/` yields
+a float, so a day count past 2^53 would lose exactness silently. Every division
+in `civil.typ` is floor division on integers. (`calc.div-euclid(-7, 2) == -4`,
+which is what the calendar algorithms need for pre-epoch dates.)
+
+**Multi-line expressions need parentheses, and continuation lines cannot lead
+with an operator.** `a and\n b` is a parse error, and `"x"\n + "y"` parses the
+`+` as unary and fails at runtime. Wrap the whole expression in `(...)` and keep
+operators at line ends.
+
+## Compatibility
+
+Verified on **Typst 0.15.1**. `typst.toml` declares a floor of 0.13.0, which is
+a conservative estimate rather than a tested one — nothing here uses a recent
+feature, but older releases have not been exercised. If you hit a problem on an
+earlier version, that floor is the thing to correct.
+
+## Comparing against another implementation
+
+If you are diffing datehog against a JavaScript or Python reference, **run the
+reference under `TZ=UTC`**. Both interpret zoneless date-time strings in the
+host zone, so their output is machine-dependent; datehog's is not. Getting this
+wrong produces differences that look like parser bugs and are really timezone
+drift — in one real corpus of 705 chart fixtures, 15 changed value depending on
+the build machine's timezone, all in the hour-of-day and `"Mon YYYY"` groups.
+
+`tests/compare.py` sets `TZ=UTC` for both reference runners for this reason.
+
+## Range and safety
+
+Native datetimes span years **-9999 to 9999**, and that is datehog's range too.
+Outside it every entry point returns `none`.
+
+That is not politeness, it is necessary. Typst's datetime has two failure modes
+neither of which can be caught:
+
+- `datetime(year: 2020, month: 2, day: 30)` is a Typst **error**, so nothing
+  here constructs one without validating first — which is why a month-length
+  table survives in `civil.typ` despite the rest being native.
+- Overrunning the upper bound is a **compiler panic** inside the underlying
+  `time` crate, not a Typst error at all. `from-ms(MAX-MS + 1)` returns `none`
+  precisely so that a stray value in a data column cannot take the compiler
+  down.
+
+`MIN-YEAR`, `MAX-YEAR`, `MIN-DAYS`, `MAX-DAYS`, `MIN-MS`, `MAX-MS` and the
+predicates `is-year-in-range` / `is-days-in-range` are exported for callers who
+want to check before converting.
+
+## Testing
+
+```bash
+./tests/run.sh          # unit tests + calendar differential
+./tests/run.sh --all    # also the V8 / flint-py differential (needs node)
+```
+
+- `test.typ` — assertions covering the arithmetic and the edges with no
+  external reference. The suite passes exactly when the file runs cleanly.
+- `civil_differential.py` — 29 031 dates from 1600 to 2400, every month
+  boundary and leap-year edge, checked against Python's `datetime`.
+- `compare.py` — every date-shaped string in a real fixture corpus plus
+  hand-picked edge cases, run through datehog, V8 and flint-py. Gated on
+  flint-py agreement, with one exception: where flint-py itself diverges from
+  V8, datehog is expected to follow V8 rather than replicate the mistake (see
+  [CHANGELOG.md](CHANGELOG.md) for the specific cases). Only a disagreement
+  with flint-py that isn't explained by one of those two patterns fails the
+  suite.
+
+Current status: unit tests pass, 29 031/29 031 calendar dates match, and on
+445/445 parser cases datehog matches flint-py or, where flint-py itself is
+wrong, matches V8 instead.
+
+## License
+
+MIT.

--- a/packages/preview/datehog/0.1.1/src/civil.typ
+++ b/packages/preview/datehog/0.1.1/src/civil.typ
@@ -1,0 +1,89 @@
+// Calendar arithmetic, on Typst's native `datetime` and `duration`.
+//
+// Typst can subtract two datetimes to get a duration and add a duration back,
+// which covers every conversion between a calendar date and a day count. That
+// is used directly here rather than reimplementing the calendar: the built-in
+// is the same `time` crate the rest of Typst dates on, so there is one
+// definition of the Gregorian calendar in play instead of two.
+//
+// Two things the built-in does *not* give us, and this module has to:
+//
+//   * **Validation.** `datetime(year: 2020, month: 2, day: 30)` is an error,
+//     and Typst has no way to catch it — a bad cell in a data table would
+//     abort the whole document. So nothing here constructs a datetime without
+//     checking it first, which is why the month-length table survives.
+//   * **Range guarding.** Native datetimes span years -9999 to 9999. Going
+//     past the top does not raise a Typst error, it *panics the compiler*
+//     (a Rust panic inside the `time` crate), so the bounds are checked
+//     rather than trusted.
+
+/// The reference instant for every day count in this package.
+#let EPOCH = datetime(year: 1970, month: 1, day: 1)
+
+/// Representable year bounds, imposed by Typst's `datetime`.
+#let MIN-YEAR = -9999
+#let MAX-YEAR = 9999
+
+/// Day-count bounds corresponding to [`MIN-YEAR`] / [`MAX-YEAR`].
+#let MIN-DAYS = int((datetime(year: MIN-YEAR, month: 1, day: 1) - EPOCH).days())
+#let MAX-DAYS = int((datetime(year: MAX-YEAR, month: 12, day: 31) - EPOCH).days())
+
+/// Is `year` inside the representable range?
+#let is-year-in-range(year) = type(year) == int and year >= MIN-YEAR and year <= MAX-YEAR
+
+/// Is `days` inside the representable range?
+#let is-days-in-range(days) = type(days) == int and days >= MIN-DAYS and days <= MAX-DAYS
+
+/// Is `year` a leap year?
+///
+/// Asks the calendar rather than restating its rule: a leap year is one whose
+/// 31 December is the 366th day.
+#let is-leap-year(year) = {
+  if not is-year-in-range(year) { return false }
+  datetime(year: year, month: 12, day: 31).ordinal() == 366
+}
+
+#let _MONTH_LENGTHS = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+
+/// Number of days in `month` (1-12) of `year`, or 0 for a bad month.
+///
+/// Kept as a table because it is the *precondition* for constructing a
+/// datetime safely — deriving it from datetime arithmetic would mean
+/// constructing one first, which is the thing being guarded against.
+#let days-in-month(year, month) = {
+  if type(month) != int or month < 1 or month > 12 { return 0 }
+  if month == 2 and is-leap-year(year) { 29 } else { _MONTH_LENGTHS.at(month - 1) }
+}
+
+/// Is (year, month, day) a real, representable calendar date?
+#let is-valid-date(year, month, day) = (
+  type(year) == int and type(month) == int and type(day) == int
+    and is-year-in-range(year)
+    and month >= 1 and month <= 12
+    and day >= 1 and day <= days-in-month(year, month)
+)
+
+/// Days since 1970-01-01, or `none` if the date is invalid or out of range.
+#let days-from-civil(year, month, day) = {
+  if not is-valid-date(year, month, day) { return none }
+  int((datetime(year: year, month: month, day: day) - EPOCH).days())
+}
+
+/// Inverse of [`days-from-civil`]: `(year, month, day)`, or `none` out of range.
+#let civil-from-days(days) = {
+  if not is-days-in-range(days) { return none }
+  let d = EPOCH + duration(days: days)
+  (d.year(), d.month(), d.day())
+}
+
+/// ISO weekday for a day count: Monday = 1 ... Sunday = 7. `none` out of range.
+#let weekday-from-days(days) = {
+  if not is-days-in-range(days) { return none }
+  (EPOCH + duration(days: days)).weekday()
+}
+
+/// Day of the year, 1-366, or `none` if the date is invalid.
+#let ordinal-from-civil(year, month, day) = {
+  if not is-valid-date(year, month, day) { return none }
+  datetime(year: year, month: month, day: day).ordinal()
+}

--- a/packages/preview/datehog/0.1.1/src/js.typ
+++ b/packages/preview/datehog/0.1.1/src/js.typ
@@ -1,0 +1,99 @@
+// JavaScript `Date.parse` / `new Date(value)` emulation.
+//
+// V8's date parsing is permissive and inconsistent in ways that matter when
+// you are reproducing the output of a JS tool. Two directions in particular:
+//
+//   * V8 *accepts* free-form prefixes like "FY 2018" or "hello world 2018",
+//     extracting the trailing year — most strict parsers reject them.
+//   * V8 *rejects* "15.01.2020" and "15/01/2020", because it reads the first
+//     component as a month and 15 is not a month — lenient parsers happily
+//     read them as 15 January.
+//
+// The strategy order below mirrors V8's, so a value that V8 parses parses
+// here, and a value V8 rejects returns `none`.
+//
+// **Timezones.** ECMAScript reads a zoneless date-*time* string in the host's
+// local zone, and an ISO date-only string as UTC. Typst exposes no local UTC
+// offset — `datetime.today()` gives a local date but no time, and 14 different
+// offsets reproduce it — so "local" is not recoverable here. Zoneless input is
+// therefore read as UTC by default, and `assume-offset` (minutes east of UTC)
+// is available for callers who know their data's zone and want it applied.
+// This makes parsing reproducible across machines, which for a typesetting
+// system is the more useful guarantee anyway.
+
+#import "moment.typ": from-ms, from-typst-datetime, is-moment, to-ms
+#import "parse.typ": is-iso-date-only, is-numeric-date-shape, parse-iso, parse-loose, parse-numeric, year-from-words
+
+/// Milliseconds since the Unix epoch for `value`, mirroring `Date.parse`.
+///
+/// Returns `none` where JavaScript would return `NaN`. Numbers pass through
+/// unchanged (as `new Date(n)` does), booleans become 1/0, Typst `datetime`
+/// values and datehog moments are converted directly.
+#let parse-ms(value, assume-offset: 0) = {
+  if value == none { return none }
+  if type(value) == bool { return if value { 1 } else { 0 } }
+  if type(value) == int { return value }
+  if type(value) == float {
+    if value.is-nan() or value.is-infinite() { return none }
+    return value
+  }
+  if type(value) == datetime { return to-ms(from-typst-datetime(value)) }
+  if is-moment(value) { return value.ms }
+  if type(value) != str { return none }
+
+  let s = value.trim()
+  if s == "" { return none }
+
+  // 1. Strict ISO 8601. Date-only forms are UTC per spec; zoned forms carry
+  //    their own offset; zoneless date-times fall back to `assume-offset`.
+  let m = parse-iso(s, assume-offset: if is-iso-date-only(s) { 0 } else { assume-offset })
+  if m != none { return m.ms }
+
+  // 2. Numeric forms. Handled before the loose parser so that a string V8
+  //    rejects (month out of range) does not get quietly re-read as a
+  //    day-first date by a more permissive path.
+  if is-numeric-date-shape(s) {
+    let m = parse-numeric(s, assume-offset: assume-offset)
+    if m != none { return m.ms }
+    // V8 rejects it; only the trailing-year heuristic can still apply.
+    let year = year-from-words(s)
+    if year != none { return to-ms(parse-iso(str(year) + "-01-01")) }
+    return none
+  }
+
+  // 3. Month-name and RFC 2822 forms.
+  let m = parse-loose(s, assume-offset: assume-offset)
+  if m != none { return m.ms }
+
+  // 4. V8's trailing-year heuristic: "FY 2018", "hello world 2018".
+  let year = year-from-words(s)
+  if year != none { return to-ms(parse-iso(str(year) + "-01-01")) }
+
+  none
+}
+
+/// A moment for `value`, mirroring `new Date(value)`. `none` where JS would
+/// produce an Invalid Date.
+#let parse(value, assume-offset: 0) = from-ms(parse-ms(value, assume-offset: assume-offset))
+
+/// Would `Date.parse(value)` succeed?
+#let is-parseable(value, assume-offset: 0) = parse-ms(value, assume-offset: assume-offset) != none
+
+// Seconds and milliseconds both appear as bare numbers in real data. The
+// boundary is the same one flint uses: 1e9 (2001-09-09) up to 4102444800
+// (2100-01-01) is read as seconds, above that as milliseconds.
+#let MAX-TIMESTAMP-SECONDS = 4102444800
+#let MAX-TIMESTAMP-MS = 4102444800000
+
+/// Does `value` look like a Unix timestamp rather than an ordinary quantity?
+#let is-likely-timestamp(value) = {
+  if type(value) != int and type(value) != float { return false }
+  if type(value) == bool { return false }
+  (
+    (value >= 1e9 and value <= MAX-TIMESTAMP-SECONDS)
+      or (value > MAX-TIMESTAMP-SECONDS and value <= MAX-TIMESTAMP-MS)
+  )
+}
+
+/// Normalise a bare timestamp to milliseconds, guessing the unit by magnitude.
+#let timestamp-to-ms(value) = if value <= MAX-TIMESTAMP-SECONDS { value * 1000 } else { value }

--- a/packages/preview/datehog/0.1.1/src/lib.typ
+++ b/packages/preview/datehog/0.1.1/src/lib.typ
@@ -1,0 +1,36 @@
+// datehog — date parsing and epoch arithmetic for Typst.
+//
+// Typst's built-in `datetime` can be constructed from calendar parts and
+// formatted, but it cannot parse a string and has no epoch conversion. datehog
+// fills exactly that gap: strings and epoch milliseconds in, a plain-dictionary
+// `moment` out, everything in UTC and everything a pure function.
+//
+//   #import "@preview/datehog:0.1.1" as dh
+//   #dh.parse("2020-03-14T08:30:00Z").day        // 14
+//   #dh.to-iso(dh.from-ms(1584174600000))        // "2020-03-14T08:30:00.000Z"
+//   #dh.js.parse-ms("FY 2018")                   // 1514764800000
+//
+// See README.md for the timezone policy and the JavaScript-compatibility notes.
+
+#import "civil.typ": EPOCH, MAX-DAYS, MAX-YEAR, MIN-DAYS, MIN-YEAR, civil-from-days, days-from-civil, days-in-month, is-days-in-range, is-leap-year, is-valid-date, is-year-in-range, ordinal-from-civil, weekday-from-days
+#import "moment.typ": MAX-MS, MIN-MS, MS-PER-DAY, MS-PER-HOUR, MS-PER-MINUTE, MS-PER-SECOND, add-days, add-months, add-ms, from-ms, from-parts, from-typst-datetime, is-moment, pad, to-days, to-iso, to-iso-date, to-ms, to-seconds, to-typst-datetime
+#import "tokens.typ": MONTH-ABBR, MONTH-NAMES, WEEKDAY-ABBR, WEEKDAY-NAMES, month-from-name, month-name, weekday-name
+#import "parse.typ": expand-two-digit-year, is-iso-date-only, is-numeric-date-shape, local-offset, offset-from-string, parse-iso, parse-loose, parse-numeric, year-from-words
+
+// The JavaScript-compatibility layer stays namespaced: its leniencies are a
+// deliberate bug-for-bug match with V8 and should be opted into by name.
+#import "js.typ"
+
+/// Parse a date string using every strategy this package knows, in the order
+/// V8 would try them. Equivalent to `js.parse`, re-exported as the obvious
+/// entry point.
+///
+/// Returns a moment (a dictionary with `ms`, `year`, `month`, `day`, `hour`,
+/// `minute`, `second`, `millisecond`, `weekday`, `ordinal`) or `none`.
+#let parse(value, assume-offset: 0) = js.parse(value, assume-offset: assume-offset)
+
+/// Milliseconds since the Unix epoch for `value`, or `none`.
+#let parse-ms(value, assume-offset: 0) = js.parse-ms(value, assume-offset: assume-offset)
+
+/// Can `value` be parsed as a date?
+#let is-parseable(value, assume-offset: 0) = js.is-parseable(value, assume-offset: assume-offset)

--- a/packages/preview/datehog/0.1.1/src/moment.typ
+++ b/packages/preview/datehog/0.1.1/src/moment.typ
@@ -1,0 +1,172 @@
+// The moment type: an instant in UTC, carried as a plain dictionary.
+//
+// A moment is a value, not an opaque handle, so it prints under `repr`,
+// compares with `==`, and — because every constructor here is a pure function —
+// gets memoised by Typst. Building the same moment twice costs one build.
+//
+// The calendar half of the work is done by Typst's native `datetime` (see
+// `civil.typ`). The one thing native datetimes cannot carry is milliseconds —
+// they have second resolution — so a moment tracks the day count and the
+// intraday milliseconds itself and only reaches for `datetime` at the
+// date boundary.
+
+#import "civil.typ": (
+  EPOCH, MAX-DAYS, MAX-YEAR, MIN-DAYS, MIN-YEAR, civil-from-days, days-from-civil,
+  days-in-month, is-days-in-range, is-valid-date, is-year-in-range, ordinal-from-civil,
+  weekday-from-days,
+)
+
+#let MS-PER-SECOND = 1000
+#let MS-PER-MINUTE = 60000
+#let MS-PER-HOUR = 3600000
+#let MS-PER-DAY = 86400000
+
+/// Millisecond bounds corresponding to the representable date range.
+#let MIN-MS = MIN-DAYS * MS-PER-DAY
+#let MAX-MS = (MAX-DAYS + 1) * MS-PER-DAY - 1
+
+/// Is `value` a moment produced by this package?
+#let is-moment(value) = type(value) == dictionary and value.at("datehog", default: none) == "moment"
+
+/// Build a moment from milliseconds since the Unix epoch (UTC).
+///
+/// `ms` may be an int or a float; it is floored to whole milliseconds, so
+/// sub-millisecond precision is discarded exactly as `new Date(ms)` does.
+/// Returns `none` for non-finite input or an instant outside the representable
+/// range, mirroring JavaScript's `Invalid Date` — and, importantly, never
+/// panicking: Typst's datetime overflow is a compiler panic, not a catchable
+/// error, so the bound is checked here.
+#let from-ms(ms) = {
+  if ms == none { return none }
+  if type(ms) != int and type(ms) != float { return none }
+  if type(ms) == float and (ms.is-nan() or ms.is-infinite()) { return none }
+
+  let total = if type(ms) == int { ms } else { int(calc.floor(ms)) }
+  if total < MIN-MS or total > MAX-MS { return none }
+
+  let days = calc.div-euclid(total, MS-PER-DAY)
+  let rest = total - days * MS-PER-DAY // [0, 86399999]
+  let civil = civil-from-days(days)
+  if civil == none { return none }
+  let (year, month, day) = civil
+
+  (
+    datehog: "moment",
+    ms: total,
+    year: year,
+    month: month,
+    day: day,
+    hour: calc.div-euclid(rest, MS-PER-HOUR),
+    minute: calc.rem-euclid(calc.div-euclid(rest, MS-PER-MINUTE), 60),
+    second: calc.rem-euclid(calc.div-euclid(rest, MS-PER-SECOND), 60),
+    millisecond: calc.rem-euclid(rest, MS-PER-SECOND),
+    weekday: weekday-from-days(days),
+    ordinal: ordinal-from-civil(year, month, day),
+  )
+}
+
+/// Build a moment from UTC calendar parts.
+///
+/// Out-of-range components normalise into neighbouring units the way
+/// `Date.UTC` does — `from-parts(2020, 13, 1)` is 2021-01-01, and
+/// `from-parts(2020, 1, 0)` is 2019-12-31. Native `datetime` construction
+/// rejects those outright, so the month is folded into range arithmetically
+/// and the day is carried as a duration from the first of the month, which
+/// keeps every constructed datetime valid.
+#let from-parts(year, month, day, hour: 0, minute: 0, second: 0, millisecond: 0) = {
+  if type(year) != int or type(month) != int or type(day) != int { return none }
+  let mz = month - 1
+  let y = year + calc.div-euclid(mz, 12)
+  let m = calc.rem-euclid(mz, 12) + 1
+  if not is-year-in-range(y) { return none }
+  let first = days-from-civil(y, m, 1)
+  if first == none { return none }
+  from-ms(
+    (first + day - 1) * MS-PER-DAY
+      + hour * MS-PER-HOUR
+      + minute * MS-PER-MINUTE
+      + second * MS-PER-SECOND
+      + millisecond,
+  )
+}
+
+/// Milliseconds since the Unix epoch, or `none` for a non-moment.
+#let to-ms(moment) = if is-moment(moment) { moment.ms } else { none }
+
+/// Whole seconds since the Unix epoch (floored).
+#let to-seconds(moment) = if is-moment(moment) { calc.div-euclid(moment.ms, MS-PER-SECOND) } else { none }
+
+/// Days since 1970-01-01 (floored).
+#let to-days(moment) = if is-moment(moment) { calc.div-euclid(moment.ms, MS-PER-DAY) } else { none }
+
+#let _pad(n, width) = {
+  let s = str(calc.abs(n))
+  let sign = if n < 0 { "-" } else { "" }
+  while s.len() < width { s = "0" + s }
+  sign + s
+}
+
+/// Zero-padded decimal, exposed because callers formatting their own date
+/// strings invariably need it.
+#let pad = _pad
+
+/// ISO 8601 with a `Z` suffix, matching JavaScript's `Date.toISOString()`:
+/// `YYYY-MM-DDTHH:mm:ss.sssZ`.
+#let to-iso(moment) = {
+  if not is-moment(moment) { return none }
+  (
+    _pad(moment.year, 4) + "-" + _pad(moment.month, 2) + "-" + _pad(moment.day, 2) + "T" +
+    _pad(moment.hour, 2) + ":" + _pad(moment.minute, 2) + ":" + _pad(moment.second, 2) + "." +
+    _pad(moment.millisecond, 3) + "Z"
+  )
+}
+
+/// Date part only: `YYYY-MM-DD`.
+#let to-iso-date(moment) = {
+  if not is-moment(moment) { return none }
+  _pad(moment.year, 4) + "-" + _pad(moment.month, 2) + "-" + _pad(moment.day, 2)
+}
+
+/// Shift a moment by a whole number of milliseconds.
+#let add-ms(moment, ms) = if is-moment(moment) { from-ms(moment.ms + ms) } else { none }
+
+/// Shift a moment by whole days.
+#let add-days(moment, days) = add-ms(moment, days * MS-PER-DAY)
+
+/// Shift by calendar months, clamping the day to the target month's length so
+/// that Jan 31 + 1 month is Feb 28/29 rather than spilling into March.
+#let add-months(moment, months) = {
+  if not is-moment(moment) { return none }
+  let mz = moment.month - 1 + months
+  let year = moment.year + calc.div-euclid(mz, 12)
+  let month = calc.rem-euclid(mz, 12) + 1
+  from-parts(
+    year, month, calc.min(moment.day, days-in-month(year, month)),
+    hour: moment.hour, minute: moment.minute,
+    second: moment.second, millisecond: moment.millisecond,
+  )
+}
+
+/// Convert to a Typst `datetime`. Lossy: Typst datetimes carry no
+/// milliseconds, so those are dropped.
+#let to-typst-datetime(moment) = {
+  if not is-moment(moment) { return none }
+  datetime(
+    year: moment.year, month: moment.month, day: moment.day,
+    hour: moment.hour, minute: moment.minute, second: moment.second,
+  )
+}
+
+/// Convert from a Typst `datetime`. A date-only datetime is taken as UTC
+/// midnight. Returns `none` if the value carries neither date nor time.
+#let from-typst-datetime(value) = {
+  if type(value) != datetime { return none }
+  let y = value.year()
+  if y == none { return none }
+  // A date-only `datetime` returns `none` from the time accessors.
+  let or0(v) = if v == none { 0 } else { v }
+  from-parts(
+    y, value.month(), value.day(),
+    hour: or0(value.hour()), minute: or0(value.minute()), second: or0(value.second()),
+  )
+}

--- a/packages/preview/datehog/0.1.1/src/parse.typ
+++ b/packages/preview/datehog/0.1.1/src/parse.typ
@@ -1,0 +1,306 @@
+// String -> moment parsers.
+//
+// Three independent strategies, each usable on its own:
+//
+//   parse-iso     strict ECMAScript Date Time String Format
+//   parse-numeric slash/dash/dot separated numeric dates
+//   parse-loose   month-name forms ("Feb 2020", "15 January 2020", RFC 2822)
+//
+// `js.typ` layers V8's `Date.parse` ordering on top of these. Everything here
+// returns a moment in UTC or `none`; nothing throws, because Typst has no way
+// to catch an error and a bad cell in a data table must not take down the
+// document.
+//
+// Every regex is bound at module level so it is compiled once per compile
+// rather than once per call, and every parser is a pure top-level function so
+// repeated parses of the same string are memoised by Typst — which matters a
+// lot, since real data re-presents the same handful of dates thousands of times.
+
+#import "civil.typ": is-valid-date
+#import "moment.typ": from-parts, from-ms
+#import "tokens.typ": month-from-name
+
+// ---------------------------------------------------------------------------
+// ISO 8601 / ECMAScript Date Time String Format
+// ---------------------------------------------------------------------------
+
+// YYYY | YYYY-MM | YYYY-MM-DD, optionally followed by a time and a zone.
+// A leading `+`/`-` six-digit expanded year is deliberately not supported;
+// it does not occur in tabular data and complicates the year sign handling.
+#let _ISO = regex(
+  "^(\\d{4})(?:-(\\d{2})(?:-(\\d{2}))?)?" +
+  "(?:[T ](\\d{2}):(\\d{2})(?::(\\d{2})(?:\\.(\\d{1,9}))?)?" +
+  "(Z|z|[+-]\\d{2}:?\\d{2})?)?$",
+)
+
+/// Is `s` an ISO date with no time part (`2020`, `2020-03`, `2020-03-14`)?
+///
+/// ECMAScript treats these as UTC while date-*time* forms without a zone are
+/// local, so callers reproducing JS semantics need to distinguish them.
+#let is-iso-date-only(s) = {
+  if type(s) != str { return false }
+  s.trim().match(regex("^\\d{4}(-\\d{2}(-\\d{2})?)?$")) != none
+}
+
+// Offset string ("Z", "+02:00", "-0500") -> minutes east of UTC.
+#let _zone-minutes(zone) = {
+  if zone == none { return none }
+  if zone == "Z" or zone == "z" { return 0 }
+  let sign = if zone.starts-with("-") { -1 } else { 1 }
+  let digits = zone.slice(1).replace(":", "")
+  if digits.len() != 4 { return none }
+  sign * (int(digits.slice(0, 2)) * 60 + int(digits.slice(2, 4)))
+}
+
+/// Parse a strict ISO 8601 / ECMAScript date-time string.
+///
+/// `assume-offset` (minutes east of UTC) is applied when the string carries no
+/// zone of its own. The default of 0 means a zoneless string is read as UTC,
+/// which keeps parsing reproducible across machines — see the README.
+/// Returns a moment or `none`.
+#let parse-iso(s, assume-offset: 0) = {
+  if type(s) != str { return none }
+  let m = s.trim().match(_ISO)
+  if m == none { return none }
+  let g = m.captures
+
+  let year = int(g.at(0))
+  let month = if g.at(1) == none { 1 } else { int(g.at(1)) }
+  let day = if g.at(2) == none { 1 } else { int(g.at(2)) }
+  if not is-valid-date(year, month, day) { return none }
+
+  let hour = if g.at(3) == none { 0 } else { int(g.at(3)) }
+  let minute = if g.at(4) == none { 0 } else { int(g.at(4)) }
+  let second = if g.at(5) == none { 0 } else { int(g.at(5)) }
+  // Fractional seconds: pad or truncate to exactly three digits.
+  let millisecond = if g.at(6) == none { 0 } else {
+    let f = g.at(6)
+    int((f + "000").slice(0, 3))
+  }
+  // 24:00 is a legal ECMAScript end-of-day marker; anything else out of range
+  // is a rejection rather than a normalisation.
+  if hour > 24 or minute > 59 or second > 59 { return none }
+  if hour == 24 and (minute != 0 or second != 0 or millisecond != 0) { return none }
+
+  let zone = _zone-minutes(g.at(7))
+  let offset = if zone == none { assume-offset } else { zone }
+
+  from-parts(
+    year, month, day,
+    hour: hour, minute: minute - offset, second: second, millisecond: millisecond,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Numeric dates
+// ---------------------------------------------------------------------------
+
+// The two separators must be the same character. Typst's regex engine is
+// Rust's, which has no backreferences, so `\2` is not available: both
+// separators are captured and compared in code instead.
+#let _NUMERIC = regex("^\\s*(\\d{1,4})\\s*([./-])\\s*(\\d{1,2})\\s*([./-])\\s*(\\d{1,4})\\s*$")
+
+#let _numeric-captures(s) = {
+  if type(s) != str { return none }
+  let m = s.match(_NUMERIC)
+  if m == none { return none }
+  if m.captures.at(1) != m.captures.at(3) { return none }
+  m.captures
+}
+
+/// Does `s` have the shape of a slash/dash/dot separated numeric date?
+///
+/// Shape only — `is-numeric-date-shape("15.01.2020")` is `true` even though
+/// `parse-numeric` rejects it (see below).
+#let is-numeric-date-shape(s) = _numeric-captures(s) != none
+
+/// Parse `M/D/YYYY`, `YYYY-M-D` and the dot/dash variants.
+///
+/// Follows V8: a leading four-digit component means year-first, otherwise the
+/// first component is the **month** (US ordering). A month outside 1-12 is a
+/// rejection, not a re-interpretation — so `"15.01.2020"` returns `none`
+/// rather than being read as 15 January. Forms where no component is
+/// four digits are rejected outright.
+#let parse-numeric(s, assume-offset: 0) = {
+  let caps = _numeric-captures(s)
+  if caps == none { return none }
+  let a = caps.at(0)
+  let b = caps.at(2)
+  let c = caps.at(4)
+
+  let parts = if a.len() == 4 {
+    (int(a), int(b), int(c))
+  } else if c.len() == 4 {
+    (int(c), int(a), int(b))
+  } else {
+    return none
+  }
+  let (year, month, day) = parts
+  if not is-valid-date(year, month, day) { return none }
+  from-parts(year, month, day, minute: -assume-offset)
+}
+
+// ---------------------------------------------------------------------------
+// Loose / month-name forms
+// ---------------------------------------------------------------------------
+
+// "Feb 2020", "February 2020"
+#let _MON-YEAR = regex("^([A-Za-z]{3,9})\\.?\\s+(\\d{4})$")
+// "Feb 15 2020", "Feb 15, 2020", "February 15, 2020"
+#let _MON-DAY-YEAR = regex("^([A-Za-z]{3,9})\\.?\\s+(\\d{1,2})(?:st|nd|rd|th)?\\s*,?\\s+(\\d{4})$")
+// "15 Feb 2020", "15 February 2020"
+#let _DAY-MON-YEAR = regex("^(\\d{1,2})(?:st|nd|rd|th)?\\s+([A-Za-z]{3,9})\\.?\\s*,?\\s+(\\d{4})$")
+// RFC 2822: "Tue, 15 Feb 2020 08:30:00 GMT"
+#let _RFC2822 = regex(
+  "^(?:[A-Za-z]{3},?\\s+)?(\\d{1,2})\\s+([A-Za-z]{3,9})\\.?\\s+(\\d{4})" +
+  "(?:\\s+(\\d{2}):(\\d{2})(?::(\\d{2}))?)?" +
+  "(?:\\s+(?:GMT|UTC|UT|Z)?([+-]\\d{4})?)?\\s*$",
+)
+// A bare year, or a "word soup plus exactly one year" string like "FY 2018".
+#let _YEAR-TOKEN = regex("\\b(\\d{4})\\b")
+#let _WORDS-ONLY = regex("^[A-Za-z\\s]+$")
+
+/// If `s` is words plus exactly one four-digit year (`"FY 2018"`, `"Q1 2018"`
+/// after its digit is stripped, `"hello world 2018"`), return that year.
+///
+/// This mirrors a genuine V8 leniency that stricter parsers reject, and it is
+/// load-bearing for real spreadsheet data where a column reads "FY 2018".
+#let year-from-words(s) = {
+  if type(s) != str { return none }
+  let years = s.matches(_YEAR-TOKEN)
+  if years.len() != 1 { return none }
+  let year = int(years.first().captures.at(0))
+  if year < 1000 or year > 9999 { return none }
+  let rest = s.replace(_YEAR-TOKEN, "").trim()
+  if rest != "" and rest.match(_WORDS-ONLY) == none { return none }
+  year
+}
+
+/// Parse month-name and RFC 2822 forms. Returns a moment or `none`.
+#let parse-loose(s, assume-offset: 0) = {
+  if type(s) != str { return none }
+  let t = s.trim()
+  if t == "" { return none }
+
+  let at-offset(year, month, day, hour: 0, minute: 0, second: 0, offset: assume-offset) = {
+    if not is-valid-date(year, month, day) { return none }
+    from-parts(year, month, day, hour: hour, minute: minute - offset, second: second)
+  }
+
+  // "15 Feb 2020 08:30:00 GMT" -- tried first, being the most specific.
+  let m = t.match(_RFC2822)
+  if m != none {
+    let month = month-from-name(m.captures.at(1))
+    if month != none {
+      let zone = m.captures.at(6)
+      let offset = if zone == none { assume-offset } else {
+        let sign = if zone.starts-with("-") { -1 } else { 1 }
+        sign * (int(zone.slice(1, 3)) * 60 + int(zone.slice(3, 5)))
+      }
+      let hh = m.captures.at(3)
+      let mm = m.captures.at(4)
+      let ss = m.captures.at(5)
+      return at-offset(
+        int(m.captures.at(2)), month, int(m.captures.at(0)),
+        hour: if hh == none { 0 } else { int(hh) },
+        minute: if mm == none { 0 } else { int(mm) },
+        second: if ss == none { 0 } else { int(ss) },
+        offset: offset,
+      )
+    }
+  }
+
+  let m = t.match(_MON-DAY-YEAR)
+  if m != none {
+    let month = month-from-name(m.captures.at(0))
+    if month != none {
+      return at-offset(int(m.captures.at(2)), month, int(m.captures.at(1)))
+    }
+  }
+
+  let m = t.match(_DAY-MON-YEAR)
+  if m != none {
+    let month = month-from-name(m.captures.at(1))
+    if month != none {
+      return at-offset(int(m.captures.at(2)), month, int(m.captures.at(0)))
+    }
+  }
+
+  let m = t.match(_MON-YEAR)
+  if m != none {
+    let month = month-from-name(m.captures.at(0))
+    if month != none {
+      return at-offset(int(m.captures.at(1)), month, 1)
+    }
+  }
+
+  none
+}
+
+// ---------------------------------------------------------------------------
+// UTC offsets
+// ---------------------------------------------------------------------------
+
+#let _OFFSET = regex("^(?:UTC|GMT)?([+-])(\\d{2}):?(\\d{2})?$")
+
+/// Parse a UTC offset string into minutes east of UTC.
+///
+/// Accepts `Z`, `+02:00`, `+0200`, `-05`, `UTC+02:00`, and a bare number of
+/// minutes. Returns `none` if it is not an offset.
+///
+/// Useful with `sys.inputs`: Typst cannot discover the host's timezone (see
+/// `local-offset`), so passing it in on the command line is the only channel.
+#let offset-from-string(value) = {
+  if type(value) == int { return value }
+  if type(value) != str { return none }
+  let s = value.trim()
+  if s == "" { return none }
+  if s == "Z" or s == "z" or s == "UTC" or s == "GMT" { return 0 }
+  let m = s.match(_OFFSET)
+  if m == none { return none }
+  let sign = if m.captures.at(0) == "-" { -1 } else { 1 }
+  let hh = int(m.captures.at(1))
+  let mm = if m.captures.at(2) == none { 0 } else { int(m.captures.at(2)) }
+  if hh > 18 or mm > 59 { return none }
+  sign * (hh * 60 + mm)
+}
+
+/// The UTC offset supplied by the caller via `--input`, in minutes.
+///
+/// Typst has no way to discover the host's timezone — plugins are sandboxed
+/// with a single host import and no clock, and `datetime.today()` reports a
+/// local date but no time of day, so the offset cannot be derived. Passing it
+/// in explicitly is the only mechanism:
+///
+/// ```sh
+/// typst compile --input tz="$(date +%z)" doc.typ
+/// ```
+///
+/// ```typst
+/// #dh.parse("2020-03-14T08:30:00", assume-offset: dh.local-offset())
+/// ```
+///
+/// Returns `default` (0, i.e. UTC) when the input is absent or unparseable, so
+/// a document that does not pass one still compiles — and still compiles the
+/// same way everywhere.
+///
+/// Note the caveat: this is the offset *at compile time*. For data spanning a
+/// DST boundary it is the wrong offset for half the rows. Where that matters,
+/// prefer input data that carries its own zone.
+#let local-offset(key: "tz", default: 0) = {
+  let raw = sys.inputs.at(key, default: none)
+  if raw == none { return default }
+  let parsed = offset-from-string(raw)
+  if parsed == none { default } else { parsed }
+}
+
+/// Expand a bare two-digit year the way spreadsheet software does:
+/// `00`-`49` are 2000s, `50`-`99` are 1900s. Non-two-digit input is returned
+/// unchanged, so this is safe to apply blindly to a column.
+#let expand-two-digit-year(value) = {
+  if type(value) != str { return value }
+  let t = value.trim()
+  if t.match(regex("^\\d{2}$")) == none { return value }
+  let n = int(t)
+  str(if n <= 49 { 2000 + n } else { 1900 + n })
+}

--- a/packages/preview/datehog/0.1.1/src/tokens.typ
+++ b/packages/preview/datehog/0.1.1/src/tokens.typ
@@ -1,0 +1,52 @@
+// Month and weekday name tables, and the lookups over them.
+//
+// Kept in one place because the parser and any formatter both need them, and
+// because building the lookup dictionary once at module level means the cost
+// is paid per compile rather than per call.
+
+#let MONTH-NAMES = (
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+)
+
+#let MONTH-ABBR = (
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+)
+
+#let WEEKDAY-NAMES = (
+  "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+)
+
+#let WEEKDAY-ABBR = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+// Lowercased name -> month number. Includes both the full names and the
+// three-letter abbreviations, plus "sept", which appears in the wild often
+// enough to be worth the one extra entry.
+#let _MONTH-LOOKUP = {
+  let m = (:)
+  for (i, name) in MONTH-NAMES.enumerate() { m.insert(lower(name), i + 1) }
+  for (i, name) in MONTH-ABBR.enumerate() { m.insert(lower(name), i + 1) }
+  m.insert("sept", 9)
+  m
+}
+
+/// Month number (1-12) for a month name or abbreviation, else `none`.
+/// Case-insensitive; a trailing `.` is tolerated (`"Jan."`).
+#let month-from-name(name) = {
+  if type(name) != str { return none }
+  let key = lower(name.trim().trim(".", at: end))
+  _MONTH-LOOKUP.at(key, default: none)
+}
+
+/// English month name for 1-12, else `none`.
+#let month-name(month, abbreviated: false) = {
+  if type(month) != int or month < 1 or month > 12 { return none }
+  if abbreviated { MONTH-ABBR.at(month - 1) } else { MONTH-NAMES.at(month - 1) }
+}
+
+/// English weekday name for ISO weekday 1-7 (Monday = 1), else `none`.
+#let weekday-name(weekday, abbreviated: false) = {
+  if type(weekday) != int or weekday < 1 or weekday > 7 { return none }
+  if abbreviated { WEEKDAY-ABBR.at(weekday - 1) } else { WEEKDAY-NAMES.at(weekday - 1) }
+}

--- a/packages/preview/datehog/0.1.1/typst.toml
+++ b/packages/preview/datehog/0.1.1/typst.toml
@@ -1,0 +1,14 @@
+[package]
+name = "datehog"
+version = "0.1.1"
+entrypoint = "src/lib.typ"
+authors = ["Zral0kh"]
+license = "MIT"
+description = "Date parsing and epoch arithmetic."
+keywords = ["date", "time", "parse", "iso8601", "timestamp"]
+categories = ["utility"]
+repository = "https://github.com/zral0kh/datehog"
+# Verified on 0.15.1. The floor is a conservative estimate -- nothing here uses
+# a recent feature, but older releases have not been tested. See README.
+compiler = "0.13.0"
+exclude = ["tests"]


### PR DESCRIPTION

<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [x] a new package
- [ ] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

**Datehog** enables parsing of datestrings and adds epoch arithmetics, adding a week or similar.
Dates are parsed as moments, dicts of various time fields, against the epoch root 1970-01-01 and can be extracted as milliseconds, iso strings and typst datetime objects and more.

It is basically on par with js v8, but deviates on a small number of instances where it follows pythons datetime utils. In other cases it follows v8 and not python's datetime.

For more details and the whole API, please see the [README.md](https://github.com/zral0kh/datehog/blob/v0.1.1/README.md).

The reason why this is not v0.1.0 but a patch is that i forgot the changelog which the readme links to and the repository field. could have updated inplace idk.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [X] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
  - Explanation: The name just comes from that this package can feed on all kinds of date strings and still works fine.
    <!--
    Please write one or two sentences explaining:
    1. the name of your package, if necessary, e.g:
      > Pergamon was an ancient Greek city state in Asia Minor. Its library was second only to the Library of Alexandria around 200 BC.
    2. why it isn't too canonical/descriptive and complies with the naming rules, e.g:
      - The name is a related but creative term
      - The name is a neologism combining the words … and …
      - The name contains a non-descriptive prefix
      - The package is official ⇒ an email will be sent to hello@typst.app
    -->
- [X] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [X] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [X] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [X] tested my package locally on my system and it worked
- [X] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
