### PR TITLE
ea-nasir:0.1.0

### DIFF
--- a/packages/preview/ea-nasir/0.1.0/LICENSE
+++ b/packages/preview/ea-nasir/0.1.0/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2026 Fiona Runge
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/packages/preview/ea-nasir/0.1.0/README.md
+++ b/packages/preview/ea-nasir/0.1.0/README.md
@@ -1,0 +1,275 @@
+# ea-nasir
+
+A package for plaintext accounting named after the famous copper merchant [Ea-nāṣir](https://en.wikipedia.org/wiki/Ea-n%C4%81%E1%B9%A3ir).
+
+This package does not handle clay tablets, but sees value in the ideas of [plaintext accounting](https://plaintextaccounting.org/) and aims to make them available in typst.
+
+As such this package allows for the creation of accounts and transactions and to group these in a ledger.
+
+The beancount format can be used to read accounts and transactions from a text file.
+
+## Usage example
+
+Say you've got a beancount file like [ea-nasir.beancount](https://codeberg.org/runjak/ea-nasir/src/commit/65dd274671fdaf793be56c5ca2185b8265187751/ea-nasir.beancount).
+
+You can read it into a ledger like this:
+
+```typst
+#import "@preview/ea-nasir:0.1.0": parseLedger, reportLedger
+
+#let ledger = parseLedger(read("./ea-nasir.beancount"))
+```
+
+Which gives you a `ledger` holding all the accounts and transactions defined in that file.
+
+You can then create a report on it like this:
+
+```typst
+#let report = reportLedger(ledger)
+```
+
+giving you a detailed report of the ledger.
+
+`#report.prefixes` then holds data like this:
+
+```typst
+#{
+  (
+  assets: (
+    EUR: (
+      total:
+      decimal("1"),
+      plus: decimal("7"),
+      minus: decimal("-6"),
+    ),
+  ),
+  copper: (
+    XCP: (
+      total:
+      decimal("0"),
+      plus: decimal("8"),
+      minus: decimal("-8"),
+    ),
+  ),
+  expenses: (
+    EUR: (
+      total:
+      decimal("6"),
+      plus: decimal("6"),
+      minus: decimal("0"),
+    ),
+  ),
+  income: (
+    EUR: (
+      total:
+      decimal("-7"),
+      plus: 0,
+      minus: decimal("-7"),
+    ),
+  ),
+)
+}
+```
+
+## Beancount syntax
+
+The syntax used by this package is (currently) only a subset of what other tools support. This section describes what is supported.
+
+### Example
+
+```beancount
+2026-08-01 open expenses:copper EUR ; Money spent on copper
+2026-08-01 open expenses:travel EUR ; Travel costs
+2026-08-01 open assets:money EUR    ; Money kept by us
+2026-08-01 open copper:ea-nasir XCP ; Copper held by Ea-nāṣir
+2026-08-01 open copper:warehouse XCP ; Copper in our warehouse
+
+2026-08-02 * "Buy copper" "We buy some sub-par copper from ea-nasir"
+  assets:money ; Inferred to -6 EUR
+  expenses:copper 5 EUR
+  expenses:travel 1 EUR
+  copper:ea-nasir -4 XCP
+  copper:warehouse 4 XCP
+```
+
+### Empty lines
+
+Empty lines may contain arbitrary whitespace.
+
+### Comments
+
+Comments start with `;` and are generally allowed on their own lines as well as at the end of other lines.
+
+### Dates
+
+Dates generally have the Form `yyyy-MM-dd` - the date portion of an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) string.
+
+When comparing dates this package only cares about the day, never the time of day of account openings and transactions.
+
+So a transaction may happen on the same day as an account is opened or later, but never before.
+
+### Account opening
+
+Account opening statements have the form of
+`<date> open <account name> <currency>`.
+
+They can have a trailing comment that will be interpreted as the `description` for the account, like so: `<date> open <account name> <currency> ; <description>`.
+
+#### Monotone
+
+Parsing config will decide on the monotone behaviour of an account: some accounts may only receive (`positive`) or only loose (`negative`) money.
+
+The default here is to treat accounts where the name starts with `expenses:` as monotone positive, and ones where the name starts with `income:` as monotone negative.
+
+### Transactions
+
+Transactions generally start with a headline followed by a number of deltas.
+
+A transaction headline has the form of `<date> * "<name>" "<narration>"`.
+
+Like with the account opening statement we accept a trailing comment as description: `<date> * "<name>" "<description>"`.
+
+Both `name` and `narration` are not allowed to contain `"` - because escaping just isn't implemented.
+
+Deltas generally have this form: `<account name> <amount> <currency>`.
+
+It is allowed for a delta to just be the `account name`, if that account is the only one of unspecified `amount` and `currency` so that the `amount` can be inferred from the other deltas, and the `currency` can be looked up from the ledger.
+
+Recall our example:
+
+```beancount
+2026-08-02 * "Buy copper" "We buy some sub-par copper from ea-nasir"
+  assets:money ; Inferred to -6 EUR
+  expenses:copper 5 EUR
+  expenses:travel 1 EUR
+  copper:ea-nasir -4 XCP
+  copper:warehouse 4 XCP
+```
+
+## Concepts
+
+### Currency
+
+- A currency is a string.
+- Same string means same currency.
+- Typical currencies are USD, EUR.
+- We also allow 🍿, "milk" or whatever else.
+
+### Date
+
+- Dates are generally of type datetime
+- We parse strings of the form yyyy-mm-dd into datetimes.
+
+### Account
+
+- A (hierarchical) name
+- An opening date
+- A currency (USD, EUR, 🍿)
+- A starting amount - missing will default to 0.
+- An optional description
+- An optional rule called monotone
+  - positive: amount may only grow.
+  - negative: amount may only shrink.
+  - If a monotone rule is given all deltas must obey it.
+- A sorted log of deltas and times. We expect to append only.
+  - deltas are always decimals.
+  - times are always ?
+
+#### Account naming
+
+We understand the `:` in an account name to express hierarchy.
+
+If we have accounts `Expenses:Foo` and `Expenses:Bar`
+we can compute sums for both accounts as well as for `Expenses`.
+
+### Transaction
+
+- A date
+- A name
+- A narration
+- An optional description to expand on name and narration.
+- A list of account deltas
+  - Triplets of account, amount, currency
+  - All deltas of the same currency must sum up to 0.
+
+### Ledger
+
+- A collection of accounts and transactions.
+
+### Reports
+
+- A report is calculated over an account or over a ledger.
+- A report can be constrained to a date range.
+- A report adds up all sums (of a date range) for an account.
+  - They are returned as (total, plus, minus).
+  - If the opening time of the account is in the date range,
+    the initial amount is included in the sum.
+
+#### Account reports
+
+The report for an account consists of the following fields:
+
+- The `name` for the account the report was computed on
+- The `currency` used for the account
+- The `from`, `to` fields for the date range of the report
+- The `total` sum
+- The `plus` sum (sum of all positive additions to the account)
+- The `minus` sum (sum of all negative additions to the account)
+
+#### Ledger reports
+
+The report for a ledger consists of the following fields:
+
+- A dictionary of `accounts` that maps account names to the report for that account
+- A dictionary of `prefixes` that map prefixes for account names (as separated by `:`) to currencySums
+  - Where each currencySum maps a currency string to (total, plus, minus)
+- An `all` dictionary, that is the union of `accounts` and `prefixes`.
+- The `from`, `to` fields for the date range of the report
+
+## API
+
+This package exports the following functions:
+
+### Beancount
+
+The central function to parse beancount text is `parseLedger`.
+
+It takes a second, optional argument config, which defaults to `parseAccountConfig`, but can be overwritten accordingly.
+
+### Report
+
+Two reporting functions exist:
+
+- `reportLedger`: create a report for a ledger over an optional timeframe.
+- `reportAccount`: create a report for an account over an optional timeframe.
+
+### Ledger
+
+A ledger is generally handled as immutable.
+This means the following functions don't modify the ledger, but create a new one instead.
+
+- `mkLedger`: creates a new, empty ledger
+- `addAccount`: adds an account to a ledger
+- `addTransaction`: applies a transaction to a ledger
+
+### Transaction
+
+The package exports the following functions for the transaction concept:
+
+- `mkTransaction`: it is how transactions are created.
+- `mkDelta`: a helper functions to create deltas for a transaction.
+- `validateDelta`: a helper function to validate the structure of deltas.
+
+### Account
+
+The package exports two functions working on the account concept:
+
+- `mkAccount`, which creates new accounts.
+- `log`, which takes an account and some data to add to the log of an account. It handles the account as immutable.
+
+### Date
+
+We have two helper functions for date handling:
+
+- `toDate`, which converts a date of the form `yyyy-MM-dd` to a `datetime`.
+- `sameDayOrLater`, which compares two dates checking that the second argument is on the same day or later than the first argument.

--- a/packages/preview/ea-nasir/0.1.0/account.typ
+++ b/packages/preview/ea-nasir/0.1.0/account.typ
@@ -1,0 +1,115 @@
+#import "date.typ": _toDate, sameDayOrLater
+
+#let _mkAccount = (name, opening_date, currency, start_amount, description, monotone) => {
+  if (type(name) != str or name.len() == 0) {
+    return (none, "name must be a non-empty string.")
+  }
+
+  let (opening_date, error) = _toDate(opening_date)
+  if (opening_date == none) {
+    return (none, "opening_date: " + error)
+  }
+
+  if (type(currency) != str or currency.len() == 0) {
+    return (none, "currency must be a non-empty string.")
+  }
+
+  if (start_amount != none and type(start_amount) != int and type(start_amount) != decimal) {
+    return (none, "start_amount must be of type none, int or decimal.")
+  }
+  if start_amount == none {
+    start_amount = decimal(0)
+  } else {
+    start_amount = decimal(start_amount)
+  }
+
+  if (description != none and type(description) != str and type(description) != content) {
+    return (none, "description must be of type none, str, content.")
+  }
+
+  if (monotone != none and monotone != "positive" and monotone != "negative") {
+    return (none, "monotone must be one of {none, 'positive', 'negative'}")
+  }
+
+  return (
+    (
+      name: name,
+      opening_date: opening_date,
+      currency: currency,
+      start_amount: start_amount,
+      description: description,
+      monotone: monotone,
+      log: (), // array(dictionary(date, amount, name, narration))
+    ),
+    none,
+  )
+}
+
+/**
+ * mkAccount creates an account given the following parameters:
+ * - name
+ * - opening_date
+ * - currency
+ * - start_amount
+ * - description: none|str|content
+ * - monotone: none|"positive"|"negative"
+ */
+#let mkAccount = (name, opening_date, currency, start_amount, description, monotone) => {
+  let (account, error) = _mkAccount(name, opening_date, currency, start_amount, description, monotone)
+  assert.ne(account, none, message: "" + error)
+  return account
+}
+
+#let _log = (account, date, amount, name, narration) => {
+  if (amount == 0) {
+    return (none, "amount must be != 0 to log.")
+  }
+
+  if (account.monotone == "positive" and amount < 0) {
+    return (none, "account has monotone == 'positive', but given amount is < 0.")
+  }
+  if (account.monotone == "negative" and amount > 0) {
+    return (none, "account has monotone == 'negative', but given amount is > 0.")
+  }
+
+  let (date, error) = _toDate(date)
+  if (date == none) {
+    return (none, error)
+  }
+
+  if (not sameDayOrLater(account.opening_date, date)) {
+    return (
+      none,
+      "date ("
+        + date.display()
+        + ") must be same day or later than account.opening_date ("
+        + account.opening_date.display()
+        + ").",
+    )
+  }
+
+  if (account.log.len() > 0) {
+    let lastDate = account.log.last().date
+    if (not sameDayOrLater(lastDate, date)) {
+      return (none, "Given date " + date.display() + "is earlier than last log entry (" + lastDate.display() + ").")
+    }
+  }
+
+  let entry = (date: date, amount: amount, name: name, narration: narration)
+  return ((..account, log: (..account.log, entry)), none)
+}
+
+/**
+ * Create a new account with some change appended to it' log.
+ * Parameters are:
+ * - account: The account with the log we want to append to.
+ * - date: datetime|str for the log entry, must be same day or later to the last log entry.
+ * - amount: int|str|decimal
+ * - name: non-empty string
+ * - narration: string
+ */
+#let log = (account, date, amount, name, narration) => {
+  let (account, error) = _log(account, date, amount, name, narration)
+  assert.ne(account, none, message: "" + error)
+  return account
+}

--- a/packages/preview/ea-nasir/0.1.0/beancount.typ
+++ b/packages/preview/ea-nasir/0.1.0/beancount.typ
@@ -1,0 +1,204 @@
+#import "account.typ": _mkAccount
+#import "transaction.typ": _mkDelta, _mkTransaction
+#import "ledger.typ": _addAccount, _addTransaction, mkLedger
+
+/**
+ * The default config to parse an account.
+ * It is used when no other config is given.
+ *
+ * - positivePrefix: configures the account name prefix that will be interpreted as a monotone positive account.
+ * - negativePrefix: configures the account name prefix that will be interpreted as a monotone negative account.
+ */
+#let parseAccountConfig = (positivePrefix: "expenses:", negativePrefix: "income:")
+
+/**
+ * Parse a beancount line to open an account.
+ * We understand a comment on the account line as an optional description to the account.
+ *
+ * Per default config we:
+ * - understand accounts starting with 'expenses:' to be monotone positive.
+ * - understand account starting with 'income' to be monotone negative.
+ */
+#let _parseAccount = (line, config: parseAccountConfig) => {
+  let match = line.match(
+    regex("^(\d{4}-\d{2}-\d{2})\s+open\s+(\S+)\s+(\w+)\s*;?\s*(.*)$"),
+  )
+
+  if (match == none) { return (match, "line '" + line + "' is not a valid statement to open an account.") }
+
+  let (date, name, currency, description) = match.captures
+
+  let monotone = none
+  if (name.starts-with(config.positivePrefix)) {
+    monotone = "positive"
+  }
+  if (name.starts-with(config.negativePrefix)) {
+    monotone = "negative"
+  }
+
+  return _mkAccount(name, date, currency, 0, description, monotone)
+}
+
+#let _parseTransaction = (ledger, lines) => {
+  let (headline, ..deltaLines) = lines
+  let matches = headline.match(regex("^(\d{4}-\d{2}-\d{2})\s+\*\s+\"([^\"]+)\"\s+\"([^\"]+)\"\s*;?\s*(.*)$"))
+
+  if (matches == none) {
+    return (none, "line '" + headline + "' is not a valid transaction start.")
+  }
+
+  let (date, name, narration, description) = matches.captures
+
+  let deltas = ()
+  let missingAccountNames = ()
+
+  for line in deltaLines {
+    let matches = line.trim().match(regex("^([\w:]+)\s+(-?\d+\.?\d*)\s+(\w+)\s*;?.*$"))
+
+    if (matches != none) {
+      let (name, amount, currency) = matches.captures
+      let (delta, error) = _mkDelta(name, amount, currency)
+
+      if (error != none) {
+        return (none, error)
+      }
+
+      deltas.push(delta)
+      continue
+    }
+
+    let matches = line.trim().match(regex("^([^;\s]+)\s*;?.*$"))
+
+    if (matches == none) {
+      return (none, "Could not read line '" + line + "' as a transaction delta.")
+    }
+
+    missingAccountNames.push(matches.captures.at(0))
+  }
+
+  for accountName in missingAccountNames {
+    let account = ledger.accounts.at(accountName, default: none)
+
+    if (account == none) {
+      return (none, "Account '" + accountName + "' not found in ledger.")
+    }
+
+    let currency = account.currency
+
+    let imbalance = decimal(0)
+    for delta in deltas {
+      if (delta.currency == currency) {
+        imbalance += delta.amount
+      }
+    }
+
+    let (delta, error) = _mkDelta(accountName, -imbalance, currency)
+    if (error != none) { return (none, error) }
+
+    deltas.push(delta)
+  }
+
+  let (t, e) = _mkTransaction(date, name, narration, deltas, description)
+
+  assert.eq(e, none, message: "" + e)
+
+  return (t, e)
+}
+
+#let isTransactionStart = line => {
+  return line.starts-with(regex("^(\d{4}-\d{2}-\d{2})\s+\*\s+\""))
+}
+
+#let isIndented = line => { return line.starts-with(regex("^\s+")) }
+
+#let isAccountOpen = line => {
+  return line.starts-with(regex("^(\d{4}-\d{2}-\d{2})\s+open\s+"))
+}
+
+#let isComment = line => { return line.starts-with(regex("^\s*;")) }
+
+#let isEmpty = line => {
+  return line.trim() == ""
+}
+
+/**
+ * _parseLedger takes a string in beancount format
+ * and parses it into a ledger.
+ *
+ * It understands:
+ * - comments
+ * - opening of accounts
+ * - transactions
+ *   - partial deltas,
+ *     if only one option is missing for a currency
+ *
+ * It does not handle:
+ * - includes
+ * - assert statements
+ * - padding accounts
+ */
+#let _parseLedger = (text, config: parseAccountConfig) => {
+  let ledger = mkLedger()
+  let transactionLines = ()
+
+  for line in text.split("\n") {
+    // We ignore all empty and comment only lines.
+    if (isEmpty(line) or isComment(line)) { continue }
+
+    // If we're in a transaction block we continue with it.
+    if (transactionLines.len() > 0) {
+      if (isIndented(line)) {
+        transactionLines.push(line)
+        continue
+      }
+
+      let (transaction, error) = _parseTransaction(ledger, transactionLines)
+      if (error != none) { return (none, error) }
+
+      let (_ledger, error) = _addTransaction(ledger, transaction)
+      if (error != none) { return (none, error) }
+
+      ledger = _ledger
+      transactionLines = ()
+    }
+
+    // Detect account opening
+    if (isAccountOpen(line)) {
+      let (account, error) = _parseAccount(line, config: config)
+      if (error != none) { return (none, error) }
+
+      let (_ledger, error) = _addAccount(ledger, account)
+      if (error != none) { return (none, error) }
+
+      ledger = _ledger
+    }
+
+    // Detect start of transaction
+    if (isTransactionStart(line)) {
+      transactionLines.push(line)
+    }
+  }
+  // Maybe we were still parsing a transaction?
+  if (transactionLines.len() > 0) {
+    let (transaction, error) = _parseTransaction(ledger, transactionLines)
+    if (error != none) { return (none, error) }
+
+    let (_ledger, error) = _addTransaction(ledger, transaction)
+    if (error != none) { return (none, error) }
+
+    ledger = _ledger
+  }
+
+  return (ledger, none)
+}
+
+/**
+ * parses text in the beancount format into a ledger.
+ * - text: str
+ * - config: optional, in the shape of parseAccountConfig
+ */
+#let parseLedger = (text, config: parseAccountConfig) => {
+  let (ledger, error) = _parseLedger(text, config: config)
+  assert.eq(error, none, message: "" + error)
+  return ledger
+}

--- a/packages/preview/ea-nasir/0.1.0/date.typ
+++ b/packages/preview/ea-nasir/0.1.0/date.typ
@@ -1,0 +1,43 @@
+#let _toDate = date => {
+  if (type(date) != datetime and type(date) != str) {
+    return (none, "date must be datetime or string, but got: " + str(type(date)))
+  }
+
+  if type(date) == datetime {
+    return (date, none)
+  }
+
+  let parts = date.match(regex("^(\d{1,4})-(\d{1,2})-(\d{1,2})$"))
+  if (parts == none) {
+    return (none, "Expecting date string to obey format yyyy-mm-dd.")
+  }
+
+  let (year, month, day) = parts.captures
+  return (datetime(year: int(year), month: int(month), day: int(day)), none)
+}
+
+/**
+ * toDate is a helper function to convert strings to datetime.
+ * The date parameter must be datetime|str.
+ * If the date parameter is `str`, it must be of the format `yyyy-MM-dd`.
+ * If the date parameter already is a datetime toDate just returns it.
+ */
+#let toDate = date => {
+  let (date, error) = _toDate(date)
+  assert.ne(date, none, message: "" + error)
+  return date
+}
+
+/**
+ * True if dateB is on the same day or later than dateA.
+ * Expects both parameters to be datetimes.
+ */
+#let sameDayOrLater = (dateA, dateB) => {
+  if dateA.year() > dateB.year() { return false }
+  if dateA.year() < dateB.year() { return true }
+
+  if dateA.month() > dateB.month() { return false }
+  if dateA.month() < dateB.month() { return true }
+
+  return dateA.day() <= dateB.day()
+}

--- a/packages/preview/ea-nasir/0.1.0/ledger.typ
+++ b/packages/preview/ea-nasir/0.1.0/ledger.typ
@@ -1,0 +1,85 @@
+#import "date.typ": sameDayOrLater
+#import "transaction.typ": _validateDeltaSums
+#import "account.typ": _log
+
+/**
+ * Creates a new, empty ledger.
+ */
+#let mkLedger = () => (accounts: (:), transactions: ())
+
+#let _addAccount = (ledger, account) => {
+  if (account.name in ledger.accounts) {
+    return (none, "Account name '" + account.name + "' already present in ledger.")
+  }
+
+  let ledger = (..ledger, accounts: (..ledger.accounts, account.name: account))
+
+  return (ledger, none)
+}
+
+/**
+ * Given a ledger and an account creates a new ledger that includes the account.
+ */
+#let addAccount = (ledger, account) => {
+  let (ledger, error) = _addAccount(ledger, account)
+  assert.eq(error, none, message: "" + error)
+  return ledger
+}
+
+#let _addTransaction = (ledger, transaction) => {
+  if (ledger.transactions.len() > 0) {
+    // If a lastTransaction exists it must be same day or before current one.
+    let lastTransaction = ledger.transactions.last()
+
+    if (not sameDayOrLater(lastTransaction.date, transaction.date)) {
+      return (
+        none,
+        "last transaction in ledger is from "
+          + lastTransaction.date.display()
+          + ". Will not add transaction from "
+          + transaction.date.display()
+          + " after it.",
+      )
+    }
+  }
+
+  // Transaction must have valid delta sums
+  let error = _validateDeltaSums(transaction.deltas)
+  if (error != none) {
+    return (none, error)
+  }
+
+  // Transaction must be added to account logs
+  let updated_accounts = (:..ledger.accounts)
+  for delta in transaction.deltas {
+    let account = ledger.accounts.at(delta.account, default: none)
+
+    if (account == none) {
+      return (none, "account '" + delta.account + "' not found in ledger.")
+    }
+
+    let (account, error) = _log(account, transaction.date, delta.amount, transaction.name, transaction.narration)
+    if (account == none) {
+      return (none, error)
+    }
+
+    updated_accounts.at(account.name) = account
+  }
+  // Now that we know that all accounts can be processed, and the transaction is fine we modify the ledger.
+  let ledger = (
+    ..ledger,
+    accounts: updated_accounts,
+    transactions: (..ledger.transactions, transaction),
+  )
+
+  return (ledger, none)
+}
+
+/**
+ * Given a ledger and a transaction creates a new ledger with the transaction applied.
+ */
+#let addTransaction = (ledger, transaction) => {
+  let (ledger, error) = _addTransaction(ledger, transaction)
+  assert.eq(error, none, message: "" + error)
+  return ledger
+}

--- a/packages/preview/ea-nasir/0.1.0/lib.typ
+++ b/packages/preview/ea-nasir/0.1.0/lib.typ
@@ -1,0 +1,7 @@
+#import "date.typ": sameDayOrLater, toDate
+#import "account.typ": log, mkAccount
+#import "transaction.typ": mkDelta, mkTransaction, validateDelta
+#import "ledger.typ": addAccount, addTransaction, mkLedger
+#import "report.typ": reportAccount, reportLedger
+#import "beancount.typ": parseAccountConfig, parseLedger
+

--- a/packages/preview/ea-nasir/0.1.0/report.typ
+++ b/packages/preview/ea-nasir/0.1.0/report.typ
@@ -1,0 +1,156 @@
+#import "date.typ": _toDate, sameDayOrLater
+
+#let _reportAccount = (account, from: none, to: none) => {
+  if (from != none) {
+    let (_from, error) = _toDate(from)
+    if (error != none) {
+      return (none, "from: " + error)
+    }
+    from = _from
+  }
+
+  if (to != none) {
+    let (_to, error) = _toDate(to)
+    if (error != none) {
+      return (none, "to: " + error)
+    }
+    to = _to
+  }
+
+  let plus = 0
+  let minus = 0
+
+  if (
+    (from == none or sameDayOrLater(from, account.opening_date))
+      and (to == none or sameDayOrLater(account.opening_date, to))
+  ) {
+    if (account.start_amount > 0) {
+      plus += account.start_amount
+    } else {
+      minus += account.start_amount
+    }
+  }
+
+  for entry in account.log {
+    if (from != none and not sameDayOrLater(from, entry.date)) { continue }
+
+    if (to != none and not sameDayOrLater(entry.date, to)) { continue }
+
+    if (entry.amount > 0) { plus += entry.amount } else {
+      minus += entry.amount
+    }
+  }
+
+  return (
+    (
+      name: account.name,
+      currency: account.currency,
+      from: from,
+      to: to,
+      total: plus + minus,
+      plus: plus,
+      minus: minus,
+    ),
+    none,
+  )
+}
+
+/**
+ * Create a report for an account over an optional timeframe.
+ * Arguments are:
+ * - account: the account to create the report for.
+ * - from: none|datetime|str
+ * - to: none|datetime|str
+ */
+#let reportAccount = (account, from: none, to: none) => {
+  let (report, error) = _reportAccount(account, from: from, to: to)
+  assert.eq(error, none, message: "" + error)
+  return report
+}
+
+#let _namePrefixes = name => {
+  let parts = name.split(":")
+
+  if (parts.len() <= 1) { return () }
+
+  let prefixes = ()
+  for i in range(1, parts.len()) {
+    prefixes.push(parts.slice(0, i).join(":"))
+  }
+
+  return prefixes
+}
+
+#let _prefixes = accounts => {
+  let prefixes = (:)
+
+  for account in accounts {
+    for prefix in _namePrefixes(account.name) {
+      prefixes.insert(prefix, 1)
+    }
+  }
+
+  return prefixes.keys().sorted()
+}
+
+#let _reportLedger = (ledger, from: none, to: none) => {
+  let accountReports = (:)
+  for account in ledger.accounts.values() {
+    let (report, error) = _reportAccount(account, from: from, to: to)
+
+    if (error != none) {
+      return (none, error)
+    }
+
+    accountReports.insert(account.name, report)
+  }
+
+  let prefixReports = (:)
+  for prefix in _prefixes(ledger.accounts.values()) {
+    let defaultSum = (total: 0, plus: 0, minus: 0)
+    let currencySums = (:)
+
+    for (accountName, report) in accountReports {
+      if (not accountName.starts-with(prefix)) {
+        continue
+      }
+
+      let existing = currencySums.at(report.currency, default: defaultSum)
+      let next = (
+        total: report.total + existing.total,
+        plus: report.plus + existing.plus,
+        minus: report.minus + existing.minus,
+      )
+
+      let nextDict = (:)
+      nextDict.insert(report.currency, next)
+      currencySums = (:..currencySums, ..nextDict)
+    }
+
+    prefixReports.insert(prefix, currencySums)
+  }
+
+  return (
+    (
+      accounts: accountReports,
+      prefixes: prefixReports,
+      all: (:..prefixReports, ..accountReports),
+      from: from,
+      to: to,
+    ),
+    none,
+  )
+}
+
+/**
+ * Create a report for a ledger over an optional timeframe.
+ * Arguments are:
+ * - ledger: the ledger to create the report for.
+ * - from: none|datetime|str
+ * - to: none|datetime|str
+ */
+#let reportLedger = (ledger, from: none, to: none) => {
+  let (report, error) = _reportLedger(ledger, from: from, to: to)
+  assert.eq(error, none, message: "" + error)
+  return report
+}

--- a/packages/preview/ea-nasir/0.1.0/transaction.typ
+++ b/packages/preview/ea-nasir/0.1.0/transaction.typ
@@ -1,0 +1,160 @@
+#import "date.typ": _toDate
+
+#let _mkDelta = (account, amount, currency) => {
+  if (type(account) != str or account.len() == 0) {
+    return (none, "account must be a non-empty string.")
+  }
+
+  if (type(amount) == float) {
+    return (none, "amount may not be a float.")
+  }
+  if (type(amount) != decimal and type(amount) != str and type(amount) != int) {
+    return (none, "amount must be a decimal, int or str.")
+  }
+
+  if (type(currency) != str or currency.len() == 0) {
+    return (none, "currency must be a non-empty string.")
+  }
+
+  return ((account: account, amount: decimal(amount), currency: currency), none)
+}
+
+/**
+ * Create a delta that can later become part of a transaction.
+ * A delta is composed of:
+ * - account: the name of the account. A non-empty string.
+ * - amount: decimal|str|int
+ * - currency: A non-empty string matching the currency of the account.
+ */
+#let mkDelta = (account, amount, currency) => {
+  let (delta, error) = _mkDelta(account, amount, currency)
+  assert.ne(delta, none, message: "" + error)
+  return delta
+}
+
+#let _validateDelta = delta => {
+  if (type(delta) != dictionary) {
+    return (none, "delta must be a dictionary.")
+  }
+
+  let (account: account, amount: amount, currency: currency) = delta
+
+  if (type(account) != str or account.len() == 0) {
+    return (none, "account must be a non-empty string.")
+  }
+  if (type(amount) != decimal) {
+    return (none, "amount must be of type decimal.")
+  }
+  if (type(currency) != str or currency.len() == 0) {
+    return (none, "currency must be a non-empty string.")
+  }
+
+  return (delta, none)
+}
+
+/**
+ * Verifies that a given delta is valid.
+ * A valid delta is returned, an invalid one causes an assertion failure.
+ */
+#let validateDelta = delta => {
+  let (delta, error) = _validateDelta(delta)
+  assert.ne(delta, none, message: "" + error)
+  return delta
+}
+
+#let _validateDeltaSums = deltas => {
+  // we expect the per-currency sums to all be 0.
+  let currency_sums = (:)
+
+  if (deltas.len() == 0) { return "deltas must be a non-empty list." }
+
+  for delta in deltas {
+    let (amount: amount, currency: currency) = delta
+    currency_sums.insert(currency, amount + currency_sums.at(currency, default: decimal(0)))
+  }
+
+  for (currency, amount) in currency_sums.pairs() {
+    if (amount != 0) {
+      return "amount should be 0 for currency '" + currency + "', but is " + str(amount) + "."
+    }
+  }
+
+  return none
+}
+
+#let _uniqueDeltaAccounts = deltas => {
+  let accounts = (:)
+
+  for delta in deltas {
+    if delta.account in accounts {
+      return "Account name '" + delta.account + "' is present in more than one delta."
+    }
+
+    accounts.insert(delta.account, none)
+  }
+
+  return none
+}
+
+#let _mkTransaction = (date, name, narration, deltas, description) => {
+  let (date, error) = _toDate(date)
+  if (date == none) { return (none, "mkTransaction: " + error) }
+
+  if (type(name) != str or name.len() == 0) {
+    return (none, "name must be a non-empty string.")
+  }
+
+  if (type(narration) != str) {
+    // narration is allowed to be empty.
+    return (none, "narration must be of type str.")
+  }
+
+  if (type(deltas) != array or deltas.len() == 0) {
+    return (none, "deltas must be a non-empty array.")
+  }
+  for delta in deltas {
+    let (delta, error) = _validateDelta(delta)
+    if (error != none) {
+      return (none, "invalid delta in mkTransaction: " + error)
+    }
+  }
+
+  let error = _validateDeltaSums(deltas)
+  if (error != none) {
+    return (none, error)
+  }
+
+  let error = _uniqueDeltaAccounts(deltas)
+  if (error != none) {
+    return (none, error)
+  }
+
+  if (description != none and type(description) != str and type(description) != content) {
+    return (none, "description must be none, str or content.")
+  }
+
+  return (
+    (
+      date: date,
+      name: name,
+      narration: narration,
+      description: description,
+      deltas: deltas,
+    ),
+    none,
+  )
+}
+
+/**
+ * Creates a new transaction given the following parameters:
+ * - date: datetime|str of the transaction
+ * - name: non-empty string
+ * - narration: string
+ * - deltas: longer than 1 array of deltas
+ * - description: none|str|content
+ */
+#let mkTransaction = (date, name, narration, deltas, description) => {
+  let (transaction, error) = _mkTransaction(date, name, narration, deltas, description)
+  assert.ne(transaction, none, message: "" + error)
+  return transaction
+}

--- a/packages/preview/ea-nasir/0.1.0/typst.toml
+++ b/packages/preview/ea-nasir/0.1.0/typst.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ea-nasir"
+version = "0.1.0"
+authors = ["Fiona Runge <https://runjak.codes>"]
+license = "MIT"
+description = "Plaintext accounting: manage accounts and transactions for multiple currencies and create reports from that. Parse and process beancount files."
+keywords = ["plaintext", "accounting", "ledger", "transaction", "report", "beancount"]
+entrypoint = "lib.typ"
+repository = "https://codeberg.org/runjak/ea-nasir"


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description: ea-nasir is a package for [plaintext accounting](https://plaintextaccounting.org/).
- It implements double-entry bookkeeping by organizing accounts and transactions in a ledger.
- It parses `.beancount` files in the sense that a subset of this format, that is also used by software such as [rustledger](https://rustledger.github.io/) is supported.
- It supports generating reports over select timeframes, both for individual accounts and for a complete ledger.

<!--
These things need to be checked for a new submission to be merged. If you're just submitting an update, you can delete the following section.
-->

I have read and followed the submission guidelines and, in particular, I
- [x] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
  - Explanation: The package is named after the famous copper merchant [Ea-nāṣir](https://en.wikipedia.org/wiki/Ea-n%C4%81%E1%B9%A3ir). It is intended as a tongue-in-cheek nod to keeping detailed receipts for a long time - as such the name is a related but creative term.
- [x] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [x] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [x] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [x] tested my package locally on my system and it worked
- [x] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
