### PR TITLE
palimpsest:0.1.0

### DIFF
--- a/packages/preview/palimpsest/0.1.0/LICENSE
+++ b/packages/preview/palimpsest/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 David Hajage
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/palimpsest/0.1.0/README.md
+++ b/packages/preview/palimpsest/0.1.0/README.md
@@ -80,7 +80,7 @@ main.typ          the pilot (a handful of lines)
 #import "@preview/palimpsest:0.1.0": *
 
 #show: revisions.with(
-  template: my-journal-template.with(title: [...], authors: (...)),
+  template: my-journal-template.with(title: [...], authors: ("...",)),
   exchanges: include "responses.typ",
 )
 

--- a/packages/preview/palimpsest/0.1.0/README.md
+++ b/packages/preview/palimpsest/0.1.0/README.md
@@ -1,0 +1,168 @@
+# Palimpsest
+
+**Palimpsest** turns one annotated manuscript into everything a peer-review response needs: the clean manuscript, a tracked-changes version showing every edit, and a response letter that cites the manuscript's own real page and figure numbers — automatically, and always in sync.
+
+You mark changes once, inline, in the manuscript itself. Two `typst compile` commands then produce all of it.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/passage-basics/result-tracked.png" width="720" alt="A passage with an addition and a replacement, shown in tracked-changes style">
+</p>
+
+## The problem
+
+Responding to peer review normally means maintaining four things by hand: the revised manuscript, a version showing what changed, a letter citing modified passages and page numbers, and the certainty that no comment went unanswered. These drift apart the moment a last-minute fix lands — a page number in the letter goes stale, a quoted passage no longer matches the manuscript, a comment is quietly forgotten.
+
+Palimpsest makes the second, third, and fourth of those *derivable* from the first. You write the manuscript and your responses; everything else — tracked changes, page numbers, quoted excerpts, cross-references — is generated at compile time.
+
+This works because Typst 0.15's experimental **bundle export** lets a single compilation produce several documents that share one introspection space: the response letter can `query()` the manuscript and know its *real* page numbers, because they are, quite literally, part of the same compilation. A LaTeX assembly of `changes` + `latexdiff` + a letter class cannot do this — there, the letter and the manuscript are two unrelated compilations that happen to sit next to each other.
+
+Palimpsest is *not* a diff tool (marking what changed is explicit), *not* a template (your manuscript keeps your journal's own template), and *not* a project manager (no database, no state outside your source files).
+
+## Key features
+
+- **Mark once, get up to four documents.** `add`, `del`, `rep` inline in your manuscript; two compiles produce the clean manuscript and the tracked-changes manuscript — plus, if you've written responses to reviewer comments, a clean and a tracked response letter alongside them.
+- **Real cross-references, not copy-pasted page numbers.** `pinpoint(<anchor>)` reports the manuscript's actual, current page — `xref`/`xcomment` resolve figures, tables, and other comments the same way. Nothing to update by hand after a last-minute edit.
+- **Quote the manuscript verbatim in the letter.** `pinpoint(<anchor>, excerpt: true)` re-emits the real passage — clean or tracked style, your choice — so the letter can never drift from what the manuscript actually says.
+- **Reviewers, editor, and co-authors, all colored and tracked.** `<r1-2>` (reviewer 1, comment 2), `<e1>` (editor), or `<bob-3>` (co-author) — each anchor kind gets its own color and its own letter section, automatically.
+- **Figure/table/equation/heading numbering that survives tracking.** A deleted element keeps its own real number, struck through, instead of leaking a shifted one onto everything after it — the tracked manuscript and the clean one always agree on "Figure 3" (or "2.1", for a section).
+- **A built-in checklist.** `change-list()` renders a table of every marked passage (comment, type of change, page, section) in the tracked manuscript — tick it off against the response letter.
+- **Diagnostics.** Orphan comments, duplicate exchanges, unanswered anchors, empty responses — flagged visibly in the tracked manuscript, or turned into hard compile errors with `strict: true` so a broken bundle can't slip through unnoticed.
+- **Works with any journal template.** `template:` accepts any `content -> content` function — swap in your actual Typst Universe template, palimpsest asks nothing more of it.
+
+## Installation
+
+Import the package from the Typst Universe:
+
+```typ
+#import "@preview/palimpsest:0.1.0": *
+```
+
+Requires **Typst 0.15** or later, specifically its `--features bundle` export (still experimental — Typst prints a warning about this on every compile, which is expected).
+
+## Quick start
+
+A palimpsest project is normally three files, plus whatever bibliographies your manuscript and letter use:
+
+```
+manuscript.typ    the manuscript, annotated with passage()/add()/del()/...
+responses.typ     the exchanges with reviewers
+main.typ          the pilot (a handful of lines)
+```
+
+`manuscript.typ` — mark changes inline, anchored to the comment they answer:
+
+```typ
+#import "@preview/palimpsest:0.1.0": *
+
+#passage(<r1-2>)[
+  Propensity scores were estimated by logistic regression
+  and their overlap #add[assessed graphically].
+]
+```
+
+`responses.typ` — write the reply, and let `pinpoint` cite the manuscript for you:
+
+```typ
+#import "@preview/palimpsest:0.1.0": *
+
+#reviewer(1)[
+  #exchange(<r1-2>)[
+    Please also assess the overlap in propensity scores.
+  ][
+    Done. #pinpoint(<r1-2>, excerpt: true)
+  ]
+]
+```
+
+`main.typ` — wire the manuscript to your journal's template and the responses to a letter:
+
+```typ
+#import "@preview/palimpsest:0.1.0": *
+
+#show: revisions.with(
+  template: my-journal-template.with(title: [...], authors: (...)),
+  exchanges: include "responses.typ",
+)
+
+#include "manuscript.typ"
+```
+
+Two compiles produce everything:
+
+```sh
+typst compile --features bundle --format bundle main.typ
+typst compile --features bundle --format bundle --input mode=tracked main.typ
+```
+
+| Command | Produces |
+|---|---|
+| First (mode defaults to `clean`) | `manuscript.pdf` — what you submit, no marks visible at all — and `response.pdf`, citing *this* manuscript's own pagination |
+| Second (`--input mode=tracked`) | `manuscript-tracked.pdf` — every change visible, colored by reviewer, anchor-tagged — and `response-tracked.pdf`, the same letter citing *that* manuscript's pagination instead |
+
+A letter comes out of *both* compiles automatically, as soon as `exchanges:` is set — no separate flag to remember, and a citation always follows whichever mode it's actually compiled under. Take the same marked passage — a replacement and a deletion, both anchored to a reviewer comment — through both compiles.
+
+The first compile accepts both marks: `manuscript.pdf` carries no trace of either, and its letter quotes the accepted wording only:
+
+<p align="center">
+  <sub>↓ manuscript.pdf --- the passage, accepted, no marks</sub><br>
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/pinpoint-excerpt/manuscript-clean.png" width="720" alt="The passage in the clean manuscript.pdf: no marks, no anchor tags"><br>
+  <sub>↓ cited verbatim in the letter, real page number included</sub><br>
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/pinpoint-excerpt/response-clean.png" width="720" alt="The passage quoted back in the response letter, with its real page number">
+</p>
+
+The second compile shows every change instead: `manuscript-tracked.pdf` keeps both marks visible, anchor-tagged, and its letter quotes that same tracked wording, struck and underlined:
+
+<p align="center">
+  <sub>↓ manuscript-tracked.pdf --- every change visible, anchor-tagged</sub><br>
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/pinpoint-excerpt/manuscript-tracked.png" width="720" alt="The passage in manuscript-tracked.pdf: a replacement struck and underlined, a deletion struck, both anchor-tagged"><br>
+  <sub>↓ cited verbatim in the letter, tracked wording and page included</sub><br>
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/pinpoint-excerpt/response-tracked.png" width="720" alt="The same excerpt in response-tracked.pdf: the tracked wording, struck and underlined, quoted verbatim">
+</p>
+
+Don't want a letter for a particular run — a fast, manuscript-only preview while drafting? `--input letter=false` skips it on either compile, without touching `main.typ`.
+
+## A gallery of what's built in
+
+**Three ways to mark a change** — `style: "inline"` (underline/strike in the flow of text, the default), `style: "bar"` (a colored change-bar), or `style: "none"` (a layout sanity check — renders exactly like the clean version even when tracked):
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/style-values/result-tracked.png" width="720" alt="The same addition rendered under the inline, bar, and none styles">
+</p>
+
+**Reviewers, editor, and co-authors, colored automatically** — a project doesn't have to be reviewer-only: co-authors can mark their own edits on a shared draft the same way, with their own color and their own section in the letter:
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/anchors-kinds/result-tracked.png" width="720" alt="Additions anchored to a reviewer, the editor, and three co-authors, each with a distinct color">
+</p>
+
+**A checklist that writes itself** — `change-list()`, placed once near the top of the manuscript, tabulates every marked passage in the tracked manuscript only (never in what you submit):
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/eusebe/typst-palimpsest/0.1.0/docs/manual-snippets/change-list-basic/result-tracked.png" width="720" alt="A change-list table summarizing every marked passage by comment, type, page, and section">
+</p>
+
+## Beyond the basics
+
+- **`suppress`/`suppressed`** — replace a deletion with a short note instead of the struck-through original, for whenever showing the real thing again isn't useful — a long passage, say.
+- **`xref`/`xcomment`** — `xref(<label>)` cites a manuscript figure/table/equation by its real number *and* page; `xcomment(<anchor>)` links to another comment in the letter itself ("as already discussed in comment R1-2").
+- **`letter-bibliography`** — a second, independently-numbered bibliography for citations the letter makes on its own, alongside the manuscript's normal one.
+- **`pinpoint(mode: "tracked" | "clean")`** — quote the *tracked* wording in an otherwise-clean letter (or vice versa), for "look, we removed exactly what you objected to."
+- **`set-strict(true)`** — turn every diagnostic (orphan comment, duplicate exchange, unanswered anchor, empty response...) into a hard compile error, so nothing gets forgotten right before submission.
+
+## Documentation
+
+- [`docs/manual.typ`](docs/manual.typ) (⇒ [pdf](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/docs/manual.pdf)) — the full user manual, one function (and every one of its options) at a time, with a real compiled screenshot for each. Compile it yourself, or read the pdf directly.
+
+## Examples
+
+Four complete, working projects live under [`examples/`](examples/):
+
+- [**`pilot/`**](examples/pilot/) — the smallest complete three-file project. Copy it as a starting point. (⇒ pdf: [manuscript](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/pilot/main/manuscript.pdf), [tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/pilot/main/manuscript-tracked.pdf), [response](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/pilot/main/response.pdf), [response-tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/pilot/main/response-tracked.pdf))
+- [**`fridge-study/`**](examples/fridge-study/) (⇒ pdf: [manuscript](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/fridge-study/main/manuscript.pdf), [tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/fridge-study/main/manuscript-tracked.pdf), [response](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/fridge-study/main/response.pdf), [response-tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/fridge-study/main/response-tracked.pdf)) and [**`emoji-email/`**](examples/emoji-email/) (⇒ pdf: [manuscript](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/emoji-email/main/manuscript.pdf), [tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/emoji-email/main/manuscript-tracked.pdf), [response](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/emoji-email/main/response.pdf), [response-tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/emoji-email/main/response-tracked.pdf)) — two full, deliberately over-the-top mock studies (multi-page manuscripts built on real Typst Universe templates, `@preview/unequivocal-ams` and `@preview/charged-ieee`, with real figures via `@preview/lilaq`) exercising essentially every feature at once: two reviewers and an editor, co-authors leaving their own notes alongside them, `change-list()`, `pinpoint` both as a page reference and as a verbatim excerpt, cross-references, and a letter-only bibliography.
+- [**`coauthors-simple/`**](examples/coauthors-simple/) (⇒ pdf: [manuscript](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/coauthors-simple/manuscript.pdf), [tracked](https://github.com/eusebe/typst-palimpsest/blob/0.1.0/examples/coauthors-simple/manuscript-tracked.pdf)) — the no-reviewer, no-letter, no-bundle shape: just `add`/`del`/`change-list` in a single file, for co-authors tracking their own edits with nothing else attached.
+
+Each ships its own `compile.sh`.
+
+## License
+
+MIT

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-bare.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-bare.typ
@@ -1,0 +1,8 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#added(<dave>)[Dave's first change --- a bare anchor, no number.]
+
+#added(<dave>)[Dave's second change, same bare anchor reused --- no "duplicate" warning, no "no matching exchange" warning either, even though no response document exists anywhere in this example.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-kinds.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-kinds.typ
@@ -1,0 +1,21 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(
+  require-exchange: false,
+  authors: (
+    bob: (name: "Bobby Fischer", color: rgb("#c026d3")),
+    alice: "Alice Smith",
+  ),
+)
+
+#added(<r1-1>)[A reviewer's comment, `<r1-1>` --- one color per reviewer number.]
+
+#added(<e1>)[An editor's comment, `<e1>` --- its own fixed color, distinct from every reviewer.]
+
+#added(<bob-1>)[Bob's own change, `<bob-1>` --- name and color both registered explicitly.]
+
+#added(<alice-1>)[Alice's own change, `<alice-1>` --- name registered, color assigned automatically.]
+
+#added(<carol-1>)[Carol's own change, `<carol-1>` --- nothing registered at all, still a distinct color, displayed under her raw id.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-multi.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-multi.typ
@@ -1,0 +1,7 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+#added((<r1-2>, <r2-1>))[A concern raised jointly by two reviewers, addressed in one place.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-require-exchange.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/anchors-require-exchange.typ
@@ -1,0 +1,10 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#added(<erin-1>)[A numbered anchor with no matching exchange anywhere --- warns by default.]
+
+#set-revisions(require-exchange: false)
+
+#added(<frank-1>)[Same situation, but `require-exchange: false` is now active --- no warning.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-add-del.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-add-del.typ
@@ -1,0 +1,13 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+#added(<r1-1>)[A new claim, supported by @smith2020.]
+
+#deleted(<r1-2>, summary: [an outdated claim])[
+  An outdated claim, previously supported by @jones2019.
+]
+
+#bibliography("/docs/manual-snippets/biblio-manuscript.bib")

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-letter.bib
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-letter.bib
@@ -1,0 +1,12 @@
+@article{smith2020,
+  author  = {Smith, John},
+  title   = {A relevant finding},
+  journal = {Journal of Examples},
+  year    = {2020},
+}
+@article{lee2022,
+  author  = {Lee, Grace},
+  title   = {A related method, not cited in the manuscript},
+  journal = {Journal of Methods},
+  year    = {2022},
+}

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-letter.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-letter.typ
@@ -1,0 +1,24 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#let my-template(title: none, authors: (), body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  body
+}
+
+// `template:` only wraps the manuscript -- the letter uses its own,
+// separate `letter-template:` (defaulting to a minimal title-only
+// template if not given), so the page setup has to be repeated here too.
+#let my-letter-template(body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  default-letter-template(body)
+}
+
+#show: revisions.with(
+  template: my-template,
+  letter-template: my-letter-template,
+  exchanges: include "shared/biblio-letter/responses.typ",
+)
+
+#include "shared/biblio-letter/manuscript.typ"

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-manuscript.bib
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/biblio-manuscript.bib
@@ -1,0 +1,12 @@
+@article{smith2020,
+  author  = {Smith, John},
+  title   = {A relevant finding},
+  journal = {Journal of Examples},
+  year    = {2020},
+}
+@article{jones2019,
+  author  = {Jones, Alice},
+  title   = {An outdated finding},
+  journal = {Journal of Examples},
+  year    = {2019},
+}

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/change-list-basic.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/change-list-basic.typ
@@ -1,0 +1,23 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set heading(numbering: "1.")
+#set-revisions(require-exchange: false, authors: (bob: "Bobby Fischer"))
+
+#change-list()
+
+= Introduction
+
+#added(<r1-1>)[A reviewer's addition.]
+#deleted(<bob-1>)[Bobby's own deletion.]
+
+== Background
+
+#replaced(<r1-2>)[A second reviewer comment, addressed in this subsection.][A second reviewer comment, revised in this subsection.]
+
+= Methods
+
+#added(<e1>)[An editor's addition.]
+#added(none)[An anonymous typo fix, no anchor attached.]
+#touched(<r9-9>)[This paragraph is unchanged --- never listed below.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/change-list-level.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/change-list-level.typ
@@ -1,0 +1,20 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set heading(numbering: "1.")
+#set-revisions(require-exchange: false)
+
+*level: 1 (default) --- "Section" names the top-level heading:*
+
+#change-list()
+
+*level: 2 --- "Section" names the subsection instead:*
+
+#change-list(level: 2)
+
+= Introduction
+
+== Background
+
+#added(<r1-1>)[A reviewer's addition, inside a subsection.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/change-list-title.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/change-list-title.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+*Without `title: none` --- your own heading, then the package's own "Summary of changes" on top of it:*
+
+#text(weight: "bold", size: 1.2em)[Summary of Revisions]
+#change-list()
+
+*With `title: none` --- no second, redundant heading:*
+
+#text(weight: "bold", size: 1.2em)[Summary of Revisions]
+#change-list(title: none)
+
+#added(<r1-1>)[A reviewer's addition.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/diagnostics-gallery.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/diagnostics-gallery.typ
@@ -1,0 +1,22 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+*Comment with no matching passage anywhere:*
+#reviewer(1)[
+  #exchange(<r9-1>)[A comment with nothing in the manuscript to answer.][A response anyway.]
+]
+
+*Exchange with a blank response:*
+#passage(<r9-2>)[#add[A real addition, matched below.]]
+#reviewer(1)[
+  #exchange(<r9-2>)[A real comment.][]
+]
+
+*A mark outside any passage:*
+#add[Added text with no enclosing `passage`.]
+
+*A passage with no mark and no `summary:`:*
+#passage(<r9-3>)[Plain text, nothing added, removed, or replaced.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-author.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-author.typ
@@ -1,0 +1,18 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(authors: (bob: "Bobby Fischer"))
+
+// Manuscript-side passages.
+#added(<bob-1>)[Bobby's own addition.]
+#added(<bob-2>)[Bobby's second change.]
+
+// Response-side notes -- no reviewer comment to quote, just an author
+// explaining their own change.
+#author("bob")[
+  #note(<bob-1>)[Explaining why I made this change.]
+
+  // exchange() with two arguments renders identically to note() above.
+  #exchange(<bob-2>)[Explaining the second change, via exchange() instead.]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-reviewer-editor.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-reviewer-editor.typ
@@ -1,0 +1,27 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+// Manuscript-side passages, matched by the exchanges below.
+#added(<r1-1>)[A justification for the sample size.]
+#added(<r1-2>)[A sensitivity analysis, added alongside it.]
+#added(<e1>)[A clarified abstract word count.]
+
+// Response-side exchanges -- a reviewer's block holds as many
+// successive exchanges as needed, one heading for the whole group.
+#reviewer(1)[
+  #exchange(<r1-1>)[The sample size is not justified.][
+    We agree and have added a justification.
+  ]
+
+  #exchange(<r1-2>)[A sensitivity analysis would strengthen this.][
+    Added, using the same assumptions.
+  ]
+]
+
+#editor[
+  #exchange(<e1>)[Please double-check the abstract word count.][
+    Confirmed within the journal's limit.
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-words.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-words.typ
@@ -1,0 +1,29 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(authors: (bob: "Bobby Fischer"))
+
+#added(<r1-1>)[Default word: "comment".]
+#added(<bob-1>)[Default word: "change".]
+#added(<r2-1>)[Global override applies here.]
+#added(<bob-2>)[Per-call override applies here.]
+
+#reviewer(1)[
+  #exchange(<r1-1>)[A remark.][The default reviewer word.]
+]
+#author("bob")[
+  #note(<bob-1>)[The default author word.]
+]
+
+#set-revisions(comment-word: "remark", change-word: "revision")
+
+#reviewer(2)[
+  #exchange(<r2-1>)[Another remark.][Now under the global override --- "remark", not "comment".]
+]
+
+#author("bob")[
+  #note(<bob-2>, term: "aside")[This one overrides the word for just this call.]
+]
+
+Cross-references: #xcomment(<r1-1>), #xcomment(<r2-1>), and #xcomment(<bob-2>).

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-xcomment.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/exchanges-xcomment.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#added(<r1-1>)[The scope was narrowed to three use cases.]
+#added(<r1-2>)[A sensitivity analysis was added, consistent with the narrower scope.]
+
+#reviewer(1)[
+  #exchange(<r1-1>)[The scope seems too broad.][
+    Narrowed as suggested.
+  ]
+
+  #exchange(<r1-2>)[A sensitivity analysis would help.][
+    Added --- see also our response to #xcomment(<r1-1>).
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/letter-numbering.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/letter-numbering.typ
@@ -1,0 +1,43 @@
+#import "@preview/palimpsest:0.1.0": *
+#import "../../src/letter.typ": with-letter-numbering
+
+#document("manuscript.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #set heading(numbering: "1.1.")
+
+  = Introduction
+  = Methods
+
+  #passage(<r1-1>)[
+    #add[
+      #figure(rect(width: 3cm, height: 2cm, fill: luma(220)), caption: [A subgroup analysis, added per reviewer request.]) <fig-subgroup>
+    ]
+  ]
+
+  #passage(<r1-2>)[
+    #add[
+      == Sensitivity analysis <sub-sensitivity>
+      Added per reviewer request.
+    ]
+  ]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #with-letter-numbering[
+    #reviewer(1)[
+      #exchange(<r1-1>)[Please add a subgroup analysis.][
+        Done. #pinpoint(<r1-1>, excerpt: true)
+      ]
+      #exchange(<r1-2>)[Please add a sensitivity analysis subsection.][
+        Done. #pinpoint(<r1-2>, excerpt: true)
+      ]
+    ]
+
+    For the reviewer's convenience only, not in the manuscript:
+
+    #figure(rect(width: 3cm, height: 2cm, fill: luma(150)), caption: [A figure the letter adds on its own.])
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/marks-suppress.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/marks-suppress.typ
@@ -1,0 +1,10 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#passage[
+  The method section stands as before.
+  #suppress[An accompanying diagnostic plot has been removed: it duplicated Figure 2.]
+  The next paragraph is unaffected.
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/passage-basics.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/passage-basics.typ
@@ -1,0 +1,13 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#passage[
+  Propensity scores were estimated by logistic regression
+  #add[and their overlap was assessed graphically].
+]
+
+#passage[
+  The positivity assumption #rep[was not discussed][is now assessed graphically].
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-basic.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-basic.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #passage(<r1-1>)[The sample size #rep[was not justified][was determined by a power calculation].]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #reviewer(1)[
+    #exchange(<r1-1>)[The sample size is not justified.][
+      We thank the reviewer. #pinpoint(<r1-1>)
+    ]
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-excerpt.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-excerpt.typ
@@ -1,0 +1,24 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #passage(<r1-1>)[The sample size #rep[was not justified][was determined by a power calculation].]
+  #deleted(<r1-2>, summary: [an outdated caveat about generalizability])[
+    An earlier caveat about generalizability, no longer needed.
+  ]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #reviewer(1)[
+    #exchange(<r1-1>)[The sample size is not justified.][
+      Addressed as follows: #pinpoint(<r1-1>, excerpt: true)
+    ]
+
+    #exchange(<r1-2>)[This caveat is no longer accurate.][
+      Agreed: #pinpoint(<r1-2>, excerpt: true)
+    ]
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-mode-clean-in-tracked-letter.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-mode-clean-in-tracked-letter.typ
@@ -1,0 +1,21 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#let my-template(body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  body
+}
+
+#let exchanges = reviewer(1)[
+  #exchange(<r1-1>)[This claim needs more support.][
+    We have expanded this sentence. #pinpoint(<r1-1>, excerpt: true, mode: "clean")
+  ]
+]
+
+#show: revisions.with(
+  template: my-template,
+  letter-template: my-template,
+  exchanges: exchanges,
+)
+
+#passage(<r1-1>)[The treatment #rep[has an effect][has a clinically meaningful effect] on survival.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-mode.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-mode.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #passage(<r1-1>)[The sample size #rep[was not justified][was determined by a power calculation].]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #reviewer(1)[
+    #exchange(<r1-1>)[The sample size is not justified.][
+      Compare the wording: #pinpoint(<r1-1>, excerpt: true, mode: "tracked")
+    ]
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-on-empty-format.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-on-empty-format.typ
@@ -1,0 +1,19 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+No anchor `<r9-9>` exists anywhere in this document.
+
+Default `on-empty:` warns: #pinpoint(<r9-9>)
+
+#pinpoint(<r9-9>, on-empty: none) shows nothing instead when given `on-empty: none`.
+
+#pinpoint(<r9-9>, on-empty: [not found in this round]) shows custom content instead, given as `on-empty:`.
+
+#passage(<r2-1>)[A change #add[on this page].]
+
+Default wording: #pinpoint(<r2-1>)
+
+Custom `format:`: #pinpoint(<r2-1>, format: (pages, has-marks) => [(see line 1 of p. #pages.first())])

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-parens-verb.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-parens-verb.typ
@@ -1,0 +1,22 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #passage(<r1-1>)[The sample size #rep[was not justified][was determined by a power calculation].]
+  #touched(<r1-2>)[We kept the eligibility criteria exactly as submitted.]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #reviewer(1)[
+    #exchange(<r1-1>)[The sample size is not justified.][
+      See #pinpoint(<r1-1>, parens: false, verb: none) for the updated wording.
+    ]
+
+    #exchange(<r1-2>)[Please confirm the eligibility criteria are unchanged.][
+      Confirmed --- #pinpoint(<r1-2>).
+    ]
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-show-page-quotes.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-show-page-quotes.typ
@@ -1,0 +1,19 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #passage(<r1-1>)[The sample size #rep[was not justified][was determined by a power calculation].]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #reviewer(1)[
+    #exchange(<r1-1>)[The sample size is not justified.][
+      #pinpoint(<r1-1>, excerpt: true, quotes: true)
+
+      On page 1: #pinpoint(<r1-1>, excerpt: true, show-page: false)
+    ]
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-two-pages.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/pinpoint-two-pages.typ
@@ -1,0 +1,19 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.pdf")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #passage(<r1-1>)[This revision responds to a single comment that required changes in two separate sections.]
+  #pagebreak()
+  #passage(<r1-1>)[The same comment, addressed a second time here.]
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #reviewer(1)[
+    #exchange(<r1-1>)[A single comment requiring changes in two places.][
+      Addressed in both places. #pinpoint(<r1-1>)
+    ]
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/revisions-exchanges-letter.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/revisions-exchanges-letter.typ
@@ -1,0 +1,27 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#let my-template(body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  body
+}
+
+#let my-letter-template(body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  default-letter-template(body)
+}
+
+#let exchanges = reviewer(1)[
+  #exchange(<r1-1>)[This claim needs more support.][
+    We have expanded this sentence. #pinpoint(<r1-1>, excerpt: true)
+  ]
+]
+
+#show: revisions.with(
+  template: my-template,
+  letter-template: my-letter-template,
+  exchanges: exchanges,
+)
+
+#passage(<r1-1>)[The treatment #rep[has an effect][has a clinically meaningful effect] on survival.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/revisions-pilot.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/revisions-pilot.typ
@@ -1,0 +1,24 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#let my-template(title: none, authors: (), body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  set heading(numbering: "1.")
+  align(center, text(size: 1.3em, weight: "bold")[#title])
+  v(0.5em)
+  body
+}
+
+#let my-letter-template(body) = {
+  set page(width: 16.6cm, height: auto, margin: 12pt)
+  set text(size: 10.5pt)
+  default-letter-template(body)
+}
+
+#show: revisions.with(
+  template: my-template.with(title: [A Minimal Study]),
+  letter-template: my-letter-template,
+  exchanges: include "shared/responses.typ",
+)
+
+#include "shared/manuscript.typ"

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/biblio-letter/manuscript.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/biblio-letter/manuscript.typ
@@ -1,0 +1,7 @@
+#import "@preview/palimpsest:0.1.0": *
+
+An earlier claim, supported by @jones2019.
+
+#added(<r1-1>)[A second claim, supported by @smith2020.]
+
+#bibliography("/docs/manual-snippets/biblio-manuscript.bib")

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/biblio-letter/responses.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/biblio-letter/responses.typ
@@ -1,0 +1,16 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#reviewer(1)[
+  #exchange(<r1-1>)[Please support this claim.][
+    Done, see @smith2020. Also relevant, though not cited in the manuscript: @lee2022. #pinpoint(<r1-1>)
+  ]
+]
+
+For the reviewer's convenience only:
+
+#figure(
+  table(columns: 2, [Group], [N]),
+  caption: [Sample sizes, not shown in the manuscript.],
+)
+
+#letter-bibliography("/docs/manual-snippets/biblio-letter.bib")

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/manuscript.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/manuscript.typ
@@ -1,0 +1,7 @@
+#import "@preview/palimpsest:0.1.0": *
+
+= Introduction
+
+#added(<r1-1>)[The study rationale, expanded per the reviewer's request.]
+
+#touched(<r1-2>)[This paragraph is unchanged; addressed in our response instead.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/responses.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shared/responses.typ
@@ -1,0 +1,11 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#reviewer(1)[
+  #exchange(<r1-1>)[Please expand the rationale.][
+    Done. #pinpoint(<r1-1>)
+  ]
+
+  #exchange(<r1-2>)[This point seems underdeveloped.][
+    We believe the current wording is sufficient. #pinpoint(<r1-2>)
+  ]
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shortcuts-basics.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shortcuts-basics.typ
@@ -1,0 +1,11 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+#added(<r1-1>)[This whole sentence is new.]
+
+#deleted(<r1-2>)[This whole sentence is being removed.]
+
+#replaced(<r1-3>)[The old wording.][The new wording.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shortcuts-suppressed.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shortcuts-suppressed.typ
@@ -1,0 +1,15 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+#suppressed(<r2-1>, [Equation removed: superseded by the equation below.])
+
+$ E = m c^2 (1 + epsilon) $
+
+#suppressed(
+  <r2-2>,
+  [Table removed: see response to R2-2.], // shown in the tracked manuscript
+  summary: [the old sensitivity table],   // for the letter, later
+)

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shortcuts-touched.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/shortcuts-touched.typ
@@ -1,0 +1,7 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+#touched(<r1-4>)[This paragraph has not changed; we address the reviewer's concern in our response instead.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-add-del-style.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-add-del-style.typ
@@ -1,0 +1,13 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+*add-style: underline, del-style: default (strikes plain text like this)*
+#passage[Some text with #add[an addition] and #del[a deletion].]
+
+#v(0.8em)
+#let boxed-mark(body) = box(stroke: 0.6pt, inset: (x: 2pt), radius: 1.5pt, body)
+#set-revisions(add-style: boxed-mark, del-style: boxed-mark)
+*add-style/del-style: a custom `body -> content` function*
+#passage[Some text with #add[an addition] and #del[a deletion], both boxed instead of underlined/struck. The reviewer color still applies on top --- it's added separately by the passage, not by this function.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-color.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-color.typ
@@ -1,0 +1,15 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+*color: auto (default) — one color per reviewer*
+#passage(<r1-1>)[Reviewer 1's #add[addition].]
+#passage(<r2-1>)[Reviewer 2's #add[addition] — a different color, automatically.]
+
+#v(0.8em)
+#set-revisions(color: rgb("#7a7a7a"))
+*color: a fixed value — overrides per-reviewer colors*
+#passage(<r1-1>)[Reviewer 1's #add[addition], now in the fixed color.]
+#passage(<r2-1>)[Reviewer 2's #add[addition], the same fixed color, not a different one.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-del-numbering-keep.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-del-numbering-keep.typ
@@ -1,0 +1,38 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set math.equation(numbering: "(1)")
+#set heading(numbering: "1.1.")
+#set-revisions(require-exchange: false, del-numbering: "keep")
+
+*del-numbering: "keep"*
+
+= Methods
+
+#figure(rect(width: 2cm, height: 1cm, fill: luma(230)), caption: [Kept figure.]) <fig-d>
+#passage(<x4>)[
+  #del[#figure(rect(width: 2cm, height: 1cm, fill: luma(230)), caption: [Removed figure --- still consumes a number here.]) <fig-e>]
+]
+#figure(rect(width: 2cm, height: 1cm, fill: luma(230)), caption: [Next figure --- number has shifted, diverging from the clean version.]) <fig-f>
+
+#figure(table(columns: 2, [Kept], [table]), caption: [Kept table.]) <tab-d>
+#passage(<x5>)[
+  #del[#figure(table(columns: 2, [Removed], [table]), caption: [Removed table --- still consumes a number here.]) <tab-e>]
+]
+#figure(table(columns: 2, [Next], [table]), caption: [Next table --- number has shifted, diverging from the clean version.]) <tab-f>
+
+Kept equation. $ a = b $ <eq-a-kept-b>
+#passage(<x6>)[
+  #del[$ E = m c^2 $ <eq-b>]
+]
+Next equation --- number has shifted, diverging from the clean version. $ c = d $ <eq-c-kept-b>
+
+== Kept subsection.
+#passage(<x8>)[
+  #del[
+    == Removed subsection --- still consumes a number here.
+    Removed content.
+  ]
+]
+== Next subsection --- number has shifted, diverging from the clean version.

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-del-numbering-none.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-del-numbering-none.typ
@@ -1,0 +1,38 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set math.equation(numbering: "(1)")
+#set heading(numbering: "1.1.")
+#set-revisions(require-exchange: false)
+
+*del-numbering: "none" (default)*
+
+= Methods
+
+#figure(rect(width: 2cm, height: 1cm, fill: luma(230)), caption: [Kept figure.]) <fig-a>
+#passage(<x1>)[
+  #del[#figure(rect(width: 2cm, height: 1cm, fill: luma(230)), caption: [Removed figure.]) <fig-b>]
+]
+#figure(rect(width: 2cm, height: 1cm, fill: luma(230)), caption: [Next figure --- same number as in the clean version.]) <fig-c>
+
+#figure(table(columns: 2, [Kept], [table]), caption: [Kept table.]) <tab-a>
+#passage(<x2>)[
+  #del[#figure(table(columns: 2, [Removed], [table]), caption: [Removed table.]) <tab-b>]
+]
+#figure(table(columns: 2, [Next], [table]), caption: [Next table --- same number as in the clean version.]) <tab-c>
+
+Kept equation. $ a = b $ <eq-a-kept>
+#passage(<x3>)[
+  #del[$ E = m c^2 $ <eq-a>]
+]
+Next equation --- same number as in the clean version. $ c = d $ <eq-c-kept>
+
+== Kept subsection.
+#passage(<x7>)[
+  #del[
+    == Removed subsection.
+    Removed content.
+  ]
+]
+== Next subsection --- same number as in the clean version.

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-highlight-passage.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-highlight-passage.typ
@@ -1,0 +1,12 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+*highlight-passage: false (default)*
+#passage[Only the #add[actually changed words] are tinted --- the rest of the sentence stays plain black text.]
+
+#v(0.8em)
+#set-revisions(highlight-passage: true)
+*highlight-passage: true*
+#passage[The whole passage's background is lightly tinted, not just #add[the changed words] --- useful when a reviewer asked for a full rewrite.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-show-anchor.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-show-anchor.typ
@@ -1,0 +1,13 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+#set-revisions(require-exchange: false)
+
+*show-anchor: true (default)*
+#passage(<r1-2>)[The #add[anchor tag] appears in superscript at the end of the passage.]
+
+#v(0.8em)
+#set-revisions(show-anchor: false)
+*show-anchor: false*
+#passage(<r1-2>)[No tag at the end of #add[the passage] anymore --- still colored by reviewer, just no visible label.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-values.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/style-values.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+*style: "inline" (default)*
+#passage[This whole sentence is marked #add[with an inline addition] in the flow of text.]
+
+#v(0.8em)
+#set-revisions(style: "bar")
+*style: "bar"*
+#passage[This whole sentence is marked #add[with an addition] under the bar style instead.]
+
+#v(0.8em)
+#set-revisions(style: "none")
+*style: "none"*
+#passage[This whole sentence is marked #add[with an addition] but renders exactly like the clean version — a layout sanity check.]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-column-both.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-column-both.typ
@@ -1,0 +1,18 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+// Only the removed column enters the mode-dependent delta --- the
+// added column is part of the fixed base count, present in both
+// compiles, same as the added row above.
+#passage[
+  #figure(
+    table(
+      columns: 3 + int(mode() != "clean"),
+      [Group], [N], add[p-value], ..if mode() == "clean" { () } else { (del[Old score],) },
+      [Control], [42], add[0.03], ..if mode() == "clean" { () } else { (del[--],) },
+    ),
+    caption: [Sample sizes --- p-value column added, Old score column dropped.],
+  )
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-row-add.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-row-add.typ
@@ -1,0 +1,16 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#passage[
+  #figure(
+    table(
+      columns: 2,
+      [Group], [N],
+      [Control], [42],
+      add[Treatment], add[45],
+    ),
+    caption: [Sample sizes by group.],
+  )
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-row-both.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-row-both.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#passage[
+  #figure(
+    table(
+      columns: 2,
+      [Group], [N],
+      [Control], [42],
+      ..if mode() == "clean" { () } else { (del[Placebo], del[40]) },
+      add[Treatment], add[45],
+    ),
+    caption: [Sample sizes by group --- Placebo dropped, Treatment added.],
+  )
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-row-remove.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/table-row-remove.typ
@@ -1,0 +1,17 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 16.6cm, height: auto, margin: 12pt)
+#set text(size: 10.5pt)
+
+#passage[
+  #figure(
+    table(
+      columns: 2,
+      [Group], [N],
+      [Control], [42],
+      ..if mode() == "clean" { () } else { (del[Treatment], del[45]) },
+      [Placebo], [40],
+    ),
+    caption: [Sample sizes by group.],
+  )
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual-snippets/xref-basic.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual-snippets/xref-basic.typ
@@ -1,0 +1,21 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#document("manuscript.pdf")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+  #set heading(numbering: "1.")
+  = Results
+  #pagebreak()
+  #figure(rect(width: 3cm, height: 1.5cm, fill: luma(230)), caption: [Propensity score distribution.]) <fig-a>
+]
+
+#document("response.png")[
+  #set page(width: 16.6cm, height: auto, margin: 12pt)
+  #set text(size: 10.5pt)
+
+  A bare reference resolves the real manuscript number, for free: @fig-a.
+
+  `xref` adds the page number on top: #xref(<fig-a>).
+
+  A label that doesn't exist: #xref(<fig-nonexistent>).
+]

--- a/packages/preview/palimpsest/0.1.0/docs/manual.typ
+++ b/packages/preview/palimpsest/0.1.0/docs/manual.typ
@@ -1,0 +1,696 @@
+// The real new manual — progressive, one function (and every one of
+// its options) at a time. Imports NOTHING from palimpsest and runs no
+// package code: every result shown below is a PNG produced by actually
+// compiling a real file under docs/manual-snippets/, not a
+// simulation. Regenerate everything with:
+//   bash docs/manual-snippets/compile.sh
+
+#set document(title: "palimpsest — manual")
+#set page(paper: "a4", margin: (x: 2.2cm, y: 2cm))
+#set text(size: 10.5pt, font: "Libertinus Serif")
+#set heading(numbering: "1.1.")
+#set par(justify: true)
+#show raw: set text(font: "Linux Libertine Mono", size: 0.85em)
+
+#let code(src) = block(
+  fill: luma(247), stroke: 0.5pt + luma(210), inset: 10pt, radius: 3pt, width: 100%,
+  raw(src, block: true, lang: if src.starts-with("typst") { "sh" } else { "typ" }),
+)
+
+#let code-of(path) = code(read(path))
+
+#let shot(path, caption: none, width: 100%) = block(width: width)[
+  #block(stroke: 0.5pt + luma(210), inset: 4pt, radius: 3pt, width: 100%, image(path, width: 100%))
+  #if caption != none [#text(size: 0.78em, fill: luma(120), style: "italic")[#caption]]
+]
+
+#let snippet(name, embed) = {
+  code-of("manual-snippets/" + name + ".typ")
+  v(0.5em)
+  embed("manual-snippets/" + name + "/")
+  v(1em)
+}
+
+#align(center)[
+  #v(0.5cm)
+  #text(size: 1.8em, weight: "bold")[palimpsest]
+  #v(0.2em)
+  #text(size: 1.1em, style: "italic")[User manual]
+  #v(0.8cm)
+]
+
+#outline(indent: auto)
+#pagebreak()
+
+= Installation and compiling
+
+Import the package from the Typst Universe:
+
+#code("#import \"@preview/palimpsest:0.1.0\": *")
+
+A full project (manuscript, tracked manuscript, response letter) compiles with two commands:
+
+#code(
+  "typst compile --features bundle --format bundle main.typ\n" +
+  "typst compile --features bundle --format bundle --input mode=tracked main.typ"
+)
+
+The first produces `manuscript.pdf` and, once there are responses to answer, `response.pdf`; the second produces `manuscript-tracked.pdf` and, under the same condition, `response-tracked.pdf`. Marking functions --- `add`, `del`, `rep`, `passage`, `set-revisions` --- also work directly in a single ordinary file, with a plain `typst compile` / `typst compile --input mode=tracked`, no bundle involved --- that's the form used throughout the next chapter.
+
+= Marking changes: `add`, `del`, `rep`, `suppress`
+
+/ `passage(anchors, body)`: the citable unit --- wraps `body` (plain text and/or `add`/`del`/`rep`/`suppress`) and attaches the anchor(s) a response letter will resolve back to this location. `anchors` is `none`, one label, or an array of labels; called as `passage(body)` (no anchors) for a typo fix with no comment to answer.
+/ `add(body)`: marks `body` as newly added.
+/ `del(body)`: marks `body` as removed.
+/ `rep(old, new)`: a replacement in one call.
+
+#code-of("manual-snippets/passage-basics.typ")
+
+Compiled once clean:
+
+#shot("manual-snippets/passage-basics/result-clean.png")
+
+Once more with `--input mode=tracked`:
+
+#shot("manual-snippets/passage-basics/result-tracked.png")
+
+Two things to notice: `add` shows nothing extra in clean mode --- `body` is just there, as if it had always been. `del` shows *nothing at all* in clean mode --- no `hide()`, no reserved space; a deletion that survives into the clean version isn't a deletion.
+
+== `suppress`
+
+/ `suppress(note)`: like `del`, but never shows the real content, in *either* mode --- only `note`, centered and italic, and only in tracked mode.
+
+#code-of("manual-snippets/marks-suppress.typ")
+
+#shot("manual-snippets/marks-suppress/result-tracked.png")
+
+The obvious question is why this exists next to `del`, which already hides its content in clean mode. The difference shows up specifically in the *tracked* manuscript: `del` still renders the real removed content there --- struck through, as the previous section demonstrated. Sometimes that's not what you want: a long passage struck through end to end reads worse than a short note saying what used to be there, or the removed content simply isn't worth showing again once it's gone. `suppress` replaces it with `note` instead --- centered, italic, shown only in tracked mode --- rather than the real thing, struck.
+
+`suppress` takes no content to hide, only `note` --- there's no parameter for the real content at all, not even an unused one. Since that content is never rendered by this function, in any mode, keeping it as an argument would only be a place for some future edit to start rendering it by accident, undoing the whole point.
+
+If you want the removed material kept at hand in the source to reconsider later, comment it out beside the call rather than deleting it outright --- a `//` line is never evaluated by Typst, so there's no risk of it resurfacing on its own:
+
+#code(
+  "// #figure(table(...), caption: [The old table.])\n" +
+  "#passage(<r2-1>)[#suppress[Table removed: see response.]]"
+)
+
+== `set-revisions`: every option, one at a time
+
+Call once, before any `passage`, to change how tracked marks look. Takes effect for everything *after* the call --- a document can use different styles in different sections.
+
+#code(
+  "#set-revisions(\n" +
+  "  style: \"inline\",          // \"inline\" | \"bar\" | \"none\"\n" +
+  "  color: auto,               // auto, or a fixed color for every mark\n" +
+  "  add-style: underline,      // body -> content\n" +
+  "  del-style: (smart default),// body -> content\n" +
+  "  highlight-passage: false,  // tint the whole passage's background\n" +
+  "  show-anchor: true,         // show [R1-2] at the end of the passage\n" +
+  "  del-numbering: \"none\",     // \"none\" | \"keep\"\n" +
+  ")"
+)
+
+=== `style`
+
+#snippet("style-values", p => shot(p + "result-tracked.png"))
+
+`"inline"` (the default) underlines additions and strikes deletions in the flow of text. `"bar"` keeps that same underline/strike on the marks themselves and adds a colored vertical bar to the left of the whole passage's block --- best when a passage forms its own block, not text mid-paragraph. `"none"` turns underline/strike off entirely, rendering exactly like the clean version even in the tracked compile --- a layout sanity check, to confirm marking hasn't shifted anything.
+
+=== `color`
+
+#snippet("style-color", p => shot(p + "result-tracked.png"))
+
+`auto` (the default) colors each mark by its anchor --- one color per reviewer, a separate palette per co-author (a later chapter). A fixed color --- `rgb(...)`, a named color --- overrides that entirely: every mark gets the same color, regardless of anchor.
+
+=== `add-style` / `del-style`
+
+#snippet("style-add-del-style", p => shot(p + "result-tracked.png"))
+
+Both take a single `body -> content` function --- *not* `(body, color)`: the color is applied afterward, wrapped around whatever this function returns, so a custom style only needs to decide the visual treatment (box, highlight, ...), never the color itself.
+
+`add-style`'s default is plain `underline`. `del-style`'s default is smarter, because `strike()` never decorates a real math glyph or a figure's drawing --- only literal text: ordinary text still gets struck, but a *block* equation, a figure, or a table gets a diagonal cross instead (figures/tables also keep their caption struck natively, since a caption is real text), and an *inline* equation gets a line straight through it rather than a full cross. A custom function passed here always replaces this default outright for every kind of content, the same way it would replace plain `strike`.
+
+Deletions are also automatically desaturated relative to additions --- a muted, darker version of the same reviewer's color, not merely "the same color with a different decoration". This matters specifically because the strike/cross/line above is the *only* other signal on math or on a figure's drawing: without a color difference, an added and a removed equation would otherwise look identical at a glance. This isn't a `del-style` option --- it always applies, on top of whatever `del-style` renders.
+
+=== `highlight-passage`
+
+#snippet("style-highlight-passage", p => shot(p + "result-tracked.png"))
+
+`false` (the default) tints only the marks themselves --- a passage where one word changed doesn't light up entirely. `true` tints the whole passage's background lightly, useful when a reviewer asked for a full rewrite and marking only the changed words would understate how much moved.
+
+=== `show-anchor`
+
+#snippet("style-show-anchor", p => shot(p + "result-tracked.png"))
+
+The `[R1-2]` superscript at the end of a marked passage --- what reviewers use most in practice to find their own comment in the manuscript without cross-referencing the letter. `false` removes the tag; the passage is still colored.
+
+=== `del-numbering`
+
+A figure, table, equation, or heading that gets deleted still exists as a real element in the tracked manuscript --- and by default would still consume a number, shifting every one of its kind that comes after it out of sync with the clean version. `del-numbering: "none"` (the default) keeps the deleted element's own real number visible, struck through, but resets the count right after it, so the *next* real one of that kind keeps the same number in both versions:
+
+#code-of("manual-snippets/style-del-numbering-none.typ")
+
+Tracked:
+
+#shot("manual-snippets/style-del-numbering-none/result-tracked.png")
+
+The *clean* compile of that same source, for comparison --- the numbers match:
+
+#shot("manual-snippets/style-del-numbering-none/result-clean.png")
+
+`"keep"` lets a deleted element consume a number like anything else --- rarely what you want (the whole point of `del-numbering: "none"` above is that a reviewer reading the tracked manuscript and citing "Figure 3" is citing the same Figure 3 that exists in the clean version you submit), but available:
+
+#code-of("manual-snippets/style-del-numbering-keep.typ")
+
+Tracked:
+
+#shot("manual-snippets/style-del-numbering-keep/result-tracked.png")
+
+The *clean* compile of that same source --- watch the third and fifth figures' numbers diverge from the tracked version above:
+
+#shot("manual-snippets/style-del-numbering-keep/result-clean.png")
+
+Both examples also include a table, an equation, and a heading, deleted the same way, worth looking at closely: the table's cells and caption are struck through, same as ordinary text, and its diagonal cross covers the drawing itself. The equation gets the same diagonal cross rather than a strikethrough (see `del-style` above for why), and the heading is struck like any other text. All three keep their own number visible, frozen under `del-numbering: "none"` so whatever comes after them stays in sync with the clean version, or consume a real number under `"keep"`, exactly the same freeze/consume distinction shown above for figures.
+
+This works the same way under a template that recomputes its own figure or table numbers via a custom show rule --- `@preview/charged-ieee`, for instance --- since the underlying counter it reads is the same one being frozen here.
+
+== Adding or removing a whole table row or column <sec-table-rows>
+
+`add`/`del` mark *content* --- a word, a cell, a whole figure --- but a table's own shape is different: Typst's `table()` has no built-in way to conditionally include or exclude an entire row or column depending on the compile mode. Getting this wrong doesn't just look off --- it can leave a row that reviewers were told was added missing from the manuscript actually submitted, or a removed row still sitting in it.
+
+=== Adding a row or column
+
+An added row or column stays in the table in *both* compiles, exactly like any other `#add[...]` --- accepted new content never disappears from the clean version. No `mode()` check at all: wrap each cell in `add[...]` and include the row unconditionally, same as writing any other table row by hand.
+
+#code-of("manual-snippets/table-row-add.typ")
+
+Clean:
+
+#shot("manual-snippets/table-row-add/result-clean.png")
+
+Tracked:
+
+#shot("manual-snippets/table-row-add/result-tracked.png")
+
+=== Removing a row or column
+
+The opposite: a genuinely removed row or column must be *absent* from the clean compile, and there's no native way to hide part of a table conditionally. The fix is to build that row's cells as a spread array that's empty in clean and populated in tracked --- `..if mode() == "clean" { () } else { (del[...], ...) }` --- the same `mode()` the shortcuts chapter's `touched`/conditional-content cases already use, exported by `lib.typ` for exactly this.
+
+#code-of("manual-snippets/table-row-remove.typ")
+
+Clean:
+
+#shot("manual-snippets/table-row-remove/result-clean.png")
+
+Tracked:
+
+#shot("manual-snippets/table-row-remove/result-tracked.png")
+
+=== Combining both in one table
+
+A table can have an added row *and* a removed row at the same time --- the two patterns above coexist without conflict, since neither changes `columns:`.
+
+#code-of("manual-snippets/table-row-both.typ")
+
+Clean:
+
+#shot("manual-snippets/table-row-both/result-clean.png")
+
+Tracked:
+
+#shot("manual-snippets/table-row-both/result-tracked.png")
+
+*Columns are the trap.* `columns:` is one fixed count for the whole table, so an added column and a removed column do *not* belong in the same delta: an added column is part of the fixed base count (present in both compiles, like the row case above), and only a *removed* column belongs in a mode-dependent addition to that count --- `base + int(mode() != "clean")` per removed column, never per added one. Writing it the other way around silently drops the added column from the clean, submitted manuscript --- easy to miss, since `manuscript-tracked.pdf` still looks right.
+
+#code-of("manual-snippets/table-column-both.typ")
+
+Clean:
+
+#shot("manual-snippets/table-column-both/result-clean.png")
+
+Tracked:
+
+#shot("manual-snippets/table-column-both/result-tracked.png")
+
+= Shortcuts: `added`, `deleted`, `replaced`, `touched`, `suppressed`
+
+`add`/`del`/`rep` mark part of a passage --- a clause added mid-sentence, one phrase replacing another. When the *entire* passage is new, removed, or rewritten, wrapping it by hand (`passage(anchor)[#add[...]]`) is one level of nesting that never varies --- these four shortcuts skip it.
+
+/ `added(anchors, body, summary: none)`: `passage(anchors, add(body))`.
+/ `deleted(anchors, body, summary: none)`: `passage(anchors, del(body))`.
+/ `replaced(anchors, old, new, summary: none)`: `passage(anchors, rep(old, new))`.
+
+#code-of("manual-snippets/shortcuts-basics.typ")
+
+#shot("manual-snippets/shortcuts-basics/result-tracked.png")
+
+`summary:` is accepted by all three but only matters once a passage's tracked appearance gives a letter nothing worth quoting --- `deleted` is the common case, covered below under `suppress`/`suppressed`.
+
+== `touched`
+
+/ `touched(anchors, body)`: declares a location without marking any change --- "we checked this, it stays as written." Unlike `passage` on its own, an anchor with no `add`/`del`/`rep` inside doesn't need `allow-empty:` to avoid a warning; `touched` already sets it.
+
+#code-of("manual-snippets/shortcuts-touched.typ")
+
+#shot("manual-snippets/shortcuts-touched/result-tracked.png")
+
+Still colored and tagged like any other passage --- just nothing struck or underlined, since nothing changed.
+
+== `suppressed`
+
+/ `suppressed(anchors, note, summary: auto)`: `passage(anchors, suppress(note), summary: ...)` --- `suppress` (see the previous chapter) for a passage entirely made of it.
+
+#code-of("manual-snippets/shortcuts-suppressed.typ")
+
+#shot("manual-snippets/shortcuts-suppressed/result-tracked.png")
+
+`note` and `summary:` are separate parameters on purpose. `note` has to read on its own, cold, in the middle of the manuscript --- "Equation removed: ...". `summary:` is inserted into a sentence the *letter* will already have written --- "Removed: `‹summary›`" --- so it should be a bare phrase, not repeat "removed" itself. `summary:` defaults to `note` when omitted, since most of the time the two don't need to differ; the second call above gives them separately.
+
+= Anchors: reviewer, editor, author
+
+An anchor is parsed into one of three kinds, purely from its shape: `<r1-2>` is reviewer 1, comment 2; `<e1>` is editor comment 1; anything else --- `<bob-3>`, `<bob>` --- is a co-author id, "bob", optionally followed by a change number. Each kind gets its own color automatically, without any setup:
+
+#code-of("manual-snippets/anchors-kinds.typ")
+
+#shot("manual-snippets/anchors-kinds/result-tracked.png")
+
+Reviewers are colored by number, cycling through a fixed palette. The editor gets one fixed color of its own. Co-authors draw from a *separate* palette, so a reviewer and a co-author active in the same manuscript are never confusable --- and an author's color holds even with nothing configured for them at all (Carol, above): it's a deterministic function of the id text itself, the same color everywhere that id appears. `set-revisions(authors: (...))`, used above for Bob and Alice, additionally gives an id a full display name and/or a specific color:
+
+#code(
+  "#set-revisions(authors: (\n" +
+  "  bob: (name: \"Bobby Fischer\", color: rgb(\"#c026d3\")),  // both\n" +
+  "  alice: \"Alice Smith\",                                   // name only\n" +
+  "))"
+)
+
+Either key can be omitted; an id with a `name:` but no `color:` still gets its automatic color, exactly like an id with nothing registered at all.
+
+== Multiple anchors on one passage
+
+A comment raised jointly, or addressed in the same place --- `passage`/`added`/`deleted`/`replaced` all accept an array of anchors instead of one:
+
+#code-of("manual-snippets/anchors-multi.typ")
+
+#shot("manual-snippets/anchors-multi/result-tracked.png")
+
+Colored by the first anchor in the list.
+
+== Bare anchors
+
+`<bob>`, with no trailing `-<n>`, is deliberately *not* meant to key into one particular exchange --- it's the shape for a project with no response document at all, where an anchor just says whose change this is:
+
+#code-of("manual-snippets/anchors-bare.typ")
+
+#shot("manual-snippets/anchors-bare/result-tracked.png")
+
+Reused as many times as needed, with neither of the two diagnostics that would otherwise apply: no "duplicate exchange" (there's nothing to be a duplicate *of* --- a bare anchor isn't meant to be unique), and no "no matching exchange" (covered next).
+
+== `require-exchange` <sec-req-exch>
+
+A *numbered* anchor is assumed to answer one specific comment, so `passage`/`added`/`deleted`/`replaced` check that a matching `exchange`/`note` exists somewhere and warn if not:
+
+#code-of("manual-snippets/anchors-require-exchange.typ")
+
+#shot("manual-snippets/anchors-require-exchange/result-tracked.png")
+
+`set-revisions(require-exchange: false)` turns this check off from that point on --- for a project that wants numbered, colored anchors without ever writing a response document.
+
+= Writing the exchanges: `reviewer`, `editor`, `exchange`
+
+/ `reviewer(n, body)`: groups a reviewer's comments under a heading colored by their number.
+/ `editor(body)`: same, for the editor's own comments.
+/ `exchange(anchor, comment, response)`: renders the quoted comment (in italics) and the response, with a header generated from the anchor.
+
+#code-of("manual-snippets/exchanges-reviewer-editor.typ")
+
+#shot("manual-snippets/exchanges-reviewer-editor/result-tracked.png")
+
+`exchange` checks, unconditionally, that its anchor matches a passage somewhere --- an orphan comment answering nothing is always worth flagging, so this check has no `require-exchange`-style opt-out.
+
+== Co-authors: `author`, `note`
+
+/ `author(id, body)`: groups one co-author's own notes under a heading, colored and named the same way an anchor like `<bob-3>` already would be.
+/ `note(anchor, text)`: a single block --- no comment to quote, just the author's own explanation. `exchange(anchor, text)`, with two arguments instead of three, renders identically.
+
+#code-of("manual-snippets/exchanges-author.typ")
+
+#shot("manual-snippets/exchanges-author/result-tracked.png")
+
+== `xcomment`
+
+/ `xcomment(anchor)`: a clickable cross-reference to another exchange, plus its page --- "as already answered in comment R1-2."
+
+#code-of("manual-snippets/exchanges-xcomment.typ")
+
+#shot("manual-snippets/exchanges-xcomment/result-tracked.png")
+
+== Header wording: `comment-word`, `change-word`, `term:`
+
+The noun in a header --- "comment" for reviewer/editor, "change" for a co-author --- is `set-revisions(comment-word:, change-word:)`, global from that point on, or `term:` on one `exchange`/`note` call for just that occurrence:
+
+#code-of("manual-snippets/exchanges-words.typ")
+
+#shot("manual-snippets/exchanges-words/result-tracked.png")
+
+`xcomment` echoes whichever word the exchange it points to actually used --- reading it back from that exchange's own data rather than recomputing it, so `#xcomment(<bob-2>)`'s explicit `term: "aside"` stays "aside" no matter where it's cited from. An *unoverridden* word, though, is resolved at the position where it's *read*, not where it was written: `<r1-1>`'s own exchange, near the top, renders "comment" --- the default, in effect at that point --- but `#xcomment(<r1-1>)` at the very bottom, after the global override, reads back "remark" for that same exchange. A global change to `comment-word`/`change-word` partway through a file affects every unoverridden reference read afterward, regardless of which word was showing where that exchange itself was originally written.
+
+= `pinpoint`: the manuscript/letter link
+
+#code("#pinpoint(anchor, excerpt: false, parens: true, verb: auto, show-page: true, quotes: false, format: auto, mode: auto, on-empty: auto)")
+
+`pinpoint(<anchor>)` searches the manuscript for every passage carrying that anchor and reports where it is --- the mechanism behind the real page numbers a response letter cites, since the manuscript and the letter share one bundle.
+
+== Page only (the default) <sec-pinpoint-page>
+
+#code-of("manual-snippets/pinpoint-basic.typ")
+
+Manuscript:
+
+#shot("manual-snippets/pinpoint-basic/manuscript-clean.png")
+
+Response:
+
+#shot("manual-snippets/pinpoint-basic/response-clean.png")
+
+The same anchor on two passages, on different pages, reports both:
+
+#code-of("manual-snippets/pinpoint-two-pages.typ")
+
+Manuscript, page 1:
+
+#shot("manual-snippets/pinpoint-two-pages/manuscript-clean-1.png")
+
+Manuscript, page 2:
+
+#shot("manual-snippets/pinpoint-two-pages/manuscript-clean-2.png")
+
+Response:
+
+#shot("manual-snippets/pinpoint-two-pages/response-clean.png")
+
+If the anchor matches no real `add`/`del`/`rep` mark anywhere --- a `touched` passage, cited only to point at text that didn't change --- the verb switches from "modified on" to "see" automatically. Not a style choice: asserting a change that didn't happen would simply be false, so nothing has to be configured for it.
+
+== `parens:` and `verb:`: fitting the citation into a sentence
+
+The wired-in parenthetical reads fine as a trailing citation ("We addressed this concern (modified on p. 3)."), but not every sentence ends that way:
+
+#code-of("manual-snippets/pinpoint-parens-verb.typ")
+
+Manuscript:
+
+#shot("manual-snippets/pinpoint-parens-verb/manuscript-clean.png")
+
+Response:
+
+#shot("manual-snippets/pinpoint-parens-verb/response-clean.png")
+
+`parens: false` drops the parentheses; `verb: none` additionally drops "modified on"/"see", leaving only "p. 3" (or "p. 3 and p. 7" for two pages) --- for a sentence, like `See #pinpoint(<r>, parens: false, verb: none) for the updated wording.`, that already supplies its own verb. The two are independent: `parens: false` alone still says "modified on p. 3" without the parentheses; `verb: none` alone keeps the parentheses around a bare page number. Neither one alone fits every sentence shape --- that's why both exist rather than a single "compact" switch.
+
+== `excerpt: true`: quoting the real text
+
+Rather than a page number, the actual content of every passage carrying the anchor --- exactly as it reads in the manuscript right now, so it can never go stale:
+
+#code-of("manual-snippets/pinpoint-excerpt.typ")
+
+Manuscript:
+
+#shot("manual-snippets/pinpoint-excerpt/manuscript-clean.png")
+
+Response:
+
+#shot("manual-snippets/pinpoint-excerpt/response-clean.png")
+
+A passage declared with `summary:` ignores `excerpt` and always renders "Removed: `‹summary›`" instead, as the second comment above shows --- there being no meaningful text left to quote in the clean manuscript once the passage is fully removed.
+
+== `show-page:` and `quotes:`: dropping the page, adding real quotation marks
+
+#code-of("manual-snippets/pinpoint-show-page-quotes.typ")
+
+Manuscript:
+
+#shot("manual-snippets/pinpoint-show-page-quotes/manuscript-clean.png")
+
+Response:
+
+#shot("manual-snippets/pinpoint-show-page-quotes/response-clean.png")
+
+`show-page: false` drops the leading `*p. 1* --- ` --- for a sentence that already states where the excerpt comes from ("On page 1, `‹excerpt›`"), or a caller who simply doesn't want it. `quotes: true` wraps the excerpt in real, typeset quotation marks via Typst's native `quote()`.
+
+`quotes: true` only ever *requests* quotation marks --- a passage whose content is a figure, a table, or a block equation never gets them, regardless of this setting: forcing quotation marks onto a figure produces two stray quote glyphs sitting alone above and below it, not an improvement, so this is detected and declined automatically rather than left for you to remember passage by passage.
+
+== `mode:`: overriding style for one excerpt
+
+An excerpt renders, by default, in whichever mode the *current* compile is running under --- clean text in `response.pdf`, struck-through/underlined tracked style in `response-tracked.pdf` (both produced automatically once `exchanges` is set, see #link(<sec-letter-option>)[below]). `mode:` overrides this for one call, in either direction.
+
+`mode: "tracked"`, called from a clean letter, shows the tracked style even though `response.pdf` itself is otherwise all clean text:
+
+#code-of("manual-snippets/pinpoint-mode.typ")
+
+Manuscript:
+
+#shot("manual-snippets/pinpoint-mode/manuscript-clean.png")
+
+Response:
+
+#shot("manual-snippets/pinpoint-mode/response-clean.png")
+
+Useful when the point being made is "we removed exactly what you objected to," which a clean, final-text quote doesn't convey on its own.
+
+The reverse also works: `mode: "clean"`, called from a letter compiled tracked (`--input mode=tracked`, `exchanges` set), shows the final wording for one excerpt even though the rest of that same letter is otherwise quoting tracked style:
+
+#code-of("manual-snippets/pinpoint-mode-clean-in-tracked-letter.typ")
+
+Manuscript, tracked:
+
+#shot("manual-snippets/pinpoint-mode-clean-in-tracked-letter/manuscript-tracked.png")
+
+Response, tracked --- the excerpt still reads as accepted, final text, despite the compile being tracked:
+
+#shot("manual-snippets/pinpoint-mode-clean-in-tracked-letter/response-tracked.png")
+
+== `on-empty:` and `format:`
+
+#code-of("manual-snippets/pinpoint-on-empty-format.typ")
+
+#shot("manual-snippets/pinpoint-on-empty-format/result-clean.png")
+
+`on-empty:` controls what happens when no passage anywhere carries the given anchor --- `auto` (the default) warns, `none` shows nothing, anything else is shown as-is. `format:` replaces the default page-list wording entirely, with a function `(pages-array, has-marks) -> content` --- `has-marks` is the same flag that drives the automatic "modified"/"see" switch above, passed through so a fully custom format can make that same distinction without querying the bundle again. For a journal with its own citation convention.
+
+= `xref`: pointing into the manuscript
+
+/ `xref(label)`: like `@label`/`ref(label)` --- already correct across the bundle, resolving to the manuscript's real number for free --- but with the manuscript's real page number appended.
+
+#code-of("manual-snippets/xref-basic.typ")
+
+Manuscript, page 2:
+
+#shot("manual-snippets/xref-basic/manuscript-clean-2.png")
+
+Response:
+
+#shot("manual-snippets/xref-basic/response-clean.png")
+
+A bare `@fig-a` already gets the number right, since the letter and the manuscript share one bundle --- `xref` only adds the page. A label that doesn't exist anywhere warns rather than breaking the compile.
+
+= `change-list`: a summary table of every marked passage
+
+/ `change-list(title: [Summary of changes], level: 1)`: one row per marked passage --- comment, type of change, page, section.
+
+#code-of("manual-snippets/change-list-basic.typ")
+
+#shot("manual-snippets/change-list-basic/result-tracked.png")
+
+Renders nothing in clean mode, like `del`/`suppress` --- placed once anywhere in shared manuscript content, it only ever shows up in `manuscript-tracked.pdf`. Rows are sorted by comment identifier --- reviewers in order, then co-authors alphabetically by id, then the editor, anchor-less passages last --- so the table doubles as a checklist against the letter, not just a readout of document order. `touched` never appears: nothing changed there to list. A passage with several marks shows every kind it contains, joined with "/" (`addition/deletion`, say, for a manually mixed passage that isn't a single `rep`).
+
+The "Section" column is the nearest preceding heading at `level:` (top-level by default) --- notice the reviewer comment inside "Background" above is listed under "Introduction", its enclosing top-level section, not the subsection itself.
+
+== `level:`: which heading counts as "Section"
+
+#code-of("manual-snippets/change-list-level.typ")
+
+#shot("manual-snippets/change-list-level/result-tracked.png")
+
+Same passage, same position --- only `level:` differs between the two calls, and the Section column changes with it: `1` (the default) names the enclosing top-level heading, `2` the enclosing subsection.
+
+== `title:`: avoiding a redundant heading
+
+`change-list()` prints its own bold "Summary of changes" line above the table by default. If you already write your own heading right before the call, that becomes two headings back to back:
+
+#code-of("manual-snippets/change-list-title.typ")
+
+#shot("manual-snippets/change-list-title/result-tracked.png")
+
+`title: none` removes the package's own line, leaving just your heading and the table --- `title: [Some other text]` would replace it with different wording instead, for the same reason.
+
+= Bibliography
+
+Typst 0.15's multiple bibliographies handle three situations.
+
+== A citation inside `add`/`del`
+
+Nothing special to do --- it becomes part of the manuscript's own bibliography either way. The difference shows up in *which version* the citation appears in:
+
+#code-of("manual-snippets/biblio-add-del.typ")
+
+Clean --- only the surviving citation:
+
+#shot("manual-snippets/biblio-add-del/result-clean.png")
+
+Tracked --- both, since the struck-through text is still there to resolve:
+
+#shot("manual-snippets/biblio-add-del/result-tracked.png")
+
+A citation inside a deleted passage disappears from the bibliography in the clean compile and reappears in the tracked one, so a reader following the struck-through text can still resolve what it cited --- the opposite of `latexdiff`, notorious for leaving phantom, unresolvable references behind.
+
+== `letter-bibliography`: a citation the letter makes on its own
+
+/ `letter-bibliography(path, title: [References cited in this response])`: a second bibliography, scoped to citations made *inside* the letter and numbered independently from the manuscript's own.
+
+A real project's three-file shape (`main.typ`/`manuscript.typ`/`responses.typ`, covered in the last chapter) --- `manuscript.typ`:
+
+#code-of("manual-snippets/shared/biblio-letter/manuscript.typ")
+
+#shot("manual-snippets/biblio-letter/manuscript-clean.png")
+
+`responses.typ`:
+
+#code-of("manual-snippets/shared/biblio-letter/responses.typ")
+
+#shot("manual-snippets/biblio-letter/response-clean.png")
+
+`smith2020` is `[2]` in the manuscript's own bibliography but `[1]` in the letter's --- two independent numbering sequences, not one shared list. This is also why `smith2020` had to be listed in *both* `.bib` files even though the manuscript already cites it: a citation made directly in the letter's own prose only ever resolves against the `.bib` passed to `letter-bibliography`, regardless of what the manuscript's own bibliography already knows.
+
+*Path gotcha:* `path` must be root-relative (a leading `/`, resolved against `--root`), not relative to the file that calls `letter-bibliography`. Typst resolves a path string against the file that calls the path-consuming builtin --- here, `bibliography()` inside `letter-bibliography`, in the package's own source --- not the file that wrote the string literal. A plain `"responses.bib"` looks next to the package's own source and fails.
+
+== Letter numbering
+
+A figure or table the letter adds *on its own* --- "for the reviewer's convenience only," never in the manuscript, like the table above --- is numbered independently from the manuscript's, prefixed `R`, so it can never be confused with a manuscript one.
+
+A figure, table, equation, or heading `pinpoint(excerpt: true)` re-emits *from* the manuscript is different: it keeps the manuscript's own real number, not an `R` one --- "Figure 1" reads "Figure 1" in the letter too, not "Figure R1", and a quoted subsection heading reads "2.1" the same way it does in the manuscript:
+
+#code-of("manual-snippets/letter-numbering.typ")
+
+Manuscript:
+
+#shot("manual-snippets/letter-numbering/manuscript-clean.png")
+
+Response:
+
+#shot("manual-snippets/letter-numbering/response-clean.png")
+
+The letter's own figure above is captioned "Figure R2," not "Figure R1" --- the two excerpts before it (the figure and the heading) still occupy the first two slots of the letter's own counters, even though what each *displays* is the manuscript's own number rather than that slot's.
+
+This requires a label on the original --- `query()` is how the letter's copy finds the manuscript's real number, and a label is what it queries by. An unlabelled figure, equation, or heading just falls back to whatever numbering already applies where the excerpt is re-emitted --- the letter's own `R` sequence for a figure or table, no `R` sequence at all for an equation (equations never had one), and no number at all for a heading. This matters most in practice for headings: a figure is usually labelled anyway, for `@ref`, but a heading rarely is unless an author adds one specifically so it can be quoted this way.
+
+= Diagnostics and strict mode
+
+Typst has no public API for a script to emit its own compiler warning, so every check below shows instead as a visible box, right at the fault --- muted in the clean compile for anything embedded in the manuscript itself (`manuscript.pdf` must never carry one, since it's the file actually sent out under review), shown regardless of mode for anything embedded in the letter (the letter is never sent out for blind review the way the manuscript is, so hiding it in one mode buys nothing).
+
+Two already appeared earlier, in context: a numbered anchor with #link(<sec-req-exch>)[no matching exchange] and a bare anchor's exemption from it; `pinpoint` with #link(<sec-pinpoint-page>)[no matching anchor] (`on-empty:`). Four more:
+
+#code-of("manual-snippets/diagnostics-gallery.typ")
+
+#shot("manual-snippets/diagnostics-gallery/result-tracked.png")
+
+Four more exist but aren't demonstrated live here, since each needs a slightly unusual setup to trigger: two numbered exchanges sharing one anchor (`duplicate exchange r1-2`); `xref`/`xcomment` pointing at a label or anchor that doesn't exist anywhere (`xref(<fig-x>): not found`, `xcomment(<r9-9>): no exchange found for this anchor`); and an excerpt whose passage contains a label also referenced elsewhere in the bundle, which falls back to citing the page instead of crashing the compile outright --- rare in practice, since `pinpoint(excerpt: true)` already strips labels from what it re-emits before this check would even trigger.
+
+`set-strict(true)`, or `revisions(strict: true, ...)`, turns every one of these into a hard compile error, in both modes:
+
+#code("#set-strict(true)")
+
+Not the default, since a manuscript mid-revision should still compile --- meant for a CI gate right before submission, when every one of these should already be resolved.
+
+= `revisions`: the pilot, and the final assembly <sec-project-layout>
+
+#code("#show: revisions.with(template: ..., exchanges: ..., letter-template: auto, strict: false)")
+
+Every example so far ran `add`/`del`/`passage`/`change-list`/... directly, no bundle. `revisions` is the one piece that actually needs one --- it's what turns a manuscript and a set of exchanges into the three files of a real project.
+
+A project is normally three files:
+
+#code(
+  "manuscript.typ    the manuscript, annotated with passage()/add()/del()/...\n" +
+  "responses.typ      the exchanges with reviewers\n" +
+  "main.typ           the pilot (a handful of lines)"
+)
+
+`main.typ`:
+
+#code-of("manual-snippets/revisions-pilot.typ")
+
+`manuscript.typ`:
+
+#code-of("manual-snippets/shared/manuscript.typ")
+
+`responses.typ`:
+
+#code-of("manual-snippets/shared/responses.typ")
+
+Two commands, run one after the other, produce the whole project:
+
+#code(
+  "typst compile --features bundle --format bundle main.typ\n" +
+  "typst compile --features bundle --format bundle --input mode=tracked main.typ"
+)
+
+*First command* (mode defaults to clean) --- `manuscript.pdf`:
+
+#shot("manual-snippets/revisions-pilot/manuscript-clean.png")
+
+--- and `response.pdf`:
+
+#shot("manual-snippets/revisions-pilot/response-clean.png")
+
+*Second command* (`--input mode=tracked`) --- `manuscript-tracked.pdf`:
+
+#shot("manual-snippets/revisions-pilot/manuscript-tracked.png")
+
+--- and, since `exchanges` is set, `response-tracked.pdf`: the same letter, but citing and quoting *this* manuscript, the tracked one --- see below for why that happens automatically, with no separate setting:
+
+#shot("manual-snippets/revisions-pilot/response-tracked.png")
+
+Each compile produces exactly the file(s) for its own mode, never a mix of the two --- the first never produces a tracked manuscript, and neither compile's letter is named the same as the other's.
+
+Four parameters:
+
+/ `template`: wraps the manuscript only --- any `content -> content` function, including a real journal template used the normal way. `authors:`/`title:` above are this example's own stand-in template's parameters, not `revisions`'s.
+/ `letter-template`: wraps the letter only, separately --- `auto` (the default) uses `default-letter-template`, a title and nothing else. The two templates never mix: a figure/table/heading style set inside one has no effect on the other.
+/ `exchanges`: the already-evaluated content of the responses file --- `include "responses.typ"`, as shown above. Also decides whether a letter is produced at all --- see below.
+/ `strict`: `revisions(strict: true, ...)` is shorthand for `set-strict(true)` at the top of the pilot.
+
+Each source file needs its own `#import "@preview/palimpsest:0.1.0": *` --- `#include` doesn't share scope, so `manuscript.typ` and `responses.typ` both import it too, even though only `main.typ` calls `revisions`.
+
+== The letter, automatically --- matched to the manuscript you actually send <sec-letter-option>
+
+Whether a compile produces a response document isn't something you configure --- there's nothing sensible for it to mean independently of `exchanges`: writing responses with no letter to hold them, or asking for a letter with nothing written, are both non-cases. So it's derived: a letter is produced whenever `exchanges` isn't `none`, matching *this compile's own* mode --- `response.pdf` from the clean compile, `response-tracked.pdf` from the tracked one, each citing and quoting its own manuscript. This changes nothing about the command line --- it's still the exact same two commands shown above.
+
+#code-of("manual-snippets/revisions-exchanges-letter.typ")
+
+Compiled clean, `response.pdf` quotes the accepted wording only:
+
+#shot("manual-snippets/revisions-exchanges-letter/response-clean.png")
+
+Compiled with `--input mode=tracked`, the same `exchanges` also produces `response-tracked.pdf` --- a name distinct from `response.pdf`, so neither compile can silently overwrite the other's output. Its excerpt shows the struck-through old wording next to the underlined new wording, because `pinpoint(excerpt: true)` with no explicit `mode:` always follows whichever mode the *current* compile is running under (see #link(<sec-pinpoint-page>)[pinpoint] above):
+
+#shot("manual-snippets/revisions-exchanges-letter/response-tracked.png")
+
+The one thing that *is* a command-line choice, not a fixed property of the project, is skipping the letter for a single run even though `exchanges` is set --- a fast, manuscript-only preview while drafting, without touching `main.typ`:
+
+```sh
+typst compile --features bundle --format bundle --input letter=false main.typ
+```
+
+`--input letter=true` is the symmetric, rarely-needed override --- force a letter even with `exchanges: none`.
+
+What each command writes, with `exchanges` set:
+
+#table(
+  columns: (1fr, 1fr, 1fr),
+  stroke: 0.5pt + luma(210),
+  fill: (x, y) => if y == 0 { luma(247) },
+  align: horizon,
+  [*Command*], [*default*], [*`--input letter=false`*],
+  [1st (clean)], [`manuscript.pdf`\ `response.pdf`], [`manuscript.pdf`],
+  [2nd (tracked)], [`manuscript-tracked.pdf`\ `response-tracked.pdf`], [`manuscript-tracked.pdf`],
+)

--- a/packages/preview/palimpsest/0.1.0/examples/coauthors-simple/manuscript.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/coauthors-simple/manuscript.typ
@@ -1,0 +1,63 @@
+// The "no letter at all" workflow: several co-authors editing one shared
+// draft, with no reviewer, no response document, no bundle export —
+// just an ordinary Typst file compiled twice. No `revisions()`, no
+// `#document(...)`, no `--features bundle` needed anywhere: `add`/`del`/
+// `rep`/`passage`/`change-list` all work as plain functions on their
+// own. See compile.sh for the two plain `typst compile` invocations.
+
+#import "@preview/palimpsest:0.1.0": *
+
+#set page(width: 14cm, height: auto, margin: 1.5cm)
+#set text(size: 10pt)
+#set heading(numbering: "1.")
+
+#set-revisions(authors: (
+  bob: (name: "Bobby Fischer", color: rgb("#c026d3")),
+  alice: "Alice Smith",
+))
+
+#align(center, text(size: 1.4em, weight: "bold")[Shared Project Proposal])
+#v(1.5em)
+
+// Placed near the top, self-hides in the clean compile — see
+// change-list's own doc comment (src/change-list.typ).
+#change-list()
+
+= Introduction
+
+#lorem(15)
+
+#added(<bob>)[Bobby added a paragraph motivating the approach taken
+below, after the team's kickoff call.]
+
+#passage(<alice>)[The scope #rep[was left open-ended][is now restricted
+to the three use cases agreed on last week].]
+
+= Methods
+
+#added(<carol>)[Carol contributed this whole subsection on the
+evaluation protocol — nobody registered her name or a color in
+`set-revisions`, so she still gets an automatic, distinct color and
+displays under her raw id, "carol".]
+
+#deleted(<bob>, summary: [an early draft of the risk assessment,
+superseded by the section below])[
+  An earlier, informal risk assessment that the team agreed to drop in
+  favor of a structured one.
+]
+
+#touched(<alice>)[This paragraph is unchanged — Alice reviewed it and
+confirmed it's still accurate, worth marking so nobody re-checks it
+again.]
+
+= Budget
+
+// A numbered anchor works too, without a comments file to answer it —
+// `require-exchange: false` (see below) turns off the warning that
+// would otherwise appear in the tracked version for a numbered anchor
+// with nothing answering it.
+#set-revisions(require-exchange: false)
+
+#added(<dave-1>)[Dave added a line item for external review costs,
+flagged with a number in case the team wants to discuss it later even
+though there's no response document here to discuss it in.]

--- a/packages/preview/palimpsest/0.1.0/examples/emoji-email/main.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/emoji-email/main.typ
@@ -1,5 +1,5 @@
 #import "@preview/palimpsest:0.1.0": *
-#import "@preview/charged-ieee:0.1.3": ieee
+#import "@preview/charged-ieee:0.1.4": ieee
 
 // A lightweight letter template, independent of the two-column IEEE
 // layout — the letter is a short reviewer-facing document, not a

--- a/packages/preview/palimpsest/0.1.0/examples/emoji-email/main.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/emoji-email/main.typ
@@ -1,0 +1,59 @@
+#import "@preview/palimpsest:0.1.0": *
+#import "@preview/charged-ieee:0.1.3": ieee
+
+// A lightweight letter template, independent of the two-column IEEE
+// layout — the letter is a short reviewer-facing document, not a
+// second article with its own title block and index terms.
+#let letter-template(body) = {
+  set par(justify: true, first-line-indent: 0em)
+  align(center, text(size: 1.3em, weight: 700)[Response to Reviewers])
+  v(0.3em)
+  align(center, emph[Estimating the causal effect of replying "👍"
+  versus "merci" to professional emails])
+  v(1.5em)
+  body
+}
+
+#show: revisions.with(
+  template: ieee.with(
+    title: [Estimating the causal effect of replying "👍" versus
+    "merci" to professional emails],
+    abstract: [
+      Background: professional emails increasingly close with either a
+      written sign-off or a bare emoji reaction, and whether this choice
+      causally affects downstream communication outcomes is unknown.
+      Methods: we analyzed metadata from 1,204 professional email
+      threads across six organizations, comparing threads whose final
+      message closed with a "👍" emoji, the word "merci," or no sign-off,
+      using inverse-probability-weighted estimates of the probability of
+      a further reply within 48 hours. Results: reply probability
+      differed by sign-off group both before and after adjustment for
+      measured confounders. Conclusion: these findings are consistent
+      with sign-off choice being causally relevant to reply behavior in
+      professional email correspondence.
+    ],
+    authors: (
+      (
+        name: "Constance Reply-All",
+        department: [Department of Organizational Communication],
+        organization: [Institute for Workplace Efficiency],
+        location: [Inbox City, DE],
+        email: "c.reply-all@example.org",
+      ),
+      (
+        name: "Marcus Cc",
+        department: [Behavioral Email Analytics Lab],
+        organization: [University of Inbox Zero],
+        location: [Threadford, NJ],
+        email: "marcus.cc@example.org",
+      ),
+    ),
+    index-terms: ("Causal inference", "Email etiquette", "Digital communication", "Propensity score"),
+    bibliography: bibliography("manuscript.bib"),
+    figure-supplement: [Fig.],
+  ),
+  exchanges: include "responses.typ",
+  letter-template: letter-template,
+)
+
+#include "manuscript.typ"

--- a/packages/preview/palimpsest/0.1.0/examples/emoji-email/manuscript.bib
+++ b/packages/preview/palimpsest/0.1.0/examples/emoji-email/manuscript.bib
@@ -1,0 +1,30 @@
+@article{replyall2020,
+  author  = {Reply-All, Constance},
+  title   = {Reply-All Fatigue: A Field Study of Inbox Behavior},
+  journal = {Journal of Organizational Communication},
+  year    = {2020},
+}
+@article{signoffnorms2021,
+  author  = {Cc, Marcus and Bcc, Priya},
+  title   = {Norms of the Professional Email Sign-Off: A Corpus Study},
+  journal = {Annals of Workplace Linguistics},
+  year    = {2021},
+}
+@article{ipwmethod2019,
+  author  = {Weightley, Ida},
+  title   = {Inverse Probability Weighting for Non-Randomized Communication Trials},
+  journal = {Journal of Applied Statistics},
+  year    = {2019},
+}
+@article{caffeineconfound2023,
+  author  = {Grande, Flat White},
+  title   = {Unmeasured Caffeine Confounding in Observational Workplace Studies},
+  journal = {Epidemiologic Methods},
+  year    = {2023},
+}
+@article{ivexclusion2020,
+  author  = {Instrument, Val},
+  title   = {On the Exclusion Restriction in Battery-Level Instrumental Variables},
+  journal = {Journal of Applied Econometrics},
+  year    = {2020},
+}

--- a/packages/preview/palimpsest/0.1.0/examples/emoji-email/manuscript.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/emoji-email/manuscript.typ
@@ -1,0 +1,296 @@
+#import "@preview/palimpsest:0.1.0": *
+#import "@preview/lilaq:0.6.0" as lq
+
+// The two co-authors, so they can leave their own notes below alongside
+// the reviewers' — Constance with an explicit color, Marcus with just a
+// display name (still gets an automatic, distinct color).
+#set-revisions(authors: (
+  constance: (name: "Constance Reply-All", color: rgb("#0f766e")),
+  marcus: "Marcus Cc",
+))
+
+// Shown only in manuscript-tracked.pdf (change-list() auto-hides in
+// clean, see §7.3).
+#change-list()
+
+= Introduction
+
+Professional email correspondence conventionally closes with a written
+sign-off — "Best," "Regards," "Thank you" — that varies by sender,
+recipient, and, increasingly, by whether the sender simply taps an
+emoji instead of typing anything at all. Whether this choice has any
+causal bearing on downstream communication outcomes has not, to our
+knowledge, been formally evaluated.
+
+#passage(<r1-1>)[
+  We define a sign-off #add[, following the corpus-based taxonomy of
+  @signoffnorms2021,] as any content appended after the substantive body
+  of an email and before the sender's name, including a bare emoji
+  reaction sent as the entirety of a reply.
+]
+
+#touched(<constance-1>)[
+  We re-read this definition after the change above and confirm it
+  still matches how sign-offs were actually coded during data
+  extraction.
+]
+
+#passage(<r1-10>)[
+  #add[This comment required a correction in two places in the
+  manuscript — this sentence, in the introduction, and a matching one in
+  the conclusion —] applies equally to both instances.
+]
+
+In this study, we estimate the causal effect of replying with a single
+"👍" emoji, versus the written word "merci," on the probability of
+receiving a further reply within 48 hours, using observational email
+metadata and propensity score methods. Related work has examined
+inbox behavior more broadly #cite(<replyall2020>), but has not isolated
+the sign-off itself as a treatment.
+
+#lorem(90)
+
+= Methods
+
+== Data source and study population
+
+We analyzed metadata from 1,204 professional email threads across
+six organizations, in which the final message before a 30-day
+observation window ended with either a lone "👍" emoji, the word
+"merci," or no sign-off at all (control). Threads involving fewer than
+two participants, or in which the sender was on parental leave, were
+excluded.
+
+#touched(<r1-4>)[
+  Metadata were extracted automatically from email headers and
+  timestamps; message bodies were not read by the study team.
+]
+
+#lorem(60)
+
+#passage(<r1-5>)[
+  #figure(
+    placement: auto,
+    table(
+      columns: 4,
+      table.header[][*"👍"*][*"merci"*][*Control*],
+      [Recipient is senior, %], [31], [#rep[42][47]], [38],
+      [Email length, mean words], [58], [64], [61],
+      [Sent on Friday, %], [22], [19], [24],
+      [Sender battery level, mean %], [34], [71], [68],
+    ),
+    caption: [Baseline characteristics by sign-off group.],
+  ) <tab-baseline>
+]
+
+As shown in @tab-baseline, senders who closed with a lone "👍" reported a
+markedly lower average battery level at the time of sending than
+senders who wrote "merci" or used no sign-off.
+
+== #passage(<r2-1>)[Statistical analysis #add[(updated)]]
+
+#passage(<r1-2>)[
+  #rep[The reply rate was compared across sign-off groups using a simple
+  difference in proportions.][The reply rate was compared across
+  sign-off groups using inverse probability weighting
+  #cite(<ipwmethod2019>), with weights derived from a propensity score
+  model for sign-off choice conditional on recipient seniority, email
+  length, and day of week sent.]
+]
+
+#passage(<r1-3>)[
+  Sign-off choice
+  #rep[was modeled directly as a function of recipient seniority.][was
+  modeled as
+  $ P("sign-off" = "👍" | X) \
+    = "logit"^(-1)(beta_0 + beta_1 X_"sr" + beta_2 X_"len" + beta_3 X_"fri") $
+  with $X$ the vector of measured covariates listed above.]
+]
+
+#passage(<marcus-1>)[
+  #add[While implementing the change above, we also checked covariate
+  balance across sign-off groups after weighting and found adequate
+  overlap, with no standardized mean difference exceeding 0.1.]
+]
+
+#lorem(70)
+
+#deleted(<r1-6>, summary: [the closed-form calibration equation, which
+  became redundant once sign-off choice was modeled directly on the
+  logit scale above])[
+  For completeness, calibrated assignment probabilities were also
+  computed directly as
+  $ hat(p) = "expit"(hat(beta)_0 + hat(beta)_1 X_"senior") $
+]
+
+#lorem(50)
+
+#passage(<r2-5>)[
+  #add[As an instrumental-variable robustness check, we additionally
+  used the sender's battery level at the time of sending as an
+  instrument for sign-off choice, under the exclusion restriction that
+  battery level affects reply probability only through its effect on
+  sign-off choice #cite(<ivexclusion2020>).]
+]
+
+= Results
+
+#lorem(60)
+
+#figure(
+  placement: auto,
+  lq.diagram(
+    width: 8cm,
+    height: 5cm,
+    xlabel: [Sign-off used],
+    ylabel: [Reply within 48h (%)],
+    yaxis: (lim: (0, 70)),
+    xaxis: (ticks: ((1, "\"👍\""), (2, "\"merci\""), (3, "Control"))),
+    lq.bar(
+      (1, 2, 3),
+      (41, 53, 35),
+      fill: rgb("#6c8ebf"),
+      width: 60%,
+    ),
+  ),
+  caption: [Reply-within-48-hours rate, by sign-off used.],
+) <fig-reply-rate>
+
+#touched(<e1>)[
+  @fig-reply-rate shows a higher raw reply rate for "merci" than for
+  either "👍" or no sign-off, before any adjustment for confounding.
+]
+
+#lorem(70)
+
+#passage(<r2-2>)[
+  #add[
+    #figure(
+      placement: auto,
+      lq.diagram(
+        width: 7.5cm,
+        height: 4.2cm,
+        xlabel: [Odds ratio, "👍" vs. "merci" (95% CI)],
+        xlim: (0, 3),
+        yaxis: (
+          ticks: (
+            (1, "CC includes\nmanager"),
+            (2, "Email length\n> 100 words"),
+            (3, "Sent on\nFriday"),
+            (4, "Recipient is\nsenior"),
+          ),
+          lim: (0.5, 4.5),
+        ),
+        lq.vlines(1, stroke: (paint: gray, dash: "dashed")),
+        lq.plot(
+          (0.6, 1.9, 0.9, 1.4),
+          (1, 2, 3, 4),
+          xerr: ((p: 0.3, m: 0.2), (p: 0.8, m: 0.6), (p: 0.5, m: 0.4), (p: 0.6, m: 0.5)),
+          stroke: none,
+          mark: "o",
+        ),
+      ),
+      caption: [Subgroup odds ratios for the association between
+      sign-off choice and reply within 48 hours.],
+    ) <fig-forest>
+  ]
+]
+
+#lorem(90)
+
+#suppressed(
+  <r2-3>,
+  [Sub-analysis removed: the "🙏" sign-off as a null comparator,
+  including its summary figure and table],
+  summary: [the "🙏" null-comparator sub-analysis, including its figure
+  and table],
+)
+
+#lorem(80)
+
+#passage(<r2-6>)[
+  #figure(
+    placement: auto,
+    table(
+      columns: 3,
+      table.header[Reply type][By 24h][By 48h],
+      [Full-text reply], [29%], [38%],
+      [One-word reply], [11%], [14%],
+      [Emoji-only reply], [6%], [9%],
+      // An ADDED row stays in both compiles (add[...] alone handles the
+      // clean-vs-tracked styling) — no `if mode() == "clean" { () }
+      // else {...}` gating, that pattern is for a row genuinely
+      // absent from the submitted manuscript (a DELETED row, see
+      // tests/marks-figures.typ), not an accepted addition. An earlier
+      // version of this table wrongly hid this row from manuscript.pdf
+      // entirely (see CLAUDE.md) — a real defect, since the row is
+      // actually part of what's submitted, added in response to R2-6.
+      add[Reacted only (no reply)], add[--], add[7%],
+    ),
+    caption: [Reply type breakdown, by 24 and 48 hours after the final message.],
+  ) <tab-replytype>
+]
+
+As shown in @tab-replytype, the proportion of threads receiving a full-text
+reply increased between the 24-hour and 48-hour marks.
+
+#lorem(40)
+
+#deleted(<r2-7>, summary: [the reply-latency table, redundant with @fig-reply-rate])[
+  #figure(
+    table(
+      columns: 3,
+      table.header[Sign-off][Median latency][IQR],
+      [👍], [4.2h], [1.8--9.1h],
+      [merci], [3.8h], [1.6--8.4h],
+      [Control], [5.1h], [2.0--11.3h],
+    ),
+    caption: [Reply latency by sign-off group (median, IQR).],
+  )
+]
+
+#lorem(40)
+
+#suppressed(
+  <r1-9>,
+  [Sensitivity analysis removed: results by email client (Gmail, Outlook, Apple Mail)],
+  summary: [the sensitivity analysis by email client],
+)
+
+#lorem(60)
+
+#passage(<r1-7>)[
+  #add[A sensitivity analysis was conducted to assess robustness to
+  unmeasured caffeine confounding, following @caffeineconfound2023.]
+]
+
+#lorem(100)
+
+= Discussion
+
+#lorem(80)
+
+#passage(<r2-4>)[
+  #rep[These results suggest that replying "merci" causes an increase in
+  the probability of a further reply, relative to a "👍"
+  emoji.][These results are consistent with an association between
+  sign-off choice and the probability of a further reply, though
+  residual confounding by unmeasured aspects of sender urgency cannot be
+  ruled out.]
+]
+
+#lorem(90)
+
+= Conclusion
+
+#touched(<r1-8>)[
+  Taken together, these findings suggest that a lone "👍" emoji, while
+  efficient, may not be a costless substitute for a written sign-off in
+  professional correspondence.
+]
+
+#passage(<r1-10>)[
+  #add[As already noted in the introduction, this conclusion applies
+  equally to the paired instance of the same reviewer comment discussed
+  there.]
+]

--- a/packages/preview/palimpsest/0.1.0/examples/emoji-email/responses.bib
+++ b/packages/preview/palimpsest/0.1.0/examples/emoji-email/responses.bib
@@ -1,0 +1,24 @@
+@article{replyall2020,
+  author  = {Reply-All, Constance},
+  title   = {Reply-All Fatigue: A Field Study of Inbox Behavior},
+  journal = {Journal of Organizational Communication},
+  year    = {2020},
+}
+@article{signoffnorms2021,
+  author  = {Cc, Marcus and Bcc, Priya},
+  title   = {Norms of the Professional Email Sign-Off: A Corpus Study},
+  journal = {Annals of Workplace Linguistics},
+  year    = {2021},
+}
+@article{ipwmethod2019,
+  author  = {Weightley, Ida},
+  title   = {Inverse Probability Weighting for Non-Randomized Communication Trials},
+  journal = {Journal of Applied Statistics},
+  year    = {2019},
+}
+@article{latency2018,
+  author  = {Sloe, Terrence},
+  title   = {The Sociology of Email Reply Latency},
+  journal = {Journal of Irreproducible Snacking},
+  year    = {2018},
+}

--- a/packages/preview/palimpsest/0.1.0/examples/emoji-email/responses.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/emoji-email/responses.typ
@@ -1,0 +1,266 @@
+#import "@preview/palimpsest:0.1.0": *
+
+We thank both reviewers, and the editor, for their careful reading of
+the manuscript. Below we address each comment in turn, with the
+corresponding change cited by page number in the manuscript.
+
+#reviewer(1)[
+
+  #exchange(<r1-1>)[
+    "Sign-off" needs an operational definition — in particular, please
+    clarify whether a bare emoji reaction counts as one.
+  ][
+    We have added an explicit definition, following the corpus-based
+    taxonomy of Cc and Bcc, which does include bare emoji reactions.
+
+    #pinpoint(<r1-1>, excerpt: true)
+  ]
+
+  #exchange(<r1-2>)[
+    A simple difference in proportions across sign-off groups does not
+    account for confounding — recipient seniority and email length both
+    plausibly affect both sign-off choice and reply probability.
+  ][
+    Agreed. We now use inverse probability weighting, with weights from
+    a propensity score model for sign-off choice conditional on
+    recipient seniority, email length, and day of week sent.
+
+    #pinpoint(<r1-2>, excerpt: true, mode: "tracked")
+  ]
+
+  #exchange(<r1-3>)[
+    Please also update the sign-off assignment model itself to match
+    the revised analysis.
+  ][
+    Done; sign-off choice is now modeled explicitly as a logistic
+    function of the covariates listed above. #pinpoint(<r1-3>)
+  ]
+
+  #exchange(<r1-4>)[
+    Were message bodies actually read by the study team, or only
+    metadata? This has ethical as well as methodological implications.
+  ][
+    Only metadata; we have kept this wording, which we believe is
+    already explicit on this point.
+
+    #pinpoint(<r1-4>, excerpt: true)
+  ]
+
+  #exchange(<r1-5>)[
+    Table 1's "recipient is senior" figure for the "merci" group looks
+    inconsistent with the number reported in the abstract — please
+    reconcile.
+  ][
+    Thank you for catching this; the table has been corrected.
+
+    #pinpoint(<r1-5>, excerpt: true)
+  ]
+
+  #exchange(<r1-6>)[
+    The calibration equation appears to duplicate the sign-off
+    assignment model once the latter is written on the logit scale —
+    is it still needed?
+  ][
+    Good catch, it is not: once the assignment model is written
+    directly on the logit scale, the calibration equation collapses to
+    the same closed form, so we have removed it as redundant.
+
+    #pinpoint(<r1-6>, excerpt: true)
+  ]
+
+  #exchange(<r1-7>)[
+    An analysis of robustness to unmeasured confounding is missing —
+    sender urgency in particular seems like an obvious candidate.
+  ][
+    We agree this was a gap and have added a sensitivity analysis for
+    unmeasured caffeine confounding, cited in the manuscript, as a proxy
+    for sender urgency. #pinpoint(<r1-7>)
+  ]
+
+  #exchange(<r1-8>)[
+    The conclusion's framing of the emoji sign-off as "not a costless
+    substitute" is memorable but should probably be tied more explicitly
+    to the effect estimates — or else softened.
+  ][
+    We have reviewed this passage and, on balance, prefer to keep the
+    wording as originally written.
+
+    #pinpoint(<r1-8>, excerpt: true)
+  ]
+
+  #exchange(<r1-9>)[
+    Please also report sensitivity to the email client used, in case
+    client-side rendering of the emoji affects the outcome.
+  ][
+    This analysis was performed but, on reflection, is redundant with
+    the caffeine-confounding sensitivity analysis and has been removed
+    for concision.
+
+    #pinpoint(<r1-9>, excerpt: true)
+  ]
+
+  #exchange(<r1-10>)[
+    One comment, filed here for convenience even though it concerns two
+    separate locations in the manuscript: the operational definition of
+    "sign-off," introduced early on, should be explicitly reaffirmed in
+    the conclusion.
+  ][
+    Addressed in both locations: #pinpoint(<r1-10>).
+
+    Shown as two separate excerpts, one per location:
+
+    #pinpoint(<r1-10>, excerpt: true)
+  ]
+
+]
+
+#pagebreak()
+
+#reviewer(2)[
+
+  #exchange(<r2-1>)[
+    The "Statistical analysis" heading should indicate that the analysis
+    plan changed relative to what was originally registered.
+  ][
+    The heading has been updated accordingly.
+
+    #pinpoint(<r2-1>, excerpt: true)
+  ]
+
+  #exchange(<r2-2>)[
+    A subgroup analysis (recipient seniority, day sent, CC'd manager,
+    email length) would help readers judge how broadly the main finding
+    generalizes.
+  ][
+    A subgroup figure has been added, reporting the requested
+    comparisons. #pinpoint(<r2-2>)
+  ]
+
+  #exchange(<r2-3>)[
+    The "🙏" null-comparator sub-analysis is an unusual choice and,
+    frankly, distracts from the paper's main contribution — consider
+    removing it given the space constraints.
+  ][
+    We agree and have removed this sub-analysis in its entirety,
+    including its figure and table.
+
+    #pinpoint(<r2-3>, excerpt: true)
+  ]
+
+  #exchange(<r2-4>)[
+    The discussion's causal language ("causes an increase") is stronger
+    than the observational design supports, IPW notwithstanding.
+  ][
+    We have softened this to an associational claim and flagged residual
+    confounding by unmeasured sender urgency, in the same spirit as our
+    response to #xcomment(<r1-2>) on accounting for measured confounders.
+
+    #pinpoint(<r2-4>, excerpt: true)
+  ]
+
+  #exchange(<r2-5>)[
+    Using battery level as an instrument seems like a stretch — please
+    justify the exclusion restriction more carefully, or drop this
+    analysis.
+  ][
+    We have added an explicit statement of the exclusion restriction and
+    a citation to prior work on battery-level instruments in applied
+    econometrics; we believe the assumption, while unusual, is no less
+    defensible than in other applications of the design.
+
+    #pinpoint(<r2-5>)
+  ]
+
+  #exchange(<r2-6>)[
+    The reply-type table should include a "reacted only, no reply"
+    category — a thumbs-up reaction with no further text is common
+    enough in our experience to warrant its own row.
+  ][
+    Added, at 7% of threads by the 48-hour mark.
+
+    #pinpoint(<r2-6>, excerpt: true)
+  ]
+
+  #exchange(<r2-7>)[
+    The reply-latency table duplicates what Figure 1 already shows and
+    could be cut for space.
+  ][
+    Agreed that it's redundant with the figure; removed from the
+    submitted manuscript. We've kept it visible in the tracked version
+    below, for your convenience in checking it against the figure,
+    rather than collapsing it to a bare note.
+
+    #pinpoint(<r2-7>, excerpt: true, mode: "tracked")
+  ]
+
+]
+
+#pagebreak()
+
+#editor[
+
+  #exchange(<e1>)[
+    Please ensure that every figure and table added or modified in
+    response to the reviewers is cited with a page number in this
+    letter, per journal policy.
+  ][
+    Done throughout; see in particular the subgroup figure, referenced
+    at #xref(<fig-forest>), and the reply-type table, referenced at
+    #xref(<tab-replytype>).
+  ]
+
+]
+
+== Author notes
+
+The changes above address every reviewer and editor comment. Two
+further, smaller notes are recorded here for transparency, even though
+neither answers a specific reviewer comment.
+
+#author("marcus")[
+
+  #note(<marcus-1>)[
+    While implementing the change requested in our response to
+    #xcomment(<r1-2>), I checked covariate balance after weighting and
+    added a note confirming adequate overlap.
+
+    #pinpoint(<marcus-1>, excerpt: true)
+  ]
+
+]
+
+#author("constance")[
+
+  #note(<constance-1>)[
+    Re-read the sign-off definition after the change above and confirm
+    it still matches our extraction procedure.
+
+    #pinpoint(<constance-1>)
+  ]
+
+]
+
+== For the reviewers only
+
+The table below summarizes, for the reviewers' convenience only, how
+many comments from each reviewer led to an actual textual or figure/
+table change in the manuscript, as opposed to a clarification with no
+change — consistent with prior work on the sociology of email reply
+latency #cite(<latency2018>, form: "prose").
+
+#figure(
+  table(
+    columns: 3,
+    table.header[Reviewer][Comments][Led to a change],
+    [Reviewer 1], [10], [8],
+    [Reviewer 2], [7], [7],
+  ),
+  caption: [Summary of comments and resulting changes, for the reviewers' convenience.],
+) <tab-summary>
+
+As shown in @tab-summary, the large majority of comments from both
+reviewers led directly to a manuscript change, consistent with our own
+prior finding that inbox behavior is, if nothing else, a reliable
+trigger for further action #cite(<replyall2020>, form: "prose").
+
+#letter-bibliography("/examples/emoji-email/responses.bib")

--- a/packages/preview/palimpsest/0.1.0/examples/fridge-study/main.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/fridge-study/main.typ
@@ -1,0 +1,59 @@
+#import "@preview/palimpsest:0.1.0": *
+#import "@preview/unequivocal-ams:0.1.2": ams-article, theorem, proof
+
+// A lightweight letter template echoing the manuscript's own typeface,
+// rather than reusing `ams-article` itself — the letter is a short
+// reviewer-facing document, not a second article with its own title
+// page, abstract, and author block.
+#let letter-template(body) = {
+  set text(font: "New Computer Modern", size: 10pt)
+  set par(justify: true, first-line-indent: 0em)
+  align(center, text(size: 1.3em, weight: 700)[Response to Reviewers])
+  v(0.3em)
+  align(center, emph[Association between fridge opening frequency and
+  probability of finding something new inside])
+  v(1.5em)
+  body
+}
+
+#show: revisions.with(
+  template: ams-article.with(
+    title: [Association between fridge opening frequency and probability
+    of finding something new inside],
+    authors: (
+      (
+        name: "Ivana Snackwell",
+        department: [Department of Kitchen Epidemiology],
+        organization: [Institute of Domestic Sciences],
+        location: [Fridgeport, IL],
+        email: "ivana.snackwell@example.org",
+      ),
+      (
+        name: "Tupper Ware",
+        department: [Behavioral Nutrition Laboratory],
+        organization: [University of Leftovers],
+        location: [Crispington, OH],
+        email: "tupper.ware@example.org",
+      ),
+    ),
+    abstract: [
+      Background: repeated refrigerator-door-opening behavior ("fridge-
+      checking") is common, but its relationship to the subjective
+      probability of discovering something new inside remains
+      uncharacterized. Methods: we conducted a 30-day prospective
+      observational study of 42 households, logging daily fridge-opening
+      frequency and self-reported discovery of novel contents. Results:
+      discovery probability increased steadily with opening frequency,
+      despite grocery deliveries being held constant across groups.
+      Conclusion: these findings are consistent with an intermittent-
+      reinforcement account of fridge-checking behavior, in which
+      occasional genuine discoveries maintain a high rate of
+      unrewarded checking.
+    ],
+    bibliography: bibliography("manuscript.bib"),
+  ),
+  exchanges: include "responses.typ",
+  letter-template: letter-template,
+)
+
+#include "manuscript.typ"

--- a/packages/preview/palimpsest/0.1.0/examples/fridge-study/manuscript.bib
+++ b/packages/preview/palimpsest/0.1.0/examples/fridge-study/manuscript.bib
@@ -1,0 +1,24 @@
+@article{snackwell2020,
+  author  = {Snackwell, Ivana},
+  title   = {The Fridge-Checking Phenomenon: A Preliminary Report},
+  journal = {Journal of Kitchen Epidemiology},
+  year    = {2020},
+}
+@article{midnightsnackers2019,
+  author  = {Ware, Tupper and Crumb, Nibble},
+  title   = {Defining Fridge-Checking Behavior: A Delphi Consensus Study},
+  journal = {Annals of Domestic Science},
+  year    = {2019},
+}
+@article{geemodel2017,
+  author  = {Estimator, Gene E.},
+  title   = {Generalized Estimating Equations for Clustered Snacking Data},
+  journal = {Journal of Applied Statistics},
+  year    = {2017},
+}
+@article{confoundcheese2022,
+  author  = {Brie, Camille},
+  title   = {Unmeasured Hunger Confounding in Observational Kitchen Studies},
+  journal = {Epidemiologic Methods},
+  year    = {2022},
+}

--- a/packages/preview/palimpsest/0.1.0/examples/fridge-study/manuscript.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/fridge-study/manuscript.typ
@@ -1,0 +1,335 @@
+#import "@preview/palimpsest:0.1.0": *
+#import "@preview/unequivocal-ams:0.1.2": theorem, proof
+#import "@preview/lilaq:0.6.0" as lq
+
+// Numbered display equations — unnumbered by default under this
+// template, but a numbered model equation is common enough in a real
+// paper to be worth demonstrating, and it's what lets the equation
+// pinpoint(<r1-3>, excerpt: true) quotes below show a real number to
+// match against.
+#set math.equation(numbering: "(1)")
+
+// The two co-authors, so they can leave their own notes below alongside
+// the reviewers' — Ivana with an explicit color, Tupper with just a
+// display name (still gets an automatic, distinct color).
+#set-revisions(authors: (
+  ivana: (name: "Ivana Snackwell", color: rgb("#0f766e")),
+  tupper: "Tupper Ware",
+))
+
+// Shown only in manuscript-tracked.pdf (change-list() auto-hides in
+// clean, see §7.3) — a table of every marked passage, for checking off
+// against the reviewers' letter one by one.
+#change-list()
+
+= Introduction
+
+Refrigerators are widely believed to be static containers whose contents
+change only through the deliberate actions of their owners. This
+assumption has rarely been tested directly. In this study, we
+investigate whether the frequency with which a refrigerator door is
+opened — a behavior we term fridge-checking — is associated with the
+subjective probability that its owner reports finding something new
+inside, independent of whether anything was actually added to the
+refrigerator during the observation period.
+
+#passage(<r1-1>)[
+  We define fridge-checking #add[, following the terminology introduced
+  by @midnightsnackers2019,] as any refrigerator-door-opening event that
+  is not immediately followed by either the removal or the addition of a
+  food item.
+]
+
+#touched(<ivana-1>)[
+  We re-read this definition after the change above and confirm it
+  still matches how fridge-checking events were actually coded during
+  data collection.
+]
+
+#passage(<r1-10>)[
+  #add[This comment from the first reviewer required a correction in two
+  places in the manuscript — this sentence, in the introduction, and a
+  matching one in the conclusion —] applies equally to both instances.
+]
+
+Anecdotally, household members report opening the refrigerator
+repeatedly over short periods despite reporting no expectation that its
+contents have changed. We refer to this informally as the "hope springs
+eternal" hypothesis, a fridge-specific corollary of general optimism
+bias. This preliminary report builds on our earlier observational work
+#cite(<snackwell2020>) by formally quantifying the relationship between
+opening frequency and discovery probability across a larger and more
+diverse sample of households.
+
+#lorem(90)
+
+= Methods
+
+== Study population and design
+
+We recruited 42 households across three cities to participate in a
+30-day prospective observational study. Eligible households were
+required to own at least one refrigerator, have at least one adult
+member willing to complete a daily fridge-opening log, and report no
+professional catering experience, to exclude expert fridge-checkers, who
+were assumed to behave differently.
+
+#touched(<r1-4>)[
+  Households were recruited via flyers posted in laundromats, grocery
+  stores, and one particularly well-trafficked gym.
+]
+
+#lorem(60)
+
+#passage(<r1-5>)[
+  #figure(
+    placement: auto,
+    table(
+      columns: 4,
+      table.header[][*Low tertile*][*Medium tertile*][*High tertile*],
+      [Household size, mean], [1.8], [2.4], [#rep[2.6][3.1]],
+      [Owns a pet, %], [12], [19], [31],
+      [Fridge magnets, median], [3], [5], [9],
+      [Snacks after 10pm, %], [21], [38], [64],
+    ),
+    caption: [Household characteristics by tertile of daily fridge-opening frequency.],
+  ) <tab-baseline>
+]
+
+As shown in @tab-baseline, households in the high-opening tertile
+reported markedly more fridge magnets and a higher prevalence of
+after-hours snacking.
+
+== #passage(<r2-1>)[Statistical analysis #add[(updated)]]
+
+#passage(<r1-2>)[
+  #rep[The association between opening frequency and discovery
+  probability was assessed using ordinary logistic regression, with one
+  observation per household.][The association between opening frequency
+  and discovery probability was assessed using generalized estimating
+  equations with an exchangeable working correlation structure
+  #cite(<geemodel2017>), to account for the repeated, within-household
+  structure of the daily opening logs.]
+]
+
+#passage(<r1-3>)[
+  The primary model
+  #rep[
+    $ P("discovery") = beta_0 + beta_1 dot "openings" $
+  ][
+    $ "logit"(P("discovery")) = beta_0 + beta_1 dot "openings" + u_"household" $ <eq-model>
+  ]
+  #rep[is a naive linear probability model.][, where $u_"household"$ is a
+  household-level random effect absorbing unmeasured, time-invariant
+  fridge-checking tendencies.]
+]
+
+#passage(<tupper-1>)[
+  #add[While implementing the change above, we also noted that the
+  estimated household-level random effect variance, $hat(sigma)^2_u =
+  0.42$, is worth reporting explicitly: it indicates non-trivial
+  between-household heterogeneity in fridge-checking tendencies beyond
+  what opening frequency alone explains.]
+]
+
+#lorem(70)
+
+#deleted(<r1-6>, summary: [the closed-form calibration equation, which
+  became algebraically identical to the model equation above once it was
+  refit with a logit link])[
+  For completeness, calibrated discovery probabilities were also
+  computed directly as
+  $ hat(p) = "expit"(hat(beta)_0 + hat(beta)_1 dot "openings") $
+]
+
+#lorem(50)
+
+#theorem[
+  For any household refrigerator observed for a sufficiently long time,
+  there exists at least one food item whose provenance cannot be
+  established by any current member of the household.
+]
+
+#passage(<r2-5>)[
+  #add[We propose to call this the Second Law of Fridge Thermodynamics.]
+]
+
+#proof[
+  Suppose, for contradiction, that every item in the refrigerator has a
+  known provenance at every point in time. Then no item could ever
+  transition from "recently purchased" to "mystery item" without an
+  intervening act of forgetting. But forgetting is, empirically,
+  unavoidable over a sufficiently long observation window
+  #cite(<snackwell2020>). This contradicts the assumption, and the claim
+  follows.
+]
+
+= Results
+
+#lorem(60)
+
+#figure(
+  placement: auto,
+  lq.diagram(
+    width: 8cm,
+    height: 5cm,
+    xlabel: [Daily fridge openings],
+    ylabel: [Discovery probability (%)],
+    yaxis: (lim: (0, 85)),
+    xaxis: (ticks: ((1, "1–2"), (2, "3–5"), (3, "6–10"), (4, "11–20"), (5, ">20"))),
+    lq.bar(
+      (1, 2, 3, 4, 5),
+      (14, 27, 41, 58, 73),
+      fill: rgb("#7a9e7e"),
+      width: 70%,
+    ),
+  ),
+  caption: [Reported probability of finding something new inside the
+  refrigerator, by daily opening frequency (openings per day).],
+) <fig-dose-response>
+
+#touched(<e1>)[
+  @fig-dose-response shows an apparent dose-response relationship
+  between opening frequency and discovery probability, despite grocery
+  deliveries being held constant across groups by design.
+]
+
+#lorem(70)
+
+#passage(<r2-2>)[
+  #add[
+    #figure(
+      placement: auto,
+      lq.diagram(
+        width: 7.5cm,
+        height: 4.2cm,
+        xlabel: [Odds ratio (95% CI)],
+        xlim: (0, 3),
+        yaxis: (
+          ticks: (
+            (1, "Owns a fridge\norganizer"),
+            (2, "Weekend vs.\nweekday"),
+            (3, "Lives alone"),
+            (4, "Owns a pet"),
+          ),
+          lim: (0.5, 4.5),
+        ),
+        lq.vlines(1, stroke: (paint: gray, dash: "dashed")),
+        lq.plot(
+          (0.8, 2.0, 1.1, 1.6),
+          (1, 2, 3, 4),
+          xerr: ((p: 0.3, m: 0.3), (p: 0.7, m: 0.6), (p: 0.6, m: 0.5), (p: 0.5, m: 0.4)),
+          stroke: none,
+          mark: "o",
+        ),
+      ),
+      caption: [Subgroup odds ratios for the association between
+      opening frequency and discovery probability.],
+    ) <fig-forest>
+  ]
+]
+
+#lorem(90)
+
+#deleted(<r2-7>, summary: [the day-of-week discovery-rate chart, redundant with @fig-dose-response])[
+  #figure(
+    lq.diagram(
+      width: 6.5cm,
+      height: 3.6cm,
+      xlabel: [Day of week],
+      ylabel: [Discovery rate (%)],
+      xaxis: (ticks: ((1, "Mon"), (2, "Tue"), (3, "Wed"), (4, "Thu"), (5, "Fri"), (6, "Sat"), (7, "Sun"))),
+      yaxis: (lim: (0, 60)),
+      lq.plot(
+        (1, 2, 3, 4, 5, 6, 7),
+        (38, 40, 37, 41, 39, 44, 42),
+        stroke: rgb("#7a9e7e"),
+        mark: "o",
+      ),
+    ),
+    caption: [Discovery rate by day of week.],
+  )
+]
+
+#lorem(60)
+
+#suppressed(
+  <r2-3>,
+  [Sub-analysis removed: the sock-drawer control group, including its
+  summary figure and table],
+  summary: [the sock-drawer control group sub-analysis, including its
+  figure and table],
+)
+
+#lorem(80)
+
+#passage(<r2-6>)[
+  #figure(
+    placement: auto,
+    table(
+      columns: 3,
+      table.header[Category][Day 1][Day 30],
+      [Forgotten leftovers], [61%], [58%],
+      [Mystery Tupperware], [24%], [22%],
+      [Something green], [9%], [7%],
+      [Actually edible food], [6%], [13%],
+      // An ADDED row stays in both compiles (add[...] alone handles the
+      // clean-vs-tracked styling) — no `if mode() == "clean" { () }
+      // else {...}` gating, that pattern is for a row genuinely
+      // absent from the submitted manuscript (a DELETED row, see
+      // tests/marks-figures.typ), not an accepted addition. An earlier
+      // version of this table wrongly hid this row from manuscript.pdf
+      // entirely (see CLAUDE.md) — a real defect, since the row is
+      // actually part of what's submitted, added in response to R2-6.
+      add[Unidentified frozen object], add[--], add[3%],
+    ),
+    caption: [Fridge discovery categories, day 1 versus day 30 of observation.],
+  ) <tab-discovery>
+]
+
+As shown in @tab-discovery, the proportion of discoveries classified as
+"actually edible food" more than doubled over the observation period.
+
+#suppressed(
+  <r1-9>,
+  [Sensitivity analysis removed: results by handle-contamination threshold],
+  summary: [the sensitivity analysis by handle-contamination threshold],
+)
+
+#lorem(60)
+
+#passage(<r1-7>)[
+  #add[A sensitivity analysis was conducted to assess robustness to
+  unmeasured hunger confounding, following @confoundcheese2022.]
+]
+
+#lorem(100)
+
+= Discussion
+
+#lorem(80)
+
+#passage(<r2-4>)[
+  #rep[These results suggest that fridge-checking behavior causes an
+  increase in perceived discovery probability.][These results are
+  consistent with an association between fridge-checking behavior and
+  perceived discovery probability, though the observational design and
+  the absence of a formal blinding procedure for refrigerator contents
+  limit causal interpretation.]
+]
+
+#lorem(90)
+
+= Conclusion
+
+#touched(<r1-8>)[
+  Taken together, these findings suggest that the refrigerator door
+  itself may function as an intermittent-reinforcement device, rewarding
+  repeated checking with an occasional, genuinely novel discovery.
+]
+
+#passage(<r1-10>)[
+  #add[As already noted in the introduction, this conclusion applies
+  equally to the paired instance of the same reviewer comment discussed
+  there.]
+]

--- a/packages/preview/palimpsest/0.1.0/examples/fridge-study/responses.bib
+++ b/packages/preview/palimpsest/0.1.0/examples/fridge-study/responses.bib
@@ -1,0 +1,24 @@
+@article{snackwell2020,
+  author  = {Snackwell, Ivana},
+  title   = {The Fridge-Checking Phenomenon: A Preliminary Report},
+  journal = {Journal of Kitchen Epidemiology},
+  year    = {2020},
+}
+@article{midnightsnackers2019,
+  author  = {Ware, Tupper and Crumb, Nibble},
+  title   = {Defining Fridge-Checking Behavior: A Delphi Consensus Study},
+  journal = {Annals of Domestic Science},
+  year    = {2019},
+}
+@article{geemodel2017,
+  author  = {Estimator, Gene E.},
+  title   = {Generalized Estimating Equations for Clustered Snacking Data},
+  journal = {Journal of Applied Statistics},
+  year    = {2017},
+}
+@article{peek2015,
+  author  = {Ajar, Doris},
+  title   = {The Observer Effect in Refrigerator Peeking},
+  journal = {Journal of Irreproducible Snacking},
+  year    = {2015},
+}

--- a/packages/preview/palimpsest/0.1.0/examples/fridge-study/responses.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/fridge-study/responses.typ
@@ -1,0 +1,275 @@
+#import "@preview/palimpsest:0.1.0": *
+
+We thank both reviewers, and the editor, for their careful reading of
+the manuscript. Below we address each comment in turn, with the
+corresponding change cited by page number in the manuscript.
+
+#reviewer(1)[
+
+  #exchange(<r1-1>)[
+    "Fridge-checking" needs an operational definition, not just an
+    intuitive label — otherwise readers cannot tell it apart from
+    ordinary refrigerator use.
+  ][
+    We have added an explicit definition, following the Delphi consensus
+    terminology of Ware and Crumb.
+
+    #pinpoint(<r1-1>, excerpt: true)
+  ]
+
+  #exchange(<r1-2>)[
+    A single logistic regression with one observation per household
+    seems to discard information — weren't opening events logged daily
+    over 30 days per household?
+  ][
+    Correct, and thank you for catching this. We now use generalized
+    estimating equations to account for the repeated, within-household
+    structure of the data, rather than collapsing to one observation per
+    household.
+
+    #pinpoint(<r1-2>, excerpt: true, mode: "tracked")
+  ]
+
+  #exchange(<r1-3>)[
+    Please also update the model equation itself to match the revised
+    analysis — a linear probability model for a probability outcome is
+    not appropriate here.
+  ][
+    Done; the model is now written on the logit scale, with an added
+    household-level random effect, numbered (1) in the manuscript:
+
+    #pinpoint(<r1-3>, excerpt: true)
+  ]
+
+  #exchange(<r1-4>)[
+    How were households actually recruited? "Flyers" alone is a bit
+    vague for a methods section.
+  ][
+    We have kept this wording, which we believe is already sufficiently
+    specific once the recruitment venues are listed.
+
+    #pinpoint(<r1-4>, excerpt: true)
+  ]
+
+  #exchange(<r1-5>)[
+    Table 1's household-size figure for the high tertile looks
+    inconsistent with the number reported in the abstract — please
+    reconcile.
+  ][
+    Thank you for catching this; the table has been corrected.
+
+    #pinpoint(<r1-5>, excerpt: true)
+  ]
+
+  #exchange(<r1-6>)[
+    The calibration equation appears to duplicate the main model
+    equation once the model is refit on the logit scale — is it still
+    needed?
+  ][
+    Good catch, it is not: once refit with a logit link, the calibration
+    equation collapses to the same closed form as the model equation
+    above, so we have removed it as redundant.
+
+    #pinpoint(<r1-6>, excerpt: true)
+  ]
+
+  #exchange(<r1-7>)[
+    An analysis of robustness to unmeasured confounding — hunger, in
+    particular, given the subject matter — is missing.
+  ][
+    We agree this was a gap and have added a sensitivity analysis for
+    unmeasured hunger confounding, cited in the manuscript.
+    #pinpoint(<r1-7>)
+  ]
+
+  #exchange(<r1-8>)[
+    The conclusion's "intermittent-reinforcement device" framing is
+    memorable but should probably be tied more explicitly to the
+    behavioral literature — or else softened.
+  ][
+    We have reviewed this passage and, on balance, prefer to keep the
+    wording as originally written; we believe the framing is
+    self-explanatory in context.
+
+    #pinpoint(<r1-8>, excerpt: true)
+  ]
+
+  #exchange(<r1-9>)[
+    Please also report sensitivity to the door-handle contamination
+    threshold used to define a "genuine" opening event.
+  ][
+    This analysis was performed but, on reflection, is redundant with
+    the hunger-confounding sensitivity analysis and has been removed for
+    concision.
+
+    #pinpoint(<r1-9>, excerpt: true)
+  ]
+
+  #exchange(<r1-10>)[
+    One comment, filed here for convenience even though it concerns two
+    separate locations in the manuscript: the operational definition of
+    fridge-checking, introduced early on, should be explicitly
+    reaffirmed in the conclusion, so that a reader who skips straight to
+    the conclusion isn't left guessing what was actually measured.
+  ][
+    Addressed in both locations: #pinpoint(<r1-10>).
+
+    Shown as two separate excerpts, one per location:
+
+    #pinpoint(<r1-10>, excerpt: true)
+  ]
+
+]
+
+#pagebreak()
+
+#reviewer(2)[
+
+  #exchange(<r2-1>)[
+    The "Statistical analysis" heading should indicate that the analysis
+    plan changed relative to what was originally registered.
+  ][
+    The heading has been updated accordingly.
+
+    #pinpoint(<r2-1>, excerpt: true)
+  ]
+
+  #exchange(<r2-2>)[
+    A subgroup analysis (pet ownership, household size, weekday versus
+    weekend) would help readers judge how broadly the main finding
+    generalizes.
+  ][
+    A subgroup figure has been added, reporting the requested
+    comparisons. #pinpoint(<r2-2>)
+  ]
+
+  #exchange(<r2-3>)[
+    The sock-drawer control group is an unusual choice and, frankly,
+    distracts from the paper's main contribution — consider removing it
+    given the space constraints.
+  ][
+    We agree and have removed this sub-analysis in its entirety,
+    including its figure and table.
+
+    #pinpoint(<r2-3>, excerpt: true)
+  ]
+
+  #exchange(<r2-4>)[
+    The discussion's causal language ("causes an increase") is stronger
+    than the observational design supports.
+  ][
+    We have softened this to an associational claim and noted the
+    absence of a formal blinding procedure for refrigerator contents, in
+    the same spirit as our response to #xcomment(<r1-2>) on accounting
+    properly for the repeated-measures structure of the data.
+
+    #pinpoint(<r2-4>, excerpt: true)
+  ]
+
+  #exchange(<r2-5>)[
+    Theorem 1 is charming, but if it is to remain in a revised
+    manuscript it should at least be given a name, so it can be cited by
+    future work.
+  ][
+    We have named it the Second Law of Fridge Thermodynamics.
+    #pinpoint(<r2-5>)
+  ]
+
+  #exchange(<r2-6>)[
+    Table 2 (fridge discovery categories) should include an
+    "unidentified frozen object" category — in our experience this is
+    the single most common terminal state of a forgotten leftover.
+  ][
+    Added, at 3% of day-30 discoveries.
+
+    #pinpoint(<r2-6>, excerpt: true)
+  ]
+
+  #exchange(<r2-7>)[
+    The day-of-week discovery-rate chart doesn't add much beyond
+    Figure 1's opening-frequency trend and could be cut for space.
+  ][
+    Agreed and removed from the submitted manuscript; still visible in
+    the tracked version for reference. #pinpoint(<r2-7>)
+  ]
+
+]
+
+#pagebreak()
+
+#editor[
+
+  #exchange(<e1>)[
+    Please ensure that every figure and table added or modified in
+    response to the reviewers is cited with a page number in this
+    letter, per journal policy.
+  ][
+    Done throughout; see in particular the subgroup figure, referenced
+    at #xref(<fig-forest>), and the discovery-categories table,
+    referenced at #xref(<tab-discovery>).
+  ]
+
+]
+
+== Author notes
+
+The changes above address every reviewer and editor comment. Two
+further, smaller changes were made on our own initiative during
+revision, noted here for transparency even though neither answers a
+specific reviewer comment.
+
+#author("tupper")[
+
+  #note(<tupper-1>)[
+    While implementing the change requested in our response to
+    #xcomment(<r1-2>), I noticed the household-level random effect
+    variance was worth reporting explicitly, so I added it.
+
+    #pinpoint(<tupper-1>, excerpt: true)
+  ]
+
+]
+
+#author("ivana")[
+
+  #note(<ivana-1>)[
+    Re-read the fridge-checking definition after the change above and
+    confirm it still matches our coding procedure.
+
+    #pinpoint(<ivana-1>)
+  ]
+
+]
+
+== For the reviewers only
+
+The table below summarizes, for the reviewers' convenience only, how
+many comments from each reviewer led to an actual textual or figure/
+table change in the manuscript, as opposed to a clarification with no
+change — consistent with the general observation that peer review of
+a self-monitoring behavior tends to attract more critical attention
+than the behavior itself #cite(<peek2015>, form: "prose").
+
+// Captioned "Table R3", not "Table R1", even though this is the only
+// table the letter adds on its own — the two tables quoted above
+// (<r1-5>, <r2-6>, both pinpoint(excerpt: true)) now show the
+// manuscript's own real numbers ("Table 1"/"Table 2") rather than "R"
+// ones, but they still occupy the first two slots of the letter's own
+// counter; only the *displayed* number changed, not how many slots a
+// quoted table consumes. See docs/manual.typ, "Letter numbering".
+#figure(
+  table(
+    columns: 3,
+    table.header[Reviewer][Comments][Led to a change],
+    [Reviewer 1], [10], [8],
+    [Reviewer 2], [7], [7],
+  ),
+  caption: [Summary of comments and resulting changes, for the reviewers' convenience.],
+) <tab-summary>
+
+As shown in @tab-summary, the large majority of comments from both
+reviewers led directly to a manuscript change, consistent with our own
+prior finding that fridge-checking behavior is, if nothing else, a
+reliable trigger for further action #cite(<snackwell2020>, form: "prose").
+
+#letter-bibliography("/examples/fridge-study/responses.bib")

--- a/packages/preview/palimpsest/0.1.0/examples/pilot/main.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/pilot/main.typ
@@ -1,0 +1,27 @@
+#import "@preview/palimpsest:0.1.0": *
+
+// Stand-in for a real Universe template — swap this for your journal's
+// actual template (arkheion, a two-column class, etc.). The only
+// contract `revisions` needs from `template:` is `content -> content`,
+// same as anything used with `#show:`.
+#let my-template(title: none, authors: (), body) = {
+  set page(width: 14cm, height: auto, margin: 1.5cm)
+  set text(size: 10pt)
+  set heading(numbering: "1.")
+  align(center, text(size: 1.6em, weight: "bold")[#title])
+  v(0.3em)
+  align(center, authors.map(a => a.name).join(", "))
+  v(1.5em)
+  body
+}
+
+#show: revisions.with(
+  template: my-template.with(
+    title: [Emulating a target trial of early vasopressors],
+    authors: ((name: "D. H.", affiliation: "Sorbonne Université"),),
+  ),
+  exchanges: include "responses.typ",
+  round: 1,
+)
+
+#include "manuscript.typ"

--- a/packages/preview/palimpsest/0.1.0/examples/pilot/manuscript.bib
+++ b/packages/preview/palimpsest/0.1.0/examples/pilot/manuscript.bib
@@ -1,0 +1,6 @@
+@article{hernan2016,
+  author  = {Hernán, Miguel A.},
+  title   = {Discussion on target trial emulation},
+  journal = {American Journal of Epidemiology},
+  year    = {2016},
+}

--- a/packages/preview/palimpsest/0.1.0/examples/pilot/manuscript.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/pilot/manuscript.typ
@@ -1,0 +1,38 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#change-list()
+
+= Introduction
+
+#lorem(20)
+
+#passage(<r1-1>)[
+  Propensity scores were estimated by logistic regression
+  #add[and their overlap was assessed graphically, following the
+  approach of @hernan2016].
+]
+
+= Methods
+
+#passage(<r1-2>)[
+  The positivity assumption #rep[was not discussed][is now assessed
+  graphically, see @fig-positivity].
+]
+#added(<r1-2>)[
+#figure(
+  rect(width: 4cm, height: 2cm, fill: luma(230)),
+  caption: [Distribution of propensity scores.],
+) <fig-positivity>
+]
+
+#passage(<r2-1>)[
+  A truncation-based sensitivity analysis #add[has also been performed (data not shown)].
+]
+
+= Discussion
+
+#touched(<r1-3>)[
+  We have kept this wording, which we believe remains appropriate.
+]
+
+#bibliography("manuscript.bib", title: [References])

--- a/packages/preview/palimpsest/0.1.0/examples/pilot/responses.bib
+++ b/packages/preview/palimpsest/0.1.0/examples/pilot/responses.bib
@@ -1,0 +1,6 @@
+@article{jones2021,
+  author  = {Jones, Alice},
+  title   = {On sensitivity analyses},
+  journal = {Journal of Methods},
+  year    = {2021},
+}

--- a/packages/preview/palimpsest/0.1.0/examples/pilot/responses.typ
+++ b/packages/preview/palimpsest/0.1.0/examples/pilot/responses.typ
@@ -1,0 +1,44 @@
+#import "@preview/palimpsest:0.1.0": *
+
+#reviewer(1)[
+
+  #exchange(<r1-1>)[
+    The authors should clarify how immortal time bias is handled in the
+    emulation.
+  ][
+    We thank the reviewer for this important point. The overlap of
+    propensity scores has now been assessed graphically (see the method
+    in the manuscript). #pinpoint(<r1-1>)
+  ]
+
+  #exchange(<r1-2>)[
+    The positivity assumption is not discussed.
+  ][
+    The positivity assumption is now assessed graphically.
+
+    #pinpoint(<r1-2>, excerpt: true)
+  ]
+
+  #exchange(<r1-3>)[
+    Please double-check the wording of the discussion section.
+  ][
+    We have kept this wording, which we believe remains appropriate at
+    this stage. #pinpoint(<r1-3>)
+  ]
+
+]
+
+#reviewer(2)[
+
+  #exchange(<r2-1>)[
+    A sensitivity analysis would strengthen the results.
+  ][
+    A truncation-based sensitivity analysis has been added, as suggested
+    by @jones2021. #pinpoint(<r2-1>)
+  ]
+
+]
+
+For reference, the propensity score figure is #xref(<fig-positivity>).
+
+#letter-bibliography("/examples/pilot/responses.bib")

--- a/packages/preview/palimpsest/0.1.0/lib.typ
+++ b/packages/preview/palimpsest/0.1.0/lib.typ
@@ -1,0 +1,48 @@
+#import "src/marks.typ"
+#import "src/style.typ"
+#import "src/diagnostics.typ"
+#import "src/exchange.typ"
+#import "src/pinpoint.typ"
+#import "src/letter.typ"
+#import "src/xref.typ"
+#import "src/revisions.typ"
+#import "src/change-list.typ"
+
+// Marking
+#let mode = marks.mode
+#let passage = marks.passage
+#let add = marks.add
+#let del = marks.del
+#let rep = marks.rep
+#let added = marks.added
+#let deleted = marks.deleted
+#let replaced = marks.replaced
+#let touched = marks.touched
+#let suppress = marks.suppress
+#let suppressed = marks.suppressed
+
+// Style
+#let set-revisions = style.set-revisions
+
+// Diagnostics
+#let set-strict = diagnostics.set-strict
+
+// Exchanges
+#let reviewer = exchange.reviewer
+#let editor = exchange.editor
+#let author = exchange.author
+#let xcomment = exchange.xcomment
+#let note = exchange.note
+#let exchange = exchange.exchange
+
+// Letter
+#let pinpoint = pinpoint.pinpoint
+#let letter-bibliography = letter.letter-bibliography
+#let default-letter-template = letter.default-letter-template
+#let xref = xref.xref
+
+// Pilot
+#let revisions = revisions.revisions
+
+// Change list
+#let change-list = change-list.change-list

--- a/packages/preview/palimpsest/0.1.0/src/change-list.typ
+++ b/packages/preview/palimpsest/0.1.0/src/change-list.typ
@@ -1,0 +1,104 @@
+#import "marks.typ": mode
+#import "utils.typ": parse-anchor
+
+/// English label for each mark kind (§6decies: package-generated text is
+/// fixed English, not configurable). A passage mixing several kinds (e.g.
+/// a manually composed `#del[...] #add[...]` rather than `rep`) shows
+/// every kind it contains, in the order they first appear, joined with
+/// "/" — there's no single "correct" label for a passage that both
+/// removes and adds text without being a `rep`.
+#let type-labels = (
+  add: "addition",
+  del: "deletion",
+  rep: "replacement",
+  suppress: "suppression",
+)
+
+/// "R1-2, R2-1", or "—" for a passage with no anchor (an anonymous
+/// typographical fix) — same convention `passage` itself uses for
+/// `show-anchor` (`marks.typ`).
+#let format-anchor-list(anchors) = {
+  if anchors.len() == 0 { [—] } else { anchors.map(a => upper(str(a))).join(", ") }
+}
+
+/// Sort key grouping rows the way a reviewer's own numbered list of
+/// comments reads: reviewers in order, each reviewer's comments in
+/// order, then co-authors (alphabetical by id, then by change number —
+/// authors have no natural numeric ordering the way reviewers do, so
+/// alphabetical is the simplest stable default for a summary table),
+/// then editor comments, anchor-less passages last (mirrors the spec's
+/// own example table, §10.3) — this is what makes the table useful as a
+/// checklist against the letter, not just a readout of document order.
+/// A passage's first anchor decides its key, same convention as
+/// `anchors-color` (`style.typ`). Bucket numbers only ever get compared
+/// against same-bucket numbers in practice (`.sorted()` short-circuits
+/// on the first differing tuple element), so mixing a string (author id)
+/// into the second slot alongside integers (reviewer/editor number) for
+/// other kinds is safe — verified directly.
+#let anchor-sort-key(anchors) = {
+  let p = if anchors.len() > 0 { parse-anchor(anchors.first()) } else { none }
+  if p == none {
+    (3, 0, 0)
+  } else if p.kind == "editor" {
+    (2, 0, p.num)
+  } else if p.kind == "author" {
+    (1, p.author, if p.num == none { 0 } else { p.num })
+  } else {
+    (0, p.reviewer, p.num)
+  }
+}
+
+/// Generates the "list of changes" table (§10.3): one row per `passage`
+/// (and its shortcuts `added`/`deleted`/`replaced`/`suppressed`) that
+/// carries at least one mark — an anchor that recurs across several
+/// passages gets one row per occurrence, each with its own page and
+/// section, exactly as the spec's own example shows (R1-2 listed twice).
+/// `touched` passages (no marks, `allow-empty: true`) never appear:
+/// nothing changed there to list.
+///
+/// Self-gates on the compile mode like `del`/`suppress` do: renders
+/// nothing in clean mode, so an author who places `#change-list()` once
+/// in shared manuscript content (typical: near the top, "usually placed
+/// at the head of the tracked version", §10.3) never has to remember to
+/// remove it before the clean compile ships to the journal.
+///
+/// `title` is the heading shown above the table (`none` to omit it,
+/// e.g. if the surrounding template already introduces the table).
+/// `level` picks which heading level counts as a row's "Section" —
+/// the nearest preceding heading at that level, defaulting to top-level
+/// sections (matches the spec example: "Introduction", "Methods",
+/// "Results", not their subsections). A row before any heading at that
+/// level shows "—".
+#let change-list(title: [Summary of changes], level: 1) = context {
+  if mode() == "clean" {
+    none
+  } else {
+    let hits = query(<palimpsest-passage>).filter(el => el.value.marks.len() > 0)
+    let rows = hits.map(h => {
+      let v = h.value
+      let kinds = v.marks.map(m => m.kind).dedup()
+      let heads = query(heading.where(level: level).before(h.location()))
+      (
+        sort-key: anchor-sort-key(v.anchors),
+        comment: format-anchor-list(v.anchors),
+        type: kinds.map(k => type-labels.at(k, default: k)).join("/"),
+        page: str(h.location().page()),
+        section: if heads.len() > 0 { heads.last().body } else { [—] },
+      )
+    }).sorted(key: r => r.sort-key)
+
+    if rows.len() == 0 {
+      none
+    } else {
+      if title != none {
+        block(text(weight: "bold")[#title])
+      }
+      table(
+        columns: (auto, auto, auto, 1fr),
+        align: (center, left, center, left),
+        table.header([*Comment*], [*Type*], [*Page*], [*Section*]),
+        ..rows.map(r => (r.comment, r.type, r.page, r.section)).flatten()
+      )
+    }
+  }
+}

--- a/packages/preview/palimpsest/0.1.0/src/diagnostics.typ
+++ b/packages/preview/palimpsest/0.1.0/src/diagnostics.typ
@@ -1,0 +1,45 @@
+// Typst has no public API to emit a soft compiler warning from user code
+// (github.com/typst/typst issues #1322, #600 — still open as of Typst
+// 0.15). The spec (§11) assumes warnings visible "in the editor, at the
+// fault location"; the closest available approximation is a visible
+// marker rendered directly at the fault location in the compiled output,
+// which most Typst editors preview live. `strict: true` upgrades the same
+// checks to real compile errors via `panic`.
+
+#let strict-state = state("palimpsest-strict", false)
+
+#let set-strict(v) = strict-state.update(v)
+
+/// Reports a diagnostic at the call site: a hard error under strict mode
+/// (any compile, clean or tracked — this is the CI gate), otherwise a
+/// visible inline marker.
+///
+/// `always: false` (the default) mutes the marker in the clean compile —
+/// for checks embedded *in the manuscript* (`passage`, marks): the clean
+/// compile produces `manuscript.pdf`, the file actually sent to the
+/// journal under blind review, and must never carry a visible marker
+/// regardless of strict mode being off.
+///
+/// `always: true` is for checks embedded in the *response letter*
+/// (`exchange`): v0.1 has no "tracked" compile of `response.pdf` the way
+/// it does for the manuscript (§9.1) — the only compile that ever
+/// produces `response.pdf` is the clean one — so muting there would mean
+/// these diagnostics are never seen in practice. A marker left in the
+/// letter is a lesser risk than one leaking into a blind-reviewed
+/// manuscript, but still worth fixing before submission; the author is
+/// expected to compile once more with `strict: true` right before
+/// sending, which fails loudly on either kind.
+#let diagnose(message, always: false) = context {
+  if strict-state.get() {
+    panic(message)
+  } else if always or sys.inputs.at("mode", default: "clean") != "clean" {
+    box(
+      fill: yellow.lighten(60%),
+      stroke: 0.5pt + red.darken(20%),
+      inset: (x: 4pt, y: 2pt),
+      radius: 2pt,
+    )[
+      #text(fill: red.darken(20%), weight: "bold", size: 0.85em)[⚠ #message]
+    ]
+  }
+}

--- a/packages/preview/palimpsest/0.1.0/src/exchange.typ
+++ b/packages/preview/palimpsest/0.1.0/src/exchange.typ
@@ -1,0 +1,217 @@
+#import "utils.typ": parse-anchor, is-blank
+#import "style.typ": reviewer-color, editor-color, author-color, author-display-name, style-state
+#import "diagnostics.typ": diagnose
+
+/// State holding which reviewer/editor/author section an `exchange`/
+/// `note` is currently under — set by `reviewer`/`editor`/`author` before
+/// rendering their body, read as a fallback header when the anchor
+/// itself doesn't parse with a number to key off of. Same "resolves by
+/// document position, not call order" trick as `current-passage-anchors`
+/// in `marks.typ`.
+#let current-exchange-context = state("palimpsest-exchange-context", none)
+
+/// Groups a reviewer's comments under a heading; also supplies the
+/// reviewer number and color to any `exchange` inside, and to
+/// `exchange`'s duplicate/orphan diagnostics.
+#let reviewer(n, body) = {
+  current-exchange-context.update((kind: "reviewer", n: n))
+  context [
+    #block(above: 1.2em, below: 0.8em)[
+      #text(size: 1.15em, weight: "bold", fill: reviewer-color(n))[Reviewer #n]
+    ]
+  ]
+  body
+  current-exchange-context.update(none)
+}
+
+/// Groups the editor's comments under a heading, like `reviewer` but
+/// without a reviewer number.
+#let editor(body) = {
+  current-exchange-context.update((kind: "editor"))
+  context [
+    #block(above: 1.2em, below: 0.8em)[
+      #text(size: 1.15em, weight: "bold", fill: editor-color)[Editor]
+    ]
+  ]
+  body
+  current-exchange-context.update(none)
+}
+
+/// Groups one co-author's own notes under a heading, like `reviewer`/
+/// `editor` but for the "author explaining their own change" workflow
+/// (see `note`). `id` is the raw author id (`"bob"`, matching `<bob-3>`
+/// anchors) — the heading and color come from `author-display-name`/
+/// `author-color` (`style.typ`), which resolve the `set-revisions(authors:
+/// ...)` registry the same way any `note`/`exchange` on a `bob-*` anchor
+/// already would.
+#let author(id, body) = {
+  current-exchange-context.update((kind: "author", id: id))
+  context [
+    #block(above: 1.2em, below: 0.8em)[
+      #text(size: 1.15em, weight: "bold", fill: author-color(id))[#author-display-name(id)]
+    ]
+  ]
+  body
+  current-exchange-context.update(none)
+}
+
+/// Shared renderer behind both `exchange` (3-arg form) and `note`/
+/// `exchange` (2-arg form): `comment: none` means "single block" (an
+/// author's own note, nothing to quote), anything else means "quoted
+/// comment + response". Kept as one function, not two independent code
+/// paths, so the two call shapes can never drift apart in rendering.
+///
+/// `term: auto` picks the header noun ("comment" for reviewer/editor,
+/// "change" for author) from `set-revisions(comment-word:, change-word:)`
+/// unless overridden for this one call. The *raw* `term` (possibly
+/// `auto`) is stored in the `<palimpsest-exchange>` metadata rather than
+/// the resolved word, so `xcomment` — which reads this metadata back
+/// later, from a different position in the document — reproduces the
+/// same override without needing its own copy of this resolution logic.
+///
+/// Bare, number-less anchors (`p.num == none` — the "pure change-tracking,
+/// no particular exchange to key into" case, e.g. `<bob>` reused across
+/// many notes) are exempt from the "duplicate exchange" check below:
+/// reuse is the expected shape for those, not a mistake. Numbered
+/// anchors keep the check unconditionally — it doesn't depend on
+/// `require-exchange` (`style.typ`), which only gates the *other*
+/// direction, `passage`'s "no matching exchange" (`marks.typ`).
+#let exchange-core(anchor, comment, response, term: auto) = {
+  [#metadata((tag: "palimpsest-exchange", anchor: anchor, comment: comment, response: response, term: term)) <palimpsest-exchange>]
+
+  context {
+    let p = parse-anchor(anchor)
+    let ctx = current-exchange-context.get()
+    let sty = style-state.get()
+    let kind = if p != none { p.kind } else if ctx != none { ctx.kind }
+    let word = if term != auto {
+      term
+    } else if kind == "author" {
+      sty.change-word
+    } else {
+      sty.comment-word
+    }
+
+    let header = if p != none and p.kind == "reviewer" {
+      [Reviewer #p.reviewer — #word #p.num]
+    } else if p != none and p.kind == "editor" {
+      [Editor — #word #p.num]
+    } else if p != none and p.kind == "author" {
+      let name = author-display-name(p.author)
+      if p.num != none { [#name — #word #p.num] } else { [#name] }
+    } else if ctx != none and ctx.kind == "reviewer" {
+      [Reviewer #ctx.n]
+    } else if ctx != none and ctx.kind == "editor" {
+      [Editor]
+    } else if ctx != none and ctx.kind == "author" {
+      [#author-display-name(ctx.id)]
+    } else {
+      [Comment]
+    }
+
+    let bare = p != none and p.num == none
+    let siblings = query(<palimpsest-exchange>).filter(el => el.value.anchor == anchor)
+    let dup = if not bare and siblings.len() > 1 {
+      diagnose("duplicate exchange " + str(anchor), always: true)
+    }
+
+    let orphan = if not query(<palimpsest-passage>).any(el => el.value.anchors.contains(anchor)) {
+      diagnose("comment " + str(anchor) + " has no matching revision in the manuscript", always: true)
+    }
+
+    let empty-noun = if comment == none { "note" } else { "response" }
+    let empty = if is-blank(response) {
+      diagnose("exchange " + str(anchor) + ": empty " + empty-noun, always: true)
+    }
+
+    block(above: 1em, below: 1em)[
+      #dup #orphan #empty
+      #strong(header) \
+      #if comment != none [
+        #emph(comment)
+        #v(0.4em)
+      ]
+      #response
+    ]
+  }
+}
+
+/// Renders one reviewer/editor comment and the author's response (3
+/// positional args), *or* — for the co-author workflow, where there's no
+/// separate reviewer comment to quote — a single self-authored note (2
+/// positional args, `exchange(anchor, text)`), identical in every way to
+/// calling `note(anchor, text)` directly. Stores the exchange in a
+/// `<palimpsest-exchange>` metadata for `pinpoint`/`xcomment` and for the
+/// diagnostics in `exchange-core` above. Emits nothing in the manuscript
+/// — only ever called from the exchanges document (`responses.typ`).
+///
+/// `anchor` is required in both forms: an exchange with nothing to
+/// answer isn't an exchange. Use `parse-anchor`'s convention (`<r1-2>`,
+/// `<e1>`, `<bob-3>`, with an optional round-number prefix) to get
+/// automatic headers; other label shapes fall back to the enclosing
+/// `reviewer`/`editor`/`author` context, or a bare "Comment" header.
+#let exchange(..args) = {
+  let pos = args.pos()
+  let term = args.named().at("term", default: auto)
+  if pos.len() >= 3 {
+    exchange-core(pos.at(0), pos.at(1), pos.at(2), term: term)
+  } else {
+    exchange-core(pos.at(0), none, pos.at(1), term: term)
+  }
+}
+
+/// The single-block form: an author explaining their own change, with
+/// nothing separate to quote — the co-author counterpart to `exchange`'s
+/// reviewer-comment-plus-response shape. `exchange(anchor, text)` (2
+/// positional args) produces the exact same output; `note` exists
+/// alongside it for callers who find the dedicated name clearer.
+#let note(anchor, text, term: auto) = exchange-core(anchor, none, text, term: term)
+
+/// Cross-references *another* exchange in the letter — "as already
+/// answered in comment R1-2" — the counterpart to `xref` (which points
+/// into the manuscript instead). A clickable link to where that
+/// exchange is rendered, plus its page, since the letter can span
+/// several pages same as the manuscript does.
+///
+/// Rebuilds the description from `parse-anchor(anchor)` directly rather
+/// than reading the original exchange's own rendered header: that
+/// header can fall back to the enclosing `reviewer`/`editor`/`author`
+/// context for an anchor that doesn't follow a recognized convention
+/// (see `exchange-core` above), and that context only exists at the
+/// position where the *original* `exchange`/`note` call renders — not at
+/// whatever unrelated position calls `xcomment`. The word ("comment" vs
+/// "change", and any per-call `term:` override) comes from the target
+/// exchange's own stored metadata, so `xcomment` always echoes back
+/// whatever the original call actually said, never recomputing it
+/// independently. Anchors that don't parse fall back to citing the raw
+/// label instead.
+#let xcomment(anchor) = context {
+  let hits = query(<palimpsest-exchange>).filter(el => el.value.anchor == anchor)
+  if hits.len() == 0 {
+    diagnose("xcomment(" + repr(anchor) + "): no exchange found for this anchor", always: true)
+  } else {
+    let el = hits.first()
+    let p = parse-anchor(anchor)
+    let sty = style-state.get()
+    let kind = if p != none { p.kind }
+    let term = el.value.at("term", default: auto)
+    let word = if term != auto {
+      term
+    } else if kind == "author" {
+      sty.change-word
+    } else {
+      sty.comment-word
+    }
+    let desc = if p != none and p.kind == "reviewer" {
+      [reviewer #p.reviewer, #word #p.num]
+    } else if p != none and p.kind == "editor" {
+      [editor's #word #p.num]
+    } else if p != none and p.kind == "author" {
+      let name = author-display-name(p.author)
+      if p.num != none { [#name's #word #p.num] } else { [#name's #word] }
+    } else {
+      [comment #upper(str(anchor))]
+    }
+    [#link(el.location())[#desc], p. #el.location().page()]
+  }
+}

--- a/packages/preview/palimpsest/0.1.0/src/letter.typ
+++ b/packages/preview/palimpsest/0.1.0/src/letter.typ
@@ -1,0 +1,84 @@
+/// Internal label wrapping the whole response letter's content, so that
+/// `letter-bibliography` can scope citations to it via `within` (§8) and
+/// `revisions` knows what to place inside `response.pdf`.
+#let letter-root = <palimpsest-letter>
+
+/// Minimal default letter template — a title, nothing else. Overridable
+/// wholesale via `revisions(letter-template: ...)`.
+#let default-letter-template(body) = {
+  align(center, text(size: 1.4em, weight: "bold")[Response to Reviewers])
+  v(1.5em)
+  body
+}
+
+/// Wraps `body` with the letter's own figure/table numbering (§7.2):
+/// "Figure R1", restarting from the manuscript's own numbering, so a
+/// figure the letter includes "for the reviewer only" is never
+/// confusable with a manuscript figure. Only actually reaches a figure
+/// that has no manuscript original to match — one `pinpoint(excerpt:
+/// true)` re-emits from the manuscript instead shows that original's
+/// *own* real number, pinned by `strip-labels` (`utils.typ`) before
+/// this `set` rule ever gets a say (a local `numbering:` on the figure
+/// itself always wins) — so "R1", "R2", ... now only ever means "a
+/// figure genuinely native to this letter," never "a citation of
+/// manuscript figure N," a distinction the plain "R" sequence didn't
+/// carry on its own before this pinning existed. Must structurally *wrap* `body`
+/// — not run as a sibling statement before it — because `set` rules
+/// scope to the content they contain, not to whatever a caller happens
+/// to place next to their result.
+///
+/// Resets one counter *per figure kind* (`image`, `table`, `raw` — the
+/// three Typst infers automatically depending on what a figure wraps,
+/// verified directly: `figure(rect(...))` gets `kind: image`,
+/// `figure(table(...))` gets `kind: table`, `figure(raw(...))` gets
+/// `kind: raw`), not the bare `counter(figure)`. This isn't
+/// belt-and-braces: `counter(figure)` and `counter(figure.where(kind:
+/// image))` are genuinely different counter objects in Typst 0.15 —
+/// verified directly, including across `#document(...)` boundaries in a
+/// bundle — and a `figure`'s own displayed number is computed from the
+/// *kind-scoped* one. Resetting only the bare `counter(figure)` looks
+/// like it works (`context counter(figure).get()` reads back `0` right
+/// after), but the actual number shown on the next figure of a given
+/// kind is unaffected by that reset — it keeps counting from wherever
+/// that kind's counter already was (e.g. from a manuscript figure of
+/// the same kind counted earlier in the bundle), producing "Figure R2"
+/// instead of "Figure R1" for what is the *only* figure in the letter.
+/// A figure using an explicit custom `kind:` (rare) isn't covered by
+/// this reset — out of scope for v0.1, same spirit as other
+/// template-shape assumptions already documented as limitations.
+#let with-letter-numbering(body) = {
+  set figure(numbering: n => "R" + str(n))
+  counter(figure.where(kind: image)).update(0)
+  counter(figure.where(kind: table)).update(0)
+  counter(figure.where(kind: raw)).update(0)
+  body
+}
+
+/// The letter's own bibliography, restricted to citations made *inside*
+/// the letter (`within(letter-root)`) and numbered independently from
+/// the manuscript's own bibliography (`group: "letter"`, not the
+/// manuscript's `auto` group) — without both, the letter would either
+/// absorb the manuscript's citations or share its numbering (§8).
+///
+/// Note for spec maintenance: the spec's example uses `group: false`;
+/// Typst 0.15's `bibliography()` takes `auto` or a name *string* for
+/// `group`, not a boolean — verified directly, `false` is a compile
+/// error. Fixed here; the spec text should be corrected too.
+///
+/// `path` must be root-relative (leading `/`, resolved against
+/// `--root`), not relative to `responses.typ`. Typst resolves a path
+/// string against the file that *calls the path-consuming builtin* —
+/// here, `bibliography()` inside this very function, in `letter.typ` —
+/// not the file that wrote the string literal. A plain
+/// `"responses.bib"` would make Typst look for the file next to
+/// `letter.typ` inside the package itself, and fail. Verified directly;
+/// this is standard Typst behavior; every package function that takes a
+/// user path has the same constraint.
+#let letter-bibliography(path, title: [References cited in this response]) = {
+  bibliography(
+    path,
+    title: title,
+    target: selector(cite).within(letter-root),
+    group: "letter",
+  )
+}

--- a/packages/preview/palimpsest/0.1.0/src/marks.typ
+++ b/packages/preview/palimpsest/0.1.0/src/marks.typ
@@ -1,0 +1,331 @@
+#import "utils.typ": collect-metadata, normalize-anchors, current-passage-anchors, render-mode-override, in-excerpt, strip-labels, parse-anchor, numbered-kinds-in
+#import "style.typ": style-state, anchors-color, neutral-color, del-color
+#import "diagnostics.typ": diagnose
+
+/// Always the real compile mode — for the author's own mode-dependent
+/// content. Never influenced by `pinpoint`'s local override (see
+/// `effective-mode`, which is what `add`/`del`/`rep` use internally).
+#let mode() = sys.inputs.at("mode", default: "clean")
+
+/// What `add`/`del`/`rep` actually render by, read via `context`:
+/// `render-mode-override` when `pinpoint(excerpt: true, mode: ...)` has
+/// set one for the content currently being re-emitted, otherwise the
+/// real compile mode.
+#let effective-mode() = {
+  let ov = render-mode-override.get()
+  if ov != none { ov } else { mode() }
+}
+
+/// Renders a mark's tracked-mode appearance: styled per `add-style`/
+/// `del-style`, colored by the enclosing passage's reviewer — `del`
+/// desaturated via `del-color` so an addition and a deletion of the
+/// same math never look identical (`tests/strike-methods.typ`, cases
+/// E.1–E.4) — neutralized to the clean look when `style: "none"`
+/// (layout QA mode, §10.1).
+#let mark-visual(kind, body) = context {
+  let sty = style-state.get()
+  let anchors = current-passage-anchors.get()
+  let outside = anchors == none
+  let warning = if outside {
+    diagnose("#" + kind + " outside any passage: no anchor, no page")
+  }
+  if sty.style == "none" and not outside {
+    if kind == "add" { body } else { none }
+  } else {
+    let base-color = if outside { neutral-color } else { anchors-color(anchors) }
+    let color = if kind == "del" { del-color(base-color) } else { base-color }
+    let styled = if kind == "add" { (sty.add-style)(body) } else { (sty.del-style)(body) }
+    // Still render a fallback even when outside a passage — losing the
+    // reviewer's text on top of the diagnostic would compound the
+    // author's mistake, not flag it.
+    [#warning#text(fill: color, styled)]
+  }
+}
+
+/// Keeps figure/table/equation/heading numbering in deleted content
+/// shown in tracked mode from disturbing anything that comes after it,
+/// so clean and tracked versions keep identical numbering (§7.3) —
+/// while still letting the deleted element show its own real number
+/// (struck through), rather than hiding it. Snapshots every relevant
+/// counter right before `body`, lets `body` render normally (so a
+/// deleted figure/heading/equation still consumes and displays its true
+/// number, exactly as it would if kept), then resets each counter back
+/// to its snapshot right after — an absolute restore, not a per-element
+/// decrement, so it stays correct no matter how many numbered elements
+/// `body` contains or how they're nested (a deleted top-level section
+/// that itself contains a deleted subsection and a deleted figure, all
+/// in one `del(...)`, restores correctly in one shot: verified directly,
+/// see the exploration notes below). Figures are reset per `kind`
+/// (`image`/`table`/`raw`, the same three `with-letter-numbering`,
+/// `letter.typ`, already resets) since Typst scopes a figure's real
+/// displayed number to a kind-specific counter, not the bare
+/// `counter(figure)` (§6quaterquadragies-class distinction, verified
+/// directly). `math.equation` has no such per-kind split — one shared
+/// counter for every equation.
+///
+/// Also verified directly against `@preview/charged-ieee`, which
+/// reimplements figure numbering via its own show rule and used to
+/// crash outright on `numbering: none` (the previous approach here):
+/// with a real number left in place and only the counter restored
+/// afterward, it neither crashes nor leaks — the show rule reads the
+/// same counter this restores, so it renders the correct number too.
+/// `suppress`/`suppressed` remain the answer when the deleted content
+/// itself shouldn't be shown at all, not merely mis-numbered.
+///
+/// No-op when `del-numbering: "keep"` — the deleted element consumes a
+/// real, unrestored number and everything after it shifts, on purpose.
+///
+/// Only snapshots/restores the counters actually present in the
+/// *original, unwrapped* content — `kinds`, from `numbered-kinds-in`
+/// (`utils.typ`), computed by the caller (`del`/`rep`) from the raw
+/// body *before* it's passed through `mark-visual` — not all five
+/// unconditionally. Two independent reasons, found in this order:
+/// first, correctness at scale — touching every counter on every
+/// deletion regardless of content overloads Typst's layout solver once
+/// several mixed deletions stack up in one document (see
+/// `numbered-kinds-in`'s docstring for the reproduction). Second, and
+/// more fundamental: `kinds` *cannot* be computed from `body` as
+/// received here, because by the time `del`/`rep` call this function
+/// `body` is already `mark-visual(...)`'s output — a `context` value,
+/// structurally opaque like any other, so a first attempt at detecting
+/// kinds internally, from this parameter, silently found nothing every
+/// time and disabled every restore unconditionally instead of only the
+/// unnecessary ones (verified directly, caught by re-checking actual
+/// rendered numbers after the "no convergence warning" result looked
+/// like success — the warning was gone only because nothing was being
+/// restored *at all* any more, not because the restores had become
+/// correctly selective).
+#let neutralize-numbering(body, kinds) = context {
+  let sty = style-state.get()
+  if sty.del-numbering == "none" {
+    let snap-heading = if kinds.heading { counter(heading).get() }
+    let snap-image = if kinds.image { counter(figure.where(kind: image)).get() }
+    let snap-table = if kinds.table { counter(figure.where(kind: table)).get() }
+    let snap-raw = if kinds.raw { counter(figure.where(kind: raw)).get() }
+    let snap-equation = if kinds.equation { counter(math.equation).get() }
+    body
+    if kinds.heading { counter(heading).update(snap-heading) }
+    if kinds.image { counter(figure.where(kind: image)).update(snap-image) }
+    if kinds.table { counter(figure.where(kind: table)).update(snap-table) }
+    if kinds.raw { counter(figure.where(kind: raw)).update(snap-raw) }
+    if kinds.equation { counter(math.equation).update(snap-equation) }
+  } else {
+    body
+  }
+}
+
+/// Marks `body` as newly added text. Emits nothing structural of its own
+/// beyond the mark metadata: the anchor and page come from the enclosing
+/// `passage`.
+#let add(body) = {
+  [#metadata((tag: "palimpsest-mark", kind: "add", old: none, new: body)) <palimpsest-mark>]
+  context {
+    let body = if in-excerpt.get() { strip-labels(body) } else { body }
+    if effective-mode() == "clean" {
+      body
+    } else {
+      mark-visual("add", body)
+    }
+  }
+}
+
+/// Marks `body` as removed text. Emits nothing in clean mode — a deletion
+/// that survives into the clean version isn't a deletion (§7.3): no
+/// `hide()`, no reserved space, no consumed counter.
+#let del(body) = {
+  [#metadata((tag: "palimpsest-mark", kind: "del", old: body, new: none)) <palimpsest-mark>]
+  context {
+    let body = if in-excerpt.get() { strip-labels(body) } else { body }
+    if effective-mode() == "clean" {
+      none
+    } else {
+      // `numbered-kinds-in` must see the *raw* body, before
+      // `mark-visual` wraps it in its own `context` block — a context
+      // value is structurally opaque, so computing kinds from
+      // `mark-visual`'s output instead (tried first) silently found
+      // nothing every time, disabling the counter restore below for
+      // every kind, always — verified directly, see
+      // `neutralize-numbering`'s docstring.
+      neutralize-numbering(mark-visual("del", body), numbered-kinds-in(body))
+    }
+  }
+}
+
+/// Marks a replacement of `old` by `new`. Clean mode shows `new` only;
+/// tracked mode shows both, `old` struck and numbering-neutralized, `new`
+/// styled as an addition.
+#let rep(old, new) = {
+  [#metadata((tag: "palimpsest-mark", kind: "rep", old: old, new: new)) <palimpsest-mark>]
+  context {
+    let stripping = in-excerpt.get()
+    let old = if stripping { strip-labels(old) } else { old }
+    let new = if stripping { strip-labels(new) } else { new }
+    if effective-mode() == "clean" {
+      new
+    } else {
+      let sty = style-state.get()
+      if sty.style == "none" {
+        new
+      } else {
+        [#neutralize-numbering(mark-visual("del", old), numbered-kinds-in(old)) #mark-visual("add", new)]
+      }
+    }
+  }
+}
+
+/// Marks the entirety of a passage's content as removed, like `del` —
+/// but unlike `del`, never renders the removed content in tracked mode,
+/// only `note`, centered like the floating element it typically
+/// replaces (a figure, a table, an equation). `del`'s tracked rendering
+/// still emits a real `figure`/`math.equation`, and some templates
+/// recompute their own numbering from a show rule that ignores
+/// `del-numbering: "none"` — silently (a deleted figure keeps a real,
+/// template-assigned number that doesn't exist in the clean version) or
+/// by crashing outright if forced harder (verified against
+/// `charged-ieee`, see CLAUDE.md). `suppress` sidesteps the whole
+/// problem by construction: since no real figure/table/equation is ever
+/// emitted here, there is nothing for a template's numbering to
+/// interfere with, regardless of how that template implements it.
+#let suppress(note) = {
+  [#metadata((tag: "palimpsest-mark", kind: "suppress", old: note, new: none)) <palimpsest-mark>]
+  if mode() == "clean" {
+    none
+  } else {
+    context {
+      let anchors = current-passage-anchors.get()
+      if anchors == none {
+        diagnose("#suppress outside any passage: no anchor, no page")
+      } else {
+        align(center, block(text(fill: del-color(anchors-color(anchors)), style: "italic")[[#note]]))
+      }
+    }
+  }
+}
+
+/// The citable unit: wraps `body` (plain text and/or `add`/`del`/`rep`
+/// marks) and attaches the anchor(s) that the response letter's
+/// `pinpoint` will resolve back to this location.
+///
+/// Called either as `passage(anchors, body)` or, for a passage with no
+/// anchor (typographical fix, editor request), as `passage(body)` — the
+/// arity of the positional arguments decides which.
+///
+/// `anchors` is `none`, a single label, or an array of labels.
+/// `summary`, when given, is what `pinpoint(excerpt: true)` renders
+/// instead of the passage content — for a passage that is entirely
+/// deleted and therefore has no meaningful excerpt in the clean version
+/// (§6.3).
+/// `allow-empty` suppresses the "no mark" diagnostic — used by `touched`,
+/// which declares a location without marking any change.
+#let passage(..args) = {
+  let pos = args.pos()
+  let (anchors, body) = if pos.len() >= 2 { (pos.at(0), pos.at(1)) } else { (none, pos.at(0)) }
+  let summary = args.named().at("summary", default: none)
+  let allow-empty = args.named().at("allow-empty", default: false)
+  let anchor-list = normalize-anchors(anchors)
+  let marks = collect-metadata(body, "palimpsest-mark")
+
+  current-passage-anchors.update(anchor-list)
+  [#metadata((
+    tag: "palimpsest-passage",
+    anchors: anchor-list,
+    summary: summary,
+    marks: marks,
+    raw-body: body,
+  )) <palimpsest-passage>]
+
+  if marks.len() == 0 and summary == none and not allow-empty {
+    let where = if anchor-list.len() > 0 { " " + anchor-list.map(str).join(", ") } else { "" }
+    diagnose("passage" + where + ": contains no mark (did you mean touched?)")
+  }
+
+  context {
+    let sty = style-state.get()
+    for a in anchor-list {
+      let p = parse-anchor(a)
+      // A bare, number-less anchor (`<bob>`, no `-<n>`) isn't meant to
+      // key into one particular exchange in the first place — the "pure
+      // change-tracking, no letter" workflow reuses it freely across
+      // many passages, possibly with no exchange/note ever written for
+      // it. `require-exchange: false` (`set-revisions`) additionally
+      // silences the check for *numbered* anchors too, for someone who
+      // wants the numbering/coloring but genuinely never writes a
+      // response document.
+      let bare = p != none and p.num == none
+      if not bare and sty.require-exchange {
+        let matches = query(<palimpsest-exchange>).any(el => el.value.anchor == a)
+        if not matches {
+          diagnose("anchor " + str(a) + ": no matching exchange")
+        }
+      }
+    }
+  }
+
+  context {
+    let sty = style-state.get()
+    let show-tracked = mode() != "clean" and sty.style != "none"
+    let color = anchors-color(anchor-list)
+    let content = if show-tracked and sty.highlight-passage {
+      box(fill: color.lighten(85%), inset: (x: 2pt), outset: (y: 2pt), radius: 1pt)[#body]
+    } else {
+      body
+    }
+    let tagged = if show-tracked and sty.show-anchor and anchor-list.len() > 0 {
+      [#content #super(text(fill: color, size: 0.75em)[\[#anchor-list.map(a => upper(str(a))).join(", ")\]])]
+    } else {
+      content
+    }
+    if show-tracked and sty.style == "bar" {
+      block(
+        stroke: (left: 2pt + color),
+        inset: (left: 6pt),
+        spacing: 0.65em,
+        width: 100%,
+      )[#tagged]
+    } else {
+      tagged
+    }
+  }
+  current-passage-anchors.update(none)
+}
+
+/// `passage` + `add` in one call, for a passage entirely made of new text.
+#let added(anchors, body, summary: none) = passage(anchors, add(body), summary: summary)
+
+/// `passage` + `del` in one call, for a passage entirely removed.
+#let deleted(anchors, body, summary: none) = passage(anchors, del(body), summary: summary)
+
+/// `passage` + `suppress` in one call: the passage is entirely removed,
+/// with `note` shown centered in the tracked manuscript in place of the
+/// real content — see `suppress` for why this exists alongside
+/// `deleted`. `note` also becomes `pinpoint`'s excerpt summary unless
+/// `summary:` is given explicitly: the manuscript placeholder and the
+/// letter's summary don't have to read the same way (one is written for
+/// a reader mid-manuscript, the other for a reviewer mid-letter who
+/// already has the comment in front of them), so the two are kept as
+/// distinct parameters rather than one doing double duty — but default
+/// to sharing `note`'s text, since most of the time they don't need to
+/// differ.
+///
+/// Deliberately takes **no** original-content parameter at all, unlike
+/// `deleted(anchors, body, ...)` — this is not an oversight. The real
+/// content is never rendered anywhere by this function, clean or
+/// tracked; a parameter that only ever sat there unused would be pure
+/// latent risk (a future edit that starts passing it to something that
+/// *does* render it, defeating the whole point of `suppress` over
+/// `del`) for no benefit. If you want the removed material kept at hand
+/// in the source — to reconsider later, say — a plain `//` comment
+/// right above the call is inert (Typst never evaluates it) and costs
+/// nothing; git history keeps it regardless either way.
+#let suppressed(anchors, note, summary: auto) = passage(
+  anchors,
+  suppress(note),
+  summary: if summary == auto { note } else { summary },
+)
+
+/// `passage` + `rep` in one call, for a passage entirely rewritten.
+#let replaced(anchors, old, new, summary: none) = passage(anchors, rep(old, new), summary: summary)
+
+/// Declares a location without marking any change — "see p. 4, we keep
+/// this wording as is".
+#let touched(anchors, body) = passage(anchors, body, allow-empty: true)

--- a/packages/preview/palimpsest/0.1.0/src/pinpoint.typ
+++ b/packages/preview/palimpsest/0.1.0/src/pinpoint.typ
@@ -1,0 +1,239 @@
+#import "utils.typ": current-passage-anchors, collect-labels, render-mode-override, in-excerpt, strip-labels
+#import "diagnostics.typ": diagnose
+
+/// True if `body` (already run through `strip-labels`) still carries a
+/// label that's the target of an actual `@ref`/`ref()` somewhere in the
+/// bundle. `strip-labels` on `raw-body` handles a label sitting directly
+/// in a passage's content (a bare figure inside a `touched` passage,
+/// say — not wrapped in any mark); it *can't* reach a label that's part
+/// of `add`/`del`/`rep`'s own content, because their visual rendering is
+/// wrapped in `context` (needed for `render-mode-override`) and
+/// therefore structurally opaque before layout, same as any `context`
+/// block — that case is instead handled inside the marks themselves,
+/// via `in-excerpt` (`utils.typ`), stripping their `body`/`old`/`new`
+/// *before* the `context` wrapping ever applies. This check is the
+/// backstop for whatever neither of those two reaches. Checking `ref`
+/// targets rather than mere label existence is what excludes the
+/// package's own internal tag labels (`<palimpsest-mark>` etc., reused
+/// on every mark in the bundle by design) for free — two elements can
+/// share a label harmlessly as long as nothing ever references it
+/// (verified directly); Typst only rejects a label once something tries
+/// to resolve it and finds it ambiguous.
+#let has-conflicting-label(body) = {
+  let referenced = query(ref).map(r => r.target)
+  collect-labels(body).any(lbl => lbl in referenced)
+}
+
+/// Default `format:` for the page-only mode: "(modified on p. 7)" or
+/// "(see p. 4)" when `<anchor>` matches no real `add`/`del`/`rep` mark
+/// anywhere (a `touched` passage, cited only to point at unchanged
+/// text) — never the same wrong "modified" for both cases, verified
+/// exhaustively in `tests/bundle-pinpoint-methods.typ` (case 1.6: an
+/// unqualified "modified" is not just clumsy there, it's false). This
+/// substitution is not a `parens`/`verb` option: there is no legitimate
+/// case for asserting a change that didn't happen, so it isn't gated
+/// behind anything the caller has to remember to ask for.
+///
+/// `parens:` wraps the whole thing in parentheses (the historical,
+/// still-default look — reads as a trailing citation, `tests/…` case
+/// 1.1/1.5). `verb: none` drops "modified on"/"see" entirely, leaving
+/// only "p. 7"/"p. 7 and p. 12" — for a sentence that already supplies
+/// its own verb (case 1.2/1.3, where the wired-in parenthetical clashes
+/// with "This sentence was updated:" or "See … for …"). Neither knob
+/// alone covers every sentence shape tried; combined, the two do —
+/// see the case-by-case comparison and the recap table in
+/// `tests/bundle-pinpoint-methods.typ`.
+#let format-pages(pages, has-marks, parens: true, verb: auto) = {
+  let word = if verb == none {
+    none
+  } else if has-marks {
+    "modified on"
+  } else {
+    "see"
+  }
+  let core = if pages.len() == 1 {
+    if word != none { [#word p. #pages.first()] } else { [p. #pages.first()] }
+  } else {
+    let joined = pages.map(p => "p. " + str(p)).join(", ", last: " and ")
+    if word != none { [#word #joined] } else { joined }
+  }
+  if parens { [(#core)] } else { core }
+}
+
+/// True if `body` (any Typst value) contains no `figure`, `table`, or
+/// block-mode `math.equation` at or below its own top level — decides
+/// whether an excerpt is safe to wrap in literal quotation marks
+/// (`pinpoint(..., quotes: true)`). Forcing quotation marks onto a
+/// figure produces two stray quote glyphs sitting alone above and below
+/// it, confirmed directly (`tests/bundle-pinpoint-methods.typ`, case
+/// Q.3) — not a matter of taste, a real visual defect, so `quotes:
+/// true` only ever *requests* quotation marks; this check has the final
+/// say.
+#let is-textual(body) = {
+  if type(body) != content {
+    true
+  } else {
+    let is-block-eq = body.func() == math.equation and body.at("block", default: false)
+    if body.func() == figure or body.func() == table or is-block-eq {
+      false
+    } else if repr(body.func()) == "sequence" {
+      body.children.all(is-textual)
+    } else {
+      true
+    }
+  }
+}
+
+/// `is-textual`, extended to an entire `<palimpsest-passage>` metadata
+/// value rather than a single content tree. Needed because `v.raw-body`
+/// alone under-detects: content that passes through `add`/`del`/`rep`
+/// has its *visible* copy wrapped in `context` (required for
+/// `render-mode-override`, see `marks.typ`) and is therefore
+/// structurally opaque before layout — a figure added via `#add[...]`
+/// is invisible to `is-textual(v.raw-body)` alone, which silently falls
+/// through to "textual" and would let `quotes: true` produce the very
+/// stray-glyph defect it exists to prevent. Found by testing the
+/// figure case specifically, not by inspection: an early version of
+/// this check passed on a bare figure and failed silently on the same
+/// figure nested inside `add` (`tests/bundle-pinpoint-methods.typ`, the
+/// note following case Q.4). Each mark's `old`/`new` fields, captured
+/// *before* that `context` wrapping (the same mechanism `in-excerpt`
+/// below already relies on), are what make the mark's own content
+/// inspectable — checked here in addition to `raw-body`, not instead of
+/// it, since a figure sitting directly in the passage rather than
+/// inside any mark only ever shows up in `raw-body`.
+#let passage-is-textual(v) = {
+  let marks-ok = v.marks.all(m => is-textual(m.old) and is-textual(m.new))
+  is-textual(v.raw-body) and marks-ok
+}
+
+/// Queries the manuscript for every `passage` carrying `anchor` and
+/// renders their location — or, with `excerpt: true`, their actual
+/// content. This is the mechanism the spec (§1) calls out as the point
+/// of the whole package: cross-document `query()` inside the same
+/// bundle sees the manuscript's real page numbers and real content, so
+/// the letter can never cite a stale page or a passage that no longer
+/// reads the way the letter claims it does.
+///
+/// `mode:` (§6.4) picks how an excerpt's marks render, regardless of
+/// what the *current compile* is actually doing: `auto` (default)
+/// defers to the real compile mode, same as the manuscript's own copy;
+/// `"clean"` forces the final-text-only look; `"tracked"` forces
+/// struck/underlined marks, even though `response.pdf` is only ever
+/// produced by the clean compile (§9.1) — reviewer-facing, "show what
+/// changed" excerpts don't need a second compile to look tracked.
+/// Implemented via `render-mode-override` (`utils.typ`), set right
+/// before re-emitting `raw-body` and reset right after — resolution
+/// follows document position, not call order, so this can't affect the
+/// manuscript's own copy, laid out earlier at its own position. An
+/// earlier version of this docstring called the feature out of scope,
+/// worried that deferring `add`/`del`/`rep`'s clean/tracked choice
+/// through a state would regress prose line-wrapping the way an
+/// unrelated change did in M1 (`mark-line`, see the log below) — turned
+/// out to be a different risk: `mark-line` broke things by wrapping
+/// marked content in a measured `box`, not by deferring the mode
+/// decision. Verified in isolation before wiring this in for real.
+///
+/// A figure/table/equation a passage adds, removes, or simply contains
+/// is shown here in full even when its label is cross-referenced
+/// elsewhere in the manuscript (`@fig-...`, the common case: most
+/// figures worth adding are also worth discussing in text) — two label
+/// stripping mechanisms cover this between them, one for content inside
+/// a mark, one for content that isn't: `strip-labels(v.raw-body)` (run
+/// unconditionally below) reaches a label sitting directly in the
+/// passage's content (a bare figure inside a `touched` passage, or a
+/// table with only one cell modified, say), but *can't* reach a label
+/// that's part of `add`/`del`/`rep`'s own content, because their visual
+/// rendering is wrapped in `context` (needed for `render-mode-override`
+/// above) and therefore structurally opaque before layout — `in-excerpt`
+/// (`utils.typ`), set right before re-emitting, makes each mark strip
+/// its own `body`/`old`/`new` before that wrapping ever applies, which
+/// covers the rest. Only once both have had their shot does a
+/// remaining conflict fall back to the page number with a diagnostic,
+/// rather than crash the whole compile on a duplicate label — see
+/// `has-conflicting-label`.
+///
+/// `parens:`/`verb:` (page-only mode) and `show-page:`/`quotes:`
+/// (excerpt mode) are the outcome of a dedicated exploration —
+/// `tests/bundle-pinpoint-methods.typ` — testing the default rendering
+/// against a battery of real sentence shapes, not designed up front:
+///
+/// - `parens: false` drops the parentheses around the page-only
+///   citation, for a sentence that already supplies its own punctuation
+///   ("See #pinpoint(<r>, parens: false, verb: none) for the updated
+///   wording."). `verb: none` additionally drops "modified on"/"see",
+///   leaving only the page — the two are independent because neither
+///   alone covers every sentence shape tried (case B1 vs B2 in the
+///   exploration); `verb: auto` (default) is not a style choice, it is
+///   a correctness fix — see `format-pages`.
+/// - `show-page: false` (excerpt mode) drops the leading "**p. X** — "
+///   for a sentence that already states where the excerpt comes from,
+///   or a caller who deliberately doesn't want it. `quotes: true` wraps
+///   textual excerpts in real quotation marks (native `quote()`) —
+///   silently declines to on anything `passage-is-textual` flags as
+///   non-text (a figure, a table, a block equation), rather than
+///   produce the stray-glyph defect forcing them always would (case
+///   Q.3 in the exploration).
+#let pinpoint(
+  anchor,
+  excerpt: false,
+  parens: true,
+  verb: auto,
+  show-page: true,
+  quotes: false,
+  format: auto,
+  mode: auto,
+  on-empty: auto,
+) = context {
+  let hits = query(<palimpsest-passage>).filter(el => el.value.anchors.contains(anchor))
+
+  if hits.len() == 0 {
+    if on-empty == auto {
+      diagnose("pinpoint(" + repr(anchor) + "): no revision attached to this anchor", always: true)
+    } else if on-empty == none {
+      none
+    } else {
+      on-empty
+    }
+  } else if not excerpt {
+    let pages = hits.map(h => h.location().page()).dedup()
+    let has-marks = hits.any(h => h.value.marks.len() > 0)
+    if format == auto {
+      format-pages(pages, has-marks, parens: parens, verb: verb)
+    } else {
+      format(pages, has-marks)
+    }
+  } else {
+    hits.map(h => {
+      let v = h.value
+      let stripped = strip-labels(v.raw-body)
+      if v.summary != none {
+        [Removed: #v.summary.]
+      } else if has-conflicting-label(stripped) {
+        // Falling back to the page rather than crashing the compile —
+        // same "gracefully degrade on a hard case" choice the spec
+        // makes for `window:` on non-prose (§6.3). Only reached once
+        // both label-stripping mechanisms have already had their shot —
+        // a genuinely stubborn case. Always shows the page regardless
+        // of `show-page:` — this is a degraded fallback carrying a
+        // diagnostic, not a normal citation the caller is styling.
+        [*p. #h.location().page()* — #diagnose("pinpoint(" + repr(anchor) + ", excerpt: true): passage contains a label referenced elsewhere in the bundle; showing the page only", always: true)]
+      } else {
+        let content = {
+          current-passage-anchors.update(v.anchors)
+          in-excerpt.update(true)
+          if mode != auto { render-mode-override.update(mode) }
+          if quotes and passage-is-textual(v) { quote(stripped) } else { stripped }
+          if mode != auto { render-mode-override.update(none) }
+          in-excerpt.update(false)
+          current-passage-anchors.update(none)
+        }
+        if show-page {
+          [*p. #h.location().page()* --- #content]
+        } else {
+          content
+        }
+      }
+    }).join(parbreak())
+  }
+}

--- a/packages/preview/palimpsest/0.1.0/src/revisions.typ
+++ b/packages/preview/palimpsest/0.1.0/src/revisions.typ
@@ -1,0 +1,95 @@
+#import "letter.typ": default-letter-template, with-letter-numbering
+#import "diagnostics.typ": set-strict
+#import "utils.typ": collect-metadata
+
+// The label literal here must match `letter-root` in `letter.typ` —
+// Typst labels can't be attached to content from a variable (no
+// `.labelled()` method), only via the `<name>` markup syntax, so the
+// name has to be duplicated by hand instead of shared as a value.
+
+/// The pilot. Called via `#show: revisions.with(...)`, so `body` — the
+/// last, unnamed positional parameter — is the rest of the document,
+/// i.e. `#include "manuscript.typ"`.
+///
+/// Two compiles produce the whole bundle (§9.1 — duplicating the
+/// manuscript to get both looks in one compile would duplicate every
+/// label in it too):
+///
+/// - `typst compile --features bundle --format bundle main.typ` (`mode`
+///   defaults to `"clean"`) → `manuscript.pdf`, plus `response.pdf` if
+///   `exchanges` is set (see below).
+/// - `typst compile --features bundle --format bundle --input
+///   mode=tracked main.typ` → `manuscript-tracked.pdf`, plus
+///   `response-tracked.pdf` under the same condition.
+///
+/// Both flags are required — `--features bundle` alone still errors
+/// ("constructing a document is only supported in the bundle target"),
+/// verified directly.
+///
+/// `template` is applied to the manuscript body in *both* compiles, so
+/// clean and tracked stay laid out the same way. `exchanges` is the
+/// already-evaluated content of the responses file (`include
+/// "responses.typ"`); `letter-template` overrides the letter's own
+/// minimal default (`auto`). `round` is accepted and stored for forward
+/// compatibility with v0.2's multi-round `since:` (§12); v0.1 does
+/// nothing else with it. `strict` turns every diagnostic in the bundle
+/// into a compile error (§11) — the CI gate.
+///
+/// Whether a response document is produced in this compile isn't a
+/// parameter of this function at all — there would be nothing sensible
+/// for it to mean independently of `exchanges`: writing responses with
+/// no letter to put them in, or asking for a letter with nothing
+/// written, are both non-cases. So it's derived: a letter is produced
+/// whenever `exchanges` isn't `none`, matching *this* compile's own
+/// `mode` — `response.pdf` from the clean compile, `response-tracked.pdf`
+/// (a name distinct from `response.pdf`, so neither compile can
+/// silently overwrite the other's output) from the tracked one, each
+/// citing and quoting its own manuscript. No extra flag needed to get
+/// a tracked letter: writing `exchanges` and running both compiles is
+/// enough.
+///
+/// The one thing that *is* a per-run, command-line choice — not a fixed
+/// property of the project — is skipping the letter for a single
+/// compile even though `exchanges` is set, e.g. for a fast
+/// manuscript-only preview while drafting: `--input letter=false`.
+/// `--input letter=true` is the symmetric, rarely-needed override
+/// (force a letter even with `exchanges: none`).
+#let revisions(
+  template: body => body,
+  exchanges: none,
+  round: 1,
+  letter-template: auto,
+  strict: false,
+  body,
+) = {
+  if strict {
+    set-strict(true)
+  }
+
+  let mode = sys.inputs.at("mode", default: "clean")
+  let letter-input = sys.inputs.at("letter", default: none)
+  let show-letter = if letter-input == "false" { false }
+    else if letter-input == "true" { true }
+    else { exchanges != none }
+
+  document(if mode == "tracked" { "manuscript-tracked.pdf" } else { "manuscript.pdf" }, {
+    template(body)
+    if not show-letter {
+      // Whenever this compile doesn't place `exchanges` into a real
+      // `#document(...)`, `passage`'s "anchor has no matching exchange"
+      // check would find no exchanges anywhere and false-positive on
+      // every single anchor. Re-registering just the metadata (not the
+      // rendered exchange blocks) makes the check work without putting
+      // reviewer comments in the manuscript file.
+      for m in collect-metadata(exchanges, "palimpsest-exchange") {
+        [#metadata(m) <palimpsest-exchange>]
+      }
+    }
+  })
+
+  if show-letter {
+    let lt = if letter-template == auto { default-letter-template } else { letter-template }
+    let name = if mode == "tracked" { "response-tracked.pdf" } else { "response.pdf" }
+    document(name, [#with-letter-numbering(lt(exchanges)) <palimpsest-letter>])
+  }
+}

--- a/packages/preview/palimpsest/0.1.0/src/style.typ
+++ b/packages/preview/palimpsest/0.1.0/src/style.typ
@@ -1,0 +1,217 @@
+#import "utils.typ": parse-anchor, default-del-mark
+
+/// Default palette, one color per reviewer, ordered so that adjacent
+/// reviewers stay visually distinct (varies by more than hue: styles also
+/// differ by underline vs. strike, so black-and-white printing still
+/// distinguishes add from del even where color is lost).
+#let default-palette = (
+  rgb("#1a5fb4"), // reviewer 1 — blue
+  rgb("#a51d2d"), // reviewer 2 — red
+  rgb("#2ec27e"), // reviewer 3 — green
+  rgb("#813d9c"), // reviewer 4 — purple
+  rgb("#e66100"), // reviewer 5 — orange
+  rgb("#0ab9dc"), // reviewer 6 — cyan
+)
+
+/// Color a fully neutral, template-safe gray, used for passages without a
+/// reviewer-shaped anchor (typographical fixes with no anchor at all).
+#let neutral-color = rgb("#5c5c5c")
+
+/// Color for editor comments — distinct from every reviewer slot in
+/// `default-palette`, dark enough to read as "authority", not "reviewer".
+#let editor-color = rgb("#241f31")
+
+#let reviewer-color(n) = default-palette.at(calc.rem(n - 1, default-palette.len()))
+
+/// Muted variant of an `add` color, used for `del`: desaturated and
+/// darkened rather than a plain gray, so a deletion still reads as
+/// "the same reviewer, muted" rather than losing reviewer identity
+/// altogether. Exists because `add` and `del` used to share one color,
+/// distinguished only by decoration (`underline` vs `strike`) — which
+/// works on text but leaves the two visually identical on math, where
+/// neither decoration reaches the real glyphs (`tests/strike-methods.typ`
+/// §"Le vrai problème", cases E.1–E.4; full exploration and the decision
+/// to fix it this way in `CLAUDE.md`). The exact formula is a first
+/// working draft, not tuned against the whole palette above.
+#let del-color(c) = c.desaturate(60%).darken(15%)
+
+#let default-style = (
+  style: "inline", // "inline" | "bar" | "none"  ("margin" is v0.2)
+  color: auto, // auto = anchors-color(...), or a fixed color to override per-reviewer/author colors
+  add-style: underline,
+  del-style: default-del-mark,
+  highlight-passage: false,
+  show-anchor: true,
+  del-numbering: "none", // "none" | "keep"
+  require-exchange: true, // numbered anchors with no matching exchange warn by default
+  comment-word: "comment", // header noun for reviewer/editor exchanges: "Reviewer 1 — comment 2"
+  change-word: "change", // header noun for author notes: "Bobby Fischer — change 3"
+)
+
+// Defined here (right after the plain color helpers, before the author
+// section below) rather than further down with `set-revisions`, purely
+// so `anchors-color` — which needs to read it — can be defined right
+// after it: Typst resolves top-level names in file order, a function
+// can't forward-reference a `#let` that appears later in the same
+// module (verified directly: calling a closure that reads a name bound
+// afterward errors "unknown variable", it's not hoisted).
+#let style-state = state("palimpsest-style", default-style)
+
+/// Palette for co-author anchors (`author-color`, below) — deliberately
+/// different hues from `default-palette`, not just a rotation of it, so a
+/// reviewer and a co-author showing up in the same tracked manuscript
+/// (revision and peer review overlapping) are never confusable at a
+/// glance, even by coincidence.
+#let default-author-palette = (
+  rgb("#0d9488"), // teal
+  rgb("#b45309"), // amber
+  rgb("#be185d"), // pink
+  rgb("#4d7c0f"), // olive
+  rgb("#4338ca"), // indigo
+  rgb("#78350f"), // brown
+)
+
+/// Registry populated by `set-revisions(authors: ...)`: maps an author id
+/// (the string parsed out of an anchor like `<bob-3>`) to a dict with
+/// optional `name:`/`color:` keys. Kept as its own state, separate from
+/// `style-state`, since it's data (who's who), not a rendering style
+/// knob — but still just a "set once via `set-revisions`, read many
+/// times" state, the same shape `style-state` already is, not the
+/// per-occurrence kind of state that turned out not to fit `anchors-color`
+/// (see `author-color` below).
+#let author-registry = state("palimpsest-authors", (:))
+
+/// Deterministic, configuration-free color for an author id: the sum of
+/// its characters' Unicode codepoints, modulo the palette size — verified
+/// directly (`"bob"` and `"alice"` land on different slots). Pure
+/// function of the string, not of document position: an *auto-assigned
+/// color* was originally meant to go "first author encountered in the
+/// document gets slot 0, second gets slot 1", but that requires
+/// `anchors-color`'s call sites (`mark-visual`, `passage`, `suppress` in
+/// `marks.typ`) to *emit* a state-update marker into the rendered tree at
+/// each occurrence — state updates only take effect once actually placed
+/// in content, not merely called as a side effect inside a plain
+/// function (verified directly, isolated from this codebase). That's a
+/// materially bigger, riskier change than a color lookup should need, so
+/// the hash instead: same color for the same name everywhere, no state,
+/// no restructuring, at the accepted cost that two unrelated names can
+/// coincidentally land on the same slot.
+#let author-hash-color(id) = {
+  let sum = id.clusters().map(c => c.to-unicode()).sum(default: 0)
+  default-author-palette.at(calc.rem(sum, default-author-palette.len()))
+}
+
+/// Color for an author id: the registry's explicit `color:` if one was
+/// configured via `set-revisions(authors: ...)`, otherwise the
+/// deterministic hash color above.
+///
+/// Deliberately *not* wrapped in its own `context`: `author-registry` is
+/// only ever written once (by `set-revisions`), so reading it is exactly
+/// the same "set once, read many times" shape `style-state` already is
+/// throughout this file. A plain function that calls `.get()` directly,
+/// invoked from *within* a caller's existing `context` block (as
+/// `anchors-color` already is at all three of its call sites), resolves
+/// fine and returns a plain, immediately usable color — verified
+/// directly. Wrapping it in a redundant nested `context` here would
+/// instead turn the return value into content, breaking every caller
+/// that does `color.lighten(...)`/`fill: color` on the result.
+#let author-color(id) = {
+  let entry = author-registry.get().at(id, default: (:))
+  entry.at("color", default: author-hash-color(id))
+}
+
+/// Display name for an author id: the registry's `name:` if configured,
+/// otherwise the raw id exactly as written in the anchor. Same "plain
+/// function, ambient context" reasoning as `author-color` above.
+#let author-display-name(id) = {
+  let entry = author-registry.get().at(id, default: (:))
+  entry.at("name", default: id)
+}
+
+/// Picks the color for a set of anchors: `set-revisions(color: ...)`
+/// wins outright if set (a fixed color for every mark, no exceptions —
+/// this is the one knob meant to *override* per-reviewer/author
+/// coloring entirely, not participate in it); otherwise the first
+/// anchor that parses (`r<reviewer>-<n>`, `e<n>`, or `<author>[-<n>]`)
+/// decides the color; a passage with no anchor at all, or nothing left
+/// to decide, gets `neutral-color`.
+#let anchors-color(anchors) = {
+  let sty = style-state.get()
+  if sty.color != auto {
+    return sty.color
+  }
+  for a in anchors {
+    let p = parse-anchor(a)
+    if p != none {
+      return if p.kind == "editor" {
+        editor-color
+      } else if p.kind == "author" {
+        author-color(p.author)
+      } else {
+        reviewer-color(p.reviewer)
+      }
+    }
+  }
+  neutral-color
+}
+
+/// Normalizes one `authors:` entry to `(name: ..., color: ...)`, either
+/// key possibly absent: a plain string is shorthand for `(name: string)`;
+/// a dict passes through, keeping only `name:`/`color:` if present.
+#let normalize-author-entry(v) = {
+  if type(v) == str { (name: v) } else { v }
+}
+
+/// Sets the document-wide revision style. Call once, before any `passage`.
+/// Unset (`auto`) parameters keep their current value — repeated calls
+/// merge rather than reset.
+///
+/// `authors:` registers co-author ids (see `parse-anchor`'s `author`
+/// kind) to a full display name and/or a fixed color — e.g.
+/// `authors: (bob: (name: "Bobby Fischer", color: rgb("#...")), alice:
+/// "Alice Smith")`. Unlike the other parameters here, passing `authors:`
+/// *replaces* the whole registry rather than merging key-by-key — call
+/// it once with the complete map. An author id never mentioned here
+/// still works (see `author-color`/`author-display-name`), just with an
+/// automatic hash-based color and its raw id as the display name.
+///
+/// `require-exchange:` gates the "anchor: no matching exchange" warning
+/// (`passage`, `marks.typ`) for *numbered* anchors — bare, number-less
+/// anchors (`<bob>`, no `-<n>`) are always exempt regardless of this
+/// setting, since they're not meant to key into one particular exchange
+/// in the first place.
+///
+/// `comment-word:`/`change-word:` control the noun `exchange`/`note`
+/// generate in their header ("Reviewer 1 — comment 2" / "Bobby Fischer —
+/// change 3") — overridable per call via `exchange(..., term: ...)`/
+/// `note(..., term: ...)`.
+#let set-revisions(
+  style: auto,
+  color: auto,
+  add-style: auto,
+  del-style: auto,
+  highlight-passage: auto,
+  show-anchor: auto,
+  del-numbering: auto,
+  authors: auto,
+  require-exchange: auto,
+  comment-word: auto,
+  change-word: auto,
+) = {
+  if authors != auto {
+    author-registry.update(authors.pairs().map(((k, v)) => (k, normalize-author-entry(v))).to-dict())
+  }
+  style-state.update(s => {
+    if style != auto { s.style = style }
+    if color != auto { s.color = color }
+    if add-style != auto { s.add-style = add-style }
+    if del-style != auto { s.del-style = del-style }
+    if highlight-passage != auto { s.highlight-passage = highlight-passage }
+    if show-anchor != auto { s.show-anchor = show-anchor }
+    if require-exchange != auto { s.require-exchange = require-exchange }
+    if comment-word != auto { s.comment-word = comment-word }
+    if change-word != auto { s.change-word = change-word }
+    if del-numbering != auto { s.del-numbering = del-numbering }
+    s
+  })
+}

--- a/packages/preview/palimpsest/0.1.0/src/utils.typ
+++ b/packages/preview/palimpsest/0.1.0/src/utils.typ
@@ -1,0 +1,579 @@
+/// Recursively collects the `.value` of every `metadata` element in `body`
+/// whose value is a dictionary tagged with `tag`, in document order.
+/// Purely structural (no layout, no context) — walks the content tree as
+/// data, the same way typst-navigator's `extract-text` does.
+///
+/// Walks *every* content- or array-valued field of each element, not just
+/// `body`/`children` — a mark nested in a `figure`'s `caption:` or a
+/// table's cells lives in a field the shortlist would have missed.
+#let collect-metadata(body, tag) = {
+  let walk(node) = {
+    let t = type(node)
+    if t == content {
+      if node.func() == metadata {
+        let v = node.value
+        if type(v) == dictionary and v.at("tag", default: none) == tag {
+          return (v,)
+        }
+        return ()
+      }
+      return node.fields().values().map(v => {
+        let t2 = type(v)
+        if t2 == content or t2 == array { walk(v) } else { () }
+      }).sum(default: ())
+    } else if t == array {
+      return node.map(walk).sum(default: ())
+    }
+    return ()
+  }
+  walk(body)
+}
+
+/// Normalizes the `anchors` argument accepted by `passage` and its
+/// shortcuts: `none`, a single label, or an array of labels — always
+/// returns an array.
+#let normalize-anchors(anchors) = {
+  if anchors == none { () }
+  else if type(anchors) == array { anchors }
+  else { (anchors,) }
+}
+
+/// Parses an anchor label into its round/kind/identity/number components.
+/// `<r1-2>` → round 1 (implicit), reviewer 1, comment 2.
+/// `<2r1-2>` → round 2, reviewer 1, comment 2.
+/// `<e1>` → editor comment 1 (round 1, no reviewer number).
+/// `<2e1>` → round 2, editor comment 1.
+/// `<bob-3>` → author "bob", change 3 (round 1, implicit) — anything that
+/// isn't a reviewer/editor label but still looks like `<name>` or
+/// `<name>-<number>` (tried in that order, so `r1-2`/`e3` always hit the
+/// reviewer/editor branches first, never this one). `<bob>` alone (no
+/// trailing `-<number>`) parses as author "bob" with `num: none` — a
+/// bare, non-discriminating anchor meant to be reused freely across many
+/// passages/notes with no per-occurrence identity, not an error (see
+/// `passage`'s and `exchange`'s exemptions for `num: none` anchors).
+/// A hyphen inside the name itself is handled correctly (`<bob-fischer-12>`
+/// → author "bob-fischer", change 12): only a *trailing* `-<digits>` is
+/// ever read as the number, so a name with no trailing `-<digits>` at all
+/// (`<bob>`, `<bob-fischer>`) is just a bare name, never split further.
+/// Returns `none` only for labels that don't even look like a bare
+/// identifier (essentially never, in practice, for a real Typst label).
+#let parse-anchor(lbl) = {
+  let s = str(lbl)
+  let m = s.match(regex("^(\d*)r(\d+)-(\d+)$"))
+  if m != none {
+    return (
+      round: if m.captures.at(0) in (none, "") { 1 } else { int(m.captures.at(0)) },
+      kind: "reviewer",
+      reviewer: int(m.captures.at(1)),
+      num: int(m.captures.at(2)),
+    )
+  }
+  let me = s.match(regex("^(\d*)e(\d+)$"))
+  if me != none {
+    return (
+      round: if me.captures.at(0) in (none, "") { 1 } else { int(me.captures.at(0)) },
+      kind: "editor",
+      reviewer: none,
+      num: int(me.captures.at(1)),
+    )
+  }
+  let ma = s.match(regex("^(\d*)([a-zA-Z][a-zA-Z0-9_-]*?)(?:-(\d+))?$"))
+  if ma != none {
+    return (
+      round: if ma.captures.at(0) in (none, "") { 1 } else { int(ma.captures.at(0)) },
+      kind: "author",
+      author: ma.captures.at(1),
+      num: if ma.captures.at(2) == none { none } else { int(ma.captures.at(2)) },
+    )
+  }
+  none
+}
+
+/// True if `body` contains no non-whitespace text anywhere in its tree —
+/// used to catch an `exchange` written with a comment but an empty
+/// response (§11: "exchange r3-1: empty response").
+#let is-blank(body) = {
+  let walk(node) = {
+    let t = type(node)
+    if t == content {
+      if node.func() == metadata { return false }
+      if node.has("text") {
+        return node.text.trim() != ""
+      }
+      return node.fields().values().any(v => {
+        let t2 = type(v)
+        if t2 == content or t2 == array { walk(v) } else { false }
+      })
+    } else if t == array {
+      return node.any(walk)
+    }
+    false
+  }
+  not walk(body)
+}
+
+/// Recursively collects every non-`none` `.label` found anywhere in
+/// `body`'s tree (a figure, a heading, an equation — any labelled
+/// element). Used by `pinpoint(excerpt: true)` to detect when
+/// re-emitting a passage's stored content into the letter would plant a
+/// second copy of a label that's meant to be unique in the bundle (a
+/// figure the manuscript also cross-references by that same label,
+/// typically) — Typst treats a duplicate label as a hard compile error,
+/// not a warning, so this has to be checked *before* re-emitting, not
+/// discovered by trying it.
+#let collect-labels(body) = {
+  let walk(node) = {
+    let t = type(node)
+    if t == content {
+      let lbl = node.fields().at("label", default: none)
+      let own = if lbl != none { (lbl,) } else { () }
+      own + node.fields().values().map(v => {
+        let t2 = type(v)
+        if t2 == content or t2 == array { walk(v) } else { () }
+      }).sum(default: ())
+    } else if t == array {
+      node.map(walk).sum(default: ())
+    } else {
+      ()
+    }
+  }
+  walk(body)
+}
+
+/// Walks `body` structurally (same recursion shape as `collect-labels`,
+/// above) to find which numbered element kinds it actually contains —
+/// `heading`, and `figure` broken down by `image`/`table`/`raw` kind
+/// (inferred from the figure's own `body` field, same inference Typst
+/// itself uses and the same one `mark-figure-body` has to redo
+/// explicitly after crossing), plus `math.equation`. Used by
+/// `neutralize-numbering` (`marks.typ`) to snapshot/restore only the
+/// counters a given deletion actually touches, instead of all five
+/// unconditionally on every single deletion — not just an optimization:
+/// verified directly that touching all five regardless of content, with
+/// enough mixed deletions stacked in one document (several headings,
+/// figures, tables, and equations all deleted), makes Typst's layout
+/// solver fail to converge within its default five attempts ("document
+/// did not converge" — reproduced with `tests/bundle-numbering-restore.typ`,
+/// which needed all four kinds deleted together to trigger it; any
+/// three alone converged fine, isolating the cause to the sheer volume
+/// of stacked, unconditional counter reads/writes rather than any one
+/// kind in particular).
+#let no-kinds = (heading: false, image: false, table: false, raw: false, equation: false)
+
+#let numbered-kinds-in(body) = {
+  // Typst closures can't mutate a captured variable (verified directly
+  // — "variables from outside the function are read-only"), so this
+  // combines results by *returning and OR-ing* them, the same shape
+  // `collect-labels` (above) already uses for the same reason, rather
+  // than accumulating into a shared dict from inside `walk` the way an
+  // first draft of this function tried and failed to compile.
+  let or-kinds = (a, b) => (
+    heading: a.heading or b.heading,
+    image: a.image or b.image,
+    table: a.table or b.table,
+    raw: a.raw or b.raw,
+    equation: a.equation or b.equation,
+  )
+  let walk(node) = {
+    let t = type(node)
+    if t == content {
+      let f = node.func()
+      let own = if f == heading {
+        (..no-kinds, heading: true)
+      } else if f == math.equation {
+        (..no-kinds, equation: true)
+      } else if f == figure {
+        let b = node.fields().at("body", default: none)
+        let bf = if type(b) == content { b.func() } else { none }
+        if bf == table {
+          (..no-kinds, table: true)
+        } else if bf == raw {
+          (..no-kinds, raw: true)
+        } else {
+          (..no-kinds, image: true)
+        }
+      } else {
+        no-kinds
+      }
+      node.fields().values().fold(own, (acc, v) => {
+        let t2 = type(v)
+        if t2 == content {
+          or-kinds(acc, walk(v))
+        } else if t2 == array {
+          v.fold(acc, (acc2, x) => if type(x) == content { or-kinds(acc2, walk(x)) } else { acc2 })
+        } else {
+          acc
+        }
+      })
+    } else if t == array {
+      node.fold(no-kinds, (acc, x) => or-kinds(acc, walk(x)))
+    } else {
+      no-kinds
+    }
+  }
+  walk(body)
+}
+
+/// Recursively reconstructs `node` with every label removed —
+/// `pinpoint(excerpt: true)` runs this on a passage's stored content
+/// before re-emitting it into the letter, so a figure/table/equation/
+/// heading the passage adds can be *shown*, not just cited by page,
+/// even though its label is also the target of a real `@ref` elsewhere
+/// in the bundle (§6quinquies/§6septies): the copy in the letter no
+/// longer carries that label, so citing it anywhere still resolves
+/// unambiguously to the one true original in the manuscript (verified
+/// directly, including with an `@ref` sitting inline right next to the
+/// stripped copy).
+///
+/// A `figure`, a labelled block `math.equation`, or a labelled
+/// `heading` that still has its original label at the point this runs
+/// gets one more thing done to it before that label is dropped:
+/// `query(lbl)` finds the true, already-shown manuscript original (the
+/// copy being built right now doesn't exist yet, so this can't resolve
+/// to itself), and its real, resolved number is pinned onto the
+/// reconstructed copy's `numbering:` field as a literal value (`(..) =>
+/// real-number`). A local `numbering:` always wins over whatever `set
+/// figure(numbering: ...)`/`set math.equation(numbering:
+/// ...)`/`set heading(numbering: ...)` is active where the copy is
+/// re-emitted — normally the letter's own independent "R" sequence for
+/// a figure (`with-letter-numbering`, `letter.typ`) — so a figure,
+/// equation, or heading the letter quotes shows the *same* number it
+/// has in the manuscript ("Figure 2"/"Equation 3"/"2.1" in both places)
+/// instead of a letter-local one ("Figure 2" in the manuscript, "Figure
+/// R1" in the letter) that gave no hint the two were the same element.
+/// The three element types need different fields to compute that real
+/// number, which is the only reason they're not handled by one shared
+/// branch: a `figure` synthesizes its own `.counter` once shown (scoped
+/// to its `kind`, so it already reads the right one whatever that kind
+/// is); `math.equation` and `heading` don't synthesize one, so
+/// `counter(math.equation)`/`counter(heading)` — the one, ungrouped
+/// counter every equation shares, and likewise the one counter that
+/// already returns a heading's full "2.1"-style array regardless of
+/// level (verified directly, no per-level split the way `figure` has a
+/// per-`kind` one) — have to be read explicitly instead. Skipped,
+/// falling through to whatever numbering already applies, whenever
+/// there's nothing to pin: no label, the label doesn't resolve anywhere
+/// (a figure/equation/heading the *letter* itself adds, never in the
+/// manuscript at all), or the original's own `numbering` is `none`
+/// (some future case setting it directly — not `del-numbering: "none"`
+/// itself, which since `neutralize-numbering` (`marks.typ`) switched
+/// from blanking numbering to snapshotting/restoring the counter no
+/// longer sets a deleted element's own `numbering` to `none` at all; a
+/// deleted figure/equation/heading keeps its real, resolved numbering
+/// and is pinned just like a kept one — this guard is now mostly
+/// theoretical, kept because `numbering(none, ..)` is still a hard
+/// Typst error if it's ever `none` for any other reason). An *inline*
+/// equation is covered by the same branch as a block one —
+/// `math.equation`'s `.numbering` field and the shared counter work
+/// identically either way — but an inline equation is rarely labelled
+/// or numbered in practice, so this is mostly untested territory. A
+/// `heading` is, in the same sense, rarely labelled at all outside of
+/// this use case — the gain only shows up for a heading the author
+/// specifically labels so it can be quoted with its real section
+/// number; an unlabelled one (the common case) just stays unnumbered in
+/// the letter, as before.
+///
+/// Doesn't change how many counter slots a re-emitted figure consumes
+/// — it still advances whichever kind-scoped counter is active where
+/// it's shown (a real `figure` element always does, however its number
+/// is displayed), same as before this pinning existed. A letter's own,
+/// genuinely new figure appearing after several quoted ones therefore
+/// still gets whatever "R" number that position implies, not a clean
+/// "R1" — already true before this change (an excerpt has always
+/// consumed a slot in the letter's counter, only its *displayed*
+/// number is new), so left as is rather than introducing a separate
+/// counter namespace (`kind:`) to fix a property nobody has asked for.
+///
+/// Reconstructs an element via its own `.func()(..fields)` — works
+/// uniformly across element types (figure, heading, math.equation, all
+/// verified) *except* that a `sequence`'s `children` field is one
+/// positional array argument, not one argument per child (`ctor(c)`,
+/// not `ctor(..c)` — verified: the latter errors "expected array,
+/// found content"); every other field with a content/array value goes
+/// through `..named-fields` uniformly since element constructors accept
+/// their own field names as keyword arguments.
+///
+/// Only reconstructs subtrees that actually contain a label
+/// (`collect-labels(node).len() == 0` bails out immediately) — the vast
+/// majority of any passage's content has no label anywhere in it, and
+/// skipping reconstruction there is both cheaper and safer: rebuilding
+/// content nobody needs to change is pure risk for no benefit. `metadata`
+/// nodes are never reconstructed either — the package's own internal
+/// tag labels (`<palimpsest-mark>` etc., deliberately reused across the
+/// whole bundle) must survive re-emission untouched.
+#let strip-labels(node) = {
+  let t = type(node)
+  if t == content {
+    if node.func() == metadata or collect-labels(node).len() == 0 {
+      return node
+    }
+    let f = node.fields()
+    let new-f = (:)
+    for (k, v) in f {
+      if k == "label" { continue }
+      let t2 = type(v)
+      new-f.insert(k, if t2 == content {
+        strip-labels(v)
+      } else if t2 == array {
+        v.map(x => if type(x) == content { strip-labels(x) } else { x })
+      } else {
+        v
+      })
+    }
+    let ctor = node.func()
+    if ctor == figure or ctor == math.equation or ctor == heading {
+      let lbl = f.at("label", default: none)
+      if lbl != none {
+        let hits = query(lbl)
+        if hits.len() > 0 {
+          let orig = hits.first()
+          if orig.numbering != none {
+            // `figure` synthesizes its own `.counter` once shown, scoped
+            // to its `kind`. `math.equation` and `heading` don't — both
+            // share one, plain, ungrouped counter apiece (`heading`'s
+            // isn't scoped by level either: `counter(heading)` alone
+            // already returns the full "2.1"-style array, verified
+            // directly), so both read the same generic counter directly.
+            let cval = if ctor == figure {
+              orig.counter.at(orig.location())
+            } else if ctor == math.equation {
+              counter(math.equation).at(orig.location())
+            } else {
+              counter(heading).at(orig.location())
+            }
+            let real-number = numbering(orig.numbering, ..cval)
+            new-f.insert("numbering", (..) => real-number)
+          }
+        }
+      }
+    }
+    if "body" in new-f {
+      let b = new-f.remove("body")
+      ctor(b, ..new-f)
+    } else if "children" in new-f {
+      // `children`'s calling convention isn't uniform: `sequence` wants
+      // its array as one positional argument (`ctor(c)` — spreading
+      // errors "expected array, found content"), while `table`, `grid`
+      // and likely others of that family want each child spread as its
+      // own positional argument (`ctor(..c)` — passing the array as one
+      // argument errors "expected content, found array"). Both verified
+      // directly; `repr(ctor)` is the only way found to tell them apart,
+      // since `sequence` itself isn't a nameable value to compare
+      // against directly (`node.func() == sequence` doesn't parse).
+      let c = new-f.remove("children")
+      if repr(ctor) == "sequence" { ctor(c, ..new-f) } else { ctor(..c, ..new-f) }
+    } else {
+      ctor(..new-f)
+    }
+  } else if t == array {
+    node.map(strip-labels)
+  } else {
+    node
+  }
+}
+
+/// Overlays a horizontal line at mid-height across `body`, colored by
+/// the ambient `text.fill` (not a parameter — reads the color already
+/// set by whatever `text(fill: ...)` wraps the call, so it stays in
+/// sync with `mark-visual`'s coloring without needing to be threaded
+/// through separately). Used as `del`'s default mark for an *inline*
+/// equation: `strike()`/`underline()` never decorate real math glyphs
+/// (only literal quoted-string subscripts), verified exhaustively in
+/// `tests/strike-methods.typ` §1/§2 — this overlay reaches the glyphs
+/// themselves. Safe specifically because it's only ever applied to a
+/// single inline equation, not to reflowable prose (see `CLAUDE.md`
+/// §6bis for the M1 regression this would otherwise repeat, and
+/// `tests/strike-methods.typ` cases G.12/H.4 for the residual risk that
+/// remains even scoped this narrowly: a long inline equation loses its
+/// native ability to break across lines — accepted, inline equations
+/// are rarely long in practice).
+#let strike-b(body) = context {
+  let c = text.fill
+  let sz = measure(body)
+  box(width: sz.width, height: sz.height)[
+    #body
+    #place(top + left, dy: sz.height / 2, line(length: sz.width, stroke: 0.6pt + c))
+  ]
+}
+
+/// Overlays a diagonal cross spanning all of `body`, colored by the
+/// ambient `text.fill` (same reasoning as `strike-b` above). Used as
+/// `del`'s default mark for a *block* equation, a `figure`, and a bare
+/// `table`. Preferred over `strike-b`'s single mid-height line at block
+/// scale for two reasons, both verified in `tests/strike-methods.typ`:
+/// a line at mid-height becomes *invisible* when it coincides with
+/// content that already has its own horizontal bar (a fraction — case
+/// I.1, not merely "hard to see": indistinguishable from an unmarked
+/// fraction), and a block equation/figure never needs to reflow
+/// word-by-word, so the `measure`+`box` overlay that's unsafe for prose
+/// (§6bis) is safe here (§8.2's note, `tests/strike-methods.typ`).
+#let cross(body) = context {
+  let c = text.fill
+  let sz = measure(body)
+  box(width: sz.width, height: sz.height)[
+    #body
+    #place(top + left, line(start: (0pt, 0pt), end: (sz.width, sz.height), stroke: 0.8pt + c))
+    #place(top + left, line(start: (0pt, sz.height), end: (sz.width, 0pt), stroke: 0.8pt + c))
+  ]
+}
+
+/// Reconstructs `fig` with its `body` field crossed out (`cross`,
+/// above) and everything else — crucially, `caption` — untouched, so a
+/// caller wrapping the result in `strike()` still reaches the caption's
+/// real text natively, while the figure's body (an image, a plot, a
+/// table with no text of its own) gets the overlay instead. `label` and
+/// `counter` are removed before reconstructing and the label alone is
+/// reattached after (`[#new-fig#lbl]`, the same postfix-attachment
+/// syntax as `#figure(...) <label>` in markup): `label` isn't a valid
+/// named argument to `figure()`'s constructor, and `counter` is a field
+/// Typst synthesizes once a figure has actually been shown — present on
+/// the `fig` this function is really called with (nested inside a real
+/// `del()` passage), never present when constructing a bare `figure()`
+/// by hand, which is why this gap surfaced only once tested against a
+/// *labeled* figure nested in a larger deletion, not against the
+/// simpler cases that motivated `cross` in the first place (all
+/// verified in `tests/strike-methods.typ`, case F.9's note and
+/// F.9–F.11).
+///
+/// `kind` is also removed and recomputed explicitly, from `b` — the
+/// original, uncrossed body — rather than left for Typst to re-infer on
+/// the reconstructed figure: `cross(b)` wraps `b` in a `box`, and a
+/// figure's automatic kind inference only recognizes a body whose own
+/// `.func()` is directly `table`/`raw` (falling back to `image`
+/// otherwise) — a `box` matches neither, so a crossed *table* was
+/// silently mis-inferred as `kind: image` and captioned/counted as a
+/// "Figure" instead of a "Table". Invisible as long as a deleted
+/// figure's number was hidden outright (`neutralize-numbering`'s old
+/// `numbering: none` approach); surfaced once that changed to keep the
+/// real number visible (`neutralize-numbering` now restores counters
+/// instead of blanking them) — verified directly, see
+/// `docs/manual-snippets/style-del-numbering-none.typ`'s tracked
+/// output before this fix ("Figure 3: Removed table" under a plain,
+/// non-custom template). Doesn't affect *which* counter actually
+/// advances at layout time if this inference is still somehow wrong for
+/// some future body shape — `neutralize-numbering` restores every
+/// kind-scoped counter unconditionally, so a subsequent real figure's
+/// own number was never at risk, only this element's own caption.
+#let mark-figure-body(fig) = {
+  let f = fig.fields()
+  let b = f.remove("body")
+  let lbl = f.remove("label", default: none)
+  let _ = f.remove("counter", default: none)
+  let _ = f.remove("kind", default: none)
+  let kind = if b.func() == table { table } else if b.func() == raw { raw } else { image }
+  let new-fig = fig.func()(cross(b), kind: kind, ..f)
+  if lbl != none { [#new-fig#lbl] } else { new-fig }
+}
+
+/// Reconstructs a *block* `math.equation` with only its `body` field
+/// crossed out — same shape and same underlying reason as
+/// `mark-figure-body`, above. An earlier version crossed the *whole*
+/// numbered equation directly (`cross(eq)`, `eq` still carrying its own
+/// `numbering:`): `cross`'s `measure(body)` only ever returns an
+/// element's tight, intrinsic size — for a numbered equation, that
+/// collapses back down to just the width of its glyphs, discarding the
+/// full-page-width, number-pushed-to-the-margin layout Typst's own
+/// equation-numbering machinery gives a *normally* placed numbered
+/// equation. The reconstructed box ended up exactly as wide as "E =
+/// mc²" alone, squeezing the equation's real number right up against
+/// it instead of at the margin — verified directly, reproduced with a
+/// bare `#set math.equation(numbering: ...)` equation measured and
+/// re-boxed, no palimpsest involved. Crossing only `body` avoids this:
+/// `cross` only ever measures the bare math glyphs (always meant to be
+/// tightly boxed), while the surrounding `math.equation` — reconstructed
+/// with its `numbering`/`block` fields untouched — gets Typst's native,
+/// full-width, right-justified numbering layout exactly like a kept or
+/// added equation, centering itself the same way any block equation
+/// natively does. The caller no longer needs its own `align(center,
+/// block(...))` wrapper for this (removed): that wrapper only ever
+/// existed to recenter a box that had collapsed to its tight size, not
+/// something a *correctly*-sized reconstructed equation needs.
+#let mark-equation-body(eq) = {
+  let f = eq.fields()
+  let b = f.remove("body")
+  let lbl = f.remove("label", default: none)
+  let new-eq = eq.func()(cross(b), ..f)
+  if lbl != none { [#new-eq#lbl] } else { new-eq }
+}
+
+/// `del`'s default visual mark (`style.typ`'s `default-style.del-style`):
+/// native `strike()` for plain text — reflows normally, exactly like
+/// today — with three exceptions found and fixed together, all
+/// documented at length in `tests/strike-methods.typ`: a *block* math
+/// equation or a bare `table` gets `cross`, an *inline* equation gets
+/// `strike-b`'s single line (a full cross would be disproportionate on
+/// a single symbol, and a wide cross degrades toward two near-parallel
+/// lines rather than an inline mark to begin with), and a `figure` gets
+/// `mark-figure-body` plus an outer `strike()` so its caption is still
+/// natively struck. Recurses into a `sequence` to find these wherever
+/// they sit in a passage that mixes prose, equations and a figure in
+/// one `del(...)` call (verified nested three deep, case F.9) — a show
+/// rule was tried first and rejected: reconstructing a `math.equation`
+/// or `figure` from *inside* a show rule matching that same element
+/// type re-triggers the rule on its own output (`maximum show rule
+/// depth exceeded`, cases G.9 and the note preceding this function's
+/// sibling `mark-figure-body`); a one-shot recursive rebuild, called
+/// once and never registered as a standing rule, has no such trap.
+#let default-del-mark(body) = {
+  if type(body) != content {
+    body
+  } else if body.func() == math.equation and body.at("block", default: false) {
+    mark-equation-body(body)
+  } else if body.func() == math.equation {
+    strike-b(body)
+  } else if body.func() == figure {
+    strike(mark-figure-body(body))
+  } else if body.func() == table {
+    strike(cross(body))
+  } else if repr(body.func()) == "sequence" {
+    body.children.map(default-del-mark).sum(default: [])
+  } else {
+    strike(body)
+  }
+}
+
+/// Local override for `add`/`del`/`rep`'s internal clean-vs-tracked
+/// rendering choice, read via `context`. `pinpoint(excerpt: true, mode:
+/// ...)` sets this immediately before re-emitting a passage's stored
+/// content and resets it right after, so one excerpt can render in a
+/// specific mode regardless of what the *current compile* is actually
+/// doing — the manuscript's own copy, laid out earlier at its own
+/// position, is unaffected (state resolves by document position, same
+/// trick as `current-passage-anchors` above). `none` = no override,
+/// defer to the real compile mode (today's behavior, unchanged).
+///
+/// Deliberately **not** consulted by the public `mode()` in
+/// `marks.typ`: that one always reflects the actual compile and is
+/// meant for the author's own mode-dependent content (a table's column
+/// count, say) — only the package's own marks respond to this override,
+/// not arbitrary user code re-emitted along with them.
+#let render-mode-override = state("palimpsest-render-mode-override", none)
+
+/// True while `add`/`del`/`rep` are rendering as part of a
+/// `pinpoint(excerpt: true)` re-emission, read via `context` — same
+/// set-before/reset-after bracketing and same position-based resolution
+/// as `render-mode-override` above. When true, each mark strips labels
+/// from its own `body`/`old`/`new` *before* deciding what to show
+/// (`strip-labels`, still on the plain, not-yet-`context`-wrapped
+/// value, so the structural walk it needs still works) — letting a
+/// figure/table/equation a passage adds be shown in full in the letter
+/// even though its label is also referenced elsewhere in the bundle,
+/// without duplicating that label. Must happen inside `add`/`del`/`rep`
+/// themselves, not from `pinpoint` after the fact: by the time a mark's
+/// *rendered* content exists, it is wrapped in `context` (needed for
+/// `render-mode-override` above) and therefore structurally opaque —
+/// stripping has to happen before that wrapping, on the original
+/// argument, which only the mark itself still has direct access to.
+#let in-excerpt = state("palimpsest-in-excerpt", false)
+
+/// State holding the anchors of the passage currently being emitted, so
+/// that `add`/`del`/`rep` — called *inside* a passage's body, i.e. before
+/// the enclosing `passage()` call itself runs — can still pick up the
+/// passage's anchors at layout time via `context`. Resolution follows
+/// final document order, not Typst call order, so this works even though
+/// marks are evaluated before the passage that will contain them.
+///
+/// `none` outside of any passage (the "#del outside any passage"
+/// diagnostic fires on exactly this) — distinct from `()`, a real
+/// passage that simply has no anchor (§4, "passage sans ancre").
+#let current-passage-anchors = state("palimpsest-current-anchors", none)

--- a/packages/preview/palimpsest/0.1.0/src/xref.typ
+++ b/packages/preview/palimpsest/0.1.0/src/xref.typ
@@ -1,0 +1,16 @@
+#import "diagnostics.typ": diagnose
+
+/// Like `@label` / `ref(label)` (which already resolve cross-document —
+/// `@tab-sensi` from the letter renders the manuscript's real "Tableau
+/// 3"), but appends the manuscript's real page number: "Tableau 3, p.
+/// 14". Explicit rather than a bare `@label`, so it stays correct even
+/// if a future version duplicates the manuscript in the bundle (§9) —
+/// `ref` alone would then be ambiguous between the two copies.
+#let xref(lbl) = context {
+  let hits = query(lbl)
+  if hits.len() == 0 {
+    diagnose("xref(" + repr(lbl) + "): not found", always: true)
+  } else {
+    [#ref(lbl), p. #hits.first().location().page()]
+  }
+}

--- a/packages/preview/palimpsest/0.1.0/typst.toml
+++ b/packages/preview/palimpsest/0.1.0/typst.toml
@@ -7,6 +7,6 @@ description = "Manuscript revision and reviewer response letters, generated from
 license = "MIT"
 keywords = ["revision", "peer review", "rebuttal", "manuscript", "response letter"]
 compiler = "0.15.0"
-categories = ["academic"]
+categories = ["office", "utility"]
 repository = "https://github.com/eusebe/typst-palimpsest"
 exclude = ["tests", "mockup", "CLAUDE.md", "palimpsest-specification.md", "*.pdf", "**/*.pdf", "**/*.png", ".gitignore", ".DS_Store"]

--- a/packages/preview/palimpsest/0.1.0/typst.toml
+++ b/packages/preview/palimpsest/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "palimpsest"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["David Hajage <dhajage@gmail.com>"]
+description = "Manuscript revision and reviewer response letters, generated from a single annotated source."
+license = "MIT"
+keywords = ["revision", "peer review", "rebuttal", "manuscript", "response letter"]
+compiler = "0.15.0"
+categories = ["academic"]
+repository = "https://github.com/eusebe/typst-palimpsest"
+exclude = ["tests", "mockup", "CLAUDE.md", "palimpsest-specification.md", "*.pdf", "**/*.pdf", "**/*.png", ".gitignore", ".DS_Store"]


### PR DESCRIPTION

I am submitting
- [x] a new package
- [ ] an update for a package

Description: Palimpsest turns one annotated manuscript into everything a peer-review response needs: the clean manuscript, a tracked-changes version showing every edit, and a response letter that cites the manuscript's own real page and figure numbers.

I have read and followed the submission guidelines and, in particular, I
- [X] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
  - Explanation: A palimpsest is a manuscript page that was scraped clean and reused, where traces of the erased, earlier writing remain faintly visible beneath the new text. The name is a metaphor for what the package does (showing a manuscript's revision history still legible underneath its accepted, final text) rather than a literal, descriptive term like "review-tracker" or "manuscript-diff" would be.
- [X] added a [`typst.toml`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
- [X] added a [`README.md`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
- [X] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a `LICENSE` file or linked one in my `README.md`
- [X] tested my package locally on my system and it worked
- [X] [`exclude`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE