### PR TITLE
ratchet:0.0.3

### DIFF
--- a/packages/preview/ratchet/0.0.3/LICENSE
+++ b/packages/preview/ratchet/0.0.3/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AnZreww
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/ratchet/0.0.3/README.md
+++ b/packages/preview/ratchet/0.0.3/README.md
@@ -1,0 +1,184 @@
+# ratchet
+
+`ratchet` is a typst package for improved figure/table/equation/math.equation/custom-kind numbering.
+
+This package primarily modifies the numbering of figures and equations to automatically update based on sections and reset counters when entering new sections. Additionally, it allows users to customize the depth and format of numbering. It supports element types such as `image`, `table`, `raw`, `math.equation`, and custom `figure(kind: ...)`.
+
+Chapter/section-aware numbering utilities for Typst (Typst ≥ 0.13).
+
+This package provides consistent figure/table/raw + equation + custom figure.kind numbering with:
+- configurable prefix depth,
+- correct cross-chapter references,
+- and safe “re-installation” (you can apply the package multiple times in one document with different styles).
+
+## What's new in 0.0.3
+
+- `figure-groups` configures several families of `figure(kind: ...)` independently.
+- Each family has its own heading depth, numbering pattern, color, and reset behavior.
+- `figure-number` lets a custom figure renderer place its Ratchet-managed number anywhere in its body.
+- Page settings may be applied either before or after `#show: ratchet` without creating a blank first page.
+- Repeated Ratchet configurations use stable document locations as session identities, avoiding layout convergence warnings.
+- Existing `reset-figure-kinds`, `fig-*`, and `eq-*` configurations remain compatible.
+
+## Quick start
+
+```typst
+#import "@preview/ratchet:0.0.3": *
+
+#show: ratchet.with(
+  fig-depth: 2,
+  eq-depth: 2,
+  fig-outline: "1.1",
+  eq-outline: "1.1",
+)
+```
+
+Then use normal `#figure(...) <label>` and `@label` references.
+
+## Features
+
+### 1) Configuration
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `offset` | `0` | Offset applied to the heading backbone |
+| `init` | `"rebase"` | Start from current headings; also supports `"reset"` and `"keep"` |
+| `reset-figure-kinds` | `(image, table, raw)` | Figure kinds using the base figure configuration |
+| `fig-depth` | `2` | Base figure numbering depth |
+| `fig-outline` | `"1.1"` | Base figure numbering pattern |
+| `fig-color` | `none` | Base figure/reference number color |
+| `figure-groups` | `()` | Additional independently configured figure families |
+| `eq-depth` | `2` | Equation numbering depth |
+| `eq-outline` | `"(1.1)"` | Equation numbering pattern |
+| `eq-color` | `none` | Equation/reference number color |
+
+### 2) Independent figure groups
+
+Each item in `figure-groups` is a dictionary with four required fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `kinds` | `array` | Kinds sharing this configuration and reset schedule |
+| `depth` | `int` | `1` for global, `2` for level-1 headings, `3` for level-1 and level-2 headings |
+| `outline` | `str` or function | Typst numbering pattern |
+| `color` | `color` or `none` | Color used by references and outlines |
+
+For example, theorem-like figures can use three-level numbering while algorithms use two-level numbering:
+
+```typst
+#show: ratchet.with(
+  figure-groups: (
+    (
+      kinds: ("definition", "theorem"),
+      depth: 3,
+      outline: "1.1.1",
+      color: blue,
+    ),
+    (
+      kinds: ("algorithm",),
+      depth: 2,
+      outline: "A.1",
+      color: purple,
+    ),
+  ),
+)
+```
+
+Kinds within one group share formatting and reset depth, but each kind still has its own native Typst figure counter. To share one counter, emit the same `kind` and vary the displayed `supplement`.
+
+If a kind appears in more than one group, the last matching group wins. Additional groups also override the base configuration supplied through `reset-figure-kinds` and `fig-*`.
+
+### 3) Custom renderers with `figure-number`
+
+`figure-number(kind, loc: none)` returns the number configured for `kind` at the current figure location. Call it inside the body of a matching figure:
+
+```typst
+#import "@preview/ratchet:0.0.3": figure-number, ratchet
+
+#show: ratchet.with(
+  figure-groups: (
+    (kinds: ("theorem",), depth: 3, outline: "1.1.1", color: blue),
+  ),
+)
+
+#let theorem(lab: none, body) = {
+  let elem = figure(
+    block(stroke: blue, inset: 8pt, width: 100%)[
+      *Theorem #figure-number("theorem")*
+      #body
+    ],
+    kind: "theorem",
+    supplement: [Theorem],
+    caption: none,
+    outlined: false,
+  )
+  [#elem #if lab != none { label(lab) }]
+}
+
+= Results
+== Main theorem
+
+#theorem(lab: "main-theorem")[The custom block body.]
+
+See @main-theorem.
+```
+
+For an unnumbered variant, set `numbering: none` on the figure and omit the `figure-number` call from its rendered title.
+
+### 4) Strict numbering (location-correct)
+
+References use the referenced element’s location to compute the prefix, so chapter/section prefixes are not “polluted” by the reference site.
+
+### 5) Cross-chapter references
+
+You can reference figures from other chapters/sections and still get the correct prefix numbers.
+
+### 6) Custom numbering patterns
+
+Use Typst numbering patterns such as:
+
+* `"1.1"` (decimal)
+* `"I.a.1"` (Roman + letter + decimal)
+
+Example:
+
+```typst
+#show: ratchet.with(
+  fig-depth: 3,
+  fig-outline: "I.a.1",
+)
+```
+
+## List of Figures / Tables (outline)
+
+Typst’s `outline` lists *outlined* elements.
+`figure` has an `outlined` parameter, so you can exclude unnumbered sub-figures from the list by setting `outlined: false` when `numbering: none`.
+
+```typst
+#outline(
+  title: [List of Figures],
+  target: figure.where(kind: image, outlined: true),
+)
+
+#outline(
+  title: [List of Tables],
+  target: figure.where(kind: table, outlined: true),
+)
+```
+
+## Public API
+
+- `ratchet(...)`: installs numbering, counter resets, references, and outline handling.
+- `figure-number(kind, loc: none)`: obtains the configured number for a custom figure renderer.
+
+Other helper functions live in the internal modules.
+
+## Migrating from 0.0.2
+
+No change is required for existing base figure and equation configurations. Update the import version, then use `figure-groups` only for custom kinds that need settings independent from `fig-*`:
+
+```typst
+#import "@preview/ratchet:0.0.3": ratchet
+```
+
+Custom packages that previously maintained their own counters can migrate to native `figure(kind: ...)` counters and use `figure-number` for their rendered titles. Ratchet will then manage resets and cross-references directly.

--- a/packages/preview/ratchet/0.0.3/demo.typ
+++ b/packages/preview/ratchet/0.0.3/demo.typ
@@ -1,0 +1,377 @@
+#import "@preview/ratchet:0.0.3": figure-number, ratchet
+
+#show: ratchet.with(
+  fig-outline: "1.1",
+)
+
+#align(center)[#text(size: 18pt)[Better Numbering Demo]]
+
+本 demo 演示 `ratchet` 的核心能力：基于章节/小节前缀的图表/公式编号、跨章节引用一致性、以及“同一篇文档中分段重新配置编号样式”。
+
+This demo showcases the core capabilities of `ratchet`: section/subsection-based figure/equation numbering, consistent cross-section references, and the ability to reconfigure numbering styles in different parts of the same document.
+
+该包主要更改了图表和公式的编号方式，使其能够根据章节自动更新编号，并在进入新章节时重置计数器。此外，它还允许用户自定义编号的层级深度和格式。支持`image`、`table`、`raw`、`math.equation`以及自定义的`figure(kind: ...)`等元素类型。
+
+This package primarily modifies the numbering of figures and equations to automatically update based on sections and reset counters when entering new sections. Additionally, it allows users to customize the depth and format of numbering. It supports element types such as `image`, `table`, `raw`, `math.equation`, and custom `figure(kind: ...)`.
+
+你可以像这样引入该包并启用增强编号功能：
+
+Import this package and enable better numbering with:
+```typ
+#import "@preview/ratchet:0.0.3": *
+#show: ratchet
+```
+默认的配置如下：
+
+the default settings are:
+```typ
+#show: ratchet.with(
+  offset: 0,
+  init: "rebase",
+  reset-figure-kinds: (image, table, raw),
+  fig-depth: 2,
+  fig-outline: "1.1",
+  fig-color: none,
+  figure-groups: (),
+  eq-depth: 2,
+  eq-outline: "(1.1)",
+  eq-color: none,
+)
+```
+
+如你所见，所有的图表和公式编号都根据章节自动更新，并且在进入新章节时重置计数器。你可以自由调整展示的层级深度和编号格式，以满足你的需求。在没有对应层级的章节出现时，会以0补充编号，确保编号的一致性。
+
+As you can see, all figure and equation numbers are automatically updated based on the sections, and counters are reset when entering new sections. You can freely adjust the depth of numbering and the numbering format to suit your needs. When certain heading levels are absent, zeros are used to fill in the numbering, ensuring consistency.
+
+#let placeholder-img() = rect(width: 4cm, height: 2cm, radius: 4pt, stroke: 1pt)[
+  #align(center + horizon)[*placeholder image*]
+]
+
+#let placeholder-table() = table(
+  columns: (auto, auto, auto),
+  [Item], [Qty], [Note],
+  [Apples], [2], [red],
+  [Oranges], [5], [sweet],
+)
+
+#grid(columns: (1fr,) * 2)[
+  #figure(
+    placeholder-img(),
+    caption: [This is a placeholder image],
+  )<fig1>
+
+  #figure(
+    placeholder-img(),
+    caption: [This is a placeholder image],
+    numbering: none,
+  )
+
+  #figure(
+    placeholder-img(),
+    caption: [This is a placeholder image],
+  )<fig2>
+][
+  ```typst
+  #figure(
+    placeholder-img(),
+    caption: [This is a placeholder image],
+  )<fig1>
+
+  #figure(
+    placeholder-img(),
+    caption: [This is a placeholder image],
+    numbering: none,
+  )
+
+  #figure(
+    placeholder-img(),
+    caption: [This is a placeholder image],
+  )<fig2>
+  ```
+]
+= section
+
+#figure(
+  placeholder-img(),
+  caption: [This is a placeholder image],
+)
+$
+  nabla^2 = (partial^2)/(partial x^2) + (partial^2)/(partial y^2) + (partial^2)/(partial z^2)
+$
+
+== subsection
+
+#figure(
+  placeholder-img(),
+  caption: [This is a placeholder image],
+)
+
+#figure(
+  grid(columns: (1fr, 1fr))[
+    #figure(
+      placeholder-img(),
+      caption: [(a) This is a placeholder image],
+      numbering: none,
+      outlined: false,
+    )
+  ][
+    #figure(
+      placeholder-img(),
+      caption: [(b) This is a placeholder image],
+      numbering: none,
+      outlined: false,
+    )
+  ],
+  caption: [ Figure with sub-figures ],
+)
+```typst
+#figure(
+  grid(columns: (1fr, 1fr))[
+    #figure(
+      placeholder-img(),
+      caption: [(a) This is a placeholder image],
+      numbering: none,
+      outlined: false,
+    )
+  ][
+    #figure(
+      placeholder-img(),
+      caption: [(b) This is a placeholder image],
+      numbering: none,
+      outlined: false,
+    )
+  ],
+  caption: [ Figure with sub-figures ],
+)
+```
+
+#figure(
+  grid(columns: (1fr, 1fr))[
+    #figure(
+      placeholder-table(),
+      caption: [This is a placeholder table],
+    )<tab1>
+  ][
+    #figure(
+      placeholder-table(),
+      caption: [This is another placeholder table],
+    )
+  ],
+  caption: [ Figure with sub-figures ],
+  kind: image,
+)
+```typ
+#figure(
+  grid(columns: (1fr, 1fr))[
+    #figure(
+      placeholder-table(),
+      caption: [This is a placeholder table],
+    )<tab1>
+  ][
+    #figure(
+      placeholder-table(),
+      caption: [This is another placeholder table],
+    )
+  ],
+  caption: [ Figure with sub-figures ],
+  kind: image,
+)
+```
+
+所有的编号都是合适的，在子图和表格中也是如此，你可以轻松管理和引用它们`@tab1`@tab1。
+
+All numbering is appropriate, including in sub-figures and tables, allowing you to easily manage and reference them.
+
+#figure(
+  placeholder-table(),
+  caption: [This is a placeholder table],
+)
+
+= section
+
+#figure(
+  placeholder-img(),
+  caption: [This is a placeholder image],
+)
+
+#figure(
+  placeholder-table(),
+  caption: [This is a placeholder table],
+)
+
+`label`和`ref`功能也能正常工作，可以直接用原本的方式进行引用，例如`@ref`和`<ref>`。跨章节的引用也不会出错 `@tab1:`@tab1 ，`@fig1:`@fig1；`@fig2:`@fig2 ；`@tab2:`@tab2；`@eq1:`@eq1 。
+
+The `label` and `ref` functionalities also work correctly, allowing you to reference them in the usual way, such as `@ref` and `<ref>`.Cross-section references also work correctly.
+
+你可以直接重新引用以改变编号样式，例如创建一个*附录*：
+
+You can directly re-apply to change the numbering style, for example, to create an *appendix*:
+
+如果你希望自定义 figure kind 使用独立的编号深度和样式，可以像下面通过 `figure-groups` 配置：
+
+Use `figure-groups` when custom figure kinds need an independent numbering depth and style:
+
+每个分组包含四个字段：`kinds` 指定这一组的 figure kind；`depth` 指定编号深度；`outline` 指定编号格式；`color` 指定引用和目录中的编号颜色。同一个 kind 同时出现在多个分组时，最后一个分组优先。
+
+Each group has four fields: `kinds` selects its figure kinds, `depth` controls heading-aware resets, `outline` sets the numbering pattern, and `color` styles numbers in references and outlines. If a kind occurs in multiple groups, the last group wins.
+
+#show: ratchet.with(
+  offset: 0,
+  reset-figure-kinds: (image, table, raw),
+  fig-depth: 3,
+  fig-outline: "I.1.1",
+  fig-color: blue,
+  figure-groups: (
+    (kinds: ("custom-kind",), depth: 2, outline: "A.1", color: purple),
+  ),
+  eq-depth: 3,
+  eq-outline: "(I.1.1)",
+  eq-color: red,
+)
+```typ
+#show: ratchet.with(
+  offset: 0,
+  reset-figure-kinds: (image, table, raw),
+  fig-depth: 3,
+  fig-outline: "I.1.1",
+  fig-color: blue,
+  figure-groups: (
+    (kinds: ("custom-kind",), depth: 2, outline: "A.1", color: purple),
+  ),
+  eq-depth: 3,
+  eq-outline: "(I.1.1)",
+  eq-color: red,
+)
+```
+
+#figure(
+  placeholder-img(),
+  caption: [This is a placeholder image],
+)
+
+= Appendix
+
+== subsection
+
+$
+  a^2 + b^2 = c^2
+$
+
+$
+  E = m c^2
+$<eq1>
+
+== subsection
+
+#figure(
+  placeholder-table(),
+  caption: [This is a placeholder table],
+)<tab2>
+
+你会发现编号风格已经改变，现在支持三级编号格式，例如`1.1.1`。
+
+You will notice that the numbering style has changed, now supporting three-level numbering formats, such as `1.1.1`.
+
+在这里你甚至可以引用之前的图表和公式，它们的编号也不会改变；而新的图表和公式会采用新的编号格式  `@fig1:`@fig1 ，`@tab1:`@tab1，`@fig2:`@fig2 ，`@tab2:`@tab2，`@eq1:`@eq1 。
+
+Previous figures and equations can still be referenced without changing their numbering; new figures and equations will adopt the new numbering format.
+
+可以直接生成图表目录：
+
+You can directly generate a list of figures:
+```typst
+#outline(
+  title: [List of Figures],
+  target: figure.where(kind: image, outlined: true,),
+)
+```
+#outline(
+  title: [List of Figures],
+  target: figure.where(
+    kind: image,
+    outlined: true,
+  ),
+)
+
+会排除掉`outlined: false`的图表，但会包含`numbering: none`但`outlined: true(default)`的图表。
+
+Figures with `outlined: false` will be excluded, but those with `numbering: none` but `outlined: true (default)` will be included.
+
+此外，我们也可以为自定义的`figure(kind: ...)`类型启用编号功能：
+
+Additionally, we can also enable numbering for custom `figure(kind: ...)` types:
+
+`figure-number` 可以把 Ratchet 管理的编号放进自定义渲染内容中。下面的 `custom-card` 没有使用标准 caption，而是在块标题中直接读取 `custom-kind` 的编号：
+
+`figure-number` places a Ratchet-managed number inside a custom renderer. The following `custom-card` does not use a standard caption; it reads the `custom-kind` number directly in the block title:
+
+#let custom-card(lab: none, body) = {
+  let elem = figure(
+    block(
+      fill: purple.lighten(80%),
+      stroke: (left: 4pt + purple),
+      inset: 8pt,
+      width: 100%,
+    )[
+      *Custom card #figure-number("custom-kind")*
+      #linebreak()
+      #body
+    ],
+    kind: "custom-kind",
+    supplement: [CUSTOM CARD],
+    caption: none,
+    outlined: false,
+  )
+  [#elem #if lab != none { label(lab) }]
+}
+
+#custom-card(lab: "custom-card")[This number is rendered inside the card body.]
+
+```typst
+#let custom-card(lab: none, body) = {
+  let elem = figure(
+    block(stroke: (left: 4pt + purple), inset: 8pt, width: 100%)[
+      *Custom card #figure-number("custom-kind")*
+      #linebreak()
+      #body
+    ],
+    kind: "custom-kind",
+    supplement: [CUSTOM CARD],
+    caption: none,
+    outlined: false,
+  )
+  [#elem #if lab != none { label(lab) }]
+}
+
+#custom-card(lab: "custom-card")[This number is rendered inside the card body.]
+```
+
+自定义渲染的块也可以正常引用：`@custom-card:` @custom-card。
+
+The custom-rendered block can be referenced normally: `@custom-card:` @custom-card.
+
+= next section
+
+#figure(
+  placeholder-img(),
+  caption: [This is a placeholder image],
+  kind: "custom-kind",
+  supplement: [CUSTOM KIND],
+)<custom-fig>
+
+```typst
+#figure(
+  placeholder-img(),
+  caption: [This is a placeholder image],
+  kind: "custom-kind",
+  supplement: [CUSTOM KIND],
+)<custom-fig>
+```
+
+同样也可以引用它：`@custom-fig:`@custom-fig 。
+
+It can also be referenced: `@custom-fig:`@custom-fig .
+
+刚才自定义渲染的块也可以正常引用：`@custom-card:` @custom-card。
+
+The previously custom-rendered block can also be referenced normally: `@custom-card:` @custom-card.

--- a/packages/preview/ratchet/0.0.3/lib/counter.typ
+++ b/packages/preview/ratchet/0.0.3/lib/counter.typ
@@ -1,0 +1,20 @@
+#let chap-counter = counter("chap-counter")
+
+#let extract-heading(depth, outline, s, loc: none) = context {
+  let loc = if loc == none { here() } else { loc }
+  let nums = chap-counter.at(loc)
+  while nums.len() < depth { nums.push(0) }
+  numbering(outline, ..nums.slice(0, depth), s)
+}
+
+#let generate-counter(counter-depth, it, outline, loc: none) = context {
+  let loc = if loc == none { here() } else { loc }
+  let s = int(it)
+  if counter-depth == 3 {
+    extract-heading(2, outline, s, loc: loc)
+  } else if counter-depth == 2 {
+    extract-heading(1, outline, s, loc: loc)
+  } else {
+    s
+  }
+}

--- a/packages/preview/ratchet/0.0.3/lib/main.typ
+++ b/packages/preview/ratchet/0.0.3/lib/main.typ
@@ -1,0 +1,1 @@
+#import "numbering.typ": figure-number, ratchet

--- a/packages/preview/ratchet/0.0.3/lib/numbering.typ
+++ b/packages/preview/ratchet/0.0.3/lib/numbering.typ
@@ -1,0 +1,223 @@
+#import "sty.typ": heading-counters, styfigure, stymatheq
+#import "counter.typ": generate-counter
+
+#let _last(arr) = arr.at(arr.len() - 1)
+#let _last-int(x) = if type(x) == int { x } else { _last(x) }
+
+#let _figure-config(groups, kind, fallback) = {
+  let config = fallback
+  for group in groups {
+    if group.kinds.contains(kind) { config = group }
+  }
+  config
+}
+
+
+#let freeze-counter-number(counter-name, depth: 2, outline: "1.1", loc: none) = context {
+  let loc = if loc == none { here() } else { loc }
+  let n = _last-int(counter(counter-name).at(loc))
+  generate-counter(depth, n, outline, loc: loc)
+}
+
+#let install-counter-resets(counter-names, depth: 2, body) = {
+  show heading.where(level: 1, outlined: true): it => {
+    if depth == 2 or depth == 3 { for name in counter-names { counter(name).update(0) } }
+    it
+  }
+  show heading.where(level: 2, outlined: true): it => {
+    if depth == 3 { for name in counter-names { counter(name).update(0) } }
+    it
+  }
+  body
+}
+
+#let _bn-guard = state("ratchet-guard", none)
+
+#let _bn-cfg = state("ratchet-config", (
+  fig-depth: 2,
+  fig-outline: "1.1",
+  fig-color: none,
+  figure-groups: (),
+  eq-depth: 2,
+  eq-outline: "(1.1)",
+  eq-color: none,
+))
+
+// Return the configured number of a figure kind at its own location.
+// This is useful for custom figure renderers that need to place the number
+// inside their body instead of using Typst's standard caption.
+#let figure-number(kind, loc: none) = context {
+  let loc = if loc == none { here() } else { loc }
+  let cfg = _bn-cfg.at(loc)
+  let fig = _figure-config(cfg.figure-groups, kind, (
+    depth: cfg.fig-depth,
+    outline: cfg.fig-outline,
+    color: cfg.fig-color,
+  ))
+  let n = _last-int(counter(figure.where(kind: kind)).at(loc))
+  generate-counter(fig.depth, n, fig.outline, loc: loc)
+}
+
+#let _resolve-supplement(r, el) = {
+  if r.supplement == none or r.supplement == auto { [#el.supplement] } else if type(r.supplement) == function {
+    r.supplement(el)
+  } else { r.supplement }
+}
+
+#let fix-numbered-refs(body) = {
+  let _paint(content, color) = if color == none { content } else { text(content, fill: color) }
+  let _paintc(content, color) = if color == none { content } else { text(fill: color)[#content] }
+
+  show ref: r => context {
+    let el = r.element
+    if el == none { return r }
+
+    if el.has("numbering") and el.numbering == none { return r }
+
+    let loc = el.location()
+    let cfg = _bn-cfg.at(loc)
+
+    if el.func() == math.equation {
+      let n = _last-int(counter(math.equation).at(loc))
+      let num = generate-counter(cfg.eq-depth, n, cfg.eq-outline, loc: loc)
+      return link(loc, _paint(num, cfg.eq-color))
+    }
+
+    if el.func() == figure {
+      let fig = _figure-config(cfg.figure-groups, el.kind, (
+        depth: cfg.fig-depth,
+        outline: cfg.fig-outline,
+        color: cfg.fig-color,
+      ))
+      let n = _last-int(counter(figure.where(kind: el.kind)).at(loc))
+      let num = generate-counter(fig.depth, n, fig.outline, loc: loc)
+      let sup = _resolve-supplement(r, el)
+      return link(loc, if sup == [] { _paint(num, fig.color) } else {
+        _paintc([#sup #h(0.15em) #num], fig.color)
+      })
+    }
+    r
+  }
+  body
+}
+
+#let fix-numbered-outline(body) = {
+  let _paint(content, color) = if color == none { content } else { text(content, fill: color) }
+  let _paintc(content, color) = if color == none { content } else { text(fill: color)[#content] }
+  show outline.entry: it => context {
+    let el = it.element
+    if el == none {
+      // fallback: keep default behavior
+      return link(it.element.location(), it.indented(it.prefix(), it.inner()))
+    }
+    let loc = el.location()
+    // If the element explicitly disabled numbering, keep default prefix.
+    if el.has("numbering") and el.numbering == none {
+      return link(loc, it.indented(it.prefix(), it.inner()))
+    }
+    // Fetch the config at the TARGET location (not at the outline page).
+    let cfg = _bn-cfg.at(loc)
+    // Fix equations inside outlines (equation list).
+    if el.func() == math.equation {
+      let n = _last-int(counter(math.equation).at(loc))
+      let num = generate-counter(cfg.eq-depth, n, outline: cfg.eq-outline, loc: loc)
+      let prefix = _paint(num, cfg.eq-color)
+      return link(loc, it.indented(prefix, it.inner()))
+    }
+    // Fix figures inside outlines (list of figures / tables).
+    if el.func() == figure {
+      let fig = _figure-config(cfg.figure-groups, el.kind, (
+        depth: cfg.fig-depth,
+        outline: cfg.fig-outline,
+        color: cfg.fig-color,
+      ))
+      let n = _last-int(counter(figure.where(kind: el.kind)).at(loc))
+      let num = generate-counter(fig.depth, n, fig.outline, loc: loc)
+      // Mimic outline.entry.prefix(): add supplement for figures.
+      let sup = [#el.supplement]
+      let prefix = if sup == [] { _paint(num, fig.color) } else {
+        _paintc([#sup #h(0.15em) #num], fig.color)
+      }
+      return link(loc, it.indented(prefix, it.inner()))
+    }
+    // Headings / others: keep default.
+    link(loc, it.indented(it.prefix(), it.inner()))
+  }
+  body
+}
+
+
+// One-stop wrapper (use as a show rule).
+#let ratchet(
+  // Heading backbone
+  offset: 0,
+  reset-figure-kinds: (image, table, raw),
+  init: "rebase",
+  // Formatting
+  fig-depth: 2,
+  fig-outline: "1.1",
+  fig-color: none,
+  // Additional independently configured figure kinds.
+  // Each group is (kinds: (...), depth: int, outline: str/function, color: color/none).
+  figure-groups: (),
+  eq-depth: 2,
+  eq-outline: "(1.1)",
+  eq-color: none,
+  body,
+) = context {
+  let all-figure-groups = ((
+    kinds: reset-figure-kinds,
+    depth: fig-depth,
+    outline: fig-outline,
+    color: fig-color,
+  ),) + figure-groups
+
+  // A wrapper's document location is stable across layout iterations and
+  // uniquely identifies its configuration session.
+  let session = here()
+
+  // Anchor (guard + cfg) into the document flow, otherwise the updates can be skipped
+  // during iterative layout / introspection passes.
+  context {
+    _bn-guard.update(session)
+    _bn-cfg.update((
+      fig-depth: fig-depth,
+      fig-outline: fig-outline,
+      fig-color: fig-color,
+      figure-groups: all-figure-groups,
+      eq-depth: eq-depth,
+      eq-outline: eq-outline,
+      eq-color: eq-color,
+    ))
+  }
+
+  // Only the newest session at the current location should act.
+  let active = () => _bn-guard.get() == session
+
+  show: heading-counters.with(
+    counter-depth: fig-depth,
+    matheq-depth: eq-depth,
+    offset: offset,
+    reset-figure-kinds: reset-figure-kinds,
+    figure-groups: all-figure-groups,
+    active: active,
+    init: init,
+  )
+
+  show: styfigure.with(
+    counter-depth: fig-depth,
+    fig-outline: fig-outline,
+    figure-kinds: reset-figure-kinds,
+    figure-groups: all-figure-groups,
+  )
+
+  show: stymatheq.with(
+    counter-depth: eq-depth,
+    eq-outline: eq-outline,
+  )
+
+  show: fix-numbered-refs
+  show: fix-numbered-outline
+
+  body
+}

--- a/packages/preview/ratchet/0.0.3/lib/sty.typ
+++ b/packages/preview/ratchet/0.0.3/lib/sty.typ
@@ -1,0 +1,122 @@
+#import "counter.typ": *
+
+#let _style-figure-groups(groups, body) = {
+  if groups.len() == 0 {
+    body
+  } else {
+    let group = groups.first()
+    let sels = group.kinds.map(k => figure.where(kind: k))
+    if sels.len() > 0 {
+      show selector.or(..sels): set figure(
+        numbering: n => generate-counter(group.depth, n, group.outline),
+      )
+      _style-figure-groups(groups.slice(1), body)
+    } else {
+      _style-figure-groups(groups.slice(1), body)
+    }
+  }
+}
+
+#let styfigure(
+  counter-depth: 2,
+  fig-outline: "1.1",
+  figure-kinds: (image, table, raw),
+  figure-groups: none,
+  body,
+) = {
+  let groups = if figure-groups == none { ((
+    kinds: figure-kinds,
+    depth: counter-depth,
+    outline: fig-outline,
+    color: none,
+  ),) } else { figure-groups }
+  _style-figure-groups(groups, body)
+}
+
+#let stymatheq(
+  counter-depth: 2,
+  eq-outline: "(1.1)",
+  body,
+) = {
+  set math.equation(
+    numbering: n => generate-counter(counter-depth, n, eq-outline),
+  )
+  set math.equation(supplement: [])
+  show label("-"): set math.equation(numbering: none)
+  body
+}
+
+#let heading-counters(
+  counter-depth: 2,
+  matheq-depth: 2,
+  offset: 0,
+  reset-figure-kinds: (image, table, raw),
+  figure-groups: none,
+  init: "rebase",
+  active: none,
+  body,
+) = {
+  let is-active = () => active == none or active()
+  let groups = if figure-groups == none { ((
+    kinds: reset-figure-kinds,
+    depth: counter-depth,
+    outline: "1.1",
+    color: none,
+  ),) } else { figure-groups }
+
+  context {
+    if is-active() {
+      if init == "reset" {
+        chap-counter.update((..) => (offset, 0, 0))
+      } else if init == "rebase" {
+        let h = counter(heading).get()
+        chap-counter.update((..) => (
+          h.at(0, default: 0) + offset,
+          h.at(1, default: 0),
+          h.at(2, default: 0),
+        ))
+      } else {
+        // "keep": no-op
+      }
+
+      for group in groups {
+        for k in group.kinds { counter(figure.where(kind: k)).update(0) }
+      }
+      counter(math.equation).update(0)
+    }
+  }
+
+  show heading.where(level: 1, outlined: true): it => context {
+    if not is-active() { it } else {
+      if matheq-depth == 2 or matheq-depth == 3 { counter(math.equation).update(0) }
+      for group in groups {
+        if group.depth == 2 or group.depth == 3 {
+          for k in group.kinds { counter(figure.where(kind: k)).update(0) }
+        }
+      }
+      chap-counter.step(level: 1)
+      chap-counter.update((x, ..y) => (x, 0, 0))
+      it
+    }
+  }
+  show heading.where(level: 2, outlined: true): it => context {
+    if not is-active() { it } else {
+      if matheq-depth == 3 { counter(math.equation).update(0) }
+      for group in groups {
+        if group.depth == 3 {
+          for k in group.kinds { counter(figure.where(kind: k)).update(0) }
+        }
+      }
+      chap-counter.step(level: 2)
+      chap-counter.update((x, y, ..z) => (x, y, 0))
+      it
+    }
+  }
+  show heading.where(level: 3, outlined: true): it => context {
+    if not is-active() { it } else {
+      chap-counter.step(level: 3)
+      it
+    }
+  }
+  body
+}

--- a/packages/preview/ratchet/0.0.3/typst.toml
+++ b/packages/preview/ratchet/0.0.3/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ratchet"
+version = "0.0.3"
+entrypoint = "lib/main.typ"
+authors = ["AnZreww <an112358132134@gmail.com>"]
+license = "MIT"
+description = "ratchet is a package for improved figure/table/equation/math.equation/custom-kind numbering."
+repository = "https://github.com/An-314/ratchet"
+categories = ["scripting"]
+keywords = ["numbering", "counter"]
+compiler = "0.14.0"
+exclude = ["demo.typ", "makefile"]


### PR DESCRIPTION
<!--
Thanks for submitting a package! Please read and follow the submission guidelines detailed in the repository's README and check the boxes below. Please name your PR as `name:version` of the submitted package.

If you want to make a PR for something other than a package submission, just delete all this and make a plain PR.
-->

I am submitting
- [ ] a new package
- [x] an update for a package

<!--
Please add a brief description of your package below and explain why you think it is useful to others. If this is an update, please briefly say what changed.
-->

Ratchet provides section-aware numbering for figures, tables, equations, and custom figure kinds, with consistent cross-section references and configurable numbering formats.
Version 0.0.3 adds `figure-groups`, allowing different figure kinds to use independent numbering depths, formats, colors, and reset rules. It also introduces figure-number, which enables package authors to display Ratchet-managed numbers inside custom-rendered components such as theorem or definition blocks. Documentation and examples have been updated accordingly.