### PR TITLE
sang-math:1.0.5

### DIFF
--- a/packages/preview/sang-math/1.0.5/LICENSE
+++ b/packages/preview/sang-math/1.0.5/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sang Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/sang-math/1.0.5/README.md
+++ b/packages/preview/sang-math/1.0.5/README.md
@@ -1,0 +1,210 @@
+# sang-math
+
+Bộ macro Typst dành cho Toán THPT Việt Nam: đề thi bốn dạng câu hỏi, sách/chuyên đề, bảng biến thiên, bảng xét dấu và hình học CeTZ.
+
+- Hướng dẫn trực tuyến: https://hdsd-conictypst.pages.dev
+- Mã nguồn: https://github.com/sangnhc87/conictypst
+- Yêu cầu: Typst 0.14.0 trở lên (do `cetz 0.5.2`)
+
+## Cài đặt
+
+```typ
+#import "@preview/sang-math:1.0.5": *
+```
+
+Khi chỉ dùng một nhóm chức năng, nên import đúng tên cần dùng để file dễ đọc và API rõ ràng:
+
+```typ
+#import "@preview/sang-math:1.0.5": tn, ds, tln, tl, True, sang-setup
+```
+
+## API chính
+
+| Nhóm | Macro tiêu biểu |
+|---|---|
+| Đề thi | `tn`, `ds`, `tln`, `tl`, `exam-mode`, `exam-part`, `print-answer-key` |
+| Giao diện đề | `exam-theme`, `exam-preset`, `exam-input-preset`, `exam-template-names` |
+| Sách/chuyên đề | `book-theme`, `book-chapter`, `book-lesson`, các hộp sư phạm, `book-template-names` |
+| Layout in hai mặt | `layout-draft`, `layout-2col-draft` — nội dung 70%, nháp 30% đổi bên chẵn/lẻ |
+| Bảng Toán | `bbtv2`, `bbbt`, `bxd`, `bang-gia-tri`, `bang-phan-phoi`, `auto-bbt` |
+| Hình học cơ bản | `tri-abc`, `tri-right`, `chop-sabc`, `circle-desc`, `axis-xy`, `plot` |
+| Conic | `draw-parabola`, `draw-ellipse`, `draw-hyperbola` |
+| Khối tròn xoay | `draw-cylinder`, `draw-cone`, `draw-sphere` |
+| Đường cong 3D | `draw-helix`, `draw-spring` |
+| Ký hiệu | `RR`, `ZZ`, `NN`, `QQ`, `Rightarrow`, `Leftrightarrow`, `vect`... |
+
+`lib.typ` là cổng public duy nhất và hiện đã export cả template đề, template sách cùng các module CeTZ nâng cao. Người dùng không cần import đường dẫn nội bộ.
+
+## Câu đúng/sai dạng bảng hoặc danh sách
+
+Mặc định `#ds` vẫn dùng bảng Đ/S như các phiên bản trước. Từ `1.0.4`, có thể
+chuyển nhanh sang danh sách bằng `use-table: false`:
+
+```typ
+#ds(
+  [Xét các phát biểu sau.],
+  (True([Mệnh đề đúng.]), [Mệnh đề sai.]),
+  use-table: false,
+)
+```
+
+Để chọn giao diện danh sách, dùng `ds-style` với một trong các giá trị:
+`"list"`, `"pill"`, `"modern"`, `"minimal"`, `"bookmark"`, `"folder"`,
+`"diamond"`, `"gradient"` hoặc `"checklist"`.
+
+```typ
+#ds(
+  [Xét các phát biểu sau.],
+  (True([Mệnh đề đúng.]), [Mệnh đề sai.]),
+  ds-style: "bookmark",
+)
+```
+
+`use-table: false` tương đương `ds-style: "list"`. Cú pháp cũ
+`table: false` cũng được giữ để tương thích với các ví dụ đã lưu.
+
+## Ví dụ đề thi
+
+```typ
+#import "@preview/sang-math:1.0.5": *
+
+#let preset = exam-preset(
+  theme: "teal-pro",
+  profile: "dethi", // dethi | loigiai | compact | draft | beamer
+)
+#let (tn, ds, tln, tl) = exam-mode(..preset.question)
+
+#show: sang-setup.with(math-color: preset.accent)
+#show: exam-theme.with(
+  theme: preset.theme,
+  school: "TRƯỜNG THPT SANG-MATH",
+  exam-title: "ĐỀ THI THỬ TỐT NGHIỆP THPT",
+  subject: "TOÁN 12",
+  duration: "90 phút",
+  code: "101",
+  ..preset.template,
+)
+
+#tn(
+  [Đạo hàm của $f(x)=x^3-3x+1$ tại $x=2$ bằng],
+  ([$3$], True([$9$]), [$6$], [$-3$]),
+  loigiai: [$f'(2)=3 dot 2^2-3=9$.],
+)
+```
+
+## Bộ mẫu để copy và sửa
+
+Thư mục [`examples/copy-ready`](https://github.com/sangnhc87/conictypst/tree/14b296889533c8b1897e5bebbfec499de7c5a932/typst-pkg-sang-math/examples/copy-ready) có các mẫu chạy sẵn cho
+đề 15 phút, giữa kỳ hỗn hợp, cấu trúc THPT 12–4–6, đề tự luận có nháp, phiếu học
+tập và câu có bảng biến thiên/CeTZ. Xem bảng chọn mẫu tại
+[`examples/README.md`](https://github.com/sangnhc87/conictypst/blob/14b296889533c8b1897e5bebbfec499de7c5a932/typst-pkg-sang-math/examples/README.md).
+
+Giáo viên dùng AI/OCR để tạo hoặc chuyển đề có thể sao chép bộ hướng dẫn tại
+[`PROMPT_AI_TAO_DE.md`](https://github.com/sangnhc87/conictypst/blob/14b296889533c8b1897e5bebbfec499de7c5a932/typst-pkg-sang-math/PROMPT_AI_TAO_DE.md). Prompt quy định đúng chữ ký
+`tn/ds/tln/tl`, ID ổn định, cú pháp toán Typst và bước tự kiểm tra đáp án.
+
+Các theme đề có thể lấy trực tiếp bằng `exam-template-names`; hiện gồm `classic`, `ocean`, `emerald`, `royal`, `violet`, `crimson`, `graphite`, `amber`, `teal-pro`, `sky`, `indigo-minimal`, `print-economy`, `aurora`, `lotus`, `navy-gold`, `jade`, `coral`, `plum`.
+
+## Ví dụ sách/chuyên đề
+
+```typ
+#import "@preview/sang-math:1.0.5": *
+
+#show: book-theme.with(
+  theme: "sgk-modern",
+  title: "CHUYÊN ĐỀ HÀM SỐ",
+  author: "Tổ Toán",
+)
+
+#book-chapter([Ứng dụng đạo hàm], number: 1)
+#book-lesson([Tính đơn điệu của hàm số], number: 1)
+
+#theory-box[Hàm số đồng biến trên khoảng $K$ khi...]
+#example-box[Khảo sát tính đơn điệu của $f(x)=x^3-3x$.]
+#practice-box[Giải các bài tập tương tự.]
+```
+
+Danh sách giao diện sách có sẵn nằm trong `book-template-names`.
+
+## Bảng biến thiên
+
+```typ
+#import "@preview/sang-math:1.0.5": bbtv2
+
+#bbtv2(
+  x-vals: ($-oo$, $-1$, $1$, $+oo$),
+  d-signs: ("+", 0, "-", 0, "+"),
+  v-vals: ($-oo$, $3$, $-1$, $+oo$),
+)
+```
+
+## Đề 70/30 có nháp khi in hai mặt
+
+```typ
+#import "@preview/sang-math:1.0.5": layout-draft
+
+#show: layout-draft.with(
+  nháp-pct: 30%,
+  accent: rgb("#117a65"),
+)
+
+Nội dung đề thi...
+```
+
+Trang lẻ đặt vùng nháp bên phải, trang chẵn đặt vùng nháp bên trái. Lề nội dung
+dùng cơ chế `inside`/`outside` nên tự đảo đúng khi in hai mặt. Mẫu đầy đủ nằm tại
+[`examples/copy-ready/07-de-70-30-nhap-in-hai-mat.typ`](https://github.com/sangnhc87/conictypst/blob/14b296889533c8b1897e5bebbfec499de7c5a932/typst-pkg-sang-math/examples/copy-ready/07-de-70-30-nhap-in-hai-mat.typ).
+
+
+## Hình học CeTZ nâng cao
+
+Các hàm `draw-*` được gọi bên trong `cetz.canvas`:
+
+```typ
+#import "@preview/cetz:0.5.2"
+#import "@preview/sang-math:1.0.5": draw-ellipse, draw-cylinder
+
+#cetz.canvas({
+  draw-ellipse(a: 2, b: 1, show-axes: true, show-foci: true)
+})
+
+#cetz.canvas({
+  draw-cylinder(radius: 1.4, height: 3.5, show-hidden: true)
+})
+```
+
+## Ứng dụng cho Đa môn (Vật lí, Hóa học, KHTN)
+Gói `sang-math` cung cấp khung đề thi chuẩn Bộ GD&ĐT 2025, hoàn toàn có thể dùng cho mọi môn học:
+- **Vật lí**: Đổi `subject: "VẬT LÍ 12"`, sử dụng các ký hiệu `$ohm$`, `$doC$` hoặc `$mu"F"$.
+- **Hóa học**: Kết hợp với gói công thức hóa học `@preview/typsium:0.3.2`:
+```typ
+#import "@preview/sang-math:1.0.5": *
+#import "@preview/typsium:0.3.2": *
+
+#show: exam-classic.with(subject: "HÓA HỌC 12", duration: "50 phút")
+
+#exam-part([PHẦN I. Trắc nghiệm 4 lựa chọn])
+#tn([Chất nào là este no, đơn chức, mạch hở?], (
+  [#ce("CH3COOH")],
+  True([#ce("CH3COOC2H5")]),
+  [#ce("CH2=CHCOOCH3")],
+  [#ce("HCOOCH=CH2")],
+))
+```
+
+## Tạo đề bằng AI (ChatGPT / Claude / Gemini)
+Để AI hỗ trợ soạn đề tự động đúng 100% cú pháp `sang-math:1.0.5`, xem hướng dẫn và sao chép System Prompt chuẩn tại [`PROMPT_AI_TAO_DE.md`](https://github.com/sangnhc87/conictypst/blob/14b296889533c8b1897e5bebbfec499de7c5a932/typst-pkg-sang-math/PROMPT_AI_TAO_DE.md).
+
+## Phát triển và kiểm thử
+
+```bash
+typst compile --root . examples/exam-template-demo.typ
+typst compile --root . examples/book-template-demo.typ
+typst compile --root . tests/test-public-api.typ
+```
+
+Các thay đổi phá vỡ tên hoặc chữ ký macro phải dành cho phiên bản major mới. Tính năng mới nên được export từ `lib.typ`, có ví dụ tối thiểu và có bài kiểm thử compile.
+
+## License
+
+MIT © Nguyễn Văn Sang

--- a/packages/preview/sang-math/1.0.5/bbt.typ
+++ b/packages/preview/sang-math/1.0.5/bbt.typ
@@ -1,0 +1,1135 @@
+#import "@preview/cetz:0.5.2": canvas, draw
+
+// Helper macro bổ sung giá trị trung gian chuẩn tkz-tab (\tkzTabVal)
+#let tab-val(from-col, to-col, pos: 0.5, x: none, y: none, stroke: (dash: "dashed", paint: rgb("#dc2626"), thickness: 0.8pt), mark: "stealth", y-offset: 0, start-y: none, end-y: none) = {
+  (
+    from-col: from-col,
+    to-col: to-col,
+    pos: pos,
+    x: x,
+    y: y,
+    stroke: stroke,
+    mark: mark,
+    y-offset: y-offset,
+    start-y: start-y,
+    end-y: end-y,
+  )
+}
+
+#let bbtv2(
+  var: $x$,
+  var2: none,
+  var2-vals: (),
+  u-vals: (),
+  der: $y'$,
+  der2: none,
+  func: $y$,
+  x-vals: ($-oo$, $0$, $+oo$),
+  d-signs: ($-$, $0$, $+$),
+  d2-signs: (),
+  v-vals: ($+oo$, $0$, $+oo$),
+  shade: (),
+  w1: 1.2,
+  w2: auto,
+  h1: 0.7,
+  h2: 0.7,
+  h3: auto,
+  stroke: 0.8pt,
+  arrow-stroke: none,
+  arrow-mark: "stealth",
+  node-pad: 0.18,
+  arr-shorten: 3pt,
+  guides: (),
+  annotations: (),
+  overlay: none,
+) = context {
+  let __clr = text.fill
+  let main-stroke = if stroke == none { 0.8pt + __clr } else { stroke }
+  let arr-stroke = if arrow-stroke != none { arrow-stroke } else { main-stroke }
+
+  let v2-list = if var2-vals.len() > 0 { var2-vals } else { u-vals }
+
+  let has-var2 = var2 != none
+  let has-der2 = der2 != none
+  let h-var = if has-var2 { h1 * 2 } else { h1 }
+  let h-der = if has-der2 { h2 * 2 } else { h2 }
+
+  let n = x-vals.len()
+
+  let w2-calc = if w2 == auto or w2 == 6.8 {
+    let min-col-w = 2.2
+    let auto-w = (n - 1) * min-col-w
+    calc.max(6.8, auto-w)
+  } else { w2 }
+
+  let sign-of(s) = {
+    let r = repr(s)
+    if s == "+" or s == $+$ or r.contains("+") { "+" }
+    else if s == "-" or s == $-$ or r.contains("−") or r.contains("-") { "-" }
+    else if s == "||" or r.contains("||") or r.contains("‖") or r.contains("parallel") { "||" }
+    else if s == "" or s == [] or s == none or r == "\"\"" or r == "[]" or r == "none" or s == " " { "" }
+    else { "0" }
+  }
+
+  let is-pos-inf(v) = { let r = repr(v); (r.contains("oo") or r.contains("∞")) and not (r.contains("-") or r.contains("−")) }
+  let is-neg-inf(v) = { let r = repr(v); (r.contains("oo") or r.contains("∞")) and (r.contains("-") or r.contains("−")) }
+
+  let ranks = ()
+  let cur = 0
+  ranks.push((cur,))
+  for i in range(n - 1) {
+    let sign-idx = 2 * i
+    let sign = sign-of(d-signs.at(sign-idx, default: ""))
+    if sign == "" or sign == "0" {
+      let v1 = v-vals.at(i, default: "")
+      let v2 = v-vals.at(i + 1, default: "")
+      let v1-val = if type(v1) == array and v1.len() > 1 { v1.at(1) } else if type(v1) == array { v1.at(0) } else { v1 }
+      let v2-val = if type(v2) == array { v2.at(0) } else { v2 }
+      if is-pos-inf(v2-val) or is-neg-inf(v1-val) { sign = "+" }
+      else if is-neg-inf(v2-val) or is-pos-inf(v1-val) { sign = "-" }
+    }
+    if sign == "+" { cur += 1 } else if sign == "-" { cur -= 1 }
+    let next_idx = 2 * i + 1
+    if next_idx < d-signs.len() and sign-of(d-signs.at(next_idx, default: "")) == "||" {
+      let val = v-vals.at(i + 1, default: "")
+      if type(val) == array {
+        let ns = if next_idx + 1 < d-signs.len() { sign-of(d-signs.at(next_idx + 1, default: "")) } else { "+" }
+        let rL = cur
+        let rR = if ns == "-" { rL + 2 } else { rL - 2 }
+        cur = rR
+        ranks.push((rL, rR))
+      } else { ranks.push((cur,)) }
+    } else { ranks.push((cur,)) }
+  }
+
+  let flat-r = ()
+  for r in ranks { for v in r { if v != none { flat-r.push(v) } } }
+  let min-r = if flat-r.len() > 0 { calc.min(..flat-r) } else { 0 }
+  let max-r = if flat-r.len() > 0 { calc.max(..flat-r) } else { 0 }
+  let rank-span = max-r - min-r
+
+  let h3-calc = if h3 == auto or h3 == 1.8 {
+    let base = if rank-span >= 2 { 2.5 } else { 2.0 }
+    let has-tall = v-vals.any(v => {
+      if type(v) == array {
+        v.any(sub => {
+          let r = repr(sub)
+          r.contains("frac(") or r.contains("integral(") or r.contains("lim(") or r.contains("cases(")
+        })
+      } else {
+        let r = repr(v)
+        r.contains("frac(") or r.contains("integral(") or r.contains("lim(") or r.contains("cases(")
+      }
+    })
+    if has-tall { base + 0.6 } else { base }
+  } else { h3 }
+
+  let th = h-var + h-der + h3-calc
+
+  canvas({
+    import draw: *
+    let tw = w1 + w2-calc
+
+    let x-pos = ()
+    for i in range(n) {
+      let px = w1 + 0.6 + (w2-calc - 1.2) * i / (n - 1)
+      x-pos.push(px)
+    }
+
+    rect((0, 0), (tw, -th), stroke: main-stroke)
+    line((0, -h-var), (tw, -h-var), stroke: main-stroke)
+    line((0, -h-var - h-der), (tw, -h-var - h-der), stroke: main-stroke)
+    line((w1, 0), (w1, -th), stroke: main-stroke)
+
+    if has-var2 { line((0, -h1), (tw, -h1), stroke: main-stroke) }
+    if has-der2 { line((0, -h-var - h2), (tw, -h-var - h2), stroke: main-stroke) }
+
+    for s in shade {
+      let idxL = s.at(0, default: 0)
+      let idxR = s.at(1, default: 0)
+      if idxL < x-pos.len() and idxR < x-pos.len() {
+        let xL = x-pos.at(idxL)
+        let xR = x-pos.at(idxR)
+        rect((xL, -h-var), (xR, -th), fill: rgb("#f8fafc"), stroke: none)
+        let step = 0.22
+        let H = th - h-var
+        let x0 = xL - H + 0.1
+        while x0 <= xR - 0.1 {
+          let xA = calc.max(xL, x0)
+          let xB = calc.min(xR, x0 + H)
+          if xA < xB {
+            let yA = -h-var - (xA - x0)
+            let yB = -h-var - (xB - x0)
+            line((xA, yA), (xB, yB), stroke: 0.45pt + rgb("#64748b"))
+          }
+          x0 += step
+        }
+        line((xL, -h-var - h-der), (xR, -h-var - h-der), stroke: main-stroke)
+      }
+    }
+
+    if has-var2 {
+      content((w1 / 2, -h1 / 2), var)
+      content((w1 / 2, -h1 - h1 / 2), var2)
+    } else {
+      content((w1 / 2, -h1 / 2), var)
+    }
+
+    if has-der2 {
+      content((w1 / 2, -h-var - h2 / 2), der)
+      content((w1 / 2, -h-var - h2 - h2 / 2), der2)
+    } else {
+      content((w1 / 2, -h-var - h2 / 2), der)
+    }
+
+    content((w1 / 2, -h-var - h-der - h3-calc / 2), func)
+
+    let render-sign(s) = {
+      let sig = sign-of(s)
+      if sig == "-" { $-$ } else if sig == "+" { $+$ } else if sig == "0" { $0$ } else if sig == "||" { none } else if sig == "" { none } else { s }
+    }
+
+    for i in range(n) {
+      content((x-pos.at(i), -h1 / 2), x-vals.at(i), name: "x-" + str(i))
+      if has-var2 and i < v2-list.len() {
+        content((x-pos.at(i), -h1 - h1 / 2), v2-list.at(i))
+      }
+    }
+
+    for i in range(n) {
+      if i > 0 and i < n - 1 {
+        let sign-idx = 2 * i - 1
+        if sign-of(d-signs.at(sign-idx, default: "")) == "||" {
+          let px = x-pos.at(i)
+          let is-double = type(v-vals.at(i, default: "")) == array or v-vals.at(i, default: "") == "||" or v-vals.at(i, default: "") == none or (type(v-vals.at(i, default: "")) == content and (repr(v-vals.at(i, default: "")).contains("|") or repr(v-vals.at(i, default: "")).contains("||")))
+          if is-double {
+            line((px - 0.05, -h-var), (px - 0.05, -th), stroke: main-stroke)
+            line((px + 0.05, -h-var), (px + 0.05, -th), stroke: main-stroke)
+          } else {
+            line((px - 0.05, -h-var), (px - 0.05, -h-var - h-der), stroke: main-stroke)
+            line((px + 0.05, -h-var), (px + 0.05, -h-var - h-der), stroke: main-stroke)
+          }
+        } else {
+          content((x-pos.at(i), -h-var - h2 / 2), render-sign(d-signs.at(sign-idx, default: "")))
+        }
+        if has-der2 and d2-signs.len() > sign-idx {
+          content((x-pos.at(i), -h-var - h2 - h2 / 2), render-sign(d2-signs.at(sign-idx, default: "")))
+        }
+      }
+      if i < n - 1 {
+        let is-shaded = false
+        for s in shade { if i >= s.at(0, default: 0) and i < s.at(1, default: 0) { is-shaded = true } }
+        if not is-shaded {
+          content(((x-pos.at(i) + x-pos.at(i + 1)) / 2, -h-var - h2 / 2), render-sign(d-signs.at(2 * i, default: "")))
+          if has-der2 and d2-signs.len() > 2 * i {
+            content(((x-pos.at(i) + x-pos.at(i + 1)) / 2, -h-var - h2 - h2 / 2), render-sign(d2-signs.at(2 * i, default: "")))
+          }
+        }
+      }
+    }
+
+    let y-top = -h-var - h-der - 0.35
+    let y-bot = -th + 0.35
+
+    let map-y-node(r, val) = {
+      if is-pos-inf(val) { return y-top }
+      if is-neg-inf(val) { return y-bot }
+      if max-r == min-r { (y-top + y-bot) / 2 } else { y-bot + (r - min-r) / (max-r - min-r) * (y-top - y-bot) }
+    }
+
+    for i in range(n) {
+      let rv = ranks.at(i)
+      let val = v-vals.at(i, default: "")
+      let px = x-pos.at(i)
+      if rv.len() == 1 {
+        let v-text = if type(val) == array { val.at(0) } else { val }
+        let y = map-y-node(rv.at(0), v-text)
+        if val != "" and val != none {
+          content((px, y), v-text, name: "v" + str(i), padding: node-pad, fill: white)
+        }
+      } else {
+        let vL = if type(val) == array and val.len() > 0 { val.at(0) } else { val }
+        let vR = if type(val) == array and val.len() > 1 { val.at(1) } else { val }
+        let yL = map-y-node(rv.at(0), vL)
+        let yR = map-y-node(rv.at(1), vR)
+        let off = 0.15
+        if vL != "" and vL != none { content((px - off, yL), vL, name: "v" + str(i) + "L", padding: node-pad, anchor: "east", fill: white) }
+        if vR != "" and vR != none { content((px + off, yR), vR, name: "v" + str(i) + "R", padding: node-pad, anchor: "west", fill: white) }
+      }
+    }
+
+    let node-anchors = ()
+    for i in range(n) {
+      let rv = ranks.at(i)
+      let val = v-vals.at(i, default: "")
+      let px = x-pos.at(i)
+      if rv.len() == 1 {
+        let v-text = if type(val) == array { val.at(0) } else { val }
+        let y = map-y-node(rv.at(0), v-text)
+        if val != "" and val != none {
+          node-anchors.push(("v" + str(i), "v" + str(i)))
+        } else {
+          node-anchors.push(((px, y), (px, y)))
+        }
+      } else {
+        let vL = if type(val) == array and val.len() > 0 { val.at(0) } else { val }
+        let vR = if type(val) == array and val.len() > 1 { val.at(1) } else { val }
+        let yL = map-y-node(rv.at(0), vL)
+        let yR = map-y-node(rv.at(1), vR)
+        let off = 0.15
+        let aL = if vL == "" or vL == none { (px - off, yL) } else { "v" + str(i) + "L" }
+        let aR = if vR == "" or vR == none { (px + off, yR) } else { "v" + str(i) + "R" }
+        node-anchors.push((aL, aR))
+      }
+    }
+
+    for i in range(n - 1) {
+      let is-shaded = false
+      for s in shade { if i >= s.at(0, default: 0) and i < s.at(1, default: 0) { is-shaded = true } }
+      if not is-shaded {
+        let s = node-anchors.at(i).at(1)
+        let e = node-anchors.at(i + 1).at(0)
+        if s != none and e != none {
+          let mark-spec = (end: arrow-mark, fill: __clr)
+          line(s, e, mark: mark-spec, stroke: arr-stroke, shorten-end: arr-shorten)
+        }
+      }
+    }
+
+    // Process guides / custom extra arrows:
+    let all-items = ()
+    for g in guides { all-items.push(g) }
+    for a in annotations { all-items.push(a) }
+
+    for item in all-items {
+      let px = none
+      let py = none
+      let custom-start-y = none
+      let custom-end-y = none
+      let y-off = 0
+      let label = none
+      let x-val-text = none
+      let item-stroke = (dash: "dashed", paint: rgb("#dc2626"), thickness: 0.8pt)
+      let item-mark = "stealth"
+
+      if type(item) == int {
+        if item >= 0 and item < n {
+          px = x-pos.at(item)
+          custom-start-y = -h1 - 0.15
+        }
+      } else if type(item) == dictionary {
+        if "stroke" in item { item-stroke = item.stroke }
+        if "mark" in item { item-mark = item.mark }
+        if "label" in item { label = item.label }
+        if "y" in item { label = item.y }
+        if "val" in item { label = item.val }
+        if "x-label" in item { x-val-text = item.x-label }
+        if "x" in item { x-val-text = item.x }
+        if "y-offset" in item { y-off = item.y-offset }
+        if "start-y" in item { custom-start-y = item.start-y }
+        if "end-y" in item { custom-end-y = item.end-y }
+
+        let iL = item.at("from-col", default: item.at("from-idx", default: none))
+        let iR = item.at("to-col", default: item.at("to-idx", default: none))
+        let pos = item.at("pos", default: 0.5)
+
+        if iL != none and iR != none {
+          if iL >= 0 and iL < n and iR >= 0 and iR < n {
+            let xL = x-pos.at(iL)
+            let xR = x-pos.at(iR)
+            px = xL + pos * (xR - xL)
+
+            let yL = map-y-node(ranks.at(iL).at(0), v-vals.at(iL, default: ""))
+            let yR = map-y-node(ranks.at(iR).at(0), v-vals.at(iR, default: ""))
+            py = yL + pos * (yR - yL) + y-off
+          }
+        } else if "idx" in item or "col" in item {
+          let idx = item.at("col", default: item.at("idx", default: none))
+          if idx != none and idx >= 0 and idx < n {
+            px = x-pos.at(idx)
+          }
+        }
+      }
+
+      if px != none {
+        if x-val-text != none {
+          content((px, -h1 / 2), x-val-text, fill: white, padding: 0.08)
+        }
+
+        let yL = if custom-start-y != none { custom-start-y } else { -h1 - 0.15 }
+        let target-y = if custom-end-y != none { custom-end-y } else if py != none { py } else { -h-var - h-der - h3-calc * 0.5 }
+
+        let mark-spec = if item-mark != none and item-mark != "" { (end: item-mark, fill: item-stroke.at("paint", default: rgb("#dc2626"))) } else { none }
+
+        let arrow-tip-y = if label != none and custom-end-y == none { target-y + 0.28 } else { target-y }
+
+        line((px, yL), (px, arrow-tip-y), stroke: item-stroke, mark: mark-spec)
+
+        if label != none {
+          content((px, target-y), label, fill: white, padding: 0.25)
+        }
+      }
+    }
+
+    if overlay != none {
+      overlay((
+        x-pos: x-pos,
+        h1: h1, h2: h2, h3: h3-calc,
+        h-var: h-var, h-der: h-der, th: th,
+        w1: w1, w2: w2-calc, tw: tw,
+        y-top: y-top, y-bot: y-bot,
+        draw: draw
+      ))
+    }
+  })
+}
+
+
+// ==========================================
+// MACRO BẢNG XÉT DẤU (DÀNH CHO XÉT DẤU y', BẤT PHƯƠNG TRÌNH)
+// ==========================================
+// bxd: Bảng xét dấu — hỗ trợ nhiều dòng func
+// func có thể là content đơn hoặc mảng content (nhiều dòng)
+// f-signs: mảng mảng nếu nhiều dòng, hoặc mảng đơn nếu 1 dòng
+#let bxd(
+  var: $x$,
+  func: $f(x)$, // content đơn hoặc mảng content cho nhiều dòng
+  x-vals: (),
+  f-signs: (), // mảng đơn hoặc mảng-của-mảng cho nhiều dòng
+  w1: 1.5, // chiều rộng cột nhãn trái — tăng nếu nhãn dài
+  w2: 8,
+  h1: 0.8,
+  h2: 0.8, // chiều cao mỗi dòng dấu
+) = context {
+  let __clr = text.fill
+  // Chuẩn hóa: nếu func là mảng thì nhiều dòng
+  let funcs = if type(func) == array { func } else { (func,) }
+  let signs-list = if type(f-signs) == array and f-signs.len() > 0 and type(f-signs.at(0)) == array {
+    f-signs
+  } else {
+    (f-signs,)
+  }
+  let nrows = funcs.len()
+
+  canvas(length: 1cm, {
+    import draw: *
+    let n = x-vals.len()
+    let tw = w1 + w2
+    let th = h1 + h2 * nrows
+
+    rect((0, 0), (tw, -th), stroke: 1pt + __clr)
+    line((0, -h1), (tw, -h1), stroke: 1pt + __clr)
+    line((w1, 0), (w1, -th), stroke: 1pt + __clr)
+    // Đường ngang giữa các dòng dấu (nếu > 1 dòng)
+    for r in range(1, nrows) {
+      line((0, -h1 - h2 * r), (tw, -h1 - h2 * r), stroke: 0.5pt + luma(150))
+    }
+
+    content((w1 / 2, -h1 / 2), var)
+    // Nhãn cột trái cho từng dòng
+    for r in range(nrows) {
+      content((w1 / 2, -h1 - h2 * r - h2 / 2), funcs.at(r))
+    }
+
+    let x-pos = ()
+    for i in range(n) {
+      let px = w1 + 0.6 + (w2 - 1.2) * i / (n - 1)
+      x-pos.push(px)
+      content((px, -h1 / 2), x-vals.at(i))
+    }
+
+    let sign-of(s) = {
+      let r = repr(s)
+      if s == "+" or s == $+$ or r.contains("+") { "+" }
+      else if s == "-" or s == $-$ or r.contains("−") or r.contains("-") { "-" }
+      else if s == "||" or r.contains("||") or r.contains("‖") or r.contains("parallel") { "||" }
+      else if s == "" or s == [] or s == none or r == "\"\"" or r == "[]" or r == "none" or s == " " { "" }
+      else { "0" }
+    }
+    let render-sign(s) = {
+      let sig = sign-of(s)
+      if sig == "-" { $-$ } else if sig == "+" { $+$ } else if sig == "0" { $0$ } else if sig == "||" { none } else if sig == "" { none } else { s }
+    }
+
+    for r in range(nrows) {
+      let row-signs = signs-list.at(r)
+      let y-mid = -h1 - h2 * r - h2 / 2
+      let y-top-row = -h1 - h2 * r
+      let y-bot-row = -h1 - h2 * r - h2
+      for i in range(n) {
+        if i > 0 and i < n - 1 {
+          let sign-idx = 2 * i - 1
+          if row-signs.len() > sign-idx and sign-of(row-signs.at(sign-idx)) == "||" {
+            let px = x-pos.at(i)
+            line((px - 0.05, y-top-row), (px - 0.05, y-bot-row), stroke: 0.8pt + __clr)
+            line((px + 0.05, y-top-row), (px + 0.05, y-bot-row), stroke: 0.8pt + __clr)
+          } else if row-signs.len() > sign-idx {
+            content((x-pos.at(i), y-mid), render-sign(row-signs.at(sign-idx)))
+          }
+        }
+        if i < n - 1 {
+          let mid-x = (x-pos.at(i) + x-pos.at(i + 1)) / 2
+          content((mid-x, y-mid), render-sign(row-signs.at(2 * i)))
+        }
+      }
+    }
+  })
+}
+
+// ═══════════════════════════════════════════════════════════
+// bxd-tich — Bảng xét dấu TÍCH/THƯƠNG, TỰ TÍNH dòng kết quả
+// Giáo viên chỉ khai dấu từng thừa số; dòng f(x) được nhân dấu tự động.
+// Thương dùng chung quy tắc dấu với tích: dấu(a/b) = dấu(a·b).
+// factors: (( nhãn, (dấu-1, dấu-2, ...) ), ...) — mỗi dấu-i dài 2n-1 như bxd.
+//   Ký hiệu: $+$ / $-$ / $0$ / "||" (không xác định) / [] (bỏ trống).
+// ═══════════════════════════════════════════════════════════
+#let bxd-tich(
+  var: $x$,
+  x-vals: (),
+  factors: (),
+  rows: (),
+  result-label: $f(x)$,
+  func: none,
+  w1: 1.5,
+  w2: 8,
+  h1: 0.8,
+  h2: 0.8,
+) = {
+  let factors = if factors.len() > 0 { factors } else { rows }
+  let result-label = if func != none { func } else { result-label }
+  let norm(s) = {
+    let r = repr(s)
+    if s == "+" or s == $+$ or r.contains("+") { "+" }
+    else if s == "-" or s == $-$ or r.contains("−") or r.contains("-") { "-" }
+    else if s == "||" or r.contains("||") or r.contains("parallel") { "||" }
+    else if s == "" or s == [] or s == none or r == "\"\"" or r == "[]" or r == "none" { "" }
+    else { "0" }
+  }
+  let mul2(a, b) = {
+    if a == "||" or b == "||" { "||" }
+    else if a == "0" or b == "0" { "0" }
+    else if a == "" or b == "" { "" }
+    else if a == b { "+" } else { "-" }
+  }
+  let nsig = if factors.len() > 0 { factors.at(0).at(1).len() } else { 0 }
+  let result = ()
+  for i in range(nsig) {
+    let acc = "+"
+    for f in factors { acc = mul2(acc, norm(f.at(1).at(i))) }
+    result.push(
+      if acc == "+" { $+$ } else if acc == "-" { $-$ } else if acc == "0" { $0$ } else if acc == "||" { $|$ } else { [] },
+    )
+  }
+  let all-funcs = factors.map(f => f.at(0)) + (result-label,)
+  let all-signs = factors.map(f => f.at(1)) + (result,)
+  bxd(var: var, func: all-funcs, x-vals: x-vals, f-signs: all-signs, w1: w1, w2: w2, h1: h1, h2: h2)
+}
+
+#let bbbt(
+  var: $x$,
+  der: $y'$,
+  func: $y$,
+  x-vals: (),
+  d-signs: (),
+  v-vals: (),
+  ranks: none,
+  w1: 1.5,
+  w2: 11.5,
+  h1: auto,
+  h2: 0.98, 
+  h3: auto,
+  node-pad: 0.18,
+  arr-shorten: 3pt,
+) = context {
+  let __clr = text.fill
+  // Tự động phân tích AST để điều chỉnh chiều cao nếu h1, h3 là auto
+  let h1 = if h1 == auto {
+    let has-tall = x-vals.any(x => {
+      let r = repr(x)
+      r.contains("frac(") or r.contains("integral(") or r.contains("lim(") or r.contains("cases(")
+    })
+    if has-tall { 1.2 } else { 0.98 }
+  } else { h1 }
+
+  let h3 = if h3 == auto {
+    let has-tall = v-vals.any(v => {
+      if type(v) == array {
+        let r = repr(v.at(0)) + repr(v.at(1))
+        r.contains("frac(") or r.contains("integral(") or r.contains("lim(") or r.contains("cases(")
+      } else {
+        let r = repr(v)
+        r.contains("frac(") or r.contains("integral(") or r.contains("lim(") or r.contains("cases(")
+      }
+    })
+    if has-tall { 3.2 } else { 2.8 }
+  } else { h3 }
+
+  canvas(length: 1cm, {
+    import draw: *
+
+    let n = x-vals.len()
+    let tw = w1 + w2
+    let th = h1 + h2 + h3
+
+    // Kẻ khung
+    rect((0, 0), (tw, -th), stroke: 1pt + __clr)
+    line((0, -h1), (tw, -h1), stroke: 1pt + __clr)
+    line((0, -h1 - h2), (tw, -h1 - h2), stroke: 1pt + __clr)
+    line((w1, 0), (w1, -th), stroke: 1pt + __clr)
+
+    content((w1 / 2, -h1 / 2), var)
+    content((w1 / 2, -h1 - h2 / 2), der)
+    content((w1 / 2, -h1 - h2 - h3 / 2), func)
+
+    let sign-of(s) = {
+      let r = repr(s)
+      if s == "+" or s == $+$ or r.contains("+") { "+" }
+      else if s == "-" or s == $-$ or r.contains("−") or r.contains("-") { "-" }
+      else if s == "||" or r.contains("||") or r.contains("‖") or r.contains("parallel") { "||" }
+      else if s == "" or s == [] or s == none or r == "\"\"" or r == "[]" or r == "none" or s == " " { "" }
+      else { "0" }
+    }
+    let render-sign(s) = {
+      let sig = sign-of(s)
+      if sig == "-" { $-$ } else if sig == "+" { $+$ } else if sig == "0" { $0$ } else if sig == "||" { none } else if sig == "" { none } else { s }
+    }
+
+    let x-pos = ()
+    for i in range(n) {
+      let px = w1 + 0.6 + (w2 - 1.2) * i / (n - 1)
+      x-pos.push(px)
+      content((px, -h1 / 2), x-vals.at(i))
+    }
+
+    let is-inf(v) = { if type(v) != content { false } else { repr(v).contains("oo") } }
+
+    // Hàng 2: dấu đạo hàm
+    for i in range(n) {
+      if i > 0 and i < n - 1 {
+        let sign-idx = 2 * i - 1
+        if sign-of(d-signs.at(sign-idx)) == "||" {
+          let px = x-pos.at(i)
+          let is-double = type(v-vals.at(i)) == array or v-vals.at(i) == "||" or v-vals.at(i) == none or (type(v-vals.at(i)) == content and (repr(v-vals.at(i)).contains("|") or repr(v-vals.at(i)).contains("||")))
+          if is-double {
+            line((px - 0.05, -h1), (px - 0.05, -th), stroke: 0.8pt + __clr)
+            line((px + 0.05, -h1), (px + 0.05, -th), stroke: 0.8pt + __clr)
+          } else {
+            line((px - 0.05, -h1), (px - 0.05, -h1 - h2), stroke: 0.8pt + __clr)
+            line((px + 0.05, -h1), (px + 0.05, -h1 - h2), stroke: 0.8pt + __clr)
+          }
+        } else {
+          content((x-pos.at(i), -h1 - h2 / 2), render-sign(d-signs.at(sign-idx)))
+        }
+      }
+      if i < n - 1 {
+        content(((x-pos.at(i) + x-pos.at(i + 1)) / 2, -h1 - h2 / 2), render-sign(d-signs.at(2 * i)))
+      }
+    }
+
+    // Hàng 3: rank → map-y
+    let ranks = if ranks != none {
+      ranks.map(r => if type(r) == array { r } else { (r,) })
+    } else {
+      let computed = ()
+      let cur = 0
+      computed.push((cur,))
+      for i in range(n - 1) {
+        let sign = sign-of(d-signs.at(2 * i))
+        if sign == "+" { cur += 1 } else if sign == "-" { cur -= 1 }
+        let next_idx = 2 * i + 1
+        if next_idx < d-signs.len() and sign-of(d-signs.at(next_idx)) == "||" {
+          let val = v-vals.at(i + 1)
+          if type(val) == array {
+            let ns = if next_idx + 1 < d-signs.len() { sign-of(d-signs.at(next_idx + 1)) } else { "+" }
+            let lr = cur
+            cur = if ns == "-" { lr + 2 } else { lr - 2 }
+            computed.push((lr, cur))
+          } else { computed.push((cur,)) }
+        } else { computed.push((cur,)) }
+      }
+      computed
+    }
+    let flat-r = ()
+    for r in ranks { for v in r { flat-r.push(v) } }
+    let min-r = calc.min(..flat-r)
+    let max-r = calc.max(..flat-r)
+    let y-top = -h1 - h2 - 0.5
+    let y-bot = -th + 0.4
+    let map-y(r) = {
+      if max-r == min-r { (y-top + y-bot) / 2 } else { y-bot + (r - min-r) / (max-r - min-r) * (y-top - y-bot) }
+    }
+
+    // Vẽ labels
+    for i in range(n) {
+      let rv = ranks.at(i)
+      let val = v-vals.at(i)
+      let px = x-pos.at(i)
+      if rv.len() == 1 {
+        let y = map-y(rv.at(0))
+        let v-text = if type(val) == array { val.at(0) } else { val }
+        if not is-inf(v-text) and val != "" and val != none {
+          content((px, y), v-text, name: "v" + str(i), padding: node-pad)
+        }
+      } else {
+        let yL = map-y(rv.at(0))
+        let yR = map-y(rv.at(1))
+        let vL = if type(val) == array and val.len() > 0 { val.at(0) } else { val }
+        let vR = if type(val) == array and val.len() > 1 { val.at(1) } else { val }
+        let off = 0.15
+        if not is-inf(vL) { content((px - off, yL), vL, name: "v" + str(i) + "L", padding: node-pad, anchor: "east") }
+        if not is-inf(vR) { content((px + off, yR), vR, name: "v" + str(i) + "R", padding: node-pad, anchor: "west") }
+      }
+    }
+
+    // Tính anchor (tách loop để tránh cetz/string join)
+    let node-anchors = ()
+    for i in range(n) {
+      let rv = ranks.at(i)
+      let val = v-vals.at(i)
+      let px = x-pos.at(i)
+      if rv.len() == 1 {
+        let y = map-y(rv.at(0))
+        let v-text = if type(val) == array { val.at(0) } else { val }
+        if not is-inf(v-text) and val != "" and val != none {
+          node-anchors.push(("v" + str(i), "v" + str(i)))
+        } else {
+          node-anchors.push(((px, y), (px, y)))
+        }
+      } else {
+        let yL = map-y(rv.at(0))
+        let yR = map-y(rv.at(1))
+        let vL = if type(val) == array and val.len() > 0 { val.at(0) } else { val }
+        let vR = if type(val) == array and val.len() > 1 { val.at(1) } else { val }
+        let off = 0.15
+        let aL = if is-inf(vL) { (px - off, yL) } else { "v" + str(i) + "L" }
+        let aR = if is-inf(vR) { (px + off, yR) } else { "v" + str(i) + "R" }
+        node-anchors.push((aL, aR))
+      }
+    }
+
+    // Mũi tên
+    for i in range(n - 1) {
+      let s = node-anchors.at(i).at(1)
+      let e = node-anchors.at(i + 1).at(0)
+      if s != none and e != none {
+        line(s, e, mark: (end: ">", fill: __clr), stroke: 0.8pt + __clr, shorten-end: arr-shorten)
+      }
+    }
+  })
+}
+// Chuyên dùng cho các bài toán tối ưu (1 cực trị trên đoạn)
+// ==========================================
+#let bbt-opt(
+  var: $x$,
+  der: $y'$,
+  func: $y$,
+  x-vals: ($0$, $x_0$, $oo$),
+  d-signs: ($-$, $0$, $+$),
+  v-vals: ($oo$, $0$, $oo$),
+  is-min: true, // true: cực tiểu (\/), false: cực đại (/\)
+  w1: 1.5, // Chiều rộng cột nhãn
+  w2: 7, // Chiều rộng cột nội dung
+) = context {
+  let __clr = text.fill
+  canvas(length: 1cm, {
+    import draw: *
+
+    let h1 = 0.8
+    let h2 = 0.8
+    let h3 = 2.2
+    let tw = w1 + w2
+    let th = h1 + h2 + h3
+
+    // Kẻ khung và các đường ngang, dọc
+    rect((0, 0), (tw, -th), stroke: 1pt + __clr)
+    line((0, -h1), (tw, -h1), stroke: 1pt + __clr)
+    line((0, -h1 - h2), (tw, -h1 - h2), stroke: 1pt + __clr)
+    line((w1, 0), (w1, -th), stroke: 1pt + __clr)
+
+    // Nhãn các hàng
+    content((w1 / 2, -h1 / 2), var)
+    content((w1 / 2, -h1 - h2 / 2), der)
+    content((w1 / 2, -h1 - h2 - h3 / 2), func)
+
+    // Tọa độ x cho các cột nội dung
+    let x1 = w1 + 0.6
+    let x2 = w1 + w2 / 2
+    let x3 = tw - 0.6
+
+    // Hàng 1: x
+    content((x1, -h1 / 2), x-vals.at(0))
+    content((x2, -h1 / 2), x-vals.at(1))
+    content((x3, -h1 / 2), x-vals.at(2))
+
+    // Hàng 2: Đạo hàm
+    content(((x1 + x2) / 2, -h1 - h2 / 2), d-signs.at(0))
+    content((x2, -h1 - h2 / 2), d-signs.at(1))
+    content(((x2 + x3) / 2, -h1 - h2 / 2), d-signs.at(2))
+
+    // Hàng 3: Biến thiên
+    let y-top = -h1 - h2 - 0.5
+    let y-bot = -th + 0.4
+
+    let (y1, y2, y3) = if is-min {
+      (y-top, y-bot, y-top)
+    } else {
+      (y-bot, y-top, y-bot)
+    }
+
+    content((x1, y1), v-vals.at(0), name: "v1", padding: 0.1)
+    content((x2, y2), v-vals.at(1), name: "v2", padding: 0.1)
+    content((x3, y3), v-vals.at(2), name: "v3", padding: 0.1)
+
+    // Vẽ mũi tên biến thiên
+    line("v1", "v2", mark: (end: ">", fill: __clr), stroke: 0.8pt + __clr)
+    line("v2", "v3", mark: (end: ">", fill: __clr), stroke: 0.8pt + __clr)
+  })
+}
+
+// ═══════════════════════════════════════════════════════════
+// BẢNG GIÁ TRỊ — Table đơn giản (không mũi tên)
+// items: ((nhãn, giá trị), ...) → hiển thị dạng bảng 2 dòng
+// Dùng cho: bảng giá trị hàm số, bảng xác suất, bảng tần số
+// ═══════════════════════════════════════════════════════════
+#let bang-gia-tri(
+  labels: (),    // hàng tiêu đề cột
+  rows: (),      // mảng các hàng, mỗi hàng là tuple giá trị
+  accent: rgb("#0057b8"),
+  scale: 1cm,
+) = context {
+  let __clr = text.fill
+  canvas(length: scale, {
+    import draw: *
+    let ncols = labels.len()
+    let nrows = rows.len() + 1
+    let cw = 2.2
+    let rh = 1.0
+    let tw = ncols * cw
+    let th = nrows * rh
+    rect((0, 0), (tw, -th), stroke: 0.8pt + __clr )
+    for i in range(1, ncols) {
+      line((i * cw, 0), (i * cw, -th), stroke: 0.5pt + luma(180))
+    }
+    for j in range(1, nrows) {
+      line((0, -j * rh), (tw, -j * rh), stroke: 0.5pt + luma(180))
+    }
+    for (i, lbl) in labels.enumerate() {
+      content((i * cw + cw / 2, -rh / 2), text(weight: "bold")[#lbl])
+    }
+    for (r, row) in rows.enumerate() {
+      for (c, val) in row.enumerate() {
+        content((c * cw + cw / 2, -(r + 1) * rh - rh / 2), val)
+      }
+    }
+  })
+}
+
+// ═══════════════════════════════════════════════════════════
+// BẢNG PHÂN PHỐI — Dạng table 2 cột: X | P
+// Dùng cho bảng phân phối xác suất, tần suất
+// ═══════════════════════════════════════════════════════════
+#let bang-phan-phoi(
+  header: ($X$, $P$),
+  items: (),     // ((x1, p1), (x2, p2), ...)
+  accent: rgb("#0057b8"),
+  scale: 1cm,
+) = context {
+  let __clr = text.fill
+  canvas(length: scale, {
+    import draw: *
+    let n = items.len()
+    let cw = 2.4
+    let rh = 0.9
+    let tw = 2 * cw
+    let th = (n + 1) * rh
+    rect((0, 0), (tw, -th), stroke: 0.8pt + __clr )
+    line((cw, 0), (cw, -th), stroke: 0.5pt + luma(180))
+    for j in range(1, n + 2) {
+      line((0, -j * rh), (tw, -j * rh), stroke: 0.5pt + luma(180))
+    }
+    content((cw / 2, -rh / 2), text(weight: "bold")[#header.at(0)])
+    content((cw + cw / 2, -rh / 2), text(weight: "bold")[#header.at(1)])
+    for (i, item) in items.enumerate() {
+      content((cw / 2, -(i + 1) * rh - rh / 2), item.at(0))
+      content((cw + cw / 2, -(i + 1) * rh - rh / 2), item.at(1))
+    }
+  })
+}
+
+// ═══════════════════════════════════════════════════════════
+// Ô CHÉO (diagonal-split cell) — Typst KHÔNG có sẵn, tự vẽ bằng place+line.
+// Dùng cho ô tiêu đề chia chéo, vd góc bảng "Lớp \ Môn".
+// NỐI Ô thì Typst có sẵn: table.cell(colspan: n) / table.cell(rowspan: n).
+// ───────────────────────────────────────────────────────────
+#let o-cheo(a, b, width: 100%, height: 1.2cm, stroke: 0.6pt, inset: 5pt, dir: "tl-br") = context {
+  let __clr = text.fill
+  let s = if type(stroke) == length { stroke + __clr } else { stroke }
+  box(width: width, height: height, stroke: none)[
+    #if dir == "tr-bl" [
+      #place(line(start: (100%, 0%), end: (0%, 100%), stroke: s))
+      #place(top + left, dx: inset, dy: inset * 0.6)[#a]
+      #place(bottom + right, dx: -inset, dy: -inset * 0.6)[#b]
+    ] else [
+      #place(line(start: (0%, 0%), end: (100%, 100%), stroke: s))
+      #place(top + right, dx: -inset, dy: inset * 0.6)[#a]
+      #place(bottom + left, dx: inset, dy: -inset * 0.6)[#b]
+    ]
+  ]
+}
+
+#let o-cheo-cell(a, b, height: 1.2cm, stroke: 0.6pt, fill: none, inset: 4pt, dir: "tl-br") = table.cell(inset: 0pt, fill: fill)[
+  #o-cheo(a, b, width: 100%, height: height, stroke: stroke, inset: inset, dir: dir)
+]
+
+#let o-cheo3(a, b, c, width: 100%, height: 1.6cm, stroke: 0.6pt, inset: 4pt) = context {
+  let __clr = text.fill
+  let s = if type(stroke) == length { stroke + __clr } else { stroke }
+  box(width: width, height: height, stroke: none)[
+    #place(line(start: (0%, 0%), end: (100%, 50%), stroke: s))
+    #place(line(start: (0%, 0%), end: (50%, 100%), stroke: s))
+    #place(top + right, dx: -inset, dy: inset * 0.3)[#a]
+    #place(bottom + right, dx: -inset, dy: -inset * 0.3)[#b]
+    #place(bottom + left, dx: inset * 0.6, dy: -inset * 0.3)[#c]
+  ]
+}
+
+#let o-cheo3-cell(a, b, c, height: 1.6cm, stroke: 0.6pt, fill: none, inset: 4pt) = table.cell(inset: 0pt, fill: fill)[
+  #o-cheo3(a, b, c, width: 100%, height: height, stroke: stroke, inset: inset)
+]
+
+#let cetz-cell(content, colspan: 1, rowspan: 1, fill: none) = (
+  type: "cell", body: content, colspan: colspan, rowspan: rowspan, fill: fill
+)
+
+#let cetz-o-cheo(a, b, dir: "tl-br", fill: none) = (
+  type: "o-cheo", a: a, b: b, dir: dir, fill: fill, colspan: 1, rowspan: 1
+)
+
+#let cetz-o-cheo3(a, b, c, fill: none) = (
+  type: "o-cheo3", a: a, b: b, c: c, fill: fill, colspan: 1, rowspan: 1
+)
+
+#let cetz-table(
+  cols: (3.2cm, 2.2cm, 2.2cm),
+  row-height: 1.2cm,
+  data: (),
+  line-stroke: 0.8pt,
+  fill-header: none,
+) = canvas({
+  import draw: *
+  let n-cols = cols.len()
+  let n-rows = data.len()
+  
+  let x-offsets = (0cm,)
+  let acc = 0cm
+  for w in cols {
+    acc += w
+    x-offsets.push(acc)
+  }
+  let total-w = acc
+  let total-h = n-rows * row-height
+
+  if fill-header != none {
+    rect((0cm, 0cm), (total-w, -row-height), fill: fill-header, stroke: none)
+  }
+
+  let spans = ()
+  for r in range(n-rows) {
+    let row-spans = ()
+    let row-data = data.at(r)
+    let y-top = -r * row-height
+    
+    for c in range(row-data.len()) {
+      let item = row-data.at(c)
+      let is-dict = type(item) == dictionary
+      let c-span = if is-dict { item.at("colspan", default: 1) } else { 1 }
+      let r-span = if is-dict { item.at("rowspan", default: 1) } else { 1 }
+      let fill-clr = if is-dict { item.at("fill", default: none) } else { none }
+      
+      row-spans.push((colspan: c-span, rowspan: r-span))
+      
+      let xL = x-offsets.at(c)
+      let xR = x-offsets.at(calc.min(n-cols, c + c-span))
+      let y-bot = -calc.min(n-rows, r + r-span) * row-height
+      let x-center = (xL + xR) / 2
+      let y-center = (y-top + y-bot) / 2
+      
+      if fill-clr != none {
+        rect((xL, y-top), (xR, y-bot), fill: fill-clr, stroke: none)
+      }
+      
+      if is-dict and item.at("type", default: "") == "o-cheo" {
+        let dir = item.at("dir", default: "tl-br")
+        if dir == "tr-bl" {
+          line((xR, y-top), (xL, y-bot), stroke: line-stroke)
+          content((xL + 0.6cm, y-top - 0.3cm), item.a)
+          content((xR - 0.6cm, y-bot + 0.3cm), item.b)
+        } else {
+          line((xL, y-top), (xR, y-bot), stroke: line-stroke)
+          content((xR - 0.6cm, y-top - 0.3cm), item.a)
+          content((xL + 0.6cm, y-bot + 0.3cm), item.b)
+        }
+      } else if is-dict and item.at("type", default: "") == "o-cheo3" {
+        line((xL, y-top), (xR, y-top + (y-bot - y-top) * 0.5), stroke: line-stroke)
+        line((xL, y-top), (xL + (xR - xL) * 0.5, y-bot), stroke: line-stroke)
+        content((xR - 0.5cm, y-top - 0.3cm), item.a)
+        content((xR - 0.5cm, y-bot + 0.3cm), item.b)
+        content((xL + 0.5cm, y-bot + 0.3cm), item.c)
+      } else {
+        let body = if is-dict { item.at("body", default: "") } else { item }
+        content((x-center, y-center), body)
+      }
+    }
+    spans.push(row-spans)
+  }
+
+  rect((0cm, 0cm), (total-w, -total-h), stroke: line-stroke)
+
+  for r in range(1, n-rows) {
+    let y = -r * row-height
+    for c in range(n-cols) {
+      let x1 = x-offsets.at(c)
+      let x2 = x-offsets.at(c + 1)
+      let is-blocked = false
+      for r0 in range(0, r) {
+        if c < spans.at(r0).len() {
+          let sp = spans.at(r0).at(c)
+          if r0 + sp.rowspan > r {
+            is-blocked = true
+            break
+          }
+        }
+      }
+      if not is-blocked {
+        line((x1, y), (x2, y), stroke: line-stroke)
+      }
+    }
+  }
+
+  for c in range(1, n-cols) {
+    let x = x-offsets.at(c)
+    for r in range(n-rows) {
+      let y1 = -r * row-height
+      let y2 = -(r + 1) * row-height
+      let is-blocked = false
+      for c0 in range(0, c) {
+        if c0 < spans.at(r).len() {
+          let sp = spans.at(r).at(c0)
+          if c0 + sp.colspan > c {
+            is-blocked = true
+            break
+          }
+        }
+      }
+      if not is-blocked {
+        line((x, y1), (x, y2), stroke: line-stroke)
+      }
+    }
+  }
+})
+#let o-cheo3(a, b, c, width: 3.2cm, height: 1.6cm, stroke: 0.6pt, inset: 4pt) = context {
+  let __clr = text.fill
+  let s = if type(stroke) == length { stroke + __clr } else { stroke }
+  box(width: width, height: height, stroke: s)[
+    #place(line(start: (0%, 0%), end: (60%, 100%), stroke: s))
+    #place(line(start: (0%, 0%), end: (100%, 60%), stroke: s))
+    #place(top + right, dx: -inset, dy: inset * 0.5)[#a]
+    #place(horizon + right, dx: -inset)[#b]
+    #place(bottom + left, dx: inset, dy: -inset * 0.5)[#c]
+  ]
+}
+
+// ═══════════════════════════════════════════════════════════
+// auto-bbt — BBT tự động kiểu cũ (giữ nguyên để tương thích)
+// ═══════════════════════════════════════════════════════════
+#let auto-bbt(
+  x: (),
+  y-phay: (),
+  y: (),
+) = context {
+  let __clr = text.fill
+  align(center)[
+    #canvas({
+      import draw: *
+
+      // Khởi tạo các thông số tự động
+      let n = x.len()
+      let col1 = 1.5 // Độ rộng cột tiêu đề
+      let step = 3.0 // Khoảng cách giữa các điểm x
+      let w = col1 + (n - 1) * step
+      let h = 4.0
+
+      // Vẽ khung và lưới cơ bản
+      rect((0, 0), (w, h), stroke: 0.75pt + __clr )
+      line((0, 2), (w, 2), stroke: 0.75pt + __clr )
+      line((0, 3), (w, 3), stroke: 0.75pt + __clr )
+      line((col1, 0), (col1, h), stroke: 0.75pt + __clr )
+
+      // Cột tiêu đề
+      content((col1 / 2, 3.5), [$x$])
+      content((col1 / 2, 2.5), [$f'(x)$])
+      content((col1 / 2, 1.0), [$f(x)$])
+
+      // 1. Điền hàng x tự động
+      for i in range(n) {
+        let cx = col1 + i * step
+        content((cx, 3.5), x.at(i))
+      }
+
+      // 2. Điền hàng f'(x) tự động
+      // Mảng y-phay có độ dài 2n - 1 (gồm nghiệm và khoảng giữa)
+      for i in range(y-phay.len()) {
+        let cx = col1 + i * (step / 2)
+        content((cx, 2.5), y-phay.at(i))
+      }
+
+      // 3. Điền hàng f(x) và thuật toán tự động vẽ mũi tên
+      let y_top = 1.6
+      let y_mid = 1.0
+      let y_bot = 0.4
+
+      // Hàm phụ xác định cao độ: 1 (Trên), -1 (Dưới), 0 (Giữa)
+      let get-y-coord(pos) = {
+        if pos == 1 { y_top } else if pos == -1 { y_bot } else { y_mid }
+      }
+
+      // Điền các giá trị cực trị / giới hạn
+      for i in range(n) {
+        let item = y.at(i)
+        let cx = col1 + i * step
+        let cy = get-y-coord(item.at(1))
+        content((cx, cy), item.at(0))
+      }
+
+      // Vòng lặp tự động phóng mũi tên
+      let dx = 0.6 // Độ thu vào trục x (không đâm vào chữ)
+      let dy = 0.25 // Độ thu vào trục y
+
+      for i in range(n - 1) {
+        let item1 = y.at(i)
+        let item2 = y.at(i + 1)
+
+        let x_start = col1 + i * step
+        let y_start = get-y-coord(item1.at(1))
+
+        let x_end = col1 + (i + 1) * step
+        let y_end = get-y-coord(item2.at(1))
+
+        // Thuật toán xét mũi tên đi lên hay đi xuống
+        let x1 = x_start + dx
+        let x2 = x_end - dx
+
+        if y_start > y_end {
+          // Nghịch biến (Đi xuống)
+          line((x1, y_start - dy), (x2, y_end + dy), mark: (end: "stealth", fill: __clr))
+        } else if y_start < y_end {
+          // Đồng biến (Đi lên)
+          line((x1, y_start + dy), (x2, y_end - dy), mark: (end: "stealth", fill: __clr))
+        } else {
+          // Hàm hằng (Đi ngang)
+          line((x1 + 0.2, y_start), (x2 - 0.2, y_end), mark: (end: "stealth", fill: __clr))
+        }
+      }
+    })
+  ]
+}

--- a/packages/preview/sang-math/1.0.5/book-templates.typ
+++ b/packages/preview/sang-math/1.0.5/book-templates.typ
@@ -1,0 +1,761 @@
+// ================================================================
+// SANG-MATH BOOK TEMPLATES v1.0.2
+// Bộ giao diện sách / SGK / chuyên đề / workbook dùng chung.
+// ================================================================
+
+#let _book-palettes = (
+  sgk-modern: (
+    accent: rgb("#2563eb"),
+    accent-2: rgb("#0f766e"),
+    cover: rgb("#eff6ff"),
+    ink: rgb("#172033"),
+    soft: rgb("#dbeafe"),
+    name: "SGK Modern",
+    look: "clean",
+  ),
+  vdc-elite: (
+    accent: rgb("#7e22ce"),
+    accent-2: rgb("#be185d"),
+    cover: rgb("#faf5ff"),
+    ink: rgb("#1f1b2e"),
+    soft: rgb("#ede9fe"),
+    name: "VDC Elite",
+    look: "elite",
+  ),
+  workbook-jade: (
+    accent: rgb("#059669"),
+    accent-2: rgb("#0e7490"),
+    cover: rgb("#ecfdf5"),
+    ink: rgb("#12332b"),
+    soft: rgb("#d1fae5"),
+    name: "Workbook Jade",
+    look: "workbook",
+  ),
+  solution-crimson: (
+    accent: rgb("#be123c"),
+    accent-2: rgb("#ea580c"),
+    cover: rgb("#fff1f2"),
+    ink: rgb("#34151d"),
+    soft: rgb("#ffe4e6"),
+    name: "Solution Crimson",
+    look: "solution",
+  ),
+  lesson-amber: (
+    accent: rgb("#b45309"),
+    accent-2: rgb("#2563eb"),
+    cover: rgb("#fffbeb"),
+    ink: rgb("#302113"),
+    soft: rgb("#fef3c7"),
+    name: "Lesson Amber",
+    look: "lesson",
+  ),
+  olympiad-indigo: (
+    accent: rgb("#4338ca"),
+    accent-2: rgb("#0f766e"),
+    cover: rgb("#eef2ff"),
+    ink: rgb("#15172f"),
+    soft: rgb("#e0e7ff"),
+    name: "Olympiad Indigo",
+    look: "notes",
+  ),
+  magazine-coral: (
+    accent: rgb("#ea580c"),
+    accent-2: rgb("#0e7490"),
+    cover: rgb("#fff7ed"),
+    ink: rgb("#2d1b12"),
+    soft: rgb("#fed7aa"),
+    name: "Magazine Coral",
+    look: "magazine",
+  ),
+  blackboard-green: (
+    accent: rgb("#16a34a"),
+    accent-2: rgb("#f59e0b"),
+    cover: rgb("#052e24"),
+    ink: rgb("#10251c"),
+    soft: rgb("#dcfce7"),
+    name: "Blackboard Green",
+    look: "blackboard",
+  ),
+  minimal-graphite: (
+    accent: rgb("#334155"),
+    accent-2: rgb("#64748b"),
+    cover: rgb("#f8fafc"),
+    ink: rgb("#111827"),
+    soft: rgb("#e2e8f0"),
+    name: "Minimal Graphite",
+    look: "minimal",
+  ),
+  handout-sky: (
+    accent: rgb("#0284c7"),
+    accent-2: rgb("#0f766e"),
+    cover: rgb("#f0f9ff"),
+    ink: rgb("#123044"),
+    soft: rgb("#e0f2fe"),
+    name: "Handout Sky",
+    look: "handout",
+  ),
+  research-slate: (
+    accent: rgb("#475569"),
+    accent-2: rgb("#7c3aed"),
+    cover: rgb("#f1f5f9"),
+    ink: rgb("#0f172a"),
+    soft: rgb("#e2e8f0"),
+    name: "Research Slate",
+    look: "research",
+  ),
+  lotus-study: (
+    accent: rgb("#be185d"),
+    accent-2: rgb("#059669"),
+    cover: rgb("#fdf2f8"),
+    ink: rgb("#311827"),
+    soft: rgb("#fce7f3"),
+    name: "Lotus Study",
+    look: "lotus",
+  ),
+)
+
+#let book-palette(theme) = {
+  _book-palettes.at(theme, default: _book-palettes.sgk-modern)
+}
+
+#let _smallcaps(body, fill: luma(80)) = text(size: 8.5pt, weight: "bold", fill: fill)[#upper(body)]
+
+#let _rule(accent) = line(length: 100%, stroke: 0.8pt + accent.lighten(45%))
+
+#let _meta-pill(body, accent, fill: white, dark: false) = box(
+  fill: if dark { accent.transparentize(72%) } else { fill },
+  stroke: 0.55pt + accent.lighten(if dark { 10% } else { 48% }),
+  inset: (x: 10pt, y: 5pt),
+  radius: 999pt,
+)[#text(size: 8.5pt, weight: "bold", fill: if dark { white } else { accent.darken(8%) })[#body]]
+
+#let _cover(
+  title,
+  palette,
+  subtitle: none,
+  author: none,
+  institution: none,
+  grade: none,
+  subject: none,
+  year: none,
+  note: none,
+) = {
+  pagebreak(weak: true)
+  let look = palette.look
+  if look == "clean" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: white, inset: 0pt)[
+        #block(width: 100%, height: 28%, fill: palette.cover, inset: 34pt)[
+          #grid(columns: (1fr, auto), align: (left + top, right + top),
+            [
+              #_smallcaps([SANG-MATH TEXTBOOK SERIES], fill: palette.accent)
+              #v(8pt)
+              #text(size: 11pt, fill: palette.ink.lighten(25%))[#institution]
+            ],
+            stack(dir: ltr, spacing: 6pt,
+              _meta-pill(subject, palette.accent),
+              _meta-pill(grade, palette.accent-2),
+            ),
+          )
+        ]
+        #block(width: 100%, inset: (x: 34pt, y: 0pt))[
+          #v(-22pt)
+          #block(width: 74%, fill: white, stroke: (top: 4pt + palette.accent, rest: 0.8pt + palette.accent.lighten(58%)), inset: 20pt, radius: 6pt)[
+            #text(size: 37pt, weight: "bold", fill: palette.ink)[#title]
+            #if subtitle != none [
+              #v(8pt)
+              #text(size: 14pt, fill: palette.accent.darken(8%))[#subtitle]
+            ]
+          ]
+          #v(22pt)
+          #grid(columns: (62%, 1fr), gutter: 18pt,
+            [
+              #if note != none [
+                #block(fill: palette.soft.lighten(55%), stroke: (left: 4pt + palette.accent), inset: 13pt, radius: 4pt)[
+                  #text(size: 10pt, fill: palette.ink)[#note]
+                ]
+              ]
+            ],
+            block(fill: palette.ink, inset: 16pt, radius: 6pt)[
+              #text(size: 8.5pt, weight: "bold", fill: palette.accent.lighten(45%))[TÁC GIẢ]
+              #v(4pt)
+              #text(size: 13pt, weight: "bold", fill: white)[#author]
+              #v(12pt)
+              #text(size: 8.5pt, weight: "bold", fill: palette.accent.lighten(45%))[NĂM HỌC]
+              #v(4pt)
+              #text(size: 12pt, fill: white)[#year]
+            ],
+          )
+        ]
+        #v(1fr)
+        #block(width: 100%, height: 18pt, fill: palette.accent)[]
+        #block(width: 100%, height: 10pt, fill: palette.accent-2)[]
+      ]
+    ]
+  } else if look == "elite" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: palette.ink, inset: 34pt, radius: 0pt)[
+        #v(12pt)
+        #grid(columns: (1fr, auto), align: (left, right),
+          _smallcaps([SANG-MATH ELITE SERIES], fill: palette.accent.lighten(35%)),
+          box(fill: palette.accent, inset: (x: 10pt, y: 5pt), radius: 999pt)[#text(fill: white, size: 8pt, weight: "bold")[VDC]]
+        )
+        #v(56pt)
+        #block(width: 82%, stroke: (left: 5pt + palette.accent), inset: (left: 18pt, y: 4pt))[
+          #text(size: 38pt, weight: "bold", fill: white)[#title]
+          #if subtitle != none [#v(8pt)#text(size: 14pt, fill: palette.accent.lighten(45%))[#subtitle]]
+        ]
+        #v(26pt)
+        #grid(columns: (1fr, 1fr), gutter: 10pt,
+          box(fill: palette.accent.transparentize(76%), inset: 12pt, radius: 6pt)[#text(fill: white)[#subject · #grade]],
+          box(fill: palette.accent-2.transparentize(74%), inset: 12pt, radius: 6pt)[#text(fill: white)[#author · #year]],
+        )
+        #v(1fr)
+        #if note != none [#block(width: 100%, fill: palette.accent, inset: 14pt, radius: 8pt)[#text(fill: white, size: 10pt)[#note]]]
+        #v(16pt)
+        #text(size: 9pt, fill: white.transparentize(32%))[#institution]
+      ]
+    ]
+  } else if look == "workbook" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: white, inset: 28pt, stroke: 1pt + palette.accent.lighten(50%))[
+        #block(width: 100%, fill: palette.cover, inset: 18pt, radius: 10pt)[
+          #_smallcaps([WORKBOOK · HỌC SINH], fill: palette.accent)
+          #v(22pt)
+          #text(size: 34pt, weight: "bold", fill: palette.accent)[#title]
+          #if subtitle != none [#v(6pt)#text(size: 13pt, fill: palette.ink)[#subtitle]]
+        ]
+        #v(28pt)
+        #for i in range(8) {
+          line(length: 100%, stroke: 0.55pt + palette.accent.lighten(62%))
+          v(18pt)
+        }
+        #v(1fr)
+        #grid(columns: (1fr, 1fr), gutter: 12pt,
+          box(stroke: 0.7pt + palette.accent.lighten(45%), inset: 12pt, radius: 6pt)[Tên học sinh:#v(18pt)],
+          box(stroke: 0.7pt + palette.accent.lighten(45%), inset: 12pt, radius: 6pt)[Lớp:#v(18pt)],
+        )
+        #v(14pt)
+        #text(size: 9pt, fill: palette.ink.lighten(38%))[#institution · #year]
+      ]
+    ]
+  } else if look == "lesson" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: palette.cover, inset: 30pt)[
+        #grid(columns: (36%, 1fr), gutter: 22pt,
+          block(fill: palette.accent, height: 100%, inset: 18pt, radius: 8pt)[
+            #text(fill: white, size: 11pt, weight: "bold")[GIÁO ÁN]
+            #v(1fr)
+            #text(fill: white, size: 20pt, weight: "bold")[#subject]
+            #text(fill: white.transparentize(20%), size: 11pt)[#grade · #year]
+          ],
+          [
+            #v(34pt)
+            #text(size: 34pt, weight: "bold", fill: palette.ink)[#title]
+            #if subtitle != none [#v(8pt)#text(size: 14pt, fill: palette.accent)[#subtitle]]
+            #v(28pt)
+            #block(fill: white, stroke: 0.8pt + palette.accent.lighten(48%), inset: 14pt, radius: 8pt)[
+              #text(weight: "bold", fill: palette.accent)[#author]
+              #linebreak()
+              #text(size: 9.5pt)[#institution]
+            ]
+          ],
+        )
+      ]
+    ]
+  } else if look == "magazine" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: white, inset: 0pt)[
+        #block(width: 100%, height: 34%, fill: palette.accent, inset: 28pt)[
+          #text(fill: white, size: 11pt, weight: "bold")[SANG-MATH MAGAZINE]
+          #v(1fr)
+          #text(fill: white, size: 30pt, weight: "bold")[#title]
+        ]
+        #block(width: 100%, inset: 28pt)[
+          #if subtitle != none [#text(size: 16pt, fill: palette.accent)[#subtitle]]
+          #v(24pt)
+          #grid(columns: (2fr, 1fr), gutter: 18pt,
+            block(fill: palette.cover, inset: 18pt, radius: 10pt)[#text(size: 11pt)[#if note != none [#note] else [Tài liệu học tập theo phong cách tạp chí: nhiều điểm nhấn, dễ đọc, hợp chuyên đề ngắn.]]],
+            block(fill: palette.ink, inset: 16pt, radius: 10pt)[#text(fill: white, weight: "bold")[#subject #linebreak()#grade #linebreak()#year]],
+          )
+          #v(1fr)
+          #text(size: 9pt, fill: palette.ink.lighten(40%))[#author · #institution]
+        ]
+      ]
+    ]
+  } else if look == "blackboard" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: palette.cover, inset: 32pt)[
+        #block(width: 100%, height: 100%, stroke: 1.2pt + white.transparentize(35%), inset: 24pt, radius: 6pt)[
+          #text(fill: palette.accent-2, size: 10pt, weight: "bold")[BLACKBOARD NOTES]
+          #v(55pt)
+          #text(fill: white, size: 34pt, weight: "bold")[#title]
+          #if subtitle != none [#v(10pt)#text(fill: white.transparentize(20%), size: 15pt)[#subtitle]]
+          #v(1fr)
+          #text(fill: white.transparentize(18%))[#author · #subject · #grade]
+        ]
+      ]
+    ]
+  } else if look == "minimal" or look == "research" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: white, inset: 36pt)[
+        #v(24pt)
+        #line(length: 100%, stroke: 1.4pt + palette.accent)
+        #v(34pt)
+        #text(size: 33pt, weight: "bold", fill: palette.ink)[#title]
+        #if subtitle != none [#v(10pt)#text(size: 13pt, fill: palette.accent)[#subtitle]]
+        #v(36pt)
+        #block(width: 54%, inset: (x: 0pt, y: 10pt), stroke: (top: 0.7pt + palette.accent.lighten(45%), bottom: 0.7pt + palette.accent.lighten(45%)))[
+          #text(size: 10pt)[#author #linebreak()#institution #linebreak()#subject · #grade · #year]
+        ]
+        #v(1fr)
+        #if note != none [#text(size: 9pt, fill: palette.ink.lighten(45%))[#note]]
+      ]
+    ]
+  } else if look == "handout" or look == "lotus" {
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: palette.cover, inset: 30pt)[
+        #grid(columns: (1fr, 120pt), gutter: 20pt,
+          [
+            #_smallcaps([HANDOUT · SANG-MATH], fill: palette.accent)
+            #v(34pt)
+            #text(size: 35pt, weight: "bold", fill: palette.ink)[#title]
+            #if subtitle != none [#v(8pt)#text(size: 14pt, fill: palette.accent)[#subtitle]]
+          ],
+          block(fill: palette.accent, height: 100%, radius: 12pt, inset: 14pt)[
+            #text(fill: white, size: 20pt, weight: "bold")[#subject]
+            #v(1fr)
+            #text(fill: white.transparentize(18%), size: 10pt)[#grade #linebreak()#year]
+          ],
+        )
+        #v(1fr)
+        #block(fill: white, stroke: 0.7pt + palette.accent.lighten(50%), inset: 12pt, radius: 8pt)[
+          #text(weight: "bold", fill: palette.accent)[#author]
+          #linebreak()
+          #text(size: 9pt)[#institution]
+        ]
+      ]
+    ]
+  } else {
+    // Premium generic cover with geometric background
+    align(center + horizon)[
+      #block(width: 100%, height: 100%, fill: palette.cover, clip: true, inset: 34pt, radius: 0pt)[
+        // Geometric Background elements
+        #place(top + right, dx: 34pt, dy: -34pt)[
+          #circle(radius: 120pt, fill: palette.accent.transparentize(85%))
+        ]
+        #place(bottom + left, dx: -80pt, dy: 80pt)[
+          #circle(radius: 200pt, fill: palette.accent-2.transparentize(90%))
+        ]
+        #place(top + left, dx: -34pt, dy: 150pt)[
+          #polygon(
+            fill: palette.accent.transparentize(92%),
+            (0pt, 0pt), (250pt, 0pt), (150pt, 300pt), (-100pt, 250pt)
+          )
+        ]
+
+        // Content
+        #v(20pt)
+        #align(left)[#_smallcaps([SANG-MATH PREMIUM TEMPLATE], fill: palette.accent)]
+        #v(42pt)
+        #align(left)[
+          #text(size: if look == "notes" { 32pt } else { 42pt }, weight: "bold", fill: palette.ink)[#title]
+          #if subtitle != none [
+            #v(12pt)
+            #text(size: 16pt, fill: palette.accent.darken(10%))[#subtitle]
+          ]
+        ]
+        #v(28pt)
+        #block(width: if look == "notes" { 100% } else { 85% }, fill: white.transparentize(15%), stroke: 1.5pt + palette.accent.lighten(55%), inset: 20pt, radius: 12pt)[
+          #grid(columns: (1fr, 1fr), gutter: 14pt,
+            [#_smallcaps([Môn học], fill: palette.accent)#linebreak()#text(weight: "bold", size: 13pt)[#subject]],
+            [#_smallcaps([Khối lớp], fill: palette.accent)#linebreak()#text(weight: "bold", size: 13pt)[#grade]],
+            [#_smallcaps([Tác giả], fill: palette.accent)#linebreak()#text(weight: "bold", size: 13pt)[#author]],
+            [#_smallcaps([Năm học], fill: palette.accent)#linebreak()#text(weight: "bold", size: 13pt)[#year]],
+          )
+        ]
+        #v(1fr)
+        #if note != none [
+          #block(width: 100%, fill: palette.accent, inset: 16pt, radius: 8pt)[
+            #text(fill: white, size: 11pt)[#note]
+          ]
+        ]
+        #v(24pt)
+        #align(left)[#text(size: 10pt, fill: palette.ink.lighten(20%), weight: "bold")[#institution]]
+      ]
+    ]
+  }
+  pagebreak()
+}
+
+#let book-theme(
+  body,
+  theme: "sgk-modern",
+  title: "TÀI LIỆU TOÁN",
+  subtitle: none,
+  author: "GV Nguyễn Văn Sang",
+  institution: "ConicTypst",
+  grade: "THPT",
+  subject: "Toán",
+  year: "2025-2026",
+  cover-note: none,
+  toc: true,
+  paper: "a4",
+  margin: (x: 20mm, y: 18mm),
+  body-font: "New Computer Modern",
+  heading-font: "New Computer Modern",
+) = {
+  let p = book-palette(theme)
+  set page(paper: paper, margin: margin, numbering: none, fill: white)
+  set text(font: body-font, size: 11pt, fill: p.ink)
+  set par(leading: 0.65em, first-line-indent: 0pt, justify: true)
+  show strong: it => text(fill: p.accent, weight: "bold")[#it.body]
+  show heading: it => {
+    if it.level == 1 {
+      text(font: heading-font, size: 22pt, weight: "bold", fill: p.accent)[#it.body]
+    } else if it.level == 2 {
+      text(font: heading-font, size: 16pt, weight: "bold", fill: p.accent.darken(5%))[#it.body]
+    } else {
+      text(font: heading-font, size: 12.5pt, weight: "bold", fill: p.accent-2)[#it.body]
+    }
+  }
+
+  _cover(
+    title,
+    p,
+    subtitle: subtitle,
+    author: author,
+    institution: institution,
+    grade: grade,
+    subject: subject,
+    year: year,
+    note: cover-note,
+  )
+
+  if toc {
+    align(center)[#text(size: 22pt, weight: "bold", fill: p.accent)[Mục lục]]
+    v(8pt)
+    outline(title: none)
+    pagebreak()
+  }
+
+  set page(
+    numbering: "1",
+    header: context {
+      let elems = query(selector(heading.where(level: 1)).before(here()))
+      let chapter-title = if elems.len() > 0 { elems.last().body } else { title }
+      let page-num = counter(page).get().first()
+      if calc.rem(page-num, 2) == 0 {
+        text(fill: p.accent.lighten(20%), size: 9pt, weight: "bold")[#chapter-title]
+        v(-4pt); line(length: 100%, stroke: 0.5pt + p.accent.lighten(50%))
+      } else {
+        align(right)[#text(fill: p.accent.lighten(20%), size: 9pt, weight: "bold")[#chapter-title]]
+        v(-4pt); line(length: 100%, stroke: 0.5pt + p.accent.lighten(50%))
+      }
+    },
+    footer: context {
+      let page-num = counter(page).get().first()
+      if calc.rem(page-num, 2) == 0 {
+        line(length: 100%, stroke: 0.5pt + p.accent.lighten(50%)); v(4pt)
+        text(fill: p.accent, weight: "bold")[#page-num]
+        h(1fr)
+        text(fill: p.ink.lighten(40%), size: 9pt)[#institution]
+      } else {
+        line(length: 100%, stroke: 0.5pt + p.accent.lighten(50%)); v(4pt)
+        text(fill: p.ink.lighten(40%), size: 9pt)[#title]
+        h(1fr)
+        text(fill: p.accent, weight: "bold")[#page-num]
+      }
+    }
+  )
+  counter(page).update(1)
+  body
+}
+
+#let _hidden-heading(level, title) = hide(heading(level: level, outlined: true)[#title])
+
+#let book-chapter(title, number: none, kicker: [Chương], theme: "sgk-modern") = {
+  let p = book-palette(theme)
+  _hidden-heading(1, title)
+  if p.look == "clean" {
+    block(width: 100%, inset: (x: 0pt, y: 6pt), stroke: (top: 1.2pt + p.accent.lighten(35%), bottom: 1.2pt + p.accent.lighten(55%)))[
+      #grid(columns: (72pt, 1fr), gutter: 16pt, align: (center + horizon, left + horizon),
+        block(width: 58pt, height: 58pt, fill: p.accent, radius: 4pt)[
+          #align(center + horizon)[
+            #text(size: 8pt, weight: "bold", fill: white.transparentize(12%))[#upper(kicker)]
+            #linebreak()
+            #text(size: 22pt, weight: "bold", fill: white)[#if number == none [--] else [#number]]
+          ]
+        ],
+        [
+          #text(size: 9pt, weight: "bold", fill: p.accent-2)[CHỦ ĐỀ TRỌNG TÂM]
+          #v(3pt)
+          #text(size: 25pt, weight: "bold", fill: p.ink)[#title]
+        ],
+      )
+    ]
+  } else if p.look == "elite" {
+    block(width: 100%, fill: p.ink, inset: 18pt, radius: 0pt, stroke: (bottom: 3pt + p.accent))[
+      #text(size: 9pt, weight: "bold", fill: p.accent.lighten(35%))[#upper(kicker) #if number != none [#number]]
+      #v(5pt)
+      #text(size: 25pt, weight: "bold", fill: white)[#title]
+    ]
+  } else if p.look == "workbook" {
+    grid(columns: (auto, 1fr), gutter: 12pt, align: (left + horizon, left + horizon),
+      box(width: 42pt, height: 42pt, fill: p.accent, radius: 999pt)[#align(center + horizon)[#text(fill: white, weight: "bold")[#if number == none [#kicker] else [#number]]]],
+      block(width: 100%, fill: p.cover, stroke: (bottom: 1pt + p.accent.lighten(45%)), inset: 12pt)[
+        #text(size: 22pt, weight: "bold", fill: p.accent)[#title]
+      ],
+    )
+  } else if p.look == "lesson" {
+    block(width: 100%, fill: p.cover, stroke: 0.9pt + p.accent.lighten(45%), inset: 14pt, radius: 8pt)[
+      #grid(columns: (1fr, auto), align: (left + horizon, right + horizon),
+        text(size: 21pt, weight: "bold", fill: p.ink)[#title],
+        box(fill: p.accent, inset: (x: 12pt, y: 7pt), radius: 6pt)[#text(fill: white, weight: "bold")[#kicker #if number != none [#number]]],
+      )
+    ]
+  } else if p.look == "notes" {
+    block(width: 100%, inset: (x: 0pt, y: 10pt), stroke: (top: 1.2pt + p.accent, bottom: 1.2pt + p.accent))[
+      #text(size: 10pt, fill: p.accent, weight: "bold")[#kicker #if number != none [#number]]
+      #h(1em)
+      #text(size: 23pt, weight: "bold", fill: p.ink)[#title]
+    ]
+  } else if p.look == "magazine" {
+    grid(columns: (1fr, 72pt), gutter: 14pt,
+      block(fill: p.cover, inset: 16pt, radius: 10pt)[#text(size: 24pt, weight: "bold", fill: p.accent)[#title]],
+      block(fill: p.accent, inset: 12pt, radius: 10pt)[#align(center + horizon)[#text(fill: white, size: 18pt, weight: "bold")[#if number == none [#kicker] else [#number]]]],
+    )
+  } else if p.look == "blackboard" {
+    block(width: 100%, fill: p.cover, inset: 16pt, radius: 6pt)[
+      #text(size: 10pt, fill: p.accent-2, weight: "bold")[#kicker #if number != none [#number]]
+      #v(5pt)
+      #text(size: 24pt, weight: "bold", fill: white)[#title]
+    ]
+  } else if p.look == "minimal" or p.look == "research" {
+    block(width: 100%, inset: (x: 0pt, y: 8pt), stroke: (left: 5pt + p.accent))[
+      #h(10pt)#text(size: 24pt, weight: "bold", fill: p.ink)[#if number != none [#number. ]#title]
+    ]
+  } else {
+    // Default / "sgk-modern" / Premium ribbon look
+    block(width: 100%, breakable: false)[
+      #place(top + left, dx: 0pt, dy: -5pt)[
+        #block(fill: p.accent.darken(15%), width: 100%, height: 20pt)
+      ]
+      #block(width: 100%, fill: p.accent, stroke: (bottom: 4pt + p.accent-2), inset: 18pt, radius: (top-right: 12pt, bottom-right: 12pt, top-left: 2pt, bottom-left: 2pt))[
+        #grid(columns: (auto, 1fr), gutter: 16pt, align: (left + horizon, left + horizon),
+          box(fill: white, inset: (x: 14pt, y: 10pt), radius: 7pt, stroke: 1.5pt + p.accent-2)[
+            #text(weight: "bold", fill: p.accent, size: 16pt)[#kicker #if number != none [ #number]]
+          ],
+          [
+            #text(size: 24pt, weight: "bold", fill: white)[#title]
+            #v(4pt)
+            #line(length: 100%, stroke: 0.8pt + white.transparentize(35%))
+          ],
+        )
+      ]
+    ]
+  }
+  v(14pt)
+}
+
+#let book-lesson(title, number: none, theme: "sgk-modern") = {
+  let p = book-palette(theme)
+  _hidden-heading(2, title)
+  if p.look == "clean" {
+    block(width: 100%, fill: p.cover.lighten(35%), stroke: (left: 5pt + p.accent, rest: 0.55pt + p.accent.lighten(58%)), inset: 13pt, radius: 5pt)[
+      #grid(columns: (1fr, auto), align: (left + horizon, right + horizon),
+        text(size: 16pt, weight: "bold", fill: p.ink)[#title],
+        _meta-pill(if number == none { [Bài] } else { [Bài #number] }, p.accent, fill: white),
+      )
+    ]
+  } else if p.look == "workbook" {
+    block(width: 100%, fill: white, stroke: 0.7pt + p.accent.lighten(45%), inset: 12pt, radius: 4pt)[
+      #text(size: 15pt, weight: "bold", fill: p.accent)[Phiếu #if number != none [#number · ]#title]
+      #v(5pt)
+      #for i in range(2) { line(length: 100%, stroke: 0.45pt + p.accent.lighten(65%)); v(10pt) }
+    ]
+  } else if p.look == "solution" {
+    block(width: 100%, fill: p.accent, inset: 12pt, radius: 999pt)[
+      #text(size: 15pt, weight: "bold", fill: white)[Lời giải #if number != none [#number · ]#title]
+    ]
+  } else if p.look == "lesson" {
+    grid(columns: (auto, 1fr), gutter: 10pt,
+      box(fill: p.accent, inset: 10pt, radius: 6pt)[#text(fill: white, weight: "bold")[Tiết #if number != none [#number] else [--]]],
+      block(fill: p.soft, inset: 12pt, radius: 6pt)[#text(size: 15pt, weight: "bold", fill: p.ink)[#title]],
+    )
+  } else if p.look == "magazine" or p.look == "handout" or p.look == "lotus" {
+    block(width: 100%, fill: p.accent.lighten(92%), inset: 12pt, radius: 12pt)[
+      #text(size: 15pt, weight: "bold", fill: p.accent.darken(8%))[#if number != none [Bài #number · ]#title]
+    ]
+  } else if p.look == "blackboard" {
+    block(width: 100%, fill: p.cover, stroke: 0.7pt + p.accent.lighten(20%), inset: 12pt, radius: 5pt)[
+      #text(size: 15pt, weight: "bold", fill: white)[#if number != none [Bài #number · ]#title]
+    ]
+  } else {
+    // Premium generic block for lesson
+    block(width: 100%, fill: p.soft, stroke: (left: 5pt + p.accent), inset: 13pt, radius: (top-right: 7pt, bottom-right: 7pt))[
+      #text(size: 16pt, weight: "bold", fill: p.accent)[Bài #if number != none [#number. ]#title]
+    ]
+  }
+  v(10pt)
+}
+
+#let book-section(title, number: none, theme: "sgk-modern") = {
+  let p = book-palette(theme)
+  _hidden-heading(3, title)
+  if p.look == "clean" {
+    grid(columns: (auto, 1fr), gutter: 8pt, align: (left + horizon, left + horizon),
+      box(width: 5pt, height: 22pt, fill: p.accent, radius: 999pt)[],
+      [
+        #text(size: 13.5pt, weight: "bold", fill: p.ink)[#if number != none [#number. ]#title]
+        #v(2pt)
+        #line(length: 52%, stroke: 0.65pt + p.accent.lighten(45%))
+      ],
+    )
+  } else if p.look == "notes" {
+    block(width: 100%, inset: (x: 0pt, y: 5pt), stroke: (bottom: 0.7pt + p.accent.lighten(42%)))[
+      #text(size: 12.5pt, weight: "bold", fill: p.ink)[#if number != none [#number. ]#title]
+    ]
+  } else if p.look == "blackboard" {
+    block(width: 100%, inset: (x: 0pt, y: 6pt), stroke: (bottom: 0.8pt + p.accent))[
+      #text(size: 12.5pt, weight: "bold", fill: p.accent.darken(5%))[#if number != none [#number. ]#title]
+    ]
+  } else {
+    // Premium section tag
+    grid(columns: (auto, 1fr), gutter: 9pt, align: (left + horizon, left + horizon),
+      box(fill: p.accent, inset: (x: 10pt, y: 5pt), radius: (top-left: 6pt, bottom-right: 6pt))[
+        #text(fill: white, weight: "bold", size: 10pt)[#if number == none [Mục] else [#number]]
+      ],
+      [
+        #text(size: 13.5pt, weight: "bold", fill: p.accent.darken(8%))[#title]
+        #v(2pt)
+        #_rule(p.accent)
+      ],
+    )
+  }
+  v(8pt)
+}
+
+#let _ped-box(
+  body,
+  title: [Ghi chú],
+  icon: [!],
+  accent: rgb("#2563eb"),
+  fill: auto,
+  stroke: auto,
+  radius: 8pt,
+  inset: 12pt,
+  boxed-title: true,
+  style: "card",
+) = {
+  let real-fill = if fill == auto { accent.lighten(95%) } else { fill }
+  let real-stroke = if stroke == auto { 0.75pt + accent.lighten(45%) } else { stroke }
+  
+  if style == "dark" {
+    block(width: 100%, breakable: true, fill: accent.darken(50%), stroke: 1pt + accent.lighten(20%), inset: 0pt, radius: 6pt, clip: true)[
+      #block(width: 100%, fill: accent.darken(20%), inset: (x: 12pt, y: 8pt))[
+        #grid(columns: (auto, 1fr), gutter: 8pt, align: horizon,
+          text(fill: white, weight: "bold", size: 12pt)[#icon],
+          text(weight: "bold", fill: white, size: 11.5pt)[#title]
+        )
+      ]
+      #block(width: 100%, inset: inset)[
+        #text(fill: white.transparentize(10%))[#body]
+      ]
+    ]
+  } else if style == "worksheet" {
+    block(width: 100%, breakable: true, fill: real-fill, stroke: (left: 4pt + accent, rest: 1pt + accent.lighten(50%)), radius: 4pt, inset: inset)[
+      #place(top + right, dx: 4pt, dy: -24pt)[
+        #box(fill: white, stroke: 1pt + accent, radius: 999pt, inset: (x: 12pt, y: 5pt))[
+          #text(weight: "bold", fill: accent)[#icon #h(2pt) #title]
+        ]
+      ]
+      #v(2pt)
+      #body
+      #v(4pt)
+      #for i in range(2) { line(length: 100%, stroke: 0.4pt + accent.lighten(68%)); v(8pt) }
+    ]
+  } else if style == "solution" {
+    block(width: 100%, breakable: true, fill: real-fill, stroke: (left: 3pt + accent, top: 0.5pt + accent.lighten(60%), right: 0.5pt + accent.lighten(60%), bottom: 0.5pt + accent.lighten(60%)), inset: (x: 14pt, y: 12pt), radius: 4pt)[
+      #grid(columns: (auto, 1fr), align: (left + horizon, left + horizon), gutter: 8pt,
+        box(fill: accent, radius: 4pt, inset: (x: 8pt, y: 4pt))[#text(fill: white, weight: "bold")[#icon]],
+        text(weight: "bold", fill: accent.darken(10%), size: 12pt)[#title]
+      )
+      #v(6pt)
+      #body
+    ]
+  } else if style == "rule" {
+    block(width: 100%, breakable: true, inset: (x: 0pt, y: 12pt), stroke: (top: 2pt + accent, bottom: 1pt + accent.lighten(50%)))[
+      #text(weight: "bold", fill: accent, size: 12pt)[#icon #h(4pt) #title]
+      #v(6pt)
+      #body
+    ]
+  } else {
+    // Tcolorbox-like "card" style (used by sgk-modern, lesson, etc.)
+    block(width: 100%, breakable: true, stroke: 1.2pt + accent, radius: 6pt, clip: true, fill: real-fill, inset: 0pt)[
+      #block(width: 100%, fill: accent, inset: (x: 12pt, y: 8pt), radius: 0pt, stroke: none)[
+        #text(weight: "bold", fill: white, size: 11.5pt)[#icon #h(4pt) #title]
+      ]
+      #block(width: 100%, inset: inset)[#body]
+    ]
+  }
+  v(8pt)
+}
+
+#let _box-style(theme) = {
+  let p = book-palette(theme)
+  if p.look == "elite" { "dark" }
+  else if p.look == "workbook" { "worksheet" }
+  else if p.look == "solution" { "solution" }
+  else if p.look == "notes" or p.look == "minimal" or p.look == "research" { "rule" }
+  else if p.look == "blackboard" { "dark" }
+  else if p.look == "handout" { "worksheet" }
+  else { "card" }
+}
+
+#let goal-box(body, title: [Mục tiêu], theme: "sgk-modern") = _ped-box(body, title: title, icon: [MT], accent: book-palette(theme).accent, style: _box-style(theme))
+#let warmup-box(body, title: [Khởi động], theme: "sgk-modern") = _ped-box(body, title: title, icon: [KD], accent: rgb("#ea580c"), style: _box-style(theme))
+#let explore-box(body, title: [Khám phá], theme: "sgk-modern") = _ped-box(body, title: title, icon: [KP], accent: rgb("#0e7490"), style: _box-style(theme))
+#let theory-box(body, title: [Lý thuyết], theme: "sgk-modern") = _ped-box(body, title: title, icon: [LT], accent: book-palette(theme).accent, style: _box-style(theme))
+#let definition-box(body, title: [Định nghĩa], theme: "sgk-modern") = _ped-box(body, title: title, icon: [DN], accent: rgb("#7c3aed"), style: _box-style(theme))
+#let theorem-box(body, title: [Định lý], theme: "sgk-modern") = _ped-box(body, title: title, icon: [DL], accent: rgb("#be123c"), style: _box-style(theme))
+#let method-box(body, title: [Phương pháp], theme: "sgk-modern") = _ped-box(body, title: title, icon: [PP], accent: rgb("#0f766e"), style: _box-style(theme))
+#let example-box(body, title: [Ví dụ], theme: "sgk-modern") = _ped-box(body, title: title, icon: [VD], accent: rgb("#2563eb"), fill: rgb("#eff6ff"), style: _box-style(theme))
+#let activity-box(body, title: [Hoạt động], theme: "sgk-modern") = _ped-box(body, title: title, icon: [HD], accent: rgb("#b45309"), fill: rgb("#fffbeb"), style: _box-style(theme))
+#let practice-box(body, title: [Luyện tập], theme: "sgk-modern") = _ped-box(body, title: title, icon: [LT], accent: rgb("#059669"), fill: rgb("#ecfdf5"), style: _box-style(theme))
+#let warning-box(body, title: [Lưu ý], theme: "sgk-modern") = _ped-box(body, title: title, icon: [!], accent: rgb("#dc2626"), fill: rgb("#fef2f2"), style: _box-style(theme))
+#let summary-box(body, title: [Tóm tắt], theme: "sgk-modern") = _ped-box(body, title: title, icon: [TK], accent: rgb("#334155"), fill: rgb("#f8fafc"), style: _box-style(theme))
+#let exercise-box(body, title: [Bài tập], theme: "sgk-modern", lines: 0) = {
+  _ped-box(
+    [
+      #body
+      #if lines > 0 [
+        #v(6pt)
+        #for i in range(lines) {
+          line(length: 100%, stroke: 0.45pt + luma(185))
+          v(9pt)
+        }
+      ]
+    ],
+    title: title,
+    icon: [BT],
+    accent: rgb("#4338ca"),
+    fill: rgb("#eef2ff"),
+    style: _box-style(theme),
+  )
+}
+
+#let book-template-names = (
+  "sgk-modern",
+  "vdc-elite",
+  "workbook-jade",
+  "solution-crimson",
+  "lesson-amber",
+  "olympiad-indigo",
+  "magazine-coral",
+  "blackboard-green",
+  "minimal-graphite",
+  "handout-sky",
+  "research-slate",
+  "lotus-study",
+)

--- a/packages/preview/sang-math/1.0.5/core/colors.typ
+++ b/packages/preview/sang-math/1.0.5/core/colors.typ
@@ -1,0 +1,58 @@
+// ═══════════════════════════════════════════════════════════════
+// CORE / COLORS.TYP — Bảng màu chuẩn cho sang-math
+// ═══════════════════════════════════════════════════════════════
+// Đặt tên màu theo ngữ nghĩa thay vì hardcode hex.
+// Dùng nhất quán trong toàn bộ package.
+// ───────────────────────────────────────────────────────────────
+
+// ── Màu Hình Học Chuẩn ────────────────────────────────────────
+#let sm-blue       = rgb("1976D2")   // Điểm, đường chính
+#let sm-blue-light = rgb("BBDEFB")   // Tô màu mặt phẳng
+#let sm-green      = rgb("388E3C")   // Điểm thứ hai, kết quả
+#let sm-green-light= rgb("C8E6C9")   // Tô màu vùng xanh
+#let sm-red        = rgb("E91E63")   // Đường nổi bật, nghiệm
+#let sm-red-light  = rgb("FCE4EC")   // Tô màu vùng đỏ
+#let sm-orange     = rgb("F57C00")   // Đường phụ, điểm trung
+#let sm-purple     = rgb("7B1FA2")   // Đường conic đặc biệt
+#let sm-gray       = rgb("757575")   // Nét đứt, đường khuất
+#let sm-gray-light = rgb("EEEEEE")   // Nền, fill nhạt
+
+// ── Màu Khối 3D ───────────────────────────────────────────────
+#let sm-face-top   = rgb("E3F2FD")   // Mặt trên khối
+#let sm-face-front = rgb("BBDEFB")   // Mặt trước khối
+#let sm-face-side  = rgb("90CAF9")   // Mặt bên khối
+#let sm-face-dark  = rgb("64B5F6")   // Mặt tối/khuất
+
+// ── Màu Giải Tích ─────────────────────────────────────────────
+#let sm-func-1     = rgb("1565C0")   // Đường đồ thị hàm 1
+#let sm-func-2     = rgb("C62828")   // Đường đồ thị hàm 2
+#let sm-func-3     = rgb("2E7D32")   // Đường đồ thị hàm 3
+#let sm-tangent    = rgb("FF8F00")   // Tiếp tuyến
+#let sm-area       = rgb("E8F5E9")   // Tô diện tích tích phân
+#let sm-area-stroke= rgb("43A047")   // Viền diện tích
+
+// ── Màu Trắc Nghiệm ───────────────────────────────────────────
+#let sm-correct    = rgb("388E3C")   // Đáp án đúng
+#let sm-wrong      = rgb("D32F2F")   // Đáp án sai
+#let sm-highlight  = rgb("FFF9C4")   // Highlight câu hỏi
+
+// ── Màu Xác Suất / Thống Kê ───────────────────────────────────
+#let sm-event-a    = rgb("1565C0")   // Biến cố A
+#let sm-event-b    = rgb("C62828")   // Biến cố B
+#let sm-event-ab   = rgb("6A1B9A")   // Giao AB
+#let sm-tree-node  = rgb("E3F2FD")   // Nút sơ đồ cây
+
+// ── Shorthand Palette (dùng cho hàm nhận color param) ─────────
+// Cho phép gọi: draw-helix(color: sm.red)
+#let sm = (
+  blue:        sm-blue,
+  blue-light:  sm-blue-light,
+  green:       sm-green,
+  green-light: sm-green-light,
+  red:         sm-red,
+  red-light:   sm-red-light,
+  orange:      sm-orange,
+  purple:      sm-purple,
+  gray:        sm-gray,
+  gray-light:  sm-gray-light,
+)

--- a/packages/preview/sang-math/1.0.5/core/math-utils.typ
+++ b/packages/preview/sang-math/1.0.5/core/math-utils.typ
@@ -1,0 +1,135 @@
+// ═══════════════════════════════════════════════════════════════
+// CORE / MATH-UTILS.TYP — Hàm tính toán toán học phụ trợ
+// ═══════════════════════════════════════════════════════════════
+// Không import gì — đây là tầng nền, không phụ thuộc module khác.
+// Dùng trong: geometry-2d, geometry-3d, calculus, statistics
+// ───────────────────────────────────────────────────────────────
+
+// ── Danh sách hàm ──────────────────────────────────────────────
+//   linspace(start, stop, n)          Mảng n điểm đều từ start→stop
+//   lerp(a, b, t)                     Nội suy tuyến tính
+//   clamp(x, lo, hi)                  Kẹp giá trị trong [lo, hi]
+//   rotate-2d(pt, angle)              Xoay điểm 2D quanh gốc tọa độ
+//   vec-norm((dx, dy))                Chuẩn hóa vector 2D
+//   vec-scale((x, y), s)              Nhân vector với scalar
+//   vec-add((ax, ay), (bx, by))       Cộng hai vector
+//   pt-lerp(A, B, t)                  Nội suy điểm giữa A và B
+//   sign(x)                           Dấu của x: -1, 0, +1
+//   deg-to-rad(d)                     Đổi độ → radian (wrapper tiện)
+//   rad-to-deg(r)                     Đổi radian → độ
+// ───────────────────────────────────────────────────────────────
+
+/// Tạo mảng gồm `n` giá trị phân bố đều từ `start` đến `stop` (inclusive).
+/// Tương đương numpy.linspace.
+///
+/// - start (float): Giá trị đầu.
+/// - stop (float):  Giá trị cuối.
+/// - n (int):       Số phần tử. Phải >= 2.
+/// → returns array of float
+#let linspace(start, stop, n) = {
+  if n <= 1 { return (start,) }
+  let step = (stop - start) / (n - 1)
+  range(0, n).map(i => start + i * step)
+}
+
+/// Nội suy tuyến tính giữa `a` và `b` theo tham số `t ∈ [0, 1]`.
+/// lerp(a, b, 0) = a; lerp(a, b, 1) = b.
+///
+/// - a (float): Giá trị đầu.
+/// - b (float): Giá trị cuối.
+/// - t (float): Tham số nội suy [0, 1].
+/// → returns float
+#let lerp(a, b, t) = a + (b - a) * t
+
+/// Kẹp giá trị `x` vào khoảng `[lo, hi]`.
+///
+/// - x (float): Giá trị cần kẹp.
+/// - lo (float): Cận dưới.
+/// - hi (float): Cận trên.
+/// → returns float
+#let clamp(x, lo, hi) = calc.max(lo, calc.min(hi, x))
+
+/// Dấu của x: trả về -1 (âm), 0 (zero), hoặc 1 (dương).
+///
+/// - x (float): Giá trị đầu vào.
+/// → returns int
+#let sign(x) = {
+  if x > 0 { 1 } else if x < 0 { -1 } else { 0 }
+}
+
+/// Đổi đơn vị đo góc từ độ (degree) sang radian.
+///
+/// - d (float): Góc tính bằng độ.
+/// → returns float (radian)
+#let deg-to-rad(d) = d * calc.pi / 180
+
+/// Đổi đơn vị đo góc từ radian sang độ (degree).
+///
+/// - r (float): Góc tính bằng radian.
+/// → returns float (degree)
+#let rad-to-deg(r) = r * 180 / calc.pi
+
+/// Xoay điểm `pt = (x, y)` quanh gốc tọa độ `(0, 0)` một góc `angle` (radian).
+///
+/// - pt (array): Điểm cần xoay dạng `(x, y)`.
+/// - angle (float): Góc xoay tính bằng radian (dương = ngược chiều kim đồng hồ).
+/// → returns (float, float)
+#let rotate-2d(pt, angle) = {
+  let (x, y) = pt
+  let cos-a = calc.cos(angle)
+  let sin-a = calc.sin(angle)
+  (x * cos-a - y * sin-a, x * sin-a + y * cos-a)
+}
+
+/// Cộng hai vector 2D.
+///
+/// - a (array): Vector thứ nhất `(ax, ay)`.
+/// - b (array): Vector thứ hai `(bx, by)`.
+/// → returns (float, float)
+#let vec-add(a, b) = {
+  let (ax, ay) = a
+  let (bx, by) = b
+  (ax + bx, ay + by)
+}
+
+/// Nhân vector 2D với một scalar.
+///
+/// - v (array): Vector `(x, y)`.
+/// - s (float): Scalar.
+/// → returns (float, float)
+#let vec-scale(v, s) = {
+  let (x, y) = v
+  (x * s, y * s)
+}
+
+/// Tính độ dài (norm) của vector 2D.
+///
+/// - v (array): Vector `(x, y)`.
+/// → returns float
+#let vec-length(v) = {
+  let (x, y) = v
+  calc.sqrt(x * x + y * y)
+}
+
+/// Chuẩn hóa vector 2D về độ dài bằng 1.
+/// Trả về `(0, 0)` nếu vector có độ dài bằng 0.
+///
+/// - v (array): Vector `(x, y)`.
+/// → returns (float, float)
+#let vec-norm(v) = {
+  let len = vec-length(v)
+  if len < 1e-10 { (0.0, 0.0) } else { vec-scale(v, 1.0 / len) }
+}
+
+/// Nội suy tuyến tính giữa hai điểm `A` và `B` theo tham số `t ∈ [0, 1]`.
+/// Trả về điểm nằm trên đoạn AB: pt-lerp(A, B, 0) = A, pt-lerp(A, B, 1) = B.
+///
+/// - A (array): Điểm đầu `(ax, ay)`.
+/// - B (array): Điểm cuối `(bx, by)`.
+/// - t (float): Tham số nội suy [0, 1].
+/// → returns (float, float)
+#let pt-lerp(A, B, t) = {
+  let (ax, ay) = A
+  let (bx, by) = B
+  (lerp(ax, bx, t), lerp(ay, by, t))
+}

--- a/packages/preview/sang-math/1.0.5/exam-templates.typ
+++ b/packages/preview/sang-math/1.0.5/exam-templates.typ
@@ -1,0 +1,387 @@
+// ================================================================
+// SANG-MATH EXAM TEMPLATES v1.0.2
+// Bộ preset giao diện đề thi dùng chung với thpt-school-exam.
+// Cách dùng:
+//   #import "@preview/sang-math:1.0.2": *
+//   #show: exam-ocean.with(school: "THPT ...", code: "101")
+// ================================================================
+
+#import "sang-exam.typ": thpt-school-exam, print-answer-key
+
+#let _template(
+  body,
+  accent: rgb(0, 87, 184),
+  q-style: "pill",
+  show-topbar: true,
+  header-border: true,
+  watermark: none,
+  watermark-opacity: 0.06,
+  footer-left: none,
+  body-font: "Times New Roman",
+  header-font: "Times New Roman",
+  two-columns: false,
+  column-gutter: 14pt,
+  answer-key: false,
+  ..args,
+) = {
+  let content = if two-columns {
+    columns(2, gutter: column-gutter)[#body]
+  } else {
+    body
+  }
+
+  let final-body = if answer-key {
+    [
+      #content
+      #pagebreak(weak: true)
+      #print-answer-key()
+    ]
+  } else {
+    content
+  }
+
+  thpt-school-exam(
+    final-body,
+    accent: accent,
+    q-color: accent,
+    q-style: q-style,
+    show-topbar: show-topbar,
+    header-border: header-border,
+    watermark: watermark,
+    watermark-opacity: watermark-opacity,
+    footer-left: footer-left,
+    body-font: body-font,
+    header-font: header-font,
+    ..args,
+  )
+}
+
+// 01. Cổ điển xanh: giống phong cách đề chính thức, gọn và nghiêm túc.
+#let exam-classic(body, ..args) = _template(
+  body,
+  accent: rgb(0, 87, 184),
+  q-style: "bold",
+  show-topbar: false,
+  header-border: true,
+  ..args,
+)
+
+// 02. Ocean: xanh ngọc hiện đại, hợp đề luyện tập và đề online.
+#let exam-ocean(body, ..args) = _template(
+  body,
+  accent: rgb(14, 116, 144),
+  q-style: "pill",
+  watermark: [SANG MATH],
+  ..args,
+)
+
+// 03. Emerald: xanh lá nhẹ, dễ nhìn khi in lời giải.
+#let exam-emerald(body, ..args) = _template(
+  body,
+  accent: rgb(4, 120, 87),
+  q-style: "pill",
+  watermark: [THPT],
+  ..args,
+)
+
+// 04. Royal: xanh tím sang, hợp đề chọn lọc/chuyên đề.
+#let exam-royal(body, ..args) = _template(
+  body,
+  accent: rgb(67, 56, 202),
+  q-style: "boxed",
+  watermark: [ROYAL],
+  ..args,
+)
+
+// 05. Violet: nổi bật, hợp đề ôn tốc độ hoặc đề phân hóa.
+#let exam-violet(body, ..args) = _template(
+  body,
+  accent: rgb(124, 58, 237),
+  q-style: "pill",
+  watermark: [VDC],
+  ..args,
+)
+
+// 06. Crimson: đỏ học thuật, hợp đề thi thử hoặc đề kiểm tra.
+#let exam-crimson(body, ..args) = _template(
+  body,
+  accent: rgb(190, 18, 60),
+  q-style: "boxed",
+  watermark: [EXAM],
+  ..args,
+)
+
+// 07. Graphite: đen xám tối giản, in laser rất sạch.
+#let exam-graphite(body, ..args) = _template(
+  body,
+  accent: rgb(51, 65, 85),
+  q-style: "bold",
+  show-topbar: false,
+  watermark: none,
+  ..args,
+)
+
+// 08. Amber: ấm, hợp phiếu luyện tập hoặc đề cuối tuần.
+#let exam-amber(body, ..args) = _template(
+  body,
+  accent: rgb(180, 83, 9),
+  q-style: "pill",
+  watermark: [PRACTICE],
+  ..args,
+)
+
+// 09. Teal Pro: cân bằng giữa trang trọng và hiện đại.
+#let exam-teal-pro(body, ..args) = _template(
+  body,
+  accent: rgb(15, 118, 110),
+  q-style: "boxed",
+  watermark: [SANG],
+  ..args,
+)
+
+// 10. Sky: nhẹ, thoáng, hợp tài liệu phát cho học sinh.
+#let exam-sky(body, ..args) = _template(
+  body,
+  accent: rgb(2, 132, 199),
+  q-style: "pill",
+  watermark: [LEARN],
+  watermark-opacity: 0.045,
+  ..args,
+)
+
+// 11. Indigo Minimal: tiết chế màu, nhiều khoảng thở.
+#let exam-indigo-minimal(body, ..args) = _template(
+  body,
+  accent: rgb(79, 70, 229),
+  q-style: "bold",
+  show-topbar: true,
+  header-border: false,
+  watermark: none,
+  ..args,
+)
+
+// 12. Print Economy: tối ưu in đen trắng, vẫn có cấu trúc rõ.
+#let exam-print-economy(body, ..args) = _template(
+  body,
+  accent: black,
+  q-style: "bold",
+  show-topbar: false,
+  header-border: true,
+  watermark: none,
+  ..args,
+)
+
+// 13. Aurora: xanh sapphire + hơi ngọc, nổi bật nhưng vẫn sạch khi in.
+#let exam-aurora(body, ..args) = _template(
+  body,
+  accent: rgb("#2563eb"),
+  q-style: "pill",
+  watermark: [AURORA],
+  watermark-opacity: 0.04,
+  ..args,
+)
+
+// 14. Lotus: hồng sen trang nhã, hợp phiếu chuyên đề và tài liệu luyện tập.
+#let exam-lotus(body, ..args) = _template(
+  body,
+  accent: rgb("#be185d"),
+  q-style: "pill",
+  watermark: [LOTUS],
+  watermark-opacity: 0.04,
+  ..args,
+)
+
+// 15. Navy Gold: xanh than + vàng, phong cách đề chọn lọc cao cấp.
+#let exam-navy-gold(body, ..args) = _template(
+  body,
+  accent: rgb("#1d4ed8"),
+  q-style: "boxed",
+  watermark: [ELITE],
+  watermark-opacity: 0.035,
+  ..args,
+)
+
+// 16. Jade: xanh ngọc sâu, dịu mắt cho đề có nhiều lời giải.
+#let exam-jade(body, ..args) = _template(
+  body,
+  accent: rgb("#059669"),
+  q-style: "pill",
+  watermark: [JADE],
+  watermark-opacity: 0.045,
+  ..args,
+)
+
+// 17. Coral: đỏ cam hiện đại, hợp đề kiểm tra ngắn hoặc đề luyện tốc độ.
+#let exam-coral(body, ..args) = _template(
+  body,
+  accent: rgb("#ea580c"),
+  q-style: "pill",
+  watermark: [FAST],
+  watermark-opacity: 0.04,
+  ..args,
+)
+
+// 18. Plum: tím mận học thuật, hợp chuyên đề nâng cao.
+#let exam-plum(body, ..args) = _template(
+  body,
+  accent: rgb("#7e22ce"),
+  q-style: "boxed",
+  watermark: [VDC],
+  watermark-opacity: 0.04,
+  ..args,
+)
+
+// Dispatch theme theo chuỗi, giúp demo/HDSD không cần if-else dài.
+#let exam-theme(body, theme: "royal", ..args) = {
+  if theme == "classic" { exam-classic(body, ..args) }
+  else if theme == "ocean" { exam-ocean(body, ..args) }
+  else if theme == "emerald" { exam-emerald(body, ..args) }
+  else if theme == "royal" { exam-royal(body, ..args) }
+  else if theme == "violet" { exam-violet(body, ..args) }
+  else if theme == "crimson" { exam-crimson(body, ..args) }
+  else if theme == "graphite" { exam-graphite(body, ..args) }
+  else if theme == "amber" { exam-amber(body, ..args) }
+  else if theme == "teal-pro" { exam-teal-pro(body, ..args) }
+  else if theme == "sky" { exam-sky(body, ..args) }
+  else if theme == "indigo-minimal" { exam-indigo-minimal(body, ..args) }
+  else if theme == "print-economy" { exam-print-economy(body, ..args) }
+  else if theme == "aurora" { exam-aurora(body, ..args) }
+  else if theme == "lotus" { exam-lotus(body, ..args) }
+  else if theme == "navy-gold" { exam-navy-gold(body, ..args) }
+  else if theme == "jade" { exam-jade(body, ..args) }
+  else if theme == "coral" { exam-coral(body, ..args) }
+  else if theme == "plum" { exam-plum(body, ..args) }
+  else { exam-royal(body, ..args) }
+}
+
+#let _theme-style(theme) = {
+  if theme == "classic" { (accent: rgb(0, 87, 184), opt-style: "circle", q-label-style: "underline", boxed: false) }
+  else if theme == "ocean" { (accent: rgb(14, 116, 144), opt-style: "hexagon", q-label-style: "pill", boxed: false) }
+  else if theme == "emerald" { (accent: rgb(4, 120, 87), opt-style: "solid-circle", q-label-style: "badge", boxed: false) }
+  else if theme == "royal" { (accent: rgb(67, 56, 202), opt-style: "pentagon", q-label-style: "spark", boxed: true) }
+  else if theme == "violet" { (accent: rgb(124, 58, 237), opt-style: "diamond", q-label-style: "flag", boxed: false) }
+  else if theme == "crimson" { (accent: rgb(190, 18, 60), opt-style: "solid-hexagon", q-label-style: "solid-pill", boxed: true) }
+  else if theme == "graphite" { (accent: rgb(51, 65, 85), opt-style: "double-circle", q-label-style: "underline", boxed: false) }
+  else if theme == "amber" { (accent: rgb(180, 83, 9), opt-style: "rounded-square", q-label-style: "ribbon", boxed: false) }
+  else if theme == "teal-pro" { (accent: rgb(15, 118, 110), opt-style: "solid-pentagon", q-label-style: "badge", boxed: true) }
+  else if theme == "sky" { (accent: rgb(2, 132, 199), opt-style: "circle", q-label-style: "pill", boxed: false) }
+  else if theme == "indigo-minimal" { (accent: rgb(79, 70, 229), opt-style: "plain", q-label-style: "underline", boxed: false) }
+  else if theme == "print-economy" { (accent: black, opt-style: "plain", q-label-style: "plain", boxed: false) }
+  else if theme == "aurora" { (accent: rgb("#2563eb"), opt-style: "solid-diamond", q-label-style: "spark", boxed: true) }
+  else if theme == "lotus" { (accent: rgb("#be185d"), opt-style: "solid-triangle", q-label-style: "flag", boxed: false) }
+  else if theme == "navy-gold" { (accent: rgb("#1d4ed8"), opt-style: "solid-hexagon", q-label-style: "solid-pill", boxed: true) }
+  else if theme == "jade" { (accent: rgb("#059669"), opt-style: "hexagon", q-label-style: "badge", boxed: true) }
+  else if theme == "coral" { (accent: rgb("#ea580c"), opt-style: "solid-square", q-label-style: "ribbon", boxed: false) }
+  else if theme == "plum" { (accent: rgb("#7e22ce"), opt-style: "pentagon", q-label-style: "spark", boxed: true) }
+  else { (accent: rgb(67, 56, 202), opt-style: "pentagon", q-label-style: "spark", boxed: true) }
+}
+
+#let _profile-mode(profile) = if profile == "loigiai" or profile == "solution" or profile == "beamer" or profile == "slide" or profile == "slides" {
+  "loigiai"
+} else {
+  "dethi"
+}
+
+#let _bool-input(name, default: false) = {
+  let v = sys.inputs.at(name, default: if default { "1" } else { "0" })
+  v == "1" or v == "true" or v == "yes" or v == "on"
+}
+
+// Preset gọn cho đề PDF và beamer.
+// Dùng: #let preset = exam-preset(theme: "royal", profile: "dethi")
+// Sau đó: #let (tn, ds, tln, tl) = exam-mode(..preset.question)
+#let exam-preset(
+  theme: "royal",
+  profile: "dethi",
+  mode: auto,
+  opt-style: auto,
+  q-label-style: auto,
+  show-tags: false,
+  draft: auto,
+  two-columns: auto,
+  answer-key: auto,
+  boxed: auto,
+) = {
+  let s = _theme-style(theme)
+  let real-mode = if mode == auto { _profile-mode(profile) } else { mode }
+  let is-beamer = profile == "beamer" or profile == "slide" or profile == "slides"
+  let real-draft = if draft == auto { profile == "draft" } else { draft }
+  let real-two-columns = if two-columns == auto { profile == "compact" or profile == "twocol" } else { two-columns }
+  let real-answer-key = if answer-key == auto { profile == "answer" or profile == "loigiai" } else { answer-key }
+  let real-boxed = if boxed == auto { s.boxed } else { boxed }
+  let accent = s.accent
+  (
+    theme: theme,
+    profile: profile,
+    mode: real-mode,
+    accent: accent,
+    beamer: is-beamer,
+    question: (
+      mode: real-mode,
+      accent: accent,
+      opt-style: if opt-style == auto { "plain" } else if opt-style == "theme" { s.opt-style } else { opt-style },
+      opt-label-color: if theme == "print-economy" { auto } else { accent },
+      q-label-style: if q-label-style == auto { s.q-label-style } else { q-label-style },
+      show-tags: show-tags,
+      draft: real-draft,
+      draft-width: 28%,
+      draft-lines: 6,
+      boxed: real-boxed,
+      box-fill: accent.lighten(94%),
+      box-stroke: 0.55pt + accent.lighten(55%),
+    ),
+    template: (
+      two-columns: real-two-columns,
+      answer-key: real-answer-key,
+      beamer: is-beamer,
+    ),
+    beamer-theme: (
+      accent: accent,
+      bg_color: if theme == "print-economy" { white } else { rgb("#0f172a") },
+      math_color: if theme == "amber" or theme == "coral" { rgb("#fbbf24") } else { rgb("#f59e0b") },
+    ),
+  )
+}
+
+// Preset đọc từ dòng lệnh compile:
+// --input theme=royal --input profile=loigiai --input answer-key=1
+#let exam-input-preset(default-theme: "royal", default-profile: "dethi") = {
+  let theme = sys.inputs.at("theme", default: default-theme)
+  let profile = if _bool-input("beamer", default: false) {
+    "beamer"
+  } else {
+    sys.inputs.at("profile", default: sys.inputs.at("mode", default: default-profile))
+  }
+  exam-preset(
+    theme: theme,
+    profile: profile,
+    mode: sys.inputs.at("mode", default: auto),
+    opt-style: sys.inputs.at("opt-style", default: auto),
+    q-label-style: sys.inputs.at("q-label-style", default: auto),
+    draft: _bool-input("draft", default: profile == "draft"),
+    two-columns: _bool-input("two-columns", default: profile == "compact" or profile == "twocol"),
+    answer-key: _bool-input("answer-key", default: profile == "answer" or profile == "loigiai"),
+  )
+}
+
+// Danh sách tên theme để dùng trong tài liệu/ứng dụng ngoài.
+#let exam-template-names = (
+  "classic",
+  "ocean",
+  "emerald",
+  "royal",
+  "violet",
+  "crimson",
+  "graphite",
+  "amber",
+  "teal-pro",
+  "sky",
+  "indigo-minimal",
+  "print-economy",
+  "aurora",
+  "lotus",
+  "navy-gold",
+  "jade",
+  "coral",
+  "plum",
+)

--- a/packages/preview/sang-math/1.0.5/geometry-2d/conics.typ
+++ b/packages/preview/sang-math/1.0.5/geometry-2d/conics.typ
@@ -1,0 +1,255 @@
+// ═══════════════════════════════════════════════════════════════
+// GEOMETRY-2D / CONICS.TYP — Đường conic (Parabol, Elip, Hyperbol)
+// ═══════════════════════════════════════════════════════════════
+// Dùng: #import "geometry-2d/conics.typ": *
+//
+// DANH SÁCH HÀM:
+//   parabola-points(...)     Mảng tọa độ parabol (data)
+//   draw-parabola(...)       Vẽ parabol với nhãn và anchor
+//   ellipse-points(...)      Mảng tọa độ elip (data)
+//   draw-ellipse(...)        Vẽ elip với nhãn và anchor
+//   hyperbola-points(...)    Mảng tọa độ hyperbol (data)
+//   draw-hyperbola(...)      Vẽ hyperbol với nhãn và anchor
+// ═══════════════════════════════════════════════════════════════
+
+#import "@preview/cetz:0.5.2"
+#import "../core/math-utils.typ": linspace
+#import "../core/colors.typ": sm-blue, sm-red, sm-purple
+
+
+// ────────────────────────────────────────────────────────────────
+// PARABOL  y = a(x - h)² + k
+// ────────────────────────────────────────────────────────────────
+
+/// Tính mảng tọa độ của parabol dạng y = a(x-h)² + k.
+///
+/// - a (float): Hệ số bậc 2 (a > 0: mở lên, a < 0: mở xuống).
+/// - h (float): Hoành độ đỉnh.
+/// - k (float): Tung độ đỉnh.
+/// - x-range (array): Khoảng x `(xmin, xmax)`. Mặc định: `(-3, 3)`.
+/// - steps (int): Số điểm lấy mẫu. Mặc định: `60`.
+/// → returns array of (float, float)
+#let parabola-points(
+  a: 1,
+  h: 0,
+  k: 0,
+  x-range: (-3.0, 3.0),
+  steps: 60,
+) = {
+  let xs = linspace(x-range.at(0), x-range.at(1), steps + 1)
+  xs.map(x => (x, a * (x - h) * (x - h) + k))
+}
+
+/// Vẽ parabol y = a(x-h)² + k với đầy đủ nhãn và anchor.
+///
+/// - name (str): Tên định danh anchor. Mặc định: `"par"`.
+/// - a (float): Hệ số bậc 2.
+/// - h (float): Hoành độ đỉnh.
+/// - k (float): Tung độ đỉnh.
+/// - x-range (array): Khoảng x `(xmin, xmax)`. Mặc định: `(-3, 3)`.
+/// - color (color): Màu nét. Mặc định: sm-blue.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - label-vertex (content / none): Nhãn tại đỉnh. Ví dụ: `[$P$]`.
+/// - fill (color / none): Tô màu bên trong nếu cắt trục x.
+#let draw-parabola(
+  name: "par",
+  a: 1,
+  h: 0,
+  k: 0,
+  x-range: (-3.0, 3.0),
+  color: rgb("1565C0"),   // sm-func-1 / sm-blue
+  stroke-width: 1.5pt,
+  label-vertex: none,
+  steps: 60,
+) = {
+  let d = cetz.draw
+  let pts = parabola-points(a: a, h: h, k: k, x-range: x-range, steps: steps)
+
+  d.group(name: name, {
+    d.line(..pts, stroke: stroke-width + color)
+
+    if label-vertex != none {
+      let offset = if a > 0 { -0.4 } else { 0.4 }
+      d.content((h, k + offset), label-vertex)
+    }
+
+    // ── Anchors ────────────────────────────────────────────
+    d.anchor("vertex", (h, k))
+    d.anchor("left",   (x-range.at(0), a * (x-range.at(0) - h) * (x-range.at(0) - h) + k))
+    d.anchor("right",  (x-range.at(1), a * (x-range.at(1) - h) * (x-range.at(1) - h) + k))
+  })
+}
+
+
+// ────────────────────────────────────────────────────────────────
+// ELIP  x²/a² + y²/b² = 1
+// ────────────────────────────────────────────────────────────────
+
+/// Tính mảng tọa độ của elip x²/a² + y²/b² = 1.
+///
+/// - a (float): Bán trục dài (theo x).
+/// - b (float): Bán trục ngắn (theo y).
+/// - center (array): Tâm elip `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - steps (int): Số điểm lấy mẫu. Mặc định: `120`.
+/// → returns array of (float, float)
+#let ellipse-points(
+  a: 2,
+  b: 1,
+  center: (0.0, 0.0),
+  steps: 120,
+) = {
+  let (cx, cy) = center
+  let angles = linspace(0, 2 * calc.pi, steps + 1)
+  angles.map(t => (cx + a * calc.cos(t), cy + b * calc.sin(t)))
+}
+
+/// Vẽ elip x²/a² + y²/b² = 1 với đầy đủ nhãn và anchor.
+///
+/// - name (str): Tên định danh anchor. Mặc định: `"ell"`.
+/// - a (float): Bán trục dài (theo x).
+/// - b (float): Bán trục ngắn (theo y).
+/// - center (array): Tâm elip `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - color (color): Màu nét. Mặc định: sm-purple.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - fill (color / none): Tô màu bên trong. Mặc định: `none`.
+/// - show-axes (bool): Vẽ nửa trục (nét đứt). Mặc định: `false`.
+/// - show-foci (bool): Đánh dấu 2 tiêu điểm F1, F2. Mặc định: `false`.
+#let draw-ellipse(
+  name: "ell",
+  a: 2,
+  b: 1,
+  center: (0.0, 0.0),
+  color: rgb("7B1FA2"),   // sm-purple
+  stroke-width: 1.5pt,
+  fill: none,
+  show-axes: false,
+  show-foci: false,
+  steps: 120,
+) = {
+  let d = cetz.draw
+  let (cx, cy) = center
+  let pts = ellipse-points(a: a, b: b, center: center, steps: steps)
+  let c-focal = calc.sqrt(calc.abs(a * a - b * b))
+
+  d.group(name: name, {
+    if fill != none {
+      d.line(..pts, close: true, fill: fill, stroke: stroke-width + color)
+    } else {
+      d.line(..pts, close: true, stroke: stroke-width + color)
+    }
+
+    if show-axes {
+      d.line((cx - a, cy), (cx + a, cy),
+           stroke: (dash: "dashed", paint: rgb("1976D2"), thickness: 0.8pt))
+      d.line((cx, cy - b), (cx, cy + b),
+           stroke: (dash: "dashed", paint: rgb("1976D2"), thickness: 0.8pt))
+    }
+
+    if show-foci and a > b {
+      d.circle((cx + c-focal, cy), radius: 0.08, fill: rgb("E91E63"))
+      d.circle((cx - c-focal, cy), radius: 0.08, fill: rgb("E91E63"))
+      d.content((cx + c-focal, cy - 0.3), [$F_2$])
+      d.content((cx - c-focal, cy - 0.3), [$F_1$])
+    }
+
+    // ── Anchors ────────────────────────────────────────────
+    d.anchor("center", (cx,      cy))
+    d.anchor("right",  (cx + a,  cy))
+    d.anchor("left",   (cx - a,  cy))
+    d.anchor("top",    (cx,      cy + b))
+    d.anchor("bottom", (cx,      cy - b))
+    if a > b {
+      d.anchor("focus-1", (cx - c-focal, cy))
+      d.anchor("focus-2", (cx + c-focal, cy))
+    }
+  })
+}
+
+
+// ────────────────────────────────────────────────────────────────
+// HYPERBOL  x²/a² - y²/b² = 1
+// ────────────────────────────────────────────────────────────────
+
+/// Tính mảng tọa độ của một nhánh hyperbol (nhánh phải: x > 0).
+///
+/// - a (float): Hệ số a của hyperbol.
+/// - b (float): Hệ số b của hyperbol.
+/// - branch (str): `"right"` hoặc `"left"`. Mặc định: `"right"`.
+/// - y-range (array): Khoảng y `(ymin, ymax)`. Mặc định: `(-3, 3)`.
+/// - center (array): Tâm hyperbol. Mặc định: `(0, 0)`.
+/// - steps (int): Số điểm lấy mẫu. Mặc định: `60`.
+/// → returns array of (float, float)
+#let hyperbola-branch-points(
+  a: 1,
+  b: 1,
+  branch: "right",
+  y-range: (-3.0, 3.0),
+  center: (0.0, 0.0),
+  steps: 60,
+) = {
+  let (cx, cy) = center
+  let ys = linspace(y-range.at(0), y-range.at(1), steps + 1)
+  let sign = if branch == "right" { 1 } else { -1 }
+  ys.map(y => (cx + sign * a * calc.sqrt(1 + (y - cy) * (y - cy) / (b * b)), y))
+}
+
+/// Vẽ cả hai nhánh của hyperbol x²/a² - y²/b² = 1.
+///
+/// - name (str): Tên định danh anchor. Mặc định: `"hyp"`.
+/// - a (float): Hệ số a.
+/// - b (float): Hệ số b.
+/// - center (array): Tâm `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - y-range (array): Khoảng y `(ymin, ymax)`. Mặc định: `(-3, 3)`.
+/// - color (color): Màu nét. Mặc định: sm-red.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - show-asymptotes (bool): Vẽ đường tiệm cận. Mặc định: `false`.
+/// - show-foci (bool): Đánh dấu tiêu điểm. Mặc định: `false`.
+#let draw-hyperbola(
+  name: "hyp",
+  a: 1,
+  b: 1,
+  center: (0.0, 0.0),
+  y-range: (-3.0, 3.0),
+  color: rgb("E91E63"),   // sm-red
+  stroke-width: 1.5pt,
+  show-asymptotes: false,
+  show-foci: false,
+  steps: 60,
+) = {
+  import cetz.draw: *
+  let (cx, cy) = center
+  let c-focal = calc.sqrt(a * a + b * b)
+  let pts-r = hyperbola-branch-points(a: a, b: b, branch: "right",
+               y-range: y-range, center: center, steps: steps)
+  let pts-l = hyperbola-branch-points(a: a, b: b, branch: "left",
+               y-range: y-range, center: center, steps: steps)
+
+  group(name: name, {
+    line(..pts-r, stroke: stroke-width + color)
+    line(..pts-l, stroke: stroke-width + color)
+
+    if show-asymptotes {
+      let x-range-asm = (y-range.at(0) * a / b, y-range.at(1) * a / b)
+      line((cx + x-range-asm.at(0), cy + y-range.at(0)),
+           (cx + x-range-asm.at(1), cy + y-range.at(1)),
+           stroke: (dash: "dashed", paint: rgb("1976D2"), thickness: 0.8pt))
+      line((cx - x-range-asm.at(0), cy + y-range.at(0)),
+           (cx - x-range-asm.at(1), cy + y-range.at(1)),
+           stroke: (dash: "dashed", paint: rgb("1976D2"), thickness: 0.8pt))
+    }
+
+    if show-foci {
+      circle((cx + c-focal, cy), radius: 0.08, fill: rgb("E91E63"))
+      circle((cx - c-focal, cy), radius: 0.08, fill: rgb("E91E63"))
+      content((cx + c-focal, cy - 0.3), [$F_2$])
+      content((cx - c-focal, cy - 0.3), [$F_1$])
+    }
+
+    // ── Anchors ────────────────────────────────────────────
+    anchor("center",  (cx, cy))
+    anchor("right",   (cx + a, cy))
+    anchor("left",    (cx - a, cy))
+    anchor("focus-1", (cx - c-focal, cy))
+    anchor("focus-2", (cx + c-focal, cy))
+  })
+}

--- a/packages/preview/sang-math/1.0.5/geometry-3d/curves-3d.typ
+++ b/packages/preview/sang-math/1.0.5/geometry-3d/curves-3d.typ
@@ -1,0 +1,208 @@
+// ═══════════════════════════════════════════════════════════════
+// GEOMETRY-3D / CURVES-3D.TYP — Đường cong trong không gian 3D
+// (chiếu phối cảnh 2D để in ra giấy)
+// ═══════════════════════════════════════════════════════════════
+// Dùng: #import "geometry-3d/curves-3d.typ": *
+//
+// DANH SÁCH HÀM:
+//   helix-points(...)       Trả về mảng tọa độ (x,y) của đường xoắn ốc
+//   draw-helix(...)         Vẽ đường xoắn ốc (bọc helix-points)
+//   draw-spring(...)        Vẽ lò xo (helix dày hơn, nhiều vòng hơn)
+// ───────────────────────────────────────────────────────────────
+// CÁCH DÙNG MẪU (bài kiến bò trên mặt trụ):
+//
+//   #import "@local/sang-math:1.0.2": *
+//   #cetz.canvas(length: 0.8cm, {
+//     import cetz.draw: *
+//
+//     // Vẽ khung trụ trước...
+//     // Vẽ đường xoắn chỉ cần 1 dòng:
+//     draw-helix(
+//       center: (-8, 0),     // Tâm đáy dưới
+//       radius: 2,           // Bán kính trụ
+//       height: 8,           // Chiều cao trụ
+//       loops: 1.5,          // 1.5 vòng xoắn
+//       color: sm-red,
+//     )
+//   })
+// ═══════════════════════════════════════════════════════════════
+
+#import "@preview/cetz:0.5.2"
+#import "../core/math-utils.typ": linspace, lerp
+
+// ── Hằng nội bộ ───────────────────────────────────────────────
+// Tỉ lệ co theo trục Y để tạo ảo giác phối cảnh (ellipse đáy)
+// 0.3 = đáy trụ trông như ellipse thoải nhẹ — cảm giác 3D tự nhiên
+#let _PERSP-Y = 0.3
+
+// ── HÀM DATA ──────────────────────────────────────────────────
+
+/// Tính mảng tọa độ (x, y) chiếu phối cảnh của đường xoắn ốc.
+/// Đây là hàm "data thuần" — không vẽ, chỉ trả về mảng điểm.
+/// Người dùng có thể lấy ra để chỉnh sửa trước khi vẽ.
+///
+/// - center (array): Tọa độ tâm đáy dưới `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - radius (float): Bán kính của đường tròn đáy (trục X).
+/// - height (float): Chiều cao tổng của đường xoắn.
+/// - loops (float): Số vòng xoắn. Mặc định: `1`.
+/// - steps (int): Số đoạn xấp xỉ. Mặc định: `60` (mỗi vòng = 60/loops điểm).
+/// - persp-y (float): Tỉ lệ phối cảnh theo trục Y dọc (0.1–0.5). Mặc định: `0.3`.
+/// - offset-angle (float): Góc bắt đầu tính bằng radian. Mặc định: `calc.pi` (bắt đầu từ điểm xa nhất).
+/// → returns array of (float, float)
+#let helix-points(
+  center: (0, 0),
+  radius: 1,
+  height: 4,
+  loops: 1,
+  steps: 60,
+  persp-y: 0.3,
+  offset-angle: calc.pi,   // π = bắt đầu từ điểm trái nhất (xa người xem)
+) = {
+  let (cx, cy) = center
+  let total-angle = loops * 2 * calc.pi
+  let ts = linspace(0, 1, steps + 1)
+  ts.map(t => {
+    let angle = offset-angle + t * total-angle
+    let x = cx + radius * calc.cos(angle)
+    let y = cy + t * height + radius * persp-y * calc.sin(angle)
+    (x, y)
+  })
+}
+
+/// Chia mảng điểm helix thành các segment visible/hidden theo sin(angle).
+/// Trả về tuple (vis-segs, hid-segs): mỗi seg là mảng điểm.
+/// Lưu ý: Typst array là immutable, dùng += (item,) để thêm phần tử.
+///
+/// - pts (array): Mảng tọa độ từ helix-points.
+/// - loops (float): Số vòng xoắn.
+/// - offset-angle (float): Góc bắt đầu khớp với helix-points.
+#let helix-split-visible(pts, loops: 1, offset-angle: calc.pi) = {
+  let n = pts.len()
+  let total-angle = loops * 2 * calc.pi
+  let vis-segs = ()
+  let hid-segs = ()
+  let cur = ()
+  let cur-front = none
+
+  for i in range(0, n) {
+    let t = if n > 1 { i / (n - 1) } else { 0.0 }
+    let angle = offset-angle + t * total-angle
+    let is-front = calc.sin(angle) >= 0
+    let pt = pts.at(i)
+
+    if cur-front == none {
+      cur = (pt,)
+      cur-front = is-front
+    } else if is-front == cur-front {
+      cur += (pt,)
+    } else {
+      // Thêm điểm giao để các segment nối liền nhau
+      cur += (pt,)
+      if cur.len() >= 2 {
+        if cur-front { vis-segs += (cur,) } else { hid-segs += (cur,) }
+      }
+      cur = (pt,)
+      cur-front = is-front
+    }
+  }
+
+  // Flush segment cuối
+  if cur.len() >= 2 {
+    if cur-front { vis-segs += (cur,) } else { hid-segs += (cur,) }
+  }
+  (vis-segs, hid-segs)
+}
+
+
+// ── HÀM VẼ ────────────────────────────────────────────────────
+
+/// Vẽ đường xoắn ốc (helix) quanh trục thẳng đứng.
+/// Tự động xử lý phần khuất (nét đứt) và phần nhìn thấy (nét liền).
+///
+/// Hữu dụng cho bài toán: kiến bò trên mặt trụ,
+/// dây quấn quanh ống, đường ren vít.
+///
+/// - center (array): Tọa độ tâm đáy dưới `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - radius (float): Bán kính của đường tròn đáy.
+/// - height (float): Chiều cao tổng của đường xoắn.
+/// - loops (float): Số vòng xoắn. Mặc định: `1`.
+/// - steps (int): Số đoạn xấp xỉ. Mặc định: `60`.
+/// - color (color): Màu nét vẽ. Mặc định: `rgb("E91E63")`.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - auto-dashed (bool): Tự động vẽ phần khuất bằng nét đứt. Mặc định: `true`.
+/// - persp-y (float): Tỉ lệ phối cảnh ellipse. Mặc định: `0.3`.
+/// - offset-angle (float): Góc bắt đầu (radian). Mặc định: `calc.pi`.
+#let draw-helix(
+  center: (0, 0),
+  radius: 1,
+  height: 4,
+  loops: 1,
+  steps: 60,
+  color: rgb("E91E63"),
+  stroke-width: 1.5pt,
+  auto-dashed: true,
+  persp-y: 0.3,
+  offset-angle: calc.pi,
+) = {
+  let d = cetz.draw
+  let pts = helix-points(
+    center: center,
+    radius: radius,
+    height: height,
+    loops: loops,
+    steps: steps,
+    persp-y: persp-y,
+    offset-angle: offset-angle,
+  )
+
+  if auto-dashed {
+    let (vis-segs, hid-segs) = helix-split-visible(
+      pts,
+      loops: loops,
+      offset-angle: offset-angle,
+    )
+    for seg in vis-segs {
+      if seg.len() >= 2 {
+        d.line(..seg, stroke: stroke-width + color)
+      }
+    }
+    for seg in hid-segs {
+      if seg.len() >= 2 {
+        d.line(..seg, stroke: (dash: "dashed", paint: color, thickness: stroke-width))
+      }
+    }
+  } else {
+    // Vẽ đơn giản: toàn bộ 1 màu, 1 nét
+    d.line(..pts, stroke: stroke-width + color)
+  }
+}
+
+/// Vẽ lò xo (nhiều vòng hơn helix, bán kính nhỏ, thường dùng cho bài vật lý-toán).
+/// Là wrapper của draw-helix với preset phù hợp.
+///
+/// - center (array): Tọa độ tâm đáy dưới.
+/// - radius (float): Bán kính lò xo. Mặc định: `0.4`.
+/// - height (float): Chiều dài lò xo.
+/// - coils (float): Số vòng cuộn. Mặc định: `6`.
+/// - color (color): Màu nét. Mặc định: `rgb("1976D2")`.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.2pt`.
+#let draw-spring(
+  center: (0, 0),
+  radius: 0.4,
+  height: 4,
+  coils: 6,
+  color: rgb("1976D2"),
+  stroke-width: 1.2pt,
+) = {
+  draw-helix(
+    center: center,
+    radius: radius,
+    height: height,
+    loops: coils,
+    steps: coils * 30,
+    color: color,
+    stroke-width: stroke-width,
+    auto-dashed: false,  // Lò xo không cần nét đứt
+    persp-y: 0.5,
+  )
+}

--- a/packages/preview/sang-math/1.0.5/geometry-3d/revolution.typ
+++ b/packages/preview/sang-math/1.0.5/geometry-3d/revolution.typ
@@ -1,0 +1,253 @@
+// ═══════════════════════════════════════════════════════════════
+// GEOMETRY-3D / REVOLUTION.TYP — Hình khối tròn xoay
+// (Nón, Trụ, Cầu — chiếu phối cảnh 2D)
+// ═══════════════════════════════════════════════════════════════
+// Dùng: #import "geometry-3d/revolution.typ": *
+//
+// DANH SÁCH HÀM:
+//   draw-cylinder(...)      Hình trụ với đầy đủ anchor
+//   draw-cone(...)          Hình nón với đầy đủ anchor
+//   draw-sphere(...)        Hình cầu với đầy đủ anchor
+// ───────────────────────────────────────────────────────────────
+// CÁC ANCHOR CÓ SẴN (truyền vào draw.content, draw.line, v.v.):
+//
+//   Trụ (draw-cylinder name: "C"):
+//     C.top         Tâm mặt trên
+//     C.bottom      Tâm mặt dưới
+//     C.top-left    Điểm trái mặt trên (điểm tiếp xúc đường sinh)
+//     C.top-right   Điểm phải mặt trên
+//     C.bot-left    Điểm trái mặt dưới
+//     C.bot-right   Điểm phải mặt dưới
+//     C.center      Trung điểm trục
+//
+//   Nón (draw-cone name: "N"):
+//     N.apex        Đỉnh S
+//     N.center      Tâm đáy O
+//     N.left        Điểm trái đáy
+//     N.right       Điểm phải đáy
+//
+//   Cầu (draw-sphere name: "S"):
+//     S.center      Tâm O
+//     S.top         Điểm cực Bắc
+//     S.bottom      Điểm cực Nam
+//     S.left        Điểm cực Tây
+//     S.right       Điểm cực Đông
+// ═══════════════════════════════════════════════════════════════
+
+#import "@preview/cetz:0.5.2"
+#import "../core/colors.typ": sm-blue, sm-gray, sm-face-top, sm-face-front
+
+// ── Tỉ lệ phối cảnh mặc định (bán trục ngắn ellipse / bán trục dài) ──
+#let _PERSP = 0.35
+
+
+// ────────────────────────────────────────────────────────────────
+// HÌNH TRỤ
+// ────────────────────────────────────────────────────────────────
+
+/// Vẽ hình trụ đứng chiếu phối cảnh, kèm theo các anchor.
+///
+/// - name (str): Tên định danh để tham chiếu anchor. Mặc định: `"cyl"`.
+/// - center (array): Tọa độ tâm đáy dưới `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - radius (float): Bán kính đáy.
+/// - height (float): Chiều cao hình trụ.
+/// - color (color): Màu nét viền. Mặc định: sm-blue.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - fill-side (color / none): Tô màu thân trụ. Mặc định: `none`.
+/// - fill-top (color / none): Tô màu mặt trên. Mặc định: `none`.
+/// - persp (float): Tỉ lệ phối cảnh ellipse. Mặc định: `0.35`.
+/// - show-hidden (bool): Vẽ nét đứt cho phần khuất của đáy dưới. Mặc định: `true`.
+#let draw-cylinder(
+  name: "cyl",
+  center: (0, 0),
+  radius: 1,
+  height: 4,
+  color: rgb("1976D2"),   // sm-blue
+  stroke-width: 1.5pt,
+  fill-side: none,
+  fill-top: none,
+  persp: 0.35,
+  show-hidden: true,
+) = {
+  let d = cetz.draw
+  let (cx, cy) = center
+  let ry = radius * persp
+
+  d.group(name: name, {
+    if fill-side != none {
+      let fill-pts = (
+        (cx - radius, cy),
+        (cx - radius, cy + height),
+        (cx + radius, cy + height),
+        (cx + radius, cy),
+      )
+      d.line(..fill-pts, close: true, fill: fill-side)
+    }
+
+    if show-hidden {
+      d.arc((cx, cy), start: 0deg, stop: 180deg,
+          radius: (radius, ry),
+          stroke: (dash: "dashed", paint: rgb("888888"), thickness: 0.8pt))
+    }
+    d.arc((cx, cy), start: 0deg, stop: -180deg,
+        radius: (radius, ry),
+        stroke: stroke-width + color)
+
+    if fill-top != none {
+      d.arc((cx, cy + height), start: 0deg, stop: 360deg,
+          radius: (radius, ry),
+          fill: fill-top,
+          stroke: stroke-width + color)
+    } else {
+      d.arc((cx, cy + height), start: 0deg, stop: 360deg,
+          radius: (radius, ry),
+          stroke: stroke-width + color)
+    }
+
+    d.line((cx - radius, cy), (cx - radius, cy + height), stroke: stroke-width + color)
+    d.line((cx + radius, cy), (cx + radius, cy + height), stroke: stroke-width + color)
+
+    d.anchor("bottom",    (cx,          cy))
+    d.anchor("top",       (cx,          cy + height))
+    d.anchor("center",    (cx,          cy + height / 2))
+    d.anchor("bot-left",  (cx - radius, cy))
+    d.anchor("bot-right", (cx + radius, cy))
+    d.anchor("top-left",  (cx - radius, cy + height))
+    d.anchor("top-right", (cx + radius, cy + height))
+  })
+}
+
+
+// ────────────────────────────────────────────────────────────────
+// HÌNH NÓN
+// ────────────────────────────────────────────────────────────────
+
+/// Vẽ hình nón đứng chiếu phối cảnh, kèm theo các anchor.
+///
+/// - name (str): Tên định danh để tham chiếu anchor. Mặc định: `"cone"`.
+/// - center (array): Tọa độ tâm đáy `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - radius (float): Bán kính đáy.
+/// - height (float): Chiều cao hình nón.
+/// - color (color): Màu nét viền. Mặc định: sm-blue.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - fill-base (color / none): Tô màu mặt đáy. Mặc định: `none`.
+/// - persp (float): Tỉ lệ phối cảnh ellipse. Mặc định: `0.35`.
+/// - show-hidden (bool): Vẽ nét đứt phần khuất của đáy. Mặc định: `true`.
+/// - label-apex (content / none): Nhãn tại đỉnh. Ví dụ: `[$S$]`.
+/// - label-center (content / none): Nhãn tại tâm đáy. Ví dụ: `[$O$]`.
+#let draw-cone(
+  name: "cone",
+  center: (0, 0),
+  radius: 1,
+  height: 4,
+  color: rgb("1976D2"),   // sm-blue
+  stroke-width: 1.5pt,
+  fill-base: none,
+  persp: 0.35,
+  show-hidden: true,
+  label-apex: none,
+  label-center: none,
+) = {
+  let d = cetz.draw
+  let (cx, cy) = center
+  let ry = radius * persp
+  let apex = (cx, cy + height)
+
+  d.group(name: name, {
+    if show-hidden {
+      d.arc((cx, cy), start: 0deg, stop: 180deg,
+          radius: (radius, ry),
+          stroke: (dash: "dashed", paint: rgb("888888"), thickness: 0.8pt))
+    }
+    if fill-base != none {
+      d.arc((cx, cy), start: 0deg, stop: -180deg,
+          radius: (radius, ry),
+          fill: fill-base,
+          stroke: stroke-width + color)
+    } else {
+      d.arc((cx, cy), start: 0deg, stop: -180deg,
+          radius: (radius, ry),
+          stroke: stroke-width + color)
+    }
+
+    d.line((cx - radius, cy), apex, stroke: stroke-width + color)
+    d.line((cx + radius, cy), apex, stroke: stroke-width + color)
+
+    if label-apex != none {
+      d.content((cx, cy + height + 0.3), label-apex, anchor: "south")
+    }
+    if label-center != none {
+      d.content((cx, cy - 0.3), label-center, anchor: "north")
+    }
+
+    d.anchor("apex",   apex)
+    d.anchor("center", (cx, cy))
+    d.anchor("left",   (cx - radius, cy))
+    d.anchor("right",  (cx + radius, cy))
+    d.anchor("mid",    (cx, cy + height / 2))
+  })
+}
+
+
+// ────────────────────────────────────────────────────────────────
+// HÌNH CẦU
+// ────────────────────────────────────────────────────────────────
+
+/// Vẽ hình cầu chiếu phối cảnh (đường tròn ngoài + đường xích đạo ellipse).
+///
+/// - name (str): Tên định danh để tham chiếu anchor. Mặc định: `"sph"`.
+/// - center (array): Tọa độ tâm cầu `(cx, cy)`. Mặc định: `(0, 0)`.
+/// - radius (float): Bán kính cầu.
+/// - color (color): Màu nét viền. Mặc định: sm-blue.
+/// - stroke-width (length): Độ dày nét. Mặc định: `1.5pt`.
+/// - fill (color / none): Tô màu mặt cầu. Mặc định: `none`.
+/// - persp (float): Tỉ lệ phối cảnh ellipse xích đạo. Mặc định: `0.35`.
+/// - show-equator (bool): Vẽ đường xích đạo. Mặc định: `true`.
+/// - show-meridian (bool): Vẽ kinh tuyến đứng. Mặc định: `false`.
+#let draw-sphere(
+  name: "sph",
+  center: (0, 0),
+  radius: 1,
+  color: rgb("1976D2"),   // sm-blue literal
+  stroke-width: 1.5pt,
+  fill: none,
+  persp: 0.35,            // _PERSP literal
+  show-equator: true,
+  show-meridian: false,
+) = {
+  let d = cetz.draw
+  let (cx, cy) = center
+  let ry-eq = radius * persp
+
+  d.group(name: name, {
+    if fill != none {
+      d.circle((cx, cy), radius: radius, fill: fill, stroke: stroke-width + color)
+    } else {
+      d.circle((cx, cy), radius: radius, stroke: stroke-width + color)
+    }
+
+    if show-equator {
+      d.arc((cx, cy), start: 0deg, stop: 180deg,
+          radius: (radius, ry-eq),
+          stroke: (dash: "dashed", paint: rgb("888888"), thickness: 0.8pt))
+      d.arc((cx, cy), start: 0deg, stop: -180deg,
+          radius: (radius, ry-eq),
+          stroke: stroke-width + color)
+    }
+
+    if show-meridian {
+      d.arc((cx, cy), start: 90deg, stop: 270deg,
+          radius: (ry-eq, radius),
+          stroke: (dash: "dashed", paint: rgb("888888"), thickness: 0.8pt))
+      d.arc((cx, cy), start: -90deg, stop: 90deg,
+          radius: (ry-eq, radius),
+          stroke: stroke-width + color)
+    }
+
+    d.anchor("center", (cx,          cy))
+    d.anchor("top",    (cx,          cy + radius))
+    d.anchor("bottom", (cx,          cy - radius))
+    d.anchor("left",   (cx - radius, cy))
+    d.anchor("right",  (cx + radius, cy))
+  })
+}

--- a/packages/preview/sang-math/1.0.5/geometry.typ
+++ b/packages/preview/sang-math/1.0.5/geometry.typ
@@ -1,0 +1,488 @@
+// ═══════════════════════════════════════════════════════════
+// GEOMETRY.TYP v1.0 — Vẽ hình học nhanh với Cetz
+// ═══════════════════════════════════════════════════════════
+// Import: #import "@preview/cetz:0.5.2"
+//         #import "geometry.typ": *
+//
+// Các hàm vẽ một canvas hoàn chỉnh bọc sẵn cetz.canvas().
+// Mỗi hàm trả về 1 canvas — dùng trực tiếp làm fig: trong tn/ds/tln/tl.
+// ─────────────────────────────────────────────────────────
+// DANH SÁCH HÀM:
+//   tri-xyz(a,b,c)             Tam giác ABC (toạ độ thật)
+//   tri-angles(a,α,β)         Tam giác từ 1 cạnh + 2 góc
+//   tri-right(...)            Tam giác vuông
+//   rect-abc(a,b)             Hình chữ nhật / vuông
+//   chóp-sabc(h,...)          Hình chóp S.ABC
+//   chóp-sabcd(h,...)         Hình chóp S.ABCD
+//   lang-tru-abc(h,...)       Lăng trụ đứng ABC.A'B'C'
+//   circle-desc(r)            Đường tròn tâm O, bán kính r
+//   angle-mark(A,O,B)         Đánh dấu góc ∠AOB
+//   right-angle(A,O,B)        Đánh dấu góc vuông tại O
+//   seg-label(A,B,text,pos)   Gán nhãn đoạn thẳng
+//   point-label(p,text,pos)   Gán nhãn điểm
+//   axis-xy(xmin,xmax,ymin,ymax)  Trục toạ độ Oxy
+//   parabola(a,b,c,...)       Parabol y = ax²+bx+c
+//   dashed-line(A,B)          Đường đứt nét
+// ─────────────────────────────────────────────────────────
+
+#import "@preview/cetz:0.5.2"
+
+// ── Hằng ─────────────────────────────────────────────────
+#let _ge-blue = rgb("#0057b8")
+#let _ge-red = rgb("#cc2200")
+#let _ge-green = rgb("#1a7a2e")
+#let _ge-gray = rgb("#888")
+#let _ge-bg = rgb("#fafafa")
+#let _ge-scale = 0.7cm
+#let _ge-padding = 0.4
+
+// ── Tam giác từ 3 điểm cho trước ───────────────────────
+// tri-xyz(A: (x,y), B: (x,y), C: (x,y), labels: (...))
+#let tri-xyz(A, B, C, labels: ("A", "B", "C"), right-angle: none, scale: _ge-scale) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    line(A, B, C, A, stroke: 1.2pt + black)
+    for ((p, lbl)) in ((A, labels.at(0)), (B, labels.at(1)), (C, labels.at(2))) {
+      circle(p, radius: 2.5pt, fill: black)
+      let (x, y) = p
+      let dx = 0.25; let dy = 0.25
+      if p == A { (dx, dy) = (-0.3, -0.35) }
+      if p == B { (dx, dy) = (0.3, -0.35) }
+      if p == C { (dx, dy) = (0, 0.35) }
+      content((x + dx, y + dy), text(size: 9pt, weight: "bold")[#lbl])
+    }
+    if right-angle != none {
+      let pts = (A, B, C)
+      let i = if right-angle == "A" { 0 } else if right-angle == "B" { 1 } else if right-angle == "C" { 2 } else { -1 }
+      if i >= 0 {
+        let p = pts.at(i)
+        let p1 = pts.at(calc.rem(i + 1, 3))
+        let p2 = pts.at(calc.rem(i + 2, 3))
+        let s = 0.4
+        let v1 = ((p1.at(0) - p.at(0), p1.at(1) - p.at(1)))
+        let v2 = ((p2.at(0) - p.at(0), p2.at(1) - p.at(1)))
+        let d1 = calc.sqrt(v1.at(0) * v1.at(0) + v1.at(1) * v1.at(1))
+        let d2 = calc.sqrt(v2.at(0) * v2.at(0) + v2.at(1) * v2.at(1))
+        let u1 = (v1.at(0) / d1 * s, v1.at(1) / d1 * s)
+        let u2 = (v2.at(0) / d2 * s, v2.at(1) / d2 * s)
+        line((p.at(0) + u1.at(0), p.at(1) + u1.at(1)),
+             (p.at(0) + u1.at(0) + u2.at(0), p.at(1) + u1.at(1) + u2.at(1)),
+             (p.at(0) + u2.at(0), p.at(1) + u2.at(1)),
+             stroke: 0.6pt + black)
+      }
+    }
+  })
+}
+
+// ── Tam giác thường — cạnh đáy ngang, đỉnh trên ────────
+// base = độ dài đáy, height = chiều cao
+#let tri-abc(base: 5, height: 3.5, labels: ("A", "B", "C"), scale: _ge-scale) = {
+  let hw = base / 2
+  tri-xyz(
+    (-hw, 0), (hw, 0), (0, height),
+    labels: labels,
+    scale: scale,
+  )
+}
+
+// ── Tam giác vuông tại A ────────────────────────────────
+#let tri-right(leg1: 4, leg2: 3, labels: ("A", "B", "C"), right-angle-vertex: "A", scale: _ge-scale) = {
+  tri-xyz(
+    (0, 0), (leg1, 0), (0, leg2),
+    labels: labels,
+    right-angle: right-angle-vertex,
+    scale: scale,
+  )
+}
+
+// ── Hình chữ nhật / vuông ──────────────────────────────
+#let rect-xyz(A: (0, 0), C: (5, 3), labels: ("A", "B", "C", "D"), scale: _ge-scale) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let (ax, ay) = A; let (cx, cy) = C
+    let B = (cx, ay); let D = (ax, cy)
+    line(A, B, C, D, A, stroke: 1.2pt + black)
+    for ((p, lbl)) in ((A, labels.at(0)), (B, labels.at(1)), (C, labels.at(2)), (D, labels.at(3))) {
+      circle(p, radius: 2.5pt, fill: black)
+      let (x, y) = p
+      let (dx, dy) = if p == A { (-0.3, -0.35) }
+        else if p == B { (0.3, -0.35) }
+        else if p == C { (0.3, 0.35) }
+        else { (-0.3, 0.35) }
+      content((x + dx, y + dy), text(size: 9pt, weight: "bold")[#lbl])
+    }
+  })
+}
+
+// ── Hình chữ nhật đơn giản ─────────────────────────────
+#let rect-abc(width: 5, height: 3, labels: ("A", "B", "C", "D"), scale: _ge-scale) = {
+  rect-xyz(A: (0, 0), C: (width, height), labels: labels, scale: scale)
+}
+
+// ── Hình vuông ─────────────────────────────────────────
+#let square(a: 4, labels: ("A", "B", "C", "D"), scale: _ge-scale) = {
+  rect-abc(width: a, height: a, labels: labels, scale: scale)
+}
+
+// ═══════════════════════════════════════════════════════════
+// HÌNH HỌC KHÔNG GIAN (Phối cảnh Cavalier)
+// ═══════════════════════════════════════════════════════════
+
+// ── Hình chóp tam giác S.ABC ────────────────────────────
+// base: 3 điểm đáy, S: đỉnh
+#let chop-sabc(
+  S: (0, 8),
+  A: (-4, 0), B: (4, 0), C: (0, -2),
+  labels: ("S", "A", "B", "C"),
+  hidden: (), // tuple đỉnh bị che: ("AC",) → AC nét đứt
+  scale: _ge-scale,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let pts = (S, A, B, C)
+    let edges = ((0, 1), (0, 2), (0, 3), (1, 2), (2, 3), (3, 1))
+    for e in edges {
+      let (i, j) = e
+      let lbl = labels.at(i) + labels.at(j)
+      let rev = labels.at(j) + labels.at(i)
+      let st = if hidden.contains(lbl) or hidden.contains(rev) {
+        (paint: _ge-gray, thickness: 0.7pt, dash: "dashed")
+      } else {
+        1.1pt + black
+      }
+      line(pts.at(i), pts.at(j), stroke: st)
+    }
+    for (i, lbl) in labels.enumerate() {
+      let (x, y) = pts.at(i)
+      circle((x, y), radius: 2.5pt, fill: if i == 0 { _ge-blue } else { black })
+      let (dx, dy) = if lbl == "S" { (0, 0.45) }
+        else if lbl == "A" { (-0.4, -0.3) }
+        else if lbl == "B" { (0.4, -0.3) }
+        else { (0.1, -0.4) }
+      content((x + dx, y + dy), text(size: 10pt, weight: "bold")[#lbl])
+    }
+  })
+}
+
+// ── Hình chóp tứ giác S.ABCD ────────────────────────────
+#let chop-sabcd(
+  S: (0, 7),
+  A: (-3, 0), B: (3, 0), C: (2, -2), D: (-2, -2),
+  labels: ("S", "A", "B", "C", "D"),
+  hidden: (),
+  scale: _ge-scale,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let pts = (S, A, B, C, D)
+    let edges = ((0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (2, 3), (3, 4), (4, 1))
+    for e in edges {
+      let (i, j) = e
+      let lbl = labels.at(i) + labels.at(j)
+      let rev = labels.at(j) + labels.at(i)
+      let st = if hidden.contains(lbl) or hidden.contains(rev) {
+        (paint: _ge-gray, thickness: 0.7pt, dash: "dashed")
+      } else {
+        1.1pt + black
+      }
+      line(pts.at(i), pts.at(j), stroke: st)
+    }
+    for (i, lbl) in labels.enumerate() {
+      let (x, y) = pts.at(i)
+      circle((x, y), radius: 2.5pt, fill: if i == 0 { _ge-blue } else { black })
+      let (dx, dy) = if lbl == "S" { (0, 0.45) }
+        else if lbl == "A" { (-0.35, -0.3) }
+        else if lbl == "B" { (0.35, -0.3) }
+        else if lbl == "C" { (0.3, 0.3) }
+        else { (-0.3, 0.3) }
+      content((x + dx, y + dy), text(size: 10pt, weight: "bold")[#lbl])
+    }
+  })
+}
+
+// ── Lăng trụ tam giác ABC.A'B'C' ────────────────────────
+#let lang-tru-abc(
+  A: (-3, 0), B: (3, 0), C: (0, -2),
+  A2: (-3, 5), B2: (3, 5), C2: (0, 3),
+  labels: ("A", "B", "C", "A'", "B'", "C'"),
+  hidden: (), // "AA'" hoặc "AB" để đánh dấu nét đứt
+  scale: _ge-scale,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let pts = (A, B, C, A2, B2, C2)
+    let edges = ((0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 3), (0, 3), (1, 4), (2, 5))
+    for e in edges {
+      let (i, j) = e
+      let lbl = labels.at(i) + labels.at(j)
+      let rev = labels.at(j) + labels.at(i)
+      let st = if hidden.contains(lbl) or hidden.contains(rev) {
+        (paint: _ge-gray, thickness: 0.7pt, dash: "dashed")
+      } else {
+        1.1pt + black
+      }
+      line(pts.at(i), pts.at(j), stroke: st)
+    }
+    for (i, lbl) in labels.enumerate() {
+      let (x, y) = pts.at(i)
+      circle((x, y), radius: 2.5pt, fill: black)
+      let (dx, dy) = if lbl == "A" or lbl == "A'" { (-0.35, -0.3) }
+        else if lbl == "B" or lbl == "B'" { (0.35, -0.3) }
+        else { (0, 0.35) }
+      content((x + dx, y + dy), text(size: 10pt, weight: "bold")[#lbl])
+    }
+  })
+}
+
+// ═══════════════════════════════════════════════════════════
+// ĐƯỜNG TRÒN & MARKERS
+// ═══════════════════════════════════════════════════════════
+
+// ── Đường tròn tâm O, bán kính R ────────────────────────
+#let circle-desc(
+  center: (0, 0),
+  radius: 2,
+  label: "O",
+  scale: _ge-scale,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    circle(center, radius: radius, stroke: 1.2pt + black, fill: none)
+    circle(center, radius: 2.8pt, fill: black)
+    content((center.at(0) - 0.3, center.at(1) - 0.35), text(size: 10pt, weight: "bold")[#label])
+    // Vẽ 2 đường kính nét mảnh
+    line(
+      (center.at(0) - radius, center.at(1)),
+      (center.at(0) + radius, center.at(1)),
+      stroke: (paint: _ge-gray, thickness: 0.4pt, dash: "dotted"),
+    )
+    line(
+      (center.at(0), center.at(1) - radius),
+      (center.at(0), center.at(1) + radius),
+      stroke: (paint: _ge-gray, thickness: 0.4pt, dash: "dotted"),
+    )
+  })
+}
+
+// ── Đánh dấu góc ────────────────────────────────────────
+#let angle-mark(A, O, B, radius: 0.5, label: none, fill: rgb("#FFE0B2"), scale: _ge-scale) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let (ax, ay) = A
+    let (ox, oy) = O
+    let (bx, by) = B
+    let angleA = calc.atan2(ay - oy, ax - ox)
+    let angleB = calc.atan2(by - oy, bx - ox)
+    let r = radius
+    arc(O, r, angleA, angleB, stroke: 0.7pt + _ge-red, fill: fill)
+    if label != none {
+      let mx = ox + r * 1.5 * calc.cos((angleA + angleB) / 2)
+      let my = oy + r * 1.5 * calc.sin((angleA + angleB) / 2)
+      content((mx, my), text(size: 8pt, fill: _ge-red)[#label])
+    }
+  })
+}
+
+// ── Đường đứt nét giữa 2 điểm ──────────────────────────
+#let dashed-seg(A, B, scale: _ge-scale) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    line(A, B, stroke: (paint: _ge-gray, thickness: 0.7pt, dash: "dashed"))
+  })
+}
+
+// ═══════════════════════════════════════════════════════════
+// TRỤC TOẠ ĐỘ & ĐỒ THỊ
+// ═══════════════════════════════════════════════════════════
+
+// ── Hệ trục Oxy ─────────────────────────────────────────
+#let axis-xy(
+  xmin: -3, xmax: 3, ymin: -2, ymax: 4,
+  xlabel: "x", ylabel: "y",
+  xstep: 1, ystep: 1,
+  scale: 1cm,
+  ticks: true,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    // Trục
+    line((xmin, 0), (xmax, 0), mark: (end: ">"), stroke: 1.2pt + black)
+    line((0, ymin), (0, ymax), mark: (end: ">"), stroke: 1.2pt + black)
+    content((xmax - 0.4, 0.35), $#xlabel$)
+    content((0.35, ymax - 0.3), $#ylabel$)
+    content((-0.25, -0.25), $O$)
+    // Tick marks
+    if ticks {
+      for x in range(xmin + 1, xmax) {
+        if x != 0 {
+          line((x, -0.15), (x, 0.15), stroke: 0.5pt + _ge-gray)
+          content((x, -0.4), text(size: 7pt)[#x])
+        }
+      }
+      for y in range(ymin + 1, ymax) {
+        if y != 0 {
+          line((-0.15, y), (0.15, y), stroke: 0.5pt + _ge-gray)
+          content((-0.5, y - 0.1), text(size: 7pt)[#y])
+        }
+      }
+    }
+  })
+}
+
+// ── Đồ thị hàm số (plot từ danh sách điểm) ──────────────
+#let plot(
+  points,
+  xmin: auto, xmax: auto, ymin: auto, ymax: auto,
+  stroke-color: _ge-blue,
+  stroke-width: 1.3pt,
+  scale: 1cm,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    if xmin != auto and xmax != auto and ymin != auto and ymax != auto {
+      line((xmin, 0), (xmax, 0), mark: (end: ">"), stroke: 1pt + black)
+      line((0, ymin), (0, ymax), mark: (end: ">"), stroke: 1pt + black)
+      content((xmax - 0.4, 0.35), $x$)
+      content((0.35, ymax - 0.3), $y$)
+      content((-0.25, -0.25), $O$)
+    }
+    line(..points, stroke: stroke-width + stroke-color)
+  })
+}
+
+// ── Parabol y = ax² + bx + c ────────────────────────────
+#let parabola(
+  a: 1, b: 0, c: 0,
+  xmin: -3, xmax: 3,
+  ymin: auto, ymax: auto,
+  npts: 80,
+  accent: _ge-blue,
+  show-vertex: false,
+  show-roots: false,
+  scale: 1cm,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let dx = (xmax - xmin) / npts
+    let pts = ()
+    let yvals = ()
+    for i in range(npts + 1) {
+      let x = xmin + i * dx
+      let y = a * x * x + b * x + c
+      pts.push((x, y))
+      yvals.push(y)
+    }
+    let mymin = if ymin == auto { calc.min(..yvals) - 0.5 } else { ymin }
+    let mymax = if ymax == auto { calc.max(..yvals) + 0.5 } else { ymax }
+    line((xmin, 0), (xmax, 0), mark: (end: ">"), stroke: 1pt + black)
+    line((0, mymin), (0, mymax), mark: (end: ">"), stroke: 1pt + black)
+    content((xmax - 0.4, 0.35), $x$)
+    content((0.35, mymax - 0.3), $y$)
+    content((-0.25, -0.25), $O$)
+    line(..pts, stroke: 1.2pt + accent)
+    // Đỉnh
+    if show-vertex {
+      let vx = -b / (2 * a)
+      let vy = a * vx * vx + b * vx + c
+      circle((vx, vy), radius: 3pt, fill: _ge-red)
+      content((vx + 0.25, vy + 0.3), text(size: 8pt, fill: _ge-red)[đỉnh])
+    }
+    // Nghiệm
+    if show-roots {
+      let delta = b * b - 4 * a * c
+      if delta >= 0 {
+        let sd = calc.sqrt(delta)
+        let r1 = (-b - sd) / (2 * a)
+        let r2 = (-b + sd) / (2 * a)
+        circle((r1, 0), radius: 3pt, fill: _ge-green)
+        circle((r2, 0), radius: 3pt, fill: _ge-green)
+      }
+    }
+  })
+}
+
+// ── Đường thẳng qua 2 điểm ─────────────────────────────
+#let line-through(A, B, accent: _ge-blue, scale: 1cm) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let xmin = calc.min(A.at(0), B.at(0)) - 1
+    let xmax = calc.max(A.at(0), B.at(0)) + 1
+    let ymin = calc.min(A.at(1), B.at(1)) - 1
+    let ymax = calc.max(A.at(1), B.at(1)) + 1
+    axis-xy(xmin: xmin, xmax: xmax, ymin: ymin, ymax: ymax, scale: scale)
+    line(A, B, stroke: 1.2pt + accent)
+    circle(A, radius: 3pt, fill: black)
+    circle(B, radius: 3pt, fill: black)
+  })
+}
+
+// ── Nửa đường tròn (trên / dưới) ───────────────────────
+#let semicircle(
+  center: (0, 0), radius: 2,
+  above: true,
+  accent: _ge-blue,
+  scale: 1cm,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let (cx, cy) = center
+    let r = radius
+    let n = 60
+    let pts = ()
+    for i in range(n + 1) {
+      let angle = if above { calc.pi * i / n } else { calc.pi * (n - i) / n }
+      let x = cx + r * calc.cos(angle)
+      let y = if above { cy + r * calc.sin(angle) } else { cy - r * calc.sin(angle) }
+      pts.push((x, y))
+    }
+    line(..pts, stroke: 1.2pt + accent)
+    line((cx - r, cy), (cx + r, cy), stroke: 0.5pt + _ge-gray + dotted)
+    circle((cx, cy), radius: 2.5pt, fill: black)
+  })
+}
+
+// ── Điểm ────────────────────────────────────────────────
+#let point(p, label: none, fill: black, radius: 2.5pt, scale: 0.5cm) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    circle(p, radius: radius, fill: fill)
+    if label != none {
+      let (x, y) = p
+      let (dx, dy) = (0.25, 0.25)
+      content((x + dx, y + dy), text(size: 8pt)[#label])
+    }
+  })
+}
+
+// ── Đoạn thẳng ──────────────────────────────────────────
+#let seg(A, B, stroke: 1.2pt + black, arrow: false, scale: 0.7cm) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let mark = if arrow { (end: ">") } else { none }
+    line(A, B, stroke: stroke, mark: mark)
+  })
+}
+
+// ── Elip ngang ──────────────────────────────────────────
+#let ellipse-h(
+  center: (0, 0), a: 3, b: 2,
+  accent: _ge-blue,
+  scale: 1cm,
+) = {
+  cetz.canvas(length: scale, {
+    import cetz.draw: *
+    let (cx, cy) = center
+    let n = 100
+    let pts = ()
+    for i in range(n + 1) {
+      let t = 2 * calc.pi * i / n
+      pts.push((cx + a * calc.cos(t), cy + b * calc.sin(t)))
+    }
+    line(..pts, stroke: 1.2pt + accent)
+    circle((cx, cy), radius: 2.5pt, fill: black)
+    circle((cx + a, cy), radius: 2pt, fill: _ge-red)
+    circle((cx - a, cy), radius: 2pt, fill: _ge-red)
+    circle((cx, cy + b), radius: 2pt, fill: _ge-green)
+    circle((cx, cy - b), radius: 2pt, fill: _ge-green)
+  })
+}

--- a/packages/preview/sang-math/1.0.5/lib.typ
+++ b/packages/preview/sang-math/1.0.5/lib.typ
@@ -1,0 +1,28 @@
+// ================================================================
+// SANG-MATH 1.0.5 — Bộ macro Toán & Đa môn THPT Việt Nam
+// Entry point: #import "@preview/sang-math:1.0.5": *
+// ================================================================
+
+// ── Stable public API ────────────────────────────────────────────
+#import "bbt.typ": *            // BBT, Bảng biến thiên, Bảng xét dấu
+#import "sang-exam.typ": *      // Trắc nghiệm, Tự luận, q-wrap...
+#import "exam-templates.typ": * // Preset giao diện đề thi đẹp
+#import "book-templates.typ": * // Preset giao diện sách, SGK, chuyên đề (legacy)
+#import "print-layouts.typ": *  // Layout 70/30, nháp đảo bên khi in hai mặt
+#import "math-sym.typ": *       // Ký hiệu toán tắt (vô cùng, tập hợp...)
+#import "geometry.typ": *       // Hình học phẳng/không gian CeTZ (legacy v1)
+
+// ── Core utilities ───────────────────────────────────────────────
+#import "core/math-utils.typ": *  // linspace, lerp, rotate-2d, vec-*
+#import "core/colors.typ": *      // sm-blue, sm-red, sm-green... (palette chuẩn)
+
+// ── Geometry 2D ──────────────────────────────────────────────────
+#import "geometry-2d/conics.typ": *  // draw-parabola, draw-ellipse, draw-hyperbola
+
+// ── Geometry 3D ──────────────────────────────────────────────────
+#import "geometry-3d/curves-3d.typ": *   // draw-helix, draw-spring, helix-points
+#import "geometry-3d/revolution.typ": *  // draw-cylinder, draw-cone, draw-sphere
+
+// ── Additional modules (v1.0.3) ──────────────────────────────────
+#import "sang-book.typ" as book     // Chuyên đề, Sách (smartbox, theorem...)
+#import "sang-beamer.typ" as beamer // Beamer presentation (slide, make-questions)

--- a/packages/preview/sang-math/1.0.5/math-sym.typ
+++ b/packages/preview/sang-math/1.0.5/math-sym.typ
@@ -1,0 +1,196 @@
+// ═══════════════════════════════════════════════════════════
+// MATH-SYM.TYP — Alias LaTeX → Typst cho AI/GV hay gõ nhầm
+// Import: #import "math-sym.typ": *
+// Dùng trong math mode: $A cap B$, $x geq 0$, $f rightarrow infty$
+// ═══════════════════════════════════════════════════════════
+
+// ─── Tập hợp ────────────────────────────────────────────────
+#let cap = sym.inter         // ∩  (LaTeX: \cap)
+#let cup = sym.union         // ∪  (LaTeX: \cup)
+#let notin = sym.in.not        // ∉  (LaTeX: 
+otin)
+#let subseteq = sym.subset.eq     // ⊆  (LaTeX: \subseteq)
+#let supseteq = sym.supset.eq     // ⊇  (LaTeX: \supseteq)
+#let emptyset = sym.nothing       // ∅  (LaTeX: \emptyset)
+#let varnothing = sym.nothing      // ∅  (LaTeX: \varnothing)
+#let setminus = sym.backslash     // ∖  (LaTeX: \setminus)
+
+// ─── So sánh & quan hệ ─────────────────────────────────────
+#let leq = sym.lt.eq         // ≤  (LaTeX: \leq / \le)
+#let geq = sym.gt.eq         // ≥  (LaTeX: \geq / \ge)
+#let le = sym.lt.eq         // ≤  alias ngắn
+#let ge = sym.gt.eq         // ≥  alias ngắn
+#let neq = sym.eq.not        // ≠  (LaTeX: 
+eq / 
+e)
+#let ne = sym.eq.not        // ≠  alias ngắn
+#let approx = sym.approx        // ≈  (LaTeX: \approx)
+#let equiv = sym.equiv         // ≡  (LaTeX: \equiv)
+#let sim = sym.tilde         // ~  (LaTeX: \sim)
+#let simeq = sym.tilde.eq      // ≃  (LaTeX: \simeq)
+#let cong = sym.tilde.equiv   // ≅  (LaTeX: \cong)
+#let ll = sym.lt.double     // ≪  (LaTeX: \ll)
+#let gg = sym.gt.double     // ≫  (LaTeX: \gg)
+#let propto = sym.prop          // ∝  (LaTeX: \propto)
+
+// ─── Mũi tên ────────────────────────────────────────────────
+#let rightarrow = sym.arrow.r            // →  (LaTeX: \rightarrow)
+#let leftarrow = sym.arrow.l            // ←  (LaTeX: \leftarrow)
+#let leftrightarrow = sym.arrow.l.r          // ↔  (LaTeX: \leftrightarrow)
+#let Rightarrow = sym.arrow.r.double     // ⇒  (LaTeX: \Rightarrow)
+#let Leftarrow = sym.arrow.l.double     // ⇐  (LaTeX: \Leftarrow)
+#let Leftrightarrow = sym.arrow.l.r.double   // ⇔  (LaTeX: \Leftrightarrow)
+#let uparrow = sym.arrow.t            // ↑  (LaTeX: \uparrow)
+#let downarrow = sym.arrow.b            // ↓  (LaTeX: \downarrow)
+#let to = sym.arrow.r            // →  (LaTeX: \to)
+#let mapsto = sym.arrow.r.bar        // ↦  (LaTeX: \mapsto)
+#let hookrightarrow = sym.arrow.hook.r       // ↪  (LaTeX: \hookrightarrow)
+#let longrightarrow = sym.arrow.long.r       // ⟶  (LaTeX: \longrightarrow)
+
+// ─── Phép tính ──────────────────────────────────────────────
+#let pm = sym.plus.minus    // ±  (LaTeX: \pm)
+#let mp = sym.minus.plus    // ∓  (LaTeX: \mp)
+#let cdot = sym.dot.c         // ·  (LaTeX: \cdot)
+#let times = sym.times         // ×  (LaTeX: \times)
+#let div = sym.div           // ÷  (LaTeX: \div)
+#let ast = sym.ast           // ∗  (LaTeX: \ast)
+#let circ = sym.degree        // °  (LaTeX: \circ khi dùng cho độ: 90^\circ → $90^circ$)
+#let compose = sym.circle.small  // ∘  phép hợp hàm f∘g (nếu AI gõ \circ cho composition)
+#let oplus = sym.plus.o   // ⊕  (LaTeX: \oplus)
+#let otimes = sym.times.o  // ⊗  (LaTeX: \otimes)
+
+// ─── Logic & lượng từ ──────────────────────────────────────
+#let forall = sym.forall        // ∀  (LaTeX: \forall)
+#let exists = sym.exists        // ∃  (LaTeX: \exists)
+#let nexists = sym.exists.not    // ∄  (LaTeX: 
+exists)
+#let neg = sym.not           // ¬  (LaTeX: 
+eg)
+#let land = sym.and           // ∧  (LaTeX: \land)
+#let lor = sym.or            // ∨  (LaTeX: \lor)
+#let therefore = sym.therefore     // ∴  (LaTeX: \therefore)
+#let because = sym.because       // ∵  (LaTeX: \because)
+
+// ─── Tích phân & Giải tích ─────────────────────────────────
+// Typst dùng `integral` trực tiếp trong math mode.
+// Nếu AI gõ `int` thay vì `integral`:
+#let int = sym.integral      // ∫  (LaTeX: \int)
+#let iint = sym.integral.double   // ∬  (LaTeX: \iint)
+#let iiint = sym.integral.triple   // ∭  (LaTeX: \iiint)
+#let oint = sym.integral.cont     // ∮  (LaTeX: \oint)
+#let partial = sym.partial       // ∂  (LaTeX: \partial)
+#let nabla = sym.nabla         // ∇  (LaTeX: \nabla)
+
+// ─── Vô cực & giới hạn ─────────────────────────────────────
+#let infty = sym.infinity      // ∞  (LaTeX: \infty)
+#let infinity = sym.infinity      // ∞  alias dài hơn
+#let lim = math.limits(math.lim, inline: true) // lim với cận dưới chuẩn toán Việt Nam
+
+// ─── Dấu chấm & dấu ba chấm ────────────────────────────────
+#let ldots = sym.dots.h        // …  (LaTeX: \ldots)
+#let cdots = sym.dots.c        // ⋯  (LaTeX: \cdots)
+#let vdots = sym.dots.v        // ⋮  (LaTeX: \vdots)
+
+
+// ─── Hình học ───────────────────────────────────────────────
+#let perp = sym.perp          // ⊥  (LaTeX: \perp)
+#let parallel = sym.parallel      // ∥  (LaTeX: \parallel)
+#let angle = sym.angle         // ∠  (LaTeX: \angle)
+#let measuredangle = sym.angle.arc // ∡  (LaTeX: \measuredangle)
+#let triangle = sym.triangle      // △  (LaTeX: \triangle)
+#let square = sym.square        // □  (LaTeX: \square)
+#let diamond = sym.diamond       // ◇  (LaTeX: \diamond)
+
+// ─── Ký hiệu đặc biệt ──────────────────────────────────────
+#let hbar = sym.planck // ℏ  (LaTeX: \hbar)
+#let ell = sym.ell           // ℓ  (LaTeX: \ell)
+#let Re = sym.Re            // ℜ  (LaTeX: \Re)
+#let Im = sym.Im            // ℑ  (LaTeX: \Im)
+#let aleph = sym.aleph         // ℵ  (LaTeX: \aleph)
+#let prime_sym = sym.prime         // ′  dùng khi cần prime standalone
+
+// ─── Tổ hợp chập ────────────────────────────────────────────
+// Định dạng chuẩn Việt Nam: C_n^k, A_n^k, P_n (ưu tiên user memory)
+#let C(n, k) = math.attach(math.op("C"), b: n, t: k) // Tổ hợp
+#let A(n, k) = math.attach(math.op("A"), b: n, t: k) // Chỉnh hợp
+#let P(n) = math.attach(math.op("P"), b: n)          // Hoán vị
+#let binom(n, k) = math.binom(n, k) // Giữ lại nếu lỡ cần dùng kiểu LaTeX cũ
+
+// ─── Hàm lượng giác ngược ───────────────────────────────────
+// Typst đã có: sin, cos, tan, ln, log, exp, lim, max, min, sup, inf, det, ...
+// Thêm các hàm hay thiếu:
+#let arcsin = math.op("arcsin")    // arcsin (LaTeX: \arcsin)
+#let arccos = math.op("arccos")    // arccos (LaTeX: \arccos)
+#let arctan = math.op("arctan")    // arctan (LaTeX: \arctan)
+#let arccot = math.op("arccot")    // arccot
+#let cot = math.op("cot")       // cot    (LaTeX: \cot)
+#let csc = math.op("csc")       // csc    (LaTeX: \csc)
+#let sec = math.op("sec")       // sec    (LaTeX: \sec)
+#let sgn = math.op("sgn")       // sgn    (LaTeX: \operatorname{sgn})
+
+// ─── Vector & accent ────────────────────────────────────────
+// LaTeX: \vec{v}   → Typst: $arrow(v)$  hoặc $vec(v)$
+// LaTeX: \overline → Typst: $overline(x)$
+// LaTeX: \hat{x}   → Typst: $hat(x)$
+// Alias để tránh nhầm:
+#let overrightarrow(x) = math.arrow(x)  // \overrightarrow{AB} → overrightarrow(A B)
+#let vec(x) = math.arrow(x)             // \vec{v} → vec(v)    (override nếu cần)
+#let prod = sym.product                 // \prod → prod
+#let pmat = math.mat                    // \pmatrix / \pmat → mat
+#let Tr = math.op("Tr")                 // Trace of a matrix
+
+
+
+
+// ─── Phân số & căn ──────────────────────────────────────────
+// LaTeX: \frac{a}{b} → Typst: $a/b$   hoặc $frac(a, b)$
+// LaTeX: \dfrac      → $dfrac(a, b)$ luôn giữ phân số display lớn
+// LaTeX: \sqrt[n]{x} → Typst: $root(n, x)$
+// Alias:
+#let dfrac(a, b) = math.display(math.frac(a, b))      // \dfrac{a}{b} → dfrac(a, b)
+#let tfrac-tex(a, b) = {
+  show math.frac: f => f
+  scale(x: 72%, y: 72%, origin: center + horizon, reflow: true, math.inline(math.frac(a, b)))
+} // \tfrac{a}{b} — luôn cỡ inline nhỏ
+
+// ─── Tổng kết ký hiệu thường nhầm ───────────────────────────
+//
+//  LaTeX           Typst thuần     Alias file này
+//  ──────────────  ─────────────   ──────────────
+//  \cap            sect            cap
+//  \cup            union           cup
+//  \leq / \le      lt.eq           leq / le
+//  \geq / \ge      gt.eq           geq / ge
+//  
+eq / 
+e      eq.not          neq / ne
+//  \pm             plus.minus      pm
+//  \cdot           dot.c           cdot
+//  \infty          infinity        infty
+//  \rightarrow     arrow.r         rightarrow / to
+//  \Rightarrow     arrow.r.double  Rightarrow
+//  \Leftrightarrow arrow.l.r.double Leftrightarrow
+//  \forall         forall          forall
+//  \exists         exists          exists
+//  \therefore      therefore       therefore
+//  \partial        partial         partial
+//  \int            integral        int
+//  \perp           perp            perp
+//  \parallel       parallel        parallel
+//  \subset         subset          (đã có sẵn)
+//  \subseteq       subset.eq       subseteq
+//  \emptyset       nothing         emptyset
+//  \notin          in.not          notin
+//  \cot            —               cot (math.op)
+//  \arcsin         —               arcsin (math.op)
+//  \vec{v}         arrow(v)        vec(v) / overrightarrow(v)
+
+#let boxed(x) = box(stroke: 0.5pt, inset: 3pt, outset: 0pt)[#x]
+
+// ─── Tiện ích Ký hiệu Lý - Hóa (Đa môn) ─────────────────────
+#let doC = [$degree C$]                    // Độ Celsius
+#let celsius = [$degree C$]                // Độ Celsius alias
+#let ohm = sym.Omega                       // Đơn vị Ohm (Ω)
+#let pu-tn = $arrow.l.r.double$            // Phản ứng thuận nghịch <=>
+#let pu-nhiet = $limits(arrow)^(t^compose)$ // Mũi tên có t độ
+

--- a/packages/preview/sang-math/1.0.5/print-layouts.typ
+++ b/packages/preview/sang-math/1.0.5/print-layouts.typ
@@ -1,0 +1,88 @@
+// ================================================================
+// SANG-MATH — Layout in hai mặt có vùng nháp
+// ================================================================
+
+#let _print-a4-width = 21cm
+#let _print-a4-height = 29.7cm
+
+// 70% nội dung + 30% nháp khi nháp-pct: 30%.
+// Trang lẻ: nháp ngoài bên phải. Trang chẵn: nháp ngoài bên trái.
+#let layout-draft(
+  body,
+  nháp-pct: 30%,
+  nháp-fill: rgb("#f7faf8"),
+  nháp-line: rgb("#cbd8d2"),
+  nháp-label: "NHÁP",
+  accent: rgb("#117a65"),
+  content-margin: 1.5cm,
+  top-margin: 2cm,
+  bottom-margin: 2cm,
+  line-count: 27,
+) = {
+  let draft-width = _print-a4-width * nháp-pct
+
+  set page(
+    paper: "a4",
+    binding: left,
+    margin: (
+      top: top-margin,
+      bottom: bottom-margin,
+      inside: content-margin,
+      outside: content-margin + draft-width,
+    ),
+    background: context {
+      let page-number = counter(page).get().first()
+      let odd = calc.odd(page-number)
+      let draft-x = if odd { _print-a4-width - draft-width } else { 0pt }
+
+      place(
+        top + left,
+        dx: draft-x,
+        rect(
+          width: draft-width,
+          height: _print-a4-height,
+          fill: nháp-fill,
+          stroke: if odd {
+            (left: 0.8pt + accent.lighten(55%), rest: none)
+          } else {
+            (right: 0.8pt + accent.lighten(55%), rest: none)
+          },
+        ),
+      )
+
+      let label-x = draft-x + draft-width * 0.5 - 8pt
+      place(
+        top + left,
+        dx: label-x,
+        dy: top-margin,
+        rotate(90deg, text(
+          size: 7.5pt,
+          fill: accent.lighten(58%),
+          weight: "bold",
+          tracking: 5pt,
+        )[#upper(nháp-label)]),
+      )
+
+      let content-height = _print-a4-height - top-margin - bottom-margin
+      let line-gap = content-height / line-count
+      for index in range(line-count) {
+        place(
+          top + left,
+          dx: draft-x + 6pt,
+          dy: top-margin + index * line-gap,
+          line(
+            length: draft-width - 12pt,
+            stroke: (paint: nháp-line, thickness: 0.4pt),
+          ),
+        )
+      }
+    },
+  )
+  body
+}
+
+// Biến thể phần nội dung chia hai cột, vẫn đảo vùng nháp theo trang chẵn/lẻ.
+#let layout-2col-draft(body, nháp-pct: 24%, column-gutter: 12pt, ..args) = {
+  show: layout-draft.with(nháp-pct: nháp-pct, ..args.named())
+  columns(2, gutter: column-gutter, body)
+}

--- a/packages/preview/sang-math/1.0.5/sang-beamer-themes.typ
+++ b/packages/preview/sang-math/1.0.5/sang-beamer-themes.typ
@@ -1,0 +1,228 @@
+// ====================================================================
+// SANG-BEAMER-THEMES.TYP
+// Bộ sưu tập 30 mẫu màu (Themes) chuyên nghiệp cho Beamer
+// ====================================================================
+
+#let beamer-themes = (
+  "1": (
+    name: "Navy Gold",
+    bg_color: rgb("#0f172a"),
+    accent: rgb("#f59e0b"),
+    text_fill: rgb("#f8fafc"),
+    math_color: rgb("#fcd34d")
+  ),
+  "2": (
+    name: "Midnight Ruby",
+    bg_color: rgb("#1e1b4b"),
+    accent: rgb("#e11d48"),
+    text_fill: rgb("#ffe4e6"),
+    math_color: rgb("#fb7185")
+  ),
+  "3": (
+    name: "Cyberpunk",
+    bg_color: rgb("#000000"),
+    accent: rgb("#06b6d4"),
+    text_fill: rgb("#ffffff"),
+    math_color: rgb("#ec4899")
+  ),
+  "4": (
+    name: "Coffee Bean",
+    bg_color: rgb("#271c19"),
+    accent: rgb("#d4a373"),
+    text_fill: rgb("#fefae0"),
+    math_color: rgb("#faedcd")
+  ),
+  "5": (
+    name: "Aurora Borealis",
+    bg_color: rgb("#022c22"),
+    accent: rgb("#10b981"),
+    text_fill: rgb("#f8fafc"),
+    math_color: rgb("#34d399")
+  ),
+  "6": (
+    name: "Crimson Night",
+    bg_color: rgb("#2a0a0a"),
+    accent: rgb("#ef4444"),
+    text_fill: rgb("#fecaca"),
+    math_color: rgb("#fca5a5")
+  ),
+  "7": (
+    name: "Deep Purple",
+    bg_color: rgb("#2e1065"),
+    accent: rgb("#a855f7"),
+    text_fill: rgb("#f3e8ff"),
+    math_color: rgb("#d8b4fe")
+  ),
+  "8": (
+    name: "Abyss Blue",
+    bg_color: rgb("#082f49"),
+    accent: rgb("#38bdf8"),
+    text_fill: rgb("#e0f2fe"),
+    math_color: rgb("#7dd3fc")
+  ),
+  "9": (
+    name: "Charcoal Orange",
+    bg_color: rgb("#1c1917"),
+    accent: rgb("#f97316"),
+    text_fill: rgb("#f5f5f4"),
+    math_color: rgb("#fdba74")
+  ),
+  "10": (
+    name: "Dark Forest",
+    bg_color: rgb("#14532d"),
+    accent: rgb("#84cc16"),
+    text_fill: rgb("#f7fee7"),
+    math_color: rgb("#bef264")
+  ),
+  "11": (
+    name: "Graphite Pink",
+    bg_color: rgb("#27272a"),
+    accent: rgb("#f43f5e"),
+    text_fill: rgb("#f4f4f5"),
+    math_color: rgb("#fda4af")
+  ),
+  "12": (
+    name: "Obsidian Cyan",
+    bg_color: rgb("#171717"),
+    accent: rgb("#22d3ee"),
+    text_fill: rgb("#fafafa"),
+    math_color: rgb("#67e8f9")
+  ),
+  "13": (
+    name: "Royal Violet",
+    bg_color: rgb("#1e1b4b"),
+    accent: rgb("#8b5cf6"),
+    text_fill: rgb("#ede9fe"),
+    math_color: rgb("#c4b5fd")
+  ),
+  "14": (
+    name: "Chocolate Gold",
+    bg_color: rgb("#3f2723"),
+    accent: rgb("#fbbf24"),
+    text_fill: rgb("#fffbeb"),
+    math_color: rgb("#fde68a")
+  ),
+  "15": (
+    name: "Dark Slate Teal",
+    bg_color: rgb("#0f172a"),
+    accent: rgb("#14b8a6"),
+    text_fill: rgb("#f1f5f9"),
+    math_color: rgb("#5eead4")
+  ),
+  "16": (
+    name: "Teal Pro",
+    bg_color: rgb("#f0fdfa"),
+    accent: rgb("#0f766e"),
+    text_fill: rgb("#0f172a"),
+    math_color: rgb("#115e59")
+  ),
+  "17": (
+    name: "Ocean Breeze",
+    bg_color: rgb("#f0f9ff"),
+    accent: rgb("#0284c7"),
+    text_fill: rgb("#0c4a6e"),
+    math_color: rgb("#0369a1")
+  ),
+  "18": (
+    name: "Plum Light",
+    bg_color: rgb("#fdf4ff"),
+    accent: rgb("#c026d3"),
+    text_fill: rgb("#4a044e"),
+    math_color: rgb("#a21caf")
+  ),
+  "19": (
+    name: "Forest Minimal",
+    bg_color: rgb("#f7fee7"),
+    accent: rgb("#4d7c0f"),
+    text_fill: rgb("#1a2e05"),
+    math_color: rgb("#3f6212")
+  ),
+  "20": (
+    name: "Sunset Rose",
+    bg_color: rgb("#fff1f2"),
+    accent: rgb("#e11d48"),
+    text_fill: rgb("#4c0519"),
+    math_color: rgb("#be123c")
+  ),
+  "21": (
+    name: "Amber Light",
+    bg_color: rgb("#fffbeb"),
+    accent: rgb("#d97706"),
+    text_fill: rgb("#451a03"),
+    math_color: rgb("#b45309")
+  ),
+  "22": (
+    name: "Mint Fresh",
+    bg_color: rgb("#ecfdf5"),
+    accent: rgb("#059669"),
+    text_fill: rgb("#022c22"),
+    math_color: rgb("#047857")
+  ),
+  "23": (
+    name: "Sky Blue",
+    bg_color: rgb("#e0f2fe"),
+    accent: rgb("#2563eb"),
+    text_fill: rgb("#1e3a8a"),
+    math_color: rgb("#1d4ed8")
+  ),
+  "24": (
+    name: "Lavender Minimal",
+    bg_color: rgb("#f5f3ff"),
+    accent: rgb("#7c3aed"),
+    text_fill: rgb("#2e1065"),
+    math_color: rgb("#6d28d9")
+  ),
+  "25": (
+    name: "Peach Light",
+    bg_color: rgb("#fff7ed"),
+    accent: rgb("#ea580c"),
+    text_fill: rgb("#431407"),
+    math_color: rgb("#c2410c")
+  ),
+  "26": (
+    name: "Ice Cyan",
+    bg_color: rgb("#ecfeff"),
+    accent: rgb("#0891b2"),
+    text_fill: rgb("#083344"),
+    math_color: rgb("#0e7490")
+  ),
+  "27": (
+    name: "Cloud Gray",
+    bg_color: rgb("#f8fafc"),
+    accent: rgb("#475569"),
+    text_fill: rgb("#0f172a"),
+    math_color: rgb("#334155")
+  ),
+  "28": (
+    name: "Vanilla Gold",
+    bg_color: rgb("#fefce8"),
+    accent: rgb("#ca8a04"),
+    text_fill: rgb("#422006"),
+    math_color: rgb("#a16207")
+  ),
+  "29": (
+    name: "Sakura Pink",
+    bg_color: rgb("#fdf2f8"),
+    accent: rgb("#db2777"),
+    text_fill: rgb("#500724"),
+    math_color: rgb("#be185d")
+  ),
+  "30": (
+    name: "Lime Crisp",
+    bg_color: rgb("#f7fee7"),
+    accent: rgb("#65a30d"),
+    text_fill: rgb("#1a2e05"),
+    math_color: rgb("#4d7c0f")
+  ),
+)
+
+// Hàm lấy theme theo số nguyên (1 đến 30) hoặc chuỗi ("1" đến "30")
+// Nếu không tìm thấy, trả về theme 1 (Navy Gold)
+#let get-beamer-theme(id) = {
+  let key = str(id)
+  if key in beamer-themes {
+    return beamer-themes.at(key)
+  } else {
+    return beamer-themes.at("1")
+  }
+}

--- a/packages/preview/sang-math/1.0.5/sang-beamer.typ
+++ b/packages/preview/sang-math/1.0.5/sang-beamer.typ
@@ -1,0 +1,1056 @@
+// =========================================================
+// SANG-BEAMER.TYP v4.0 — Slide trình chiếu Premium
+// ✅ Auto-counter: không cần nhập num tay
+// ✅ Hỗ trợ offset riêng cho từng loại câu (mcq/tf/tln)
+// =========================================================
+
+#import "@preview/touying:0.7.4": *
+#import themes.metropolis: *
+
+#import "sang-exam.typ": (
+  True, bode, classic, configure-step-reveal, dl, dn, draw-lines, luuy, lythuyet, meo, note, palette, ppgiai, reset-step, tc, vect,
+)
+// ── Answer registry cho beamer ─────────────────────────────
+// Lưu integer thực (không dùng lazy context) tránh bug "tất cả câu 22"
+#let _bm-ans-state = state("bm-ans", (q: 0, mcq: (), tf: (), sh: ()))
+
+// ── Màu sắc sống động ──────────────────────────────────
+#let bm-colors = (
+  bg: rgb("#0f172a"), // Nền slide xanh đậm
+  fg: white,
+  accent: rgb("#3b82f6"), // Xanh dương sáng
+  correct: rgb("#22c55e"), // Xanh lá tươi
+  wrong: rgb("#ef4444"), // Đỏ
+  card: rgb("#1e293b"), // Card tối
+  card-hi: rgb("#172554"), // Card hover
+  muted: rgb("#94a3b8"),
+  gold: rgb("#f59e0b"), // Vàng accent
+)
+
+#let _bm-style-defaults = (
+  text_size: 18pt,
+  text_fill: none, // none = auto-detect from bg_color
+  math_color: bm-colors.gold,
+  question_size: 17pt,
+  option_size: 15pt,
+  label_size: 16pt,
+  table_size: 13pt,
+  answer_size: 24pt,
+  solution_size: 13pt,
+  solution_title_size: 14pt,
+  solution_fill: none, // none = auto-detect from bg_color
+  solution_text_fill: none, // none = auto-detect from bg_color
+  card: none, // none = auto-detect from bg_color
+  card_hi: none, // none = auto-detect from bg_color
+  muted: none, // none = auto-detect from bg_color
+)
+#let _bm-style = state("bm-style", _bm-style-defaults)
+
+// ── Auto-counter cho beamer ──────────────────────────────
+// Mỗi loại câu (tn, tf, tln) có counter riêng.
+// Có thể reset về bất kỳ số nào.
+#let _bm-q-cnt = counter("bm-q")   // Toàn cục — tương tự exam engine
+
+#let _resolve-loigiai(loigiai, args) = {
+  if loigiai != none { loigiai } else { args.named().at("solution", default: none) }
+}
+
+// Đặt lại counter beamer (dùng đầu file slide)
+// Ví dụ: #bm-resetcau() hoặc #bm-setcau(13)
+#let bm-resetcau(start: 1) = [
+  #_bm-q-cnt.update(if start > 0 { start - 1 } else { 0 })
+]
+#let bm-setcau(start) = bm-resetcau(start: start)
+
+// ── Beamer Theme ────────────────────────────────────────
+#let sang-beamer-theme(
+  body,
+  title: "ĐỀ THI THPT QUỐC GIA",
+  subtitle: "TOÁN - LỚP 12",
+  author: "GV Nguyễn Văn Sang",
+  institution: "Sở GD&ĐT",
+  date: datetime.today(),
+  accent: bm-colors.accent,
+  aspect-ratio: "16-9",
+  code: "",
+  total-q: 22,
+  text_size: _bm-style-defaults.at("text_size"),
+  text_fill: _bm-style-defaults.at("text_fill"),
+  math_color: _bm-style-defaults.at("math_color"),
+  question_size: _bm-style-defaults.at("question_size"),
+  option_size: _bm-style-defaults.at("option_size"),
+  label_size: _bm-style-defaults.at("label_size"),
+  table_size: _bm-style-defaults.at("table_size"),
+  answer_size: _bm-style-defaults.at("answer_size"),
+  solution_size: _bm-style-defaults.at("solution_size"),
+  solution_title_size: _bm-style-defaults.at("solution_title_size"),
+  solution_fill: none,
+  solution_text_fill: none,
+  auto_step_pause: false,
+  bg_color: bm-colors.bg,
+) = {
+  // ── Tự tính màu từ bg_color (nhận biết nền tối / sáng) ─────────
+  let _comps = bg_color.components()
+  let _r = float(_comps.at(0))
+  let _g = float(_comps.at(1))
+  let _b = float(_comps.at(2))
+  let _bg-luma = 0.299 * _r + 0.587 * _g + 0.114 * _b
+  let _is-dark = _bg-luma < 0.5 // components() returns 0.0–1.0 (ratio)
+  // Màu tự sinh theo nền
+  let _auto-fg = if _is-dark { white } else { rgb("#0f172a") }
+  let _auto-card = if _is-dark { bg_color.lighten(13%) } else { bg_color.darken(8%) }
+  let _auto-card-hi = if _is-dark { bg_color.lighten(24%) } else { bg_color.darken(15%) }
+  let _auto-muted = if _is-dark { rgb("#94a3b8") } else { rgb("#475569") }
+  let _auto-sol-fill = if _is-dark { bg_color.lighten(8%) } else { bg_color.darken(5%) }
+  let _auto-sol-text = if _is-dark { rgb("#cbd5e1") } else { rgb("#1e293b") }
+  // Honor overrides; use none → auto
+  let _fg = if text_fill == none { _auto-fg } else { text_fill }
+  let _sol-fill = if solution_fill == none { _auto-sol-fill } else { solution_fill }
+  let _sol-text = if solution_text_fill == none { _auto-sol-text } else { solution_text_fill }
+  show: metropolis-theme.with(
+    aspect-ratio: aspect-ratio,
+    // ── Footer: dùng param của metropolis (không dùng config-page) ──
+    // config-page(footer:) bị override mỗi slide → dots chỉ slide 1
+    footer: context {
+      set text(size: 7pt, fill: _auto-muted)
+      grid(
+        columns: (auto, 1fr, auto),
+        align: (left + horizon, center + horizon, right + horizon),
+        pad(left: 4pt)[#author — #institution],
+        // ── Nút nhảy câu tròn ──
+        {
+          let dots = ()
+          for i in range(1, total-q + 1) {
+            let lbl = label("bm-q-" + str(i))
+            let has = query(lbl).len() > 0
+            if has {
+              dots.push(
+                link(lbl, box(
+                  width: 13pt,
+                  height: 13pt,
+                  radius: 50%,
+                  fill: accent.lighten(70%),
+                  stroke: 0.5pt + accent,
+                  align(center + horizon)[
+                    #text(size: 5.5pt, weight: "bold", fill: accent)[#i]
+                  ],
+                )),
+              )
+            } else {
+              dots.push(
+                box(
+                  width: 10pt,
+                  height: 10pt,
+                  radius: 50%,
+                  fill: bg_color.lighten(20%),
+                  stroke: 0.4pt + _auto-muted.lighten(40%),
+                ),
+              )
+            }
+          }
+          stack(dir: ltr, spacing: 3pt, ..dots)
+        },
+        pad(right: 4pt)[#counter(page).display() / #counter(page).final().first()],
+      )
+    },
+    footer-right: none,
+    footer-progress: false,
+    config-info(
+      title: [#title],
+      subtitle: [#subtitle #if code != "" [— Mã đề: #code]],
+      author: [#author],
+      date: date,
+      institution: [#institution],
+    ),
+    config-common(slide-fn: slide),
+    config-colors(
+      primary: accent,
+      primary-light: accent.lighten(50%),
+      secondary: bm-colors.gold,
+      neutral-lightest: bg_color,
+      neutral-darkest: _fg,
+    ),
+  )
+
+  _bm-style.update((
+    text_size: text_size,
+    text_fill: _fg,
+    math_color: math_color,
+    question_size: question_size,
+    option_size: option_size,
+    label_size: label_size,
+    table_size: table_size,
+    answer_size: answer_size,
+    solution_size: solution_size,
+    solution_title_size: solution_title_size,
+    solution_fill: _sol-fill,
+    solution_text_fill: _sol-text,
+    card: _auto-card,
+    card_hi: _auto-card-hi,
+    muted: _auto-muted,
+  ))
+  configure-step-reveal(before_nonfirst: if auto_step_pause { [#pause] } else { none })
+
+  set text(font: "Libertinus Serif", size: text_size, fill: _fg, lang: "vi")
+  show math.frac: math.display
+  show math.equation: set text(fill: math_color)
+
+  title-slide()
+  body
+}
+
+// ── Helper hiện từng dòng theo click ─────────────────────
+// Dùng: #bm-lines([Dòng 1], [Dòng 2], [Dòng 3])
+#let bm-lines(..items) = {
+  let lines = items.pos()
+  context {
+    for (index, line) in lines.enumerate() {
+      if index > 0 { pause }
+      line
+    }
+  }
+}
+
+// ── exam-part ────────────────────────────────────────────
+// Tạo slide section riêng thay vì dùng metropolis heading
+#let exam-part(title, count: auto, reset-counter: true, accent: bm-colors.accent) = {
+  slide(title: none)[
+    #align(center + horizon)[
+      #v(-1em)
+      #block(
+        width: 78%,
+        stroke: (top: 2.5pt + accent, bottom: 2.5pt + accent),
+        inset: (x: 0pt, y: 20pt),
+      )[
+        #align(center)[
+          #text(size: 11pt, fill: accent, weight: "bold", tracking: 2pt)[#upper("Chương trình")]
+          #v(0.5em)
+          #context {
+            let fg = _bm-style.get().at("text_fill", default: white)
+            text(size: 22pt, weight: "bold", fill: fg)[#title]
+          }
+        ]
+      ]
+    ]
+  ]
+}
+
+// ── Nội hàm lấy số câu tiếp theo ────────────────────────
+// num: auto  → tự tăng counter
+// num: 5     → dùng đúng số 5 và đặt counter = 5
+#let _bm-next-num(num) = context {
+  if num == auto {
+    _bm-q-cnt.step()
+    _bm-q-cnt.get().first()
+  } else {
+    _bm-q-cnt.update(num)
+    num
+  }
+}
+
+// ── MCQ ──────────────────────────────────────────────────
+#let mcq(
+  stem,
+  options,
+  correct: (),
+  loigiai: none,
+  mode: "loigiai",
+  accent: bm-colors.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 40%,
+  cols: 0,
+  lines: 0,
+  num: auto, // ← auto = tự đếm
+  prefix: "Câu",
+  card-fill: none, // none = auto tính từ style.card
+  card-stroke: auto,
+  ..args,
+) = {
+  let loigiai = _resolve-loigiai(loigiai, args)
+  let card-stroke = if card-stroke == auto { 1.2pt + accent.lighten(30%) } else { card-stroke }
+  let labels = ("A", "B", "C", "D", "E", "F")
+
+  // ── Lấy số câu (hiển thị an toàn) ──
+  // q-num-display chỉ HIỂN THỊ — không chứa step (tránh đếm 2 lần khi dùng ở 2 slide)
+  let q-num-display = if num == auto {
+    context { _bm-q-cnt.display() }
+  } else {
+    str(num)
+  }
+
+  let ai = -1
+  let idx = 0
+  for opt in options {
+    let ok = if type(opt) == dictionary { opt.at("correct", default: false) } else { correct.contains(idx + 1) }
+    if ok { ai = idx }
+    idx += 1
+  }
+  let opt-texts = options.map(o => if type(o) == dictionary { o.body } else { o })
+  let opt-oks = options
+    .enumerate()
+    .map(((i, o)) => if type(o) == dictionary { o.at("correct", default: false) } else { correct.contains(i + 1) })
+
+  // Ghi đáp án vào registry (dùng bởi print-answer-key)
+  let _ans-label = if ai >= 0 { ("A", "B", "C", "D", "E", "F").at(ai) } else { "?" }
+  let _rn = num // capture: auto or int — dùng trong lambda thuần túy
+  let _ra = _ans-label
+  [#_bm-ans-state.update(s => {
+    let n = if _rn == auto { s.q + 1 } else { _rn }
+    (q: n, mcq: s.mcq + ((num: n, ans: _ra),), tf: s.tf, sh: s.sh)
+  })]
+
+  // SLIDE 1: Câu hỏi
+  slide(title: none)[
+    // Step counter đúng 1 lần, trước label context
+    #if num == auto { _bm-q-cnt.step() } else { _bm-q-cnt.update(num) }
+    #context {
+      let n = _bm-q-cnt.get().first()
+      [#metadata(n) #label("bm-q-" + str(n))]
+    }
+    #context {
+      let style = _bm-style.get()
+      let _cf = if card-fill == none { style.at("card", default: rgb("#1e293b")) } else { card-fill }
+  show math.frac: math.display
+      show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+      v(-0.5em)
+      grid(
+        columns: (auto, 1fr),
+        column-gutter: 10pt,
+        align: (left + top, left + top),
+        box(fill: accent, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+          #text(weight: "bold", fill: white, size: style.at("label_size", default: 16pt))[#prefix #q-num-display]
+        ],
+        text(size: style.at("question_size", default: 17pt), fill: style.at("text_fill", default: bm-colors.fg))[#stem],
+      )
+
+      if fig != none {
+        v(0.3em)
+        align(center, block(
+          width: fig-width,
+          fill: white,
+          inset: 8pt,
+          radius: 6pt,
+        )[#fig])
+      }
+
+      v(0.5em)
+      grid(
+        columns: (1fr, 1fr), row-gutter: 10pt, column-gutter: 12pt,
+        ..opt-texts
+          .enumerate()
+          .map(((i, t)) => {
+            box(width: 100%, inset: (x: 0pt, y: 0pt), radius: 8pt, fill: _cf, stroke: card-stroke)[
+              #grid(columns: (auto, 1fr), column-gutter: 0pt)[
+                #box(fill: accent, inset: (x: 11pt, y: 10pt), radius: (top-left: 7pt, bottom-left: 7pt))[
+                  #text(weight: "bold", fill: white, size: style.at("label_size", default: 16pt))[#labels.at(i).]
+                ]
+              ][
+                #pad(x: 12pt, y: 10pt)[
+                  #text(size: style.at("option_size", default: 15pt), fill: style.at(
+                    "text_fill",
+                    default: bm-colors.fg,
+                  ))[#t]
+                ]
+              ]
+            ]
+          })
+      )
+    }
+  ]
+
+  // SLIDE 2: Đáp án
+  if mode == "loigiai" and (ai >= 0 or loigiai != none) {
+    slide(title: none)[
+      #context {
+        let style = _bm-style.get()
+        let _cf = if card-fill == none { style.at("card", default: rgb("#1e293b")) } else { card-fill }
+  show math.frac: math.display
+        show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+        v(-0.5em)
+        grid(
+          columns: (auto, 1fr),
+          column-gutter: 10pt,
+          align: (left + horizon, left + horizon),
+          box(fill: bm-colors.correct, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+            #text(weight: "bold", fill: white, size: style.at(
+              "label_size",
+              default: 16pt,
+            ))[#prefix #q-num-display — ĐÁP ÁN]
+          ],
+          [],
+        )
+
+        v(0.4em)
+        grid(
+          columns: (1fr, 1fr), row-gutter: 10pt, column-gutter: 12pt,
+          ..opt-texts
+            .enumerate()
+            .map(((i, t)) => {
+              let ok = opt-oks.at(i)
+              let bg = if ok { bm-colors.correct.darken(55%) } else { _cf }
+              let brd = if ok { 2pt + bm-colors.correct } else { 1pt + accent.lighten(20%) }
+              let mark = if ok { [  ✓] } else { [] }
+              let txt-col = if ok { white } else { style.at("text_fill", default: bm-colors.fg) }
+              let lbl-bg = if ok { bm-colors.correct } else { accent }
+              box(width: 100%, inset: (x: 0pt, y: 0pt), radius: 8pt, fill: bg, stroke: brd)[
+                #grid(columns: (auto, 1fr), column-gutter: 0pt)[
+                  #box(fill: lbl-bg, inset: (x: 11pt, y: 10pt), radius: (top-left: 7pt, bottom-left: 7pt))[
+                    #text(weight: "bold", fill: white, size: style.at("label_size", default: 16pt))[#labels.at(i).#mark]
+                  ]
+                ][
+                  #pad(x: 12pt, y: 10pt)[
+                    #text(size: style.at("option_size", default: 15pt), fill: txt-col)[#t]
+                  ]
+                ]
+              ]
+            })
+        )
+
+        if loigiai != none {
+          v(0.5em)
+          block(
+            width: 100%,
+            fill: style.at("solution_fill", default: rgb("#0c1a3a")),
+            stroke: (left: 3pt + style.at("math_color", default: bm-colors.gold)),
+            inset: (x: 14pt, y: 10pt),
+            radius: (right: 6pt),
+          )[
+            #text(weight: "bold", fill: style.at("math_color", default: bm-colors.gold), size: style.at(
+              "solution_title_size",
+              default: 14pt,
+            ))[📝 Lời giải]
+            #v(0.3em)
+            #set text(size: style.at("solution_size", default: 13pt), fill: style.at(
+              "solution_text_fill",
+              default: rgb("#cbd5e1"),
+            ))
+            #reset-step()
+            #loigiai
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// ── TF ───────────────────────────────────────────────────
+#let tf(
+  stem,
+  statements,
+  loigiai: none,
+  mode: "loigiai",
+  accent: bm-colors.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 30%,
+  lines: 0,
+  num: auto, // ← auto = tự đếm
+  prefix: "Câu",
+  ..args,
+) = {
+  let loigiai = _resolve-loigiai(loigiai, args)
+  let alpha = ("a", "b", "c", "d", "e", "f")
+
+  // ── Lấy số câu (hiển thị an toàn) ──
+  let q-num-display = if num == auto {
+    context { _bm-q-cnt.display() }
+  } else {
+    str(num)
+  }
+
+  // Ghi đáp án tf vào registry
+  let tf-row = statements.map(s => {
+    let ok = if type(s) == dictionary { s.at("correct", default: false) } else { false }
+    if ok { "Đ" } else { "S" }
+  })
+  let _rn = num
+  let _rr = tf-row
+  [#_bm-ans-state.update(s => {
+    let n = if _rn == auto { s.q + 1 } else { _rn }
+    (q: n, mcq: s.mcq, tf: s.tf + ((num: n, ans: _rr),), sh: s.sh)
+  })]
+
+  slide(title: none)[
+    #if num == auto { _bm-q-cnt.step() } else { _bm-q-cnt.update(num) }
+    #context {
+      let n = _bm-q-cnt.get().first()
+      [#metadata(n) #label("bm-q-" + str(n))]
+    }
+    #context {
+      let style = _bm-style.get()
+  show math.frac: math.display
+      show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+      v(-0.5em)
+      box(fill: accent, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+        #text(weight: "bold", fill: white, size: style.at(
+          "label_size",
+          default: 16pt,
+        ))[#prefix #q-num-display — Đúng/Sai]
+      ]
+      v(0.3em)
+      text(size: style.at("question_size", default: 17pt), fill: style.at("text_fill", default: bm-colors.fg))[#stem]
+      if fig != none {
+        v(0.3em)
+        align(center, block(
+          fill: white,
+          inset: 8pt,
+          radius: 6pt,
+        )[#fig])
+      }
+
+      v(0.3em)
+      table(
+        columns: (1fr, auto, auto),
+        stroke: 0.5pt + rgb("#1e3a5f"),
+        align: (left + horizon, center + horizon, center + horizon),
+        table.cell(fill: accent, pad(x: 10pt, y: 7pt)[#text(
+          fill: white,
+          weight: "bold",
+          size: style.at("table_size", default: 13pt) + 1pt,
+        )[Phát biểu]]),
+        table.cell(fill: accent, pad(x: 10pt, y: 7pt)[#text(
+          fill: white,
+          weight: "bold",
+          size: style.at("table_size", default: 13pt) + 1pt,
+        )[Đ]]),
+        table.cell(fill: accent, pad(x: 10pt, y: 7pt)[#text(
+          fill: white,
+          weight: "bold",
+          size: style.at("table_size", default: 13pt) + 1pt,
+        )[S]]),
+        ..statements
+          .enumerate()
+          .map(((i, s)) => {
+            let txt = if type(s) == dictionary { s.body } else { s }
+            let row-bg = if calc.odd(i) { style.at("card_hi", default: rgb("#1a2744")) } else {
+              style.at("card", default: bm-colors.card)
+            }
+            (
+              table.cell(fill: row-bg, pad(x: 10pt, y: 7pt)[#text(
+                  weight: "bold",
+                  fill: accent,
+                  size: style.at("table_size", default: 13pt),
+                )[#alpha.at(i))] #h(5pt) #text(size: style.at("table_size", default: 13pt), fill: style.at(
+                  "text_fill",
+                  default: bm-colors.fg,
+                ))[#txt]]),
+              table.cell(fill: row-bg, align(center)[#box(
+                width: 1.8em,
+                height: 1.8em,
+                stroke: 0.6pt + accent.lighten(40%),
+                radius: 3pt,
+                fill: style.at("card", default: bm-colors.bg),
+              )]),
+              table.cell(fill: row-bg, align(center)[#box(
+                width: 1.8em,
+                height: 1.8em,
+                stroke: 0.6pt + accent.lighten(40%),
+                radius: 3pt,
+                fill: style.at("card", default: bm-colors.bg),
+              )]),
+            )
+          })
+          .flatten(),
+      )
+    }
+  ]
+
+  if mode == "loigiai" {
+    slide(title: none)[
+      #context {
+        let style = _bm-style.get()
+  show math.frac: math.display
+        show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+        v(-0.5em)
+        box(fill: bm-colors.correct, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+          #text(weight: "bold", fill: white, size: style.at(
+            "label_size",
+            default: 16pt,
+          ))[#prefix #q-num-display — ĐÁP ÁN]
+        ]
+        v(0.3em)
+        table(
+          columns: (1fr, auto, auto),
+          stroke: 0.6pt + rgb("#334155"),
+          align: (left + horizon, center + horizon, center + horizon),
+          table.cell(fill: accent, pad(x: 10pt, y: 7pt)[#text(
+            fill: white,
+            weight: "bold",
+            size: style.at("table_size", default: 13pt) + 1pt,
+          )[Phát biểu]]),
+          table.cell(fill: accent, pad(x: 10pt, y: 7pt)[#text(
+            fill: white,
+            weight: "bold",
+            size: style.at("table_size", default: 13pt) + 1pt,
+          )[Đ]]),
+          table.cell(fill: accent, pad(x: 10pt, y: 7pt)[#text(
+            fill: white,
+            weight: "bold",
+            size: style.at("table_size", default: 13pt) + 1pt,
+          )[S]]),
+          ..statements
+            .enumerate()
+            .map(((i, s)) => {
+              let ok = if type(s) == dictionary { s.at("correct", default: false) } else { false }
+              let txt = if type(s) == dictionary { s.body } else { s }
+              let row-bg = if calc.odd(i) { style.at("card_hi", default: rgb("#1a2744")) } else {
+                style.at("card", default: bm-colors.card)
+              }
+              let _mut = style.at("muted", default: bm-colors.muted)
+              let fd = if ok { bm-colors.correct.darken(50%) } else { row-bg }
+              let fs = if not ok { bm-colors.wrong.darken(50%) } else { row-bg }
+              let md = if ok {
+                text(fill: bm-colors.correct, weight: "bold", size: style.at("table_size", default: 13pt) + 1pt)[✓]
+              } else { none }
+              let ms = if not ok {
+                text(fill: bm-colors.wrong, weight: "bold", size: style.at("table_size", default: 13pt) + 1pt)[✓]
+              } else { none }
+              (
+                table.cell(fill: row-bg, pad(x: 10pt, y: 7pt)[#text(
+                    weight: "bold",
+                    fill: accent,
+                    size: style.at("table_size", default: 13pt),
+                  )[#alpha.at(i))] #h(5pt) #text(size: style.at("table_size", default: 13pt), fill: style.at(
+                    "text_fill",
+                    default: bm-colors.fg,
+                  ))[#txt]]),
+                table.cell(fill: fd, align(center)[#box(
+                  width: 1.8em,
+                  height: 1.8em,
+                  stroke: 0.6pt + _mut,
+                  radius: 3pt,
+                  fill: fd,
+                  align(center + horizon)[#md],
+                )]),
+                table.cell(fill: fs, align(center)[#box(
+                  width: 1.8em,
+                  height: 1.8em,
+                  stroke: 0.6pt + _mut,
+                  radius: 3pt,
+                  fill: fs,
+                  align(center + horizon)[#ms],
+                )]),
+              )
+            })
+            .flatten(),
+        )
+
+        if loigiai != none {
+          v(0.3em)
+          block(
+            width: 100%,
+            fill: style.at("solution_fill", default: rgb("#0c1a3a")),
+            stroke: (left: 3pt + style.at("math_color", default: bm-colors.gold)),
+            inset: (x: 14pt, y: 8pt),
+            radius: (right: 6pt),
+          )[
+            #text(weight: "bold", fill: style.at("math_color", default: bm-colors.gold), size: style.at(
+              "solution_title_size",
+              default: 13pt,
+            ))[📝 Lời giải] #v(0.2em)
+            #set text(size: style.at("solution_size", default: 12pt), fill: style.at(
+              "solution_text_fill",
+              default: rgb("#cbd5e1"),
+            ))
+            #reset-step()
+            #loigiai
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// ── SHORT ────────────────────────────────────────────────
+#let short(
+  stem,
+  answer,
+  loigiai: none,
+  mode: "loigiai",
+  accent: bm-colors.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 30%,
+  show-boxes: true,
+  lines: 0,
+  num: auto, // ← auto = tự đếm
+  prefix: "Câu",
+  box-count: 4,
+  ..args,
+) = {
+  let loigiai = _resolve-loigiai(loigiai, args)
+
+  // ── Lấy số câu (hiển thị an toàn) ──
+  let q-num-display = if num == auto {
+    context { _bm-q-cnt.display() }
+  } else {
+    str(num)
+  }
+
+  // Ghi đáp án short vào registry
+  let _rn = num
+  let _ra = answer
+  [#_bm-ans-state.update(s => {
+    let n = if _rn == auto { s.q + 1 } else { _rn }
+    (q: n, mcq: s.mcq, tf: s.tf, sh: s.sh + ((num: n, ans: _ra),))
+  })]
+
+  slide(title: none)[
+    #if num == auto { _bm-q-cnt.step() } else { _bm-q-cnt.update(num) }
+    #context {
+      let n = _bm-q-cnt.get().first()
+      [#metadata(n) #label("bm-q-" + str(n))]
+    }
+    #context {
+      let style = _bm-style.get()
+  show math.frac: math.display
+      show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+      v(-0.5em)
+      box(fill: accent, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+        #text(weight: "bold", fill: white, size: style.at(
+          "label_size",
+          default: 16pt,
+        ))[#prefix #q-num-display — Trả lời ngắn]
+      ]
+      v(0.4em)
+      text(size: style.at("question_size", default: 17pt), fill: style.at("text_fill", default: bm-colors.fg))[#stem]
+      if fig != none {
+        v(0.3em)
+        align(center, block(
+          fill: white,
+          inset: 8pt,
+          radius: 6pt,
+        )[#fig])
+      }
+
+      if show-boxes {
+        v(0.8em)
+        align(center)[
+          #text(weight: "bold", fill: style.at("text_fill", default: bm-colors.fg), size: style.at(
+            "question_size",
+            default: 17pt,
+          ))[Đáp số: ]
+          #h(8pt)
+          #stack(
+            dir: ltr,
+            spacing: 4pt,
+            ..range(box-count).map(_ => box(
+              width: 2em,
+              height: 2em,
+              stroke: 1.2pt + style.at("math_color", default: bm-colors.gold),
+              radius: 4pt,
+              fill: bm-colors.card,
+            )),
+          )
+        ]
+      }
+    }
+  ]
+
+  if mode == "loigiai" {
+    slide(title: none)[
+      #context {
+        let style = _bm-style.get()
+  show math.frac: math.display
+        show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+        v(-0.5em)
+        box(fill: bm-colors.correct, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+          #text(weight: "bold", fill: white, size: style.at(
+            "label_size",
+            default: 16pt,
+          ))[#prefix #q-num-display — ĐÁP ÁN]
+        ]
+        v(0.6em)
+        align(center)[
+          #box(
+            fill: bm-colors.correct.darken(40%),
+            stroke: 2pt + bm-colors.correct,
+            inset: (x: 24pt, y: 14pt),
+            radius: 10pt,
+          )[
+            #text(
+              weight: "bold",
+              size: style.at("answer_size", default: 24pt),
+              fill: bm-colors.correct,
+            )[Đáp số: #answer]
+          ]
+        ]
+
+        if loigiai != none {
+          v(0.6em)
+          block(
+            width: 100%,
+            fill: style.at("solution_fill", default: rgb("#0c1a3a")),
+            stroke: (left: 3pt + style.at("math_color", default: bm-colors.gold)),
+            inset: (x: 14pt, y: 10pt),
+            radius: (right: 6pt),
+          )[
+            #text(weight: "bold", fill: style.at("math_color", default: bm-colors.gold), size: style.at(
+              "solution_title_size",
+              default: 14pt,
+            ))[📝 Lời giải] #v(0.2em)
+            #set text(size: style.at("solution_size", default: 13pt), fill: style.at(
+              "solution_text_fill",
+              default: rgb("#cbd5e1"),
+            ))
+            #reset-step()
+            #loigiai
+          ]
+        }
+      }
+    ]
+  }
+}
+
+#let tl(
+  stem,
+  loigiai: none,
+  mode: "loigiai",
+  accent: bm-colors.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 30%,
+  show-boxes: true,
+  num: auto, // ← auto = tự đếm
+  prefix: "Câu",
+  ..args,
+) = {
+  let loigiai = _resolve-loigiai(loigiai, args)
+
+  // ── Lấy số câu (hiển thị an toàn) ──
+  let q-num-display = if num == auto {
+    context { _bm-q-cnt.display() }
+  } else {
+    str(num)
+  }
+
+  slide(title: none)[
+    #if num == auto { _bm-q-cnt.step() } else { _bm-q-cnt.update(num) }
+    #context {
+      let n = _bm-q-cnt.get().first()
+      [#metadata(n) #label("bm-q-" + str(n))]
+    }
+    #context {
+      let style = _bm-style.get()
+  show math.frac: math.display
+      show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+      v(-0.5em)
+      box(fill: accent, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+        #text(weight: "bold", fill: white, size: style.at(
+          "label_size",
+          default: 16pt,
+        ))[#prefix #q-num-display — Tự luận]
+      ]
+      v(0.4em)
+      text(size: style.at("question_size", default: 17pt), fill: style.at("text_fill", default: bm-colors.fg))[#stem]
+      if fig != none {
+        v(0.3em)
+        align(center, block(
+          fill: white,
+          inset: 8pt,
+          radius: 6pt,
+        )[#fig])
+      }
+
+      if show-boxes {
+        v(0.7em)
+        block(
+          width: 100%,
+          fill: bm-colors.card,
+          stroke: 1pt + accent.lighten(30%),
+          inset: (x: 14pt, y: 12pt),
+          radius: 8pt,
+        )[
+          #text(
+            size: style.at("table_size", default: 14pt),
+            fill: bm-colors.muted,
+          )[Trình bày lời giải vào vở hoặc tài liệu phát tay.]
+        ]
+      }
+    }
+  ]
+
+  if mode == "loigiai" and loigiai != none {
+    slide(title: none)[
+      #context {
+        let style = _bm-style.get()
+  show math.frac: math.display
+        show math.equation: set text(fill: style.at("math_color", default: bm-colors.gold))
+
+        v(-0.5em)
+        box(fill: bm-colors.correct, inset: (x: 10pt, y: 6pt), radius: 4pt)[
+          #text(weight: "bold", fill: white, size: style.at(
+            "label_size",
+            default: 16pt,
+          ))[#prefix #q-num-display — LỜI GIẢI]
+        ]
+        v(0.6em)
+        block(
+          width: 100%,
+          fill: style.at("solution_fill", default: rgb("#0c1a3a")),
+          stroke: (left: 3pt + style.at("math_color", default: bm-colors.gold)),
+          inset: (x: 14pt, y: 10pt),
+          radius: (right: 6pt),
+        )[
+          #text(weight: "bold", fill: style.at("math_color", default: bm-colors.gold), size: style.at(
+            "solution_title_size",
+            default: 14pt,
+          ))[📝 Lời giải]
+          #v(0.2em)
+          #set text(size: style.at("solution_size", default: 13pt), fill: style.at(
+            "solution_text_fill",
+            default: rgb("#cbd5e1"),
+          ))
+          #loigiai
+        ]
+      }
+    ]
+  }
+}
+
+// ── Alias ────────────────────────────────────────────────
+#let tn = mcq
+#let ds = tf
+#let tln = short
+
+// ── exam-mode ────────────────────────────────────────────
+#let exam-mode(mode: "loigiai", accent: bm-colors.accent) = (
+  tn: tn.with(mode: mode, accent: accent),
+  ds: ds.with(mode: mode, accent: accent),
+  tln: tln.with(mode: mode, accent: accent),
+  tl: tl.with(mode: mode, accent: accent),
+  mcq: mcq.with(mode: mode, accent: accent),
+  tf: tf.with(mode: mode, accent: accent),
+  short: short.with(mode: mode, accent: accent),
+)
+
+// ── het ──────────────────────────────────────────────────
+#let het = slide(title: none)[
+  #align(center + horizon)[
+    #text(weight: "bold", size: 40pt, fill: bm-colors.gold)[— HẾT —]
+    #v(0.6em)
+    #text(size: 18pt, fill: bm-colors.muted)[
+      Cảm ơn các em đã theo dõi bài giảng! \
+      Chúc các em ôn thi tốt! 🎓
+    ]
+  ]
+]
+
+// ── No-ops ───────────────────────────────────────────────
+#let print-answer-key() = slide(title: none)[
+  #context {
+    let style = _bm-style.get()
+    let _bm-ans = _bm-ans-state.get()
+    let mcq-ans = _bm-ans.mcq
+    let tf-ans = _bm-ans.tf
+    let sh-ans = _bm-ans.sh
+    let fg = style.at("text_fill", default: white)
+    let card = style.at("card", default: rgb("#1e293b"))
+    let math-c = style.at("math_color", default: bm-colors.gold)
+
+    v(-0.3em)
+    box(fill: bm-colors.correct, inset: (x: 12pt, y: 6pt), radius: 4pt)[
+      #text(weight: "bold", fill: white, size: 16pt)[📋 BẢNG ĐÁP ÁN]
+    ]
+    v(0.6em)
+
+    // ── Trắc nghiệm ─────────────────────────────────
+    if mcq-ans.len() > 0 {
+      text(weight: "bold", fill: math-c, size: 12pt)[Trắc nghiệm:]
+      v(0.3em)
+      let cols = 6
+      grid(
+        columns: range(cols).map(_ => 1fr),
+        row-gutter: 6pt,
+        column-gutter: 6pt,
+        ..mcq-ans.map(it => box(
+          fill: card,
+          inset: (x: 8pt, y: 5pt),
+          radius: 4pt,
+          width: 100%,
+        )[
+          #align(center)[
+            #text(size: 10pt, fill: fg)[Câu #it.num]
+            #h(4pt)
+            #text(weight: "bold", size: 13pt, fill: math-c)[#it.ans]
+          ]
+        ])
+      )
+      v(0.5em)
+    }
+
+    // ── Đúng/Sai ────────────────────────────────────
+    if tf-ans.len() > 0 {
+      text(weight: "bold", fill: math-c, size: 12pt)[Đúng/Sai:]
+      v(0.3em)
+      let accent-c = style.at("accent", default: bm-colors.accent)
+      grid(
+        columns: range(4).map(_ => 1fr),
+        row-gutter: 6pt,
+        column-gutter: 6pt,
+        ..tf-ans.map(it => box(
+          fill: card,
+          radius: 6pt,
+          width: 100%,
+          clip: true,
+          inset: 1pt,
+        )[
+          // Header: nhãn câu
+          #box(fill: accent-c.lighten(20%), width: 100%, inset: (x: 6pt, y: 3pt))[
+            #align(center)[
+              #text(weight: "bold", size: 10pt, fill: white)[Câu #it.num]
+            ]
+          ]
+          // Body: 4 badge a/b/c/d
+          #pad(4pt)[
+            #grid(
+              columns: (1fr, 1fr, 1fr, 1fr),
+              column-gutter: 3pt,
+              ..it
+                .ans
+                .enumerate()
+                .map(((i, v)) => {
+                  let col = if v == "Đ" { bm-colors.correct } else { bm-colors.wrong }
+                  box(fill: col, radius: 3pt, width: 100%, inset: (x: 2pt, y: 3pt))[
+                    #align(center)[
+                      #text(size: 7.5pt, fill: white)[#("a", "b", "c", "d").at(i)]
+                      #linebreak()
+                      #text(weight: "bold", size: 11pt, fill: white)[#v]
+                    ]
+                  ]
+                })
+            )
+          ]
+        ])
+      )
+      v(0.5em)
+    }
+
+    // ── Điền số ─────────────────────────────────────
+    if sh-ans.len() > 0 {
+      text(weight: "bold", fill: math-c, size: 12pt)[Điền số:]
+      v(0.3em)
+      grid(
+        columns: range(6).map(_ => 1fr),
+        row-gutter: 6pt,
+        column-gutter: 6pt,
+        ..sh-ans.map(it => box(fill: card, inset: (x: 8pt, y: 5pt), radius: 4pt, width: 100%)[
+          #align(center)[
+            #text(size: 10pt, fill: fg)[Câu #it.num]
+            #linebreak()
+            #text(weight: "bold", size: 13pt, fill: math-c)[#it.ans]
+          ]
+        ])
+      )
+    }
+  }
+]
+#let thpt-school-exam(body, ..args) = body

--- a/packages/preview/sang-math/1.0.5/sang-book.typ
+++ b/packages/preview/sang-math/1.0.5/sang-book.typ
@@ -1,0 +1,1007 @@
+// ═══════════════════════════════════════════════════════════
+// STEXGV BOOK MODULE
+// Phân hệ biên soạn Sách, Chuyên đề, SGK và Phụ lục học tập
+// ═══════════════════════════════════════════════════════════
+
+#import "sang-exam.typ": palette, classic, draw-lines, _sol as _exam-sol
+#import "sang-exam.typ": lythuyet as _lythuyet, luuy as _luuy, note as _note, dn as _dn, dl as _dl, tc as _tc, bode as _bode
+
+#let _part-cnt = counter("stx-part")
+#let _chap-cnt = counter("stx-chap")
+#let _lesson-cnt = counter("stx-lesson")
+#let _section-cnt = counter("stx-section")
+#let _subsection-cnt = counter("stx-subsection")
+#let _micro-cnt = counter("stx-micro")
+#let _appendix-cnt = counter("stx-appendix")
+#let _appendix-topic-cnt = counter("stx-appendix-topic")
+#let _vd-cnt = counter("stx-vd")
+#let _bt-cnt = counter("stx-bt")
+#let _cauhoi-cnt = counter("stx-cauhoi")
+#let _activity-cnt = counter("stx-activity")
+
+#let _letters = (
+  "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+  "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+)
+
+#let _advance(counter, num: auto) = {
+  let resolved = if num == auto { counter.get().first() + 1 } else { num }
+  (
+    num: resolved,
+    update: if num == auto { counter.step() } else { counter.update(num) },
+  )
+}
+
+#let _reset-to(counter, start: 1) = [
+  #counter.update(if start > 0 { start - 1 } else { 0 })
+]
+
+#let _reset-learning-counters() = [
+  #_lesson-cnt.update(0)
+  #_section-cnt.update(0)
+  #_subsection-cnt.update(0)
+  #_micro-cnt.update(0)
+  #_appendix-topic-cnt.update(0)
+  #_vd-cnt.update(0)
+  #_bt-cnt.update(0)
+  #_cauhoi-cnt.update(0)
+  #_activity-cnt.update(0)
+]
+
+#let _resolve-loigiai(loigiai, args) = {
+  if loigiai != none { loigiai } else { args.named().at("solution", default: none) }
+}
+
+#let _outline-heading(level, body) = hide(heading(level: level, outlined: true, bookmarked: auto)[#body])
+
+#let _doc-label(doc-type) = {
+  let kind = lower(str(doc-type))
+  if kind == "sgk" or kind == "textbook" {
+    [SÁCH GIÁO KHOA]
+  } else if kind == "chuyende" {
+    [CHUYÊN ĐỀ]
+  } else if kind == "outline" or kind == "decuong" {
+    [ĐỀ CƯƠNG HỌC TẬP]
+  } else if kind == "bo-de" or kind == "exam-set" {
+    [BỘ ĐỀ THI]
+  } else {
+    [SÁCH HỌC TẬP]
+  }
+}
+
+#let _hero-banner(
+  title,
+  number: none,
+  prefix: none,
+  accent: classic.blue,
+  kicker: none,
+  fill: auto,
+  stroke: auto,
+  inset: 18pt,
+  radius: 10pt,
+) = {
+  let body-fill = if fill == auto { accent.lighten(92%) } else { fill }
+  let body-stroke = if stroke == auto { 0.8pt + accent.lighten(45%) } else { stroke }
+  let badge-text = if number != none and prefix != none {
+    [#upper(prefix) #number]
+  } else if prefix != none {
+    [#upper(prefix)]
+  } else if number != none {
+    [#number]
+  } else {
+    none
+  }
+
+  block(width: 100%, fill: body-fill, inset: inset, radius: radius, stroke: body-stroke)[
+    #if badge-text != none {
+      grid(columns: (auto, 1fr), column-gutter: 16pt, align: (left + horizon, left + horizon),
+        box(fill: accent, inset: (x: 16pt, y: 12pt), radius: 8pt)[
+          #text(size: 11pt, weight: "bold", fill: white)[#badge-text]
+        ],
+        [
+          #if kicker != none {
+            text(size: 10pt, weight: "bold", fill: accent)[#kicker]
+            v(0.35em)
+          }
+          #text(size: 22pt, weight: "bold", fill: accent.darken(10%))[#title]
+        ],
+      )
+    } else {
+      [
+        #if kicker != none {
+          text(size: 10pt, weight: "bold", fill: accent)[#kicker]
+          v(0.35em)
+        }
+        #text(size: 22pt, weight: "bold", fill: accent.darken(10%))[#title]
+      ]
+    }
+    #v(0.85em)
+    #line(length: 100%, stroke: 1pt + accent.lighten(55%))
+  ]
+}
+
+#let _section-banner(
+  title,
+  label,
+  accent: classic.blue,
+  fill: auto,
+  stroke: auto,
+  radius: 5pt,
+) = {
+  block(
+    width: 100%,
+    fill: if fill == auto { accent.lighten(95%) } else { fill },
+    inset: (x: 12pt, y: 10pt),
+    radius: radius,
+    stroke: if stroke == auto { (left: 4pt + accent) } else { stroke },
+  )[
+    #text(size: 14pt, weight: "bold", fill: accent)[#label #title]
+  ]
+}
+
+#let _rule-heading(
+  title,
+  label,
+  accent: classic.blue,
+  fill: auto,
+  stroke: auto,
+  radius: 5pt,
+) = {
+  block(
+    width: 100%,
+    fill: if fill == auto { accent.lighten(97%) } else { fill },
+    inset: (x: 12pt, y: 9pt),
+    radius: radius,
+    stroke: if stroke == auto { (bottom: 0.8pt + accent.lighten(35%)) } else { stroke },
+  )[
+    #text(size: 12.5pt, weight: "bold", fill: accent)[#label #title]
+  ]
+}
+
+#let _chip-heading(
+  title,
+  label,
+  accent: classic.blue,
+  fill: auto,
+  stroke: auto,
+  radius: 999pt,
+) = {
+  let chip-fill = accent.lighten(93%)
+  let chip-stroke = if stroke == auto { 0.6pt + accent.lighten(45%) } else { stroke }
+  grid(
+    columns: (auto, 1fr),
+    column-gutter: 10pt,
+    align: (left + horizon, left + horizon),
+    box(fill: chip-fill, stroke: chip-stroke, inset: (x: 10pt, y: 4pt), radius: radius)[
+      #text(size: 10pt, weight: "bold", fill: accent)[#label]
+    ],
+    block(fill: if fill == auto { white } else { fill }, inset: (x: 0pt, y: 2pt))[
+      #text(size: 11.5pt, weight: "bold", fill: accent.darken(10%))[#title]
+    ],
+  )
+}
+
+#let _minimal-heading(title, label, accent: classic.blue) = [
+  #text(size: 11pt, weight: "bold", fill: accent)[#label]
+  #h(0.35em)
+  #text(size: 12pt, weight: "bold", fill: accent.darken(10%))[#title]
+]
+
+#let _smart-structure-heading(
+  title,
+  prefix,
+  num,
+  accent: classic.blue,
+  level: "section",
+  look: auto,
+  fill: auto,
+  stroke: auto,
+  radius: 5pt,
+  kicker: none,
+) = {
+  let chosen = if look == auto {
+    if ("part", "chapter", "appendix").contains(level) {
+      "hero"
+    } else if level == "lesson" {
+      "band"
+    } else if level == "section" {
+      "rule"
+    } else if level == "subsection" {
+      "chip"
+    } else {
+      "minimal"
+    }
+  } else {
+    look
+  }
+  let label = [#prefix #num. ]
+
+  if chosen == "hero" {
+    _hero-banner(title, number: num, prefix: prefix, accent: accent, kicker: kicker, fill: fill, stroke: stroke)
+  } else if chosen == "band" {
+    _section-banner(title, label, accent: accent, fill: fill, stroke: stroke, radius: radius)
+  } else if chosen == "rule" {
+    _rule-heading(title, label, accent: accent, fill: fill, stroke: stroke, radius: radius)
+  } else if chosen == "chip" {
+    _chip-heading(title, label, accent: accent, fill: fill, stroke: stroke, radius: radius)
+  } else {
+    _minimal-heading(title, label, accent: accent)
+  }
+}
+
+#let _front-section(
+  body,
+  title,
+  theme-color: classic.blue,
+  pagebreak-before: false,
+  level: 1,
+  kicker: none,
+  fill: auto,
+  stroke: auto,
+) = [
+  #if pagebreak-before { pagebreak(weak: true) }
+  #_outline-heading(level, title)
+  #v(1.2em)
+  #_hero-banner(
+    title,
+    accent: theme-color,
+    kicker: kicker,
+    fill: fill,
+    stroke: stroke,
+  )
+  #v(0.9em)
+  #body
+  #v(1.2em)
+]
+
+#let _numbered-card(
+  body,
+  step,
+  prefix,
+  loigiai: none,
+  lines: 0,
+  theme-color: classic.blue,
+  boxed: true,
+  fill: white,
+  stroke: auto,
+  inset: (x: 10pt, y: 10pt),
+  radius: 4pt,
+  header-fill: auto,
+  title-fill: auto,
+) = {
+  let num = step.num
+  let border = if stroke == auto { 0.5pt + theme-color } else { stroke }
+  let banner-fill = if header-fill == auto { theme-color.lighten(85%) } else { header-fill }
+  let heading-fill = if title-fill == auto { theme-color.darken(20%) } else { title-fill }
+
+  [
+    #step.update
+    #v(1em)
+    #if boxed {
+      block(width: 100%, stroke: border, radius: radius, inset: 0pt, fill: fill, clip: true)[
+        #block(width: 100%, fill: banner-fill, inset: (x: 10pt, y: 8pt), stroke: (bottom: 0.5pt + theme-color))[
+          #text(weight: "bold", fill: heading-fill)[#prefix #num.]
+        ]
+        #block(width: 100%, inset: inset)[
+          #body
+          #if lines > 0 { draw-lines(lines) }
+          #if loigiai != none {
+            v(0.8em)
+            _exam-sol(loigiai, theme-color)
+          }
+        ]
+      ]
+    } else {
+      [
+        #text(weight: "bold", fill: heading-fill)[#prefix #num.]
+        #v(0.5em)
+        #body
+        #if lines > 0 { draw-lines(lines) }
+        #if loigiai != none {
+          v(0.8em)
+          _exam-sol(loigiai, theme-color)
+        }
+      ]
+    }
+    #v(0.5em)
+  ]
+}
+
+#let setcounter(env, start) = {
+  let name = if type(env) == str { lower(env) } else { env }
+  if ("part", "phan", "unit").contains(name) {
+    _reset-to(_part-cnt, start: start)
+  } else if ("chapter", "chuong").contains(name) {
+    _reset-to(_chap-cnt, start: start)
+  } else if ("lesson", "bai", "topic", "dang").contains(name) {
+    _reset-to(_lesson-cnt, start: start)
+  } else if ("section", "muc").contains(name) {
+    _reset-to(_section-cnt, start: start)
+  } else if ("subsection", "tieumuc").contains(name) {
+    _reset-to(_subsection-cnt, start: start)
+  } else if ("microsection", "y").contains(name) {
+    _reset-to(_micro-cnt, start: start)
+  } else if ("appendix", "phuluc").contains(name) {
+    _reset-to(_appendix-cnt, start: start)
+  } else if ("appendix-section", "mucphuluc").contains(name) {
+    _reset-to(_appendix-topic-cnt, start: start)
+  } else if ("vd", "vidu").contains(name) {
+    _reset-to(_vd-cnt, start: start)
+  } else if ("bt", "baitap").contains(name) {
+    _reset-to(_bt-cnt, start: start)
+  } else if ("cauhoi", "question").contains(name) {
+    _reset-to(_cauhoi-cnt, start: start)
+  } else if ("activity", "hoatdong").contains(name) {
+    _reset-to(_activity-cnt, start: start)
+  } else {
+    none
+  }
+}
+
+#let setbookcounter = setcounter
+#let resetbookcounter(env, start: 1) = setcounter(env, start)
+#let setchuong(start) = setcounter("chapter", start)
+#let resetchuong(start: 1) = setcounter("chapter", start)
+#let setbai(start) = setcounter("lesson", start)
+#let resetbai(start: 1) = setcounter("lesson", start)
+#let setmuc(start) = setcounter("section", start)
+#let resetmuc(start: 1) = setcounter("section", start)
+#let settieumuc(start) = setcounter("subsection", start)
+#let resettieumuc(start: 1) = setcounter("subsection", start)
+#let sety(start) = setcounter("microsection", start)
+#let resety(start: 1) = setcounter("microsection", start)
+#let setphuluc(start) = setcounter("appendix", start)
+#let resetphuluc(start: 1) = setcounter("appendix", start)
+#let setvd(start) = setcounter("vd", start)
+#let resetvd(start: 1) = setcounter("vd", start)
+#let setbt(start) = setcounter("bt", start)
+#let resetbt(start: 1) = setcounter("bt", start)
+
+#let stexgv-book(
+  title: "TÀI LIỆU TOÁN HỌC",
+  subtitle: none,
+  author: "Nguyễn Văn Sang",
+  theme-color: classic.blue,
+  doc-type: "book",
+  institution: none,
+  subject: none,
+  grade: none,
+  series: none,
+  academic-year: none,
+  publisher: none,
+  cover-note: none,
+  show-cover: true,
+  show-outline: true,
+  outline-depth: 4,
+  margin: auto,
+  body,
+) = {
+  set document(title: title, author: author)
+  set page(
+    paper: "a4",
+    margin: if margin == auto { (top: 2.5cm, bottom: 2.5cm, inside: 2.5cm, outside: 2cm) } else { margin },
+    header: context {
+      let page-num = counter(page).get().first()
+      if show-cover and page-num == 1 { return none }
+
+      set text(size: 10pt, fill: theme-color)
+      grid(columns: (1fr, auto), align: (left, right),
+        text(weight: "bold")[#title],
+        text(weight: "bold")[#author],
+      )
+      v(-4pt)
+      line(length: 100%, stroke: 0.8pt + theme-color)
+    },
+    footer: context {
+      let page-num = counter(page).get().first()
+      if show-cover and page-num == 1 { return none }
+
+      set text(size: 10pt, fill: palette.muted)
+      line(length: 100%, stroke: 0.4pt + palette.border)
+      v(2pt)
+      align(center)[Trang #page-num]
+    },
+  )
+
+  set text(font: "Libertinus Serif", size: 12pt, lang: "vi")
+  set par(justify: true, leading: 0.75em)
+  show math.frac: math.display
+  set enum(numbering: "1.")
+
+  if show-cover {
+    align(center + horizon)[
+      #if institution != none {
+        text(size: 12pt, weight: "bold", fill: theme-color)[#institution]
+        v(0.8em)
+      }
+      #text(size: 11pt, weight: "bold", tracking: 0.08em, fill: theme-color)[#_doc-label(doc-type)]
+      #v(1.2em)
+      #text(size: 30pt, weight: "bold", fill: theme-color)[#title]
+      #if subtitle != none {
+        v(0.8em)
+        text(size: 18pt, style: "italic")[#subtitle]
+      }
+      #v(1.2em)
+      #if subject != none {
+        text(size: 14pt)[Môn: #subject]
+        v(0.3em)
+      }
+      #if grade != none {
+        text(size: 13pt)[Khối/Lớp: #grade]
+        v(0.3em)
+      }
+      #if series != none {
+        text(size: 13pt)[Bộ tài liệu: #series]
+        v(0.3em)
+      }
+      #if academic-year != none {
+        text(size: 12pt, fill: palette.muted)[Năm học: #academic-year]
+      }
+      #v(2.4em)
+      #box(fill: theme-color.lighten(94%), stroke: 0.8pt + theme-color, inset: (x: 18pt, y: 12pt), radius: 10pt)[
+        #text(size: 18pt, style: "italic")[Biên soạn: #author]
+        #if publisher != none {
+          v(0.4em)
+          text(size: 11pt, fill: palette.muted)[#publisher]
+        }
+      ]
+      #if cover-note != none {
+        [
+          #v(2em)
+          note(cover-note, title: [Ghi chú xuất bản])
+        ]
+      }
+      #v(3em)
+    ]
+    pagebreak()
+  }
+
+  if show-outline {
+    outline(title: heading(level: 1, outlined: false)[MỤC LỤC], depth: outline-depth, indent: auto)
+    pagebreak()
+  }
+
+  body
+}
+
+#let loinoidau(body, title: [Lời nói đầu], theme-color: classic.blue, pagebreak-before: false, ..args) = {
+  _front-section(body, title, theme-color: theme-color, pagebreak-before: pagebreak-before, kicker: [Định hướng tài liệu], ..args)
+}
+
+#let gioithieu(body, title: [Giới thiệu], theme-color: classic.blue, pagebreak-before: false, ..args) = {
+  _front-section(body, title, theme-color: theme-color, pagebreak-before: pagebreak-before, kicker: [Tổng quan nội dung], ..args)
+}
+
+#let huongdansudung(body, title: [Hướng dẫn sử dụng], theme-color: classic.emerald, pagebreak-before: false, ..args) = {
+  _front-section(body, title, theme-color: theme-color, pagebreak-before: pagebreak-before, kicker: [Cách khai thác tài liệu], ..args)
+}
+
+#let muctieuchung(body, title: [Mục tiêu tổng quát], theme-color: classic.blue, pagebreak-before: false, ..args) = {
+  _front-section(body, title, theme-color: theme-color, pagebreak-before: pagebreak-before, kicker: [Chuẩn đầu ra], ..args)
+}
+
+#let bangthuatngu(body, title: [Bảng thuật ngữ], theme-color: rgb("#0f766e"), pagebreak-before: true, ..args) = {
+  _front-section(body, title, theme-color: theme-color, pagebreak-before: pagebreak-before, kicker: [Từ khóa và khái niệm], ..args)
+}
+
+#let tailieuthamkhao(body, title: [Tài liệu tham khảo], theme-color: classic.crimson, pagebreak-before: true, ..args) = {
+  _front-section(body, title, theme-color: theme-color, pagebreak-before: pagebreak-before, kicker: [Nguồn tham khảo], ..args)
+}
+
+#let references(body, ..args) = {
+  tailieuthamkhao(body, ..args)
+}
+
+#let glossary(body, ..args) = {
+  bangthuatngu(body, ..args)
+}
+
+#let preface(body, ..args) = {
+  loinoidau(body, ..args)
+}
+
+#let introduction(body, ..args) = {
+  gioithieu(body, ..args)
+}
+
+#let part(
+  title,
+  prefix: "Phần",
+  theme-color: classic.emerald,
+  pagebreak-before: true,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  num: auto,
+) = context {
+  let step = _advance(_part-cnt, num: num)
+  let num = step.num
+  [
+    #step.update
+    #_chap-cnt.update(0)
+    #_reset-learning-counters()
+    #_outline-heading(1, [#upper(prefix) #num. #title])
+    #if pagebreak-before { pagebreak(weak: true) }
+    #v(2em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "part", look: look, fill: fill, stroke: stroke, kicker: [Khung nội dung lớn])
+    } else {
+      [
+        #text(size: 16pt, weight: "bold", fill: theme-color)[#upper(prefix) #num.]
+        #v(0.5em)
+        #text(size: 22pt, weight: "bold", fill: theme-color.darken(10%))[#title]
+      ]
+    }
+    #v(1.6em)
+  ]
+}
+
+#let unit = part
+
+#let chapter(
+  title,
+  prefix: "Chương",
+  theme-color: classic.blue,
+  pagebreak-before: true,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  num: auto,
+) = context {
+  let step = _advance(_chap-cnt, num: num)
+  let num = step.num
+
+  [
+    #step.update
+    #_lesson-cnt.update(0)
+    #_section-cnt.update(0)
+    #_subsection-cnt.update(0)
+    #_micro-cnt.update(0)
+    #_appendix-topic-cnt.update(0)
+    #_vd-cnt.update(0)
+    #_bt-cnt.update(0)
+    #_cauhoi-cnt.update(0)
+    #_activity-cnt.update(0)
+    #_outline-heading(2, [#upper(prefix) #num. #title])
+    #if pagebreak-before { pagebreak(weak: true) }
+    #v(1.8em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "chapter", look: look, fill: fill, stroke: stroke, kicker: [Nội dung trọng tâm])
+    } else {
+      [
+        #text(size: 16pt, weight: "bold", fill: theme-color)[#upper(prefix) #num.]
+        #v(0.5em)
+        #text(size: 22pt, weight: "bold", fill: theme-color.darken(10%))[#title]
+      ]
+    }
+    #v(1.5em)
+  ]
+}
+
+#let lesson(
+  title,
+  prefix: "Bài",
+  theme-color: classic.blue,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  radius: 5pt,
+  num: auto,
+) = context {
+  let step = _advance(_lesson-cnt, num: num)
+  let num = step.num
+
+  [
+    #step.update
+    #_section-cnt.update(0)
+    #_subsection-cnt.update(0)
+    #_micro-cnt.update(0)
+    #_vd-cnt.update(0)
+    #_bt-cnt.update(0)
+    #_cauhoi-cnt.update(0)
+    #_activity-cnt.update(0)
+    #_outline-heading(3, [#prefix #num. #title])
+    #v(1.5em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "lesson", look: look, fill: fill, stroke: stroke, radius: radius)
+    } else {
+      text(size: 14pt, weight: "bold", fill: theme-color)[#prefix #num. #title]
+    }
+    #v(0.9em)
+  ]
+}
+
+#let bai = lesson
+
+#let topic(title, prefix: "Chủ Đề", theme-color: classic.blue, look: auto, boxed: true, fill: auto, stroke: auto, radius: 5pt, num: auto) = {
+  lesson(title, prefix: prefix, theme-color: theme-color, look: look, boxed: boxed, fill: fill, stroke: stroke, radius: radius, num: num)
+}
+
+#let dang = topic
+
+#let section(
+  title,
+  prefix: "Mục",
+  theme-color: classic.blue,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  radius: 4pt,
+  num: auto,
+) = context {
+  let step = _advance(_section-cnt, num: num)
+  let num = step.num
+
+  [
+    #step.update
+    #_subsection-cnt.update(0)
+    #_micro-cnt.update(0)
+    #_outline-heading(4, [#prefix #num. #title])
+    #v(1em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "section", look: look, fill: fill, stroke: stroke, radius: radius)
+    } else {
+      text(size: 13pt, weight: "bold", fill: theme-color)[#prefix #num. #title]
+    }
+    #v(0.7em)
+  ]
+}
+
+#let muc = section
+
+#let subsection(
+  title,
+  prefix: "Tiểu mục",
+  theme-color: classic.blue,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  radius: 999pt,
+  num: auto,
+) = context {
+  let step = _advance(_subsection-cnt, num: num)
+  let num = step.num
+
+  [
+    #step.update
+    #_micro-cnt.update(0)
+    #_outline-heading(5, [#prefix #num. #title])
+    #v(0.9em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "subsection", look: look, fill: fill, stroke: stroke, radius: radius)
+    } else {
+      text(size: 12pt, weight: "bold", fill: theme-color)[#prefix #num. #title]
+    }
+    #v(0.55em)
+  ]
+}
+
+#let tieumuc = subsection
+
+#let microsection(
+  title,
+  prefix: "Ý",
+  theme-color: rgb("#475569"),
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  radius: 999pt,
+  num: auto,
+) = context {
+  let step = _advance(_micro-cnt, num: num)
+  let num = step.num
+
+  [
+    #step.update
+    #_outline-heading(6, [#prefix #num. #title])
+    #v(0.75em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "micro", look: look, fill: fill, stroke: stroke, radius: radius)
+    } else {
+      text(size: 11pt, weight: "bold", fill: theme-color)[#prefix #num. #title]
+    }
+    #v(0.45em)
+  ]
+}
+
+#let y = microsection
+
+#let appendix(
+  title,
+  prefix: "Phụ lục",
+  theme-color: classic.crimson,
+  pagebreak-before: true,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  num: auto,
+) = context {
+  let step = _advance(_appendix-cnt, num: num)
+  let num = step.num
+  let label = if num <= _letters.len() { _letters.at(num - 1) } else { str(num) }
+
+  [
+    #step.update
+    #_appendix-topic-cnt.update(0)
+    #_vd-cnt.update(0)
+    #_bt-cnt.update(0)
+    #_cauhoi-cnt.update(0)
+    #_activity-cnt.update(0)
+    #_outline-heading(1, [#prefix #label. #title])
+    #if pagebreak-before { pagebreak(weak: true) }
+    #v(1.8em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, label, accent: theme-color, level: "appendix", look: look, fill: fill, stroke: stroke, kicker: [Hệ thống phụ lục])
+    } else {
+      [
+        #text(size: 16pt, weight: "bold", fill: theme-color)[#upper(prefix) #label.]
+        #v(0.5em)
+        #text(size: 22pt, weight: "bold", fill: theme-color.darken(10%))[#title]
+      ]
+    }
+    #v(1.5em)
+  ]
+}
+
+#let phuluc = appendix
+
+#let appendix-section(
+  title,
+  prefix: "Mục phụ lục",
+  theme-color: classic.crimson,
+  look: auto,
+  boxed: true,
+  fill: auto,
+  stroke: auto,
+  radius: 4pt,
+  num: auto,
+) = context {
+  let step = _advance(_appendix-topic-cnt, num: num)
+  let num = step.num
+  [
+    #step.update
+    #_outline-heading(2, [#prefix #num. #title])
+    #v(1em)
+    #if boxed or look != "minimal" {
+      _smart-structure-heading(title, prefix, num, accent: theme-color, level: "section", look: look, fill: fill, stroke: stroke, radius: radius)
+    } else {
+      text(size: 13pt, weight: "bold", fill: theme-color)[#prefix #num. #title]
+    }
+    #v(0.7em)
+  ]
+}
+
+#let mucphuluc = appendix-section
+
+#let vd(
+  stem,
+  loigiai: none,
+  lines: 0,
+  theme-color: classic.blue,
+  prefix: "Ví dụ",
+  boxed: true,
+  fill: white,
+  stroke: auto,
+  inset: (x: 10pt, y: 10pt),
+  radius: 4pt,
+  header-fill: auto,
+  title-fill: auto,
+  num: auto,
+  ..args,
+) = context {
+  let step = _advance(_vd-cnt, num: num)
+  let loigiai = _resolve-loigiai(loigiai, args)
+  _numbered-card(stem, step, prefix, loigiai: loigiai, lines: lines, theme-color: theme-color, boxed: boxed, fill: fill, stroke: stroke, inset: inset, radius: radius, header-fill: header-fill, title-fill: title-fill)
+}
+
+#let bt(
+  stem,
+  loigiai: none,
+  lines: 0,
+  theme-color: classic.emerald,
+  prefix: "Bài tập",
+  boxed: true,
+  fill: white,
+  stroke: auto,
+  inset: (x: 10pt, y: 10pt),
+  radius: 4pt,
+  header-fill: auto,
+  title-fill: auto,
+  num: auto,
+  ..args,
+) = context {
+  let step = _advance(_bt-cnt, num: num)
+  let loigiai = _resolve-loigiai(loigiai, args)
+  _numbered-card(stem, step, prefix, loigiai: loigiai, lines: lines, theme-color: theme-color, boxed: boxed, fill: fill, stroke: stroke, inset: inset, radius: radius, header-fill: header-fill, title-fill: title-fill)
+}
+
+#let cauhoi(
+  stem,
+  loigiai: none,
+  lines: 0,
+  theme-color: classic.crimson,
+  prefix: "Câu hỏi",
+  boxed: true,
+  fill: white,
+  stroke: auto,
+  inset: (x: 10pt, y: 10pt),
+  radius: 4pt,
+  header-fill: auto,
+  title-fill: auto,
+  num: auto,
+  ..args,
+) = context {
+  let step = _advance(_cauhoi-cnt, num: num)
+  let loigiai = _resolve-loigiai(loigiai, args)
+  _numbered-card(stem, step, prefix, loigiai: loigiai, lines: lines, theme-color: theme-color, boxed: boxed, fill: fill, stroke: stroke, inset: inset, radius: radius, header-fill: header-fill, title-fill: title-fill)
+}
+
+#let hoatdongn(
+  stem,
+  loigiai: none,
+  lines: 0,
+  theme-color: rgb("#0369a1"),
+  prefix: "Hoạt động",
+  boxed: true,
+  fill: white,
+  stroke: auto,
+  inset: (x: 10pt, y: 10pt),
+  radius: 4pt,
+  header-fill: auto,
+  title-fill: auto,
+  num: auto,
+  ..args,
+) = context {
+  let step = _advance(_activity-cnt, num: num)
+  let loigiai = _resolve-loigiai(loigiai, args)
+  _numbered-card(stem, step, prefix, loigiai: loigiai, lines: lines, theme-color: theme-color, boxed: boxed, fill: fill, stroke: stroke, inset: inset, radius: radius, header-fill: header-fill, title-fill: title-fill)
+}
+
+#let vidu = vd
+#let baitap = bt
+#let onluyen = bt
+#let hd = hoatdongn
+
+#let _smartbox-theme(kind) = {
+  let name = if type(kind) == str { lower(kind) } else { "note" }
+  if ("lythuyet", "theory").contains(name) {
+    (accent: classic.blue, fill: rgb("#eef4ff"), title: [Lý thuyết], title-fill: classic.blue, style: "ribbon")
+  } else if ("phuongphap", "method").contains(name) {
+    (accent: classic.emerald, fill: rgb("#ecfdf5"), title: [Phương pháp], title-fill: classic.emerald, style: "ribbon")
+  } else if ("ghinho", "memory").contains(name) {
+    (accent: rgb("#0369a1"), fill: rgb("#eff6ff"), title: [Ghi nhớ], title-fill: rgb("#075985"), style: "bar")
+  } else if ("tomtat", "summary").contains(name) {
+    (accent: rgb("#0f766e"), fill: rgb("#ecfeff"), title: [Tóm tắt], title-fill: rgb("#115e59"), style: "bar")
+  } else if ("luuy", "warning").contains(name) {
+    (accent: rgb("#c2410c"), fill: rgb("#fff7ed"), title: [Lưu ý], title-fill: rgb("#9a3412"), style: "bar")
+  } else if ("nhanxet", "remark").contains(name) {
+    (accent: rgb("#9a3412"), fill: rgb("#fff7ed"), title: [Nhận xét], title-fill: rgb("#9a3412"), style: "minimal")
+  } else if ("baitap", "exercise").contains(name) {
+    (accent: classic.emerald, fill: white, title: [Bài tập], title-fill: classic.emerald, style: "minimal")
+  } else {
+    (accent: rgb("#0f766e"), fill: rgb("#f8fafc"), title: [Ghi chú], title-fill: rgb("#115e59"), style: "bar")
+  }
+}
+
+#let _smart-panel(
+  body,
+  title: none,
+  accent: classic.blue,
+  fill: white,
+  stroke: auto,
+  inset: (x: 12pt, y: 9pt),
+  radius: 8pt,
+  title-fill: auto,
+  style: "ribbon",
+  boxed: true,
+) = {
+  let border = if stroke == auto { 0.6pt + accent.lighten(55%) } else { stroke }
+  let heading-fill = if title-fill == auto { accent.darken(12%) } else { title-fill }
+
+  if not boxed {
+    [
+      #if title != none {
+        text(weight: "bold", fill: heading-fill)[#title]
+        v(0.35em)
+      }
+      #body
+    ]
+  } else if style == "minimal" {
+    block(width: 100%, fill: fill, stroke: border, inset: inset, radius: radius)[
+      #if title != none {
+        text(size: 11pt, weight: "bold", fill: heading-fill)[#title]
+        v(0.35em)
+        line(length: 100%, stroke: 0.6pt + accent.lighten(45%))
+        v(0.45em)
+      }
+      #body
+    ]
+  } else if style == "bar" {
+    block(width: 100%, fill: fill, stroke: border, inset: 0pt, radius: radius, clip: true)[
+      #if title != none {
+        block(width: 100%, fill: accent.lighten(93%), inset: (x: 12pt, y: 8pt), stroke: (bottom: 0.6pt + accent.lighten(45%)))[
+          #text(size: 11pt, weight: "bold", fill: heading-fill)[#title]
+        ]
+      }
+      #block(width: 100%, inset: inset)[#body]
+    ]
+  } else {
+    block(width: 100%, fill: fill, stroke: border, inset: inset, radius: radius)[
+      #if title != none {
+        box(fill: accent, inset: (x: 10pt, y: 4pt), radius: 999pt)[
+          #text(size: 10.5pt, weight: "bold", fill: white)[#title]
+        ]
+        v(0.5em)
+      }
+      #body
+    ]
+  }
+}
+
+#let smartbox(
+  body,
+  kind: "note",
+  title: auto,
+  accent: auto,
+  fill: auto,
+  stroke: auto,
+  title-fill: auto,
+  style: auto,
+  compact: false,
+  radius: auto,
+  boxed: true,
+) = {
+  let theme = _smartbox-theme(kind)
+  let resolved-accent = if accent == auto { theme.accent } else { accent }
+  let resolved-fill = if fill == auto { theme.fill } else { fill }
+  let resolved-title = if title == auto { theme.title } else { title }
+  let resolved-title-fill = if title-fill == auto { theme.title-fill } else { title-fill }
+  let resolved-style = if style == auto { theme.style } else { style }
+  let resolved-radius = if radius == auto { if compact { 6pt } else { 8pt } } else { radius }
+
+  _smart-panel(
+    body,
+    title: resolved-title,
+    accent: resolved-accent,
+    fill: resolved-fill,
+    stroke: stroke,
+    inset: if compact { (x: 10pt, y: 6pt) } else { (x: 12pt, y: 9pt) },
+    radius: resolved-radius,
+    title-fill: resolved-title-fill,
+    style: resolved-style,
+    boxed: boxed,
+  )
+}
+
+#let khung = smartbox
+
+#let muctieu(body, title: [Mục tiêu bài học], ..args) = _lythuyet(body, title: title, accent: classic.blue, fill: rgb("#eef4ff"), title-fill: classic.blue, ..args)
+#let chuanbi(body, title: [Chuẩn bị], ..args) = _note(body, title: title, accent: rgb("#334155"), fill: rgb("#f8fafc"), title-fill: rgb("#1e293b"), ..args)
+#let khoidong(body, title: [Khởi động], ..args) = _note(body, title: title, accent: rgb("#ea580c"), fill: rgb("#fff7ed"), title-fill: rgb("#c2410c"), ..args)
+#let khampha(body, title: [Khám phá], ..args) = _lythuyet(body, title: title, accent: rgb("#7c3aed"), fill: rgb("#f5f3ff"), title-fill: rgb("#6d28d9"), ..args)
+#let hoatdong(body, title: [Hoạt động], ..args) = _note(body, title: title, accent: rgb("#0369a1"), fill: rgb("#eff6ff"), title-fill: rgb("#075985"), ..args)
+#let luyentap(body, title: [Luyện tập], ..args) = _note(body, title: title, accent: classic.emerald, fill: rgb("#ecfdf5"), title-fill: classic.emerald, ..args)
+#let vandung(body, title: [Vận dụng], ..args) = _note(body, title: title, accent: rgb("#b45309"), fill: rgb("#fff7ed"), title-fill: rgb("#9a3412"), ..args)
+#let morang(body, title: [Mở rộng], ..args) = _note(body, title: title, accent: rgb("#6d28d9"), fill: rgb("#f5f3ff"), title-fill: rgb("#5b21b6"), ..args)
+#let tomtat(body, title: [Tóm tắt], ..args) = _note(body, title: title, accent: rgb("#0f766e"), fill: rgb("#ecfeff"), title-fill: rgb("#115e59"), ..args)
+#let duan(body, title: [Dự án học tập], ..args) = _note(body, title: title, accent: rgb("#991b1b"), fill: rgb("#fef2f2"), title-fill: rgb("#991b1b"), ..args)
+#let nhanxet(body, title: [Nhận xét], ..args) = _note(body, title: title, accent: rgb("#b45309"), fill: rgb("#fff7ed"), title-fill: rgb("#9a3412"), ..args)
+#let ghinho(body, title: [Ghi nhớ], ..args) = _note(body, title: title, accent: rgb("#0369a1"), fill: rgb("#eff6ff"), title-fill: rgb("#075985"), ..args)
+#let phuongphap(body, title: [Phương pháp], ..args) = _lythuyet(body, title: title, accent: classic.emerald, fill: rgb("#ecfdf5"), title-fill: classic.emerald, ..args)
+
+#let lythuyet(body, ..args) = _lythuyet(body, ..args)
+#let luuy(body, ..args) = _luuy(body, ..args)
+#let note(body, ..args) = _note(body, ..args)
+#let dn(body, ..args) = _dn(body, ..args)
+#let dl(body, ..args) = _dl(body, ..args)
+#let tc(body, ..args) = _tc(body, ..args)
+#let bode(body, ..args) = _bode(body, ..args)
+
+#let definition(body, ..args) = dn(body, ..args)

--- a/packages/preview/sang-math/1.0.5/sang-exam.typ
+++ b/packages/preview/sang-math/1.0.5/sang-exam.typ
@@ -1,0 +1,1897 @@
+// =========================================================
+// SANG-EXAM.TYP v6.0 — Engine thi THPT chuẩn ex_test.sty
+// =========================================================
+
+// ── Beamer-mode flag (set by sang-beamer.typ to suppress print-only elements) ──
+#let _beamer-mode = state("_beamer-mode", false)
+#let set-beamer-mode() = { _beamer-mode.update(true) }
+
+// ── Font viết tay toàn cục ────────────────────────────────
+// Được set bởi thpt-school-exam(handwriting-font: ...)
+// Dùng #hw[text] ở bất kỳ đâu trong file .typ
+#let _hw-font = state("_hw-font", none)
+#let _hw-size = state("_hw-size", 1em)
+#let hw(it) = context {
+  let f = _hw-font.get()
+  if f != none {
+    text(font: f, size: _hw-size.get())[#it]
+  } else {
+    text(style: "italic")[#it]
+  }
+}
+
+// ── Màu ──────────────────────────────────────────────────
+#let palette = (
+  ink: black,
+  muted: rgb("#555"),
+  border: rgb("#bbb"),
+  accent: rgb("#0057b8"),
+  correct: rgb("#1a7a2e"),
+  wrong: rgb("#cc2200"),
+  sol-bg: rgb("#f0f6ff"),
+)
+#let classic = (
+  blue: rgb("#0057b8"),
+  emerald: rgb("#1a7a2e"),
+  crimson: rgb("#cc2200"),
+  ink: black,
+)
+
+// ── sang-setup: wrapper đặt show rules ───────────────────
+// Dùng: #show: sang-setup
+//       #show: sang-setup.with(math-color: accent)
+#let sang-setup(body, math-color: black) = {
+  // Chỉ phóng riêng phân số. Không biến cả phương trình inline thành display:
+  // làm vậy sẽ phá baseline và chiều cao dòng trong bảng/cột hẹp.
+  show math.frac: math.display
+  show math.equation: set text(fill: math-color)
+
+  // Tự động chuyển C, A, P (những chữ số gán sub/sup) thành chữ đứng để in đúng C_n^k
+  show math.attach: it => {
+    let f = it.base.fields()
+    if "text" in f and f.text in ("C", "A", "P") {
+      return math.attach(math.upright(f.text), t: it.t, b: it.b, tl: it.tl, bl: it.bl, tr: it.tr, br: it.br)
+    }
+    it
+  }
+
+  show list: it => {
+    let any-frac = it.children.any(item => {
+      let r = repr(item.body)
+      r.contains("frac") and not r.contains("list(")
+    })
+    if any-frac {
+      {
+        set list(spacing: 2.8em)
+        it
+      }
+    } else { it }
+  }
+  body
+}
+
+// ── Helpers ───────────────────────────────────────────────
+#let True(body) = (body: body, correct: true)
+#let False(body) = (body: body, correct: false)
+
+// ═══════════════════════════════════════════════════════════
+// HỘP SƯ PHẠM — 5 kiểu hình thức khác nhau
+// ═══════════════════════════════════════════════════════════
+//
+// ① BANNER   — thanh tiêu đề màu trên cùng (ppgiai, lythuyet)
+// ② ALERT    — viền trái 6pt + all-around thin border (luuy)
+// ③ PILL     — full border 2pt + góc tròn 10pt, tiêu đề inline (meo)
+// ④ DASHED   — viền chấm-chấm + dải phân cách (nhanxet, note)
+// ⑤ THEOREM  — đường kẻ trên 2.5pt + dưới 1pt (dn, dl, tc, bode)
+
+// ① BANNER ─────────────────────────────────────────────────
+#let _panel-banner(body, title, hdr-fill, body-fill) = block(
+  width: 100%,
+  below: 0.85em,
+  radius: 5pt,
+  clip: true,
+)[
+  #block(width: 100%, fill: hdr-fill, inset: (x: 12pt, y: 6pt))[
+    #text(fill: white, weight: "bold", size: 10.5pt)[#title]
+  ]
+  #block(width: 100%, fill: body-fill, inset: (x: 13pt, y: 9pt))[
+    #set text(fill: luma(30))
+    #body
+  ]
+]
+
+// ② ALERT ──────────────────────────────────────────────────
+#let _panel-alert(body, title, accent, fill) = block(
+  width: 100%,
+  below: 0.85em,
+  stroke: (left: 6pt + accent, rest: 0.8pt + accent.lighten(50%)),
+  inset: (left: 14pt, right: 12pt, top: 8pt, bottom: 8pt),
+  radius: (right: 5pt),
+  fill: fill,
+)[
+  #text(weight: "bold", fill: accent)[#title]
+  #v(0.25em)
+  #set text(fill: luma(30))
+  #body
+]
+
+// ③ PILL ───────────────────────────────────────────────────
+#let _panel-pill(body, title, accent, fill) = block(
+  width: 100%,
+  below: 0.85em,
+  stroke: 2pt + accent,
+  inset: (x: 14pt, y: 9pt),
+  radius: 10pt,
+  fill: fill,
+)[
+  #set text(fill: luma(30))
+  #text(weight: "bold", fill: accent)[#title] #h(3pt) #body
+]
+
+// ④ DASHED ─────────────────────────────────────────────────
+#let _panel-dashed(body, title, accent, fill) = block(
+  width: 100%,
+  below: 0.85em,
+  stroke: (paint: accent, thickness: 1pt, dash: "dashed"),
+  inset: (x: 12pt, y: 8pt),
+  radius: 4pt,
+  fill: fill,
+)[
+  #text(weight: "bold", fill: accent)[#title]
+  #v(0.15em)
+  #line(length: 100%, stroke: (paint: accent, thickness: 0.5pt, dash: "dotted"))
+  #v(0.2em)
+  #set text(fill: luma(30))
+  #body
+]
+
+// ⑤ THEOREM ────────────────────────────────────────────────
+#let _panel-theorem(body, title, accent, fill) = block(
+  width: 100%,
+  below: 0.85em,
+)[
+  #line(length: 100%, stroke: 2.5pt + accent)
+  #block(
+    width: 100%,
+    fill: fill,
+    inset: (x: 13pt, top: 7pt, bottom: 9pt),
+  )[
+    #set text(fill: luma(30))
+    #text(weight: "bold", fill: accent, style: "italic")[#title.] #h(4pt) #body
+  ]
+  #line(length: 100%, stroke: 1pt + accent.lighten(35%))
+]
+
+// ── Hộp lời giải ──────────────────────────────────────────
+
+// 💡 Phương pháp giải — Banner xanh lá
+#let ppgiai(body, title: [💡 Phương pháp giải], ..args) = _panel-banner(
+  body,
+  title,
+  rgb("#1a7a2e"),
+  rgb("#eef6ed"),
+)
+
+// ⚠ Lưu ý — Alert cam, viền trái 6pt
+#let luuy(body, title: [⚠ Lưu ý], ..args) = _panel-alert(
+  body,
+  title,
+  rgb("#e65100"),
+  rgb("#fff4e5"),
+)
+
+// 🚀 Mẹo nhanh — Pill tròn hồng, tiêu đề inline
+#let meo(body, title: [🚀 Mẹo nhanh], ..args) = _panel-pill(
+  body,
+  title,
+  rgb("#c2185b"),
+  rgb("#fce4ec"),
+)
+
+// 📝 Nhận xét — Dashed tím, có gạch phân cách
+#let nhanxet(body, title: [📝 Nhận xét], ..args) = _panel-dashed(
+  body,
+  title,
+  rgb("#6b21a8"),
+  rgb("#faf5ff"),
+)
+
+#let giainhanh(body, title: [🚀 Mẹo nhanh], ..args) = meo(body, title: title)
+
+// 📖 Lý thuyết — Banner xanh dương
+#let lythuyet(body, title: [📖 Lý thuyết], ..args) = _panel-banner(
+  body,
+  title,
+  rgb("#1553a0"),
+  rgb("#eef4ff"),
+)
+
+// Ghi chú — Dashed teal
+#let note(body, title: [Ghi chú], ..args) = _panel-dashed(
+  body,
+  title,
+  rgb("#0f766e"),
+  rgb("#f0fdfa"),
+)
+
+// ── Hộp học thuật — Kiểu Theorem (⑤) ─────────────────────
+
+// Định nghĩa — đường kẻ xanh dương
+#let dn(body, title: [Định nghĩa], ..args) = _panel-theorem(
+  body,
+  title,
+  rgb("#1d4ed8"),
+  rgb("#eff6ff"),
+)
+
+// Định lý — đường kẻ đỏ đậm
+#let dl(body, title: [Định lý], ..args) = _panel-theorem(
+  body,
+  title,
+  rgb("#b91c1c"),
+  rgb("#fff1f2"),
+)
+
+// Tính chất — đường kẻ xanh lá
+#let tc(body, title: [Tính chất], ..args) = _panel-theorem(
+  body,
+  title,
+  rgb("#15803d"),
+  rgb("#f0fdf4"),
+)
+
+// Bổ đề — đường kẻ cam đậm
+#let bode(body, title: [Bổ đề], ..args) = _panel-theorem(
+  body,
+  title,
+  rgb("#c2410c"),
+  rgb("#fff7ed"),
+)
+
+// ── Bộ đếm & state ────────────────────────────────────────
+#let _q-cnt = counter("se-q")
+#let _global-q-cnt = counter("se-g-q")
+#let _part-cnt = counter("se-p-cnt")
+#let _mcq-meta = state("se-mcq", ())
+#let _tf-meta = state("se-tf", ())
+#let _sh-meta = state("se-sh", ())
+#let _tl-meta = state("se-tl", ())
+
+// - #resetexamstate() -> xoá đáp án đã gom, reset số câu và số phần về đầu đề mới
+#let resetexamstate(question-start: 1, part-start: 1) = {
+  let current-question = if question-start > 0 { question-start - 1 } else { 0 }
+  let current-part = if part-start > 0 { part-start - 1 } else { 0 }
+  [
+    #_q-cnt.update(current-question)
+    #_global-q-cnt.update(current-question)
+    #_part-cnt.update(current-part)
+    #_mcq-meta.update(_ => ())
+    #_tf-meta.update(_ => ())
+    #_sh-meta.update(_ => ())
+    #_tl-meta.update(_ => ())
+    #metadata((kind: "question", current: current-question)) <se-q-reset>
+  ]
+}
+
+#let _q-marker = <se-q-marker>
+#let _q-reset-marker = <se-q-reset>
+
+#let _resolve-loigiai(loigiai, args) = {
+  if loigiai != none { loigiai } else { args.named().at("solution", default: none) }
+}
+
+// Helper: scale fig so its rendered width = fig-width × available width, then center.
+// Scales geometry + labels proportionally (uniform scale). To keep label size fixed
+// while changing figure geometry size, adjust `length:` inside cetz.canvas() instead.
+#let _fig-scaled-center(fig, fig-width) = layout(size => context {
+  let sz = measure(fig)
+  if sz.width > 0pt {
+    let target-w = size.width * fig-width
+    let r = target-w / sz.width
+    align(center, scale(fig, x: r * 100%, y: r * 100%, origin: top + center, reflow: true))
+  } else {
+    align(center, fig)
+  }
+})
+
+#let _question-frame(
+  body,
+  below: 1em,
+  boxed: false,
+  fill: white,
+  stroke: 0.6pt + palette.border,
+  inset: (x: 10pt, y: 8pt),
+  radius: 4pt,
+) = {
+  if boxed {
+    block(width: 100%, below: below, fill: fill, stroke: stroke, inset: inset, radius: radius)[#body]
+  } else {
+    block(width: 100%, below: below)[#body]
+  }
+}
+
+#let _next-question-num(num: auto) = {
+  let resets = query(selector(_q-reset-marker).before(here()))
+  let resolved = if num == auto {
+    if resets.len() == 0 {
+      query(selector(_q-marker).before(here())).len() + 1
+    } else {
+      let reset = resets.last()
+      let base = reset.value.current
+      let seen = query(selector(_q-marker).after(reset.location()).before(here())).len()
+      base + seen + 1
+    }
+  } else {
+    num
+  }
+  (
+    num: resolved,
+    markers: [
+      #if num != auto {
+        [#metadata((kind: "question", current: num - 1)) <se-q-reset>]
+      }
+      #metadata("question") <se-q-marker>
+      #counter("se-step").update(0)
+    ],
+  )
+}
+
+// ── Điều khiển bộ đếm ────────────────────────────────────
+// - #resetcau()      -> câu kế tiếp là Câu 1
+// - #setcau(13)      -> câu kế tiếp là Câu 13
+// - #resetphan()     -> phần kế tiếp là PHẦN I
+// - #setphan(3)      -> phần kế tiếp là PHẦN III
+// - #exam-part(..., reset-counter: true) -> reset số câu về 1 ngay đầu phần đó
+#let setcounter(env, start) = {
+  let current = if start > 0 { start - 1 } else { 0 }
+  let name = if type(env) == str { lower(env) } else { env }
+  if ("cau", "question", "tn", "ds", "tln", "tl").contains(name) {
+    [
+      #metadata((kind: "question", current: current)) <se-q-reset>
+    ]
+  } else if ("part", "phan").contains(name) {
+    [#_part-cnt.update(current)]
+  } else {
+    none
+  }
+}
+
+#let resetcounter(env, start: 1) = setcounter(env, start)
+#let setcau(start) = setcounter("cau", start)
+#let resetcau(start: 1) = resetcounter("cau", start: start)
+#let setphan(start) = setcounter("part", start)
+#let resetphan(start: 1) = resetcounter("part", start: start)
+
+// ── Kẻ dòng chấm cho HS ───────────────────────────────────
+#let draw-lines(n) = {
+  v(0.2em)
+  for i in range(n) {
+    v(0.6em)
+    line(length: 100%, stroke: (paint: rgb("#b0b0b0"), thickness: 0.6pt, dash: "dotted"))
+    v(0.8em)
+  }
+}
+
+// ── Ô ly và điền khuyết ──────────────────────────────────
+#let dien-khuyet(lines: 4) = {
+  v(0.5em)
+  for _ in range(lines) {
+    box(width: 100%, stroke: (bottom: 0.5pt + luma(150), rest: none), height: 1.5em)
+    v(0em)
+  }
+}
+
+#let o-ly(rows: 5) = {
+  v(0.5em)
+  let cell-content = []
+  let grid-content = grid(
+    columns: (1.5em,) * 25,
+    rows: (1.5em,) * rows,
+    stroke: 0.5pt + luma(200),
+    ..([#cell-content],) * 25 * rows
+  )
+  align(center, grid-content)
+}
+
+// ─────────────────────────────────────────────────────────
+// CÁC BƯỚC GIẢI CHI TIẾT (có tự động đổi màu)
+// ─────────────────────────────────────────────────────────
+#let _step-colors = (
+  rgb("#1565c0"),
+  rgb("#e65100"),
+  rgb("#2e7d32"),
+  rgb("#6a1b9a"),
+  rgb("#00838f"),
+  rgb("#c62828"),
+)
+#let _step-cnt = counter("se-step")
+#let _step-reveal-config = state("se-step-reveal-config", (before_nonfirst: none))
+#let configure-step-reveal(before_nonfirst: none) = [
+  #_step-reveal-config.update((before_nonfirst: before_nonfirst))
+]
+#let step(
+  body,
+  color: auto,
+  before_nonfirst: auto,
+  above: 0.55em,
+  below: 0.45em,
+) = {
+  _step-cnt.step()
+  context {
+    let n = _step-cnt.get().first()
+    let c = _step-colors.at(calc.rem(n - 1, _step-colors.len()))
+    let text-color = if color != auto { color } else { c.darken(10%) }
+    let border-color = if color != auto { color } else { c }
+    let reveal = if before_nonfirst != auto {
+      before_nonfirst
+    } else if n > 1 {
+      _step-reveal-config.get().at("before_nonfirst", default: none)
+    } else {
+      none
+    }
+    let step-block = block(
+      width: 100%,
+      stroke: (left: 1.5pt + border-color),
+      inset: (left: 8pt, right: 0pt, top: 1.5pt, bottom: 1.5pt),
+      below: below,
+      above: above,
+    )[
+      #text(fill: text-color, weight: "bold")[Bước #n.] #h(0.3em) #body
+    ]
+    if reveal == none {
+      step-block
+    } else {
+      [#reveal #step-block]
+    }
+  }
+}
+#let reset-step() = [#_step-cnt.update(0)]
+
+// ── Lời giải block ────────────────────────────────────────
+#let _sol(s, a) = block(
+  width: 100%,
+  fill: palette.sol-bg,
+  stroke: (left: 3pt + a),
+  inset: (left: 10pt, right: 8pt, top: 6pt, bottom: 6pt),
+  radius: (right: 4pt),
+)[#reset-step()#text(weight: "bold", fill: a)[Lời giải.] #s]
+
+#let _q-label(prefix, num, accent, style: "plain") = {
+  if style == "pill" {
+    box(
+      fill: accent.lighten(82%),
+      stroke: 0.7pt + accent.lighten(35%),
+      inset: (x: 7pt, y: 2pt),
+      radius: 999pt,
+      text(weight: "bold", fill: accent)[#prefix #num.]
+    )
+    h(4pt)
+  } else if style == "badge" {
+    box(
+      fill: accent,
+      inset: (x: 7pt, y: 2.5pt),
+      radius: 4pt,
+      text(weight: "bold", fill: white)[#prefix #num.]
+    )
+    h(5pt)
+  } else if style == "solid-pill" {
+    box(
+      fill: accent,
+      inset: (x: 8pt, y: 2.3pt),
+      radius: 999pt,
+      text(weight: "bold", fill: white)[#prefix #num]
+    )
+    text(weight: "bold", fill: accent)[. ]
+  } else if style == "underline" {
+    box(
+      stroke: (bottom: 1.1pt + accent),
+      inset: (bottom: 1.5pt),
+      text(weight: "bold", fill: accent)[#prefix #num]
+    )
+    text(weight: "bold", fill: accent)[. ]
+  } else if style == "ribbon" {
+    box(width: 3pt, height: 1.25em, fill: accent, radius: 1pt)
+    h(4pt)
+    text(weight: "bold", fill: accent)[#prefix #num.]
+    h(3pt)
+  } else if style == "flag" {
+    box(
+      fill: accent,
+      inset: (left: 7pt, right: 10pt, y: 2pt),
+      radius: (left: 3pt),
+      text(weight: "bold", fill: white)[#prefix #num]
+    )
+    text(weight: "bold", fill: accent)[. ]
+  } else if style == "spark" {
+    box(
+      stroke: 0.8pt + accent,
+      fill: accent.lighten(88%),
+      inset: (x: 6pt, y: 2pt),
+      radius: 3pt,
+      text(weight: "bold", fill: accent)[#prefix #num]
+    )
+    text(weight: "bold", fill: accent)[. ]
+  } else {
+    text(weight: "bold", fill: accent)[#prefix #num. ]
+  }
+}
+
+#let _option-label(label, col, style: "plain") = {
+  let content = text(size: 0.86em, weight: "bold", fill: col)[#label]
+  let white-content = text(size: 0.86em, weight: "bold", fill: white)[#label]
+  let poly-label(vertices, fill: col.lighten(88%), stroke: 0.75pt + col, label-body: content, angle: 0deg) = box(width: 1.45em, height: 1.45em)[
+    #place(center + horizon)[
+      #rotate(angle)[
+        #polygon.regular(
+          vertices: vertices,
+          size: 1.35em,
+          fill: fill,
+          stroke: stroke,
+        )
+      ]
+    ]
+    #place(center + horizon)[#label-body]
+  ]
+  if style == "circled" or style == "circle" {
+    box(stroke: 0.75pt + col, radius: 50%, width: 1.35em, height: 1.35em, align(center + horizon)[#content])
+  } else if style == "double-circle" {
+    box(stroke: 1.25pt + col, radius: 50%, inset: 1.1pt)[
+      #box(stroke: 0.45pt + col.lighten(35%), radius: 50%, width: 1.2em, height: 1.2em, align(center + horizon)[#content])
+    ]
+  } else if style == "solid-circle" {
+    box(fill: col, radius: 50%, width: 1.35em, height: 1.35em, align(center + horizon)[#text(size: 0.86em, weight: "bold", fill: white)[#label]])
+  } else if style == "square" {
+    box(stroke: 0.75pt + col, width: 1.28em, height: 1.28em, align(center + horizon)[#content])
+  } else if style == "solid-square" {
+    box(fill: col, width: 1.28em, height: 1.28em, align(center + horizon)[#white-content])
+  } else if style == "rounded-square" {
+    box(stroke: 0.75pt + col, fill: col.lighten(90%), radius: 3pt, width: 1.35em, height: 1.35em, align(center + horizon)[#content])
+  } else if style == "diamond" {
+    poly-label(4, angle: 45deg)
+  } else if style == "solid-diamond" {
+    poly-label(4, fill: col, stroke: 0.75pt + col, label-body: white-content, angle: 45deg)
+  } else if style == "triangle" {
+    poly-label(3)
+  } else if style == "solid-triangle" {
+    poly-label(3, fill: col, stroke: 0.75pt + col, label-body: white-content)
+  } else if style == "pentagon" {
+    poly-label(5)
+  } else if style == "solid-pentagon" {
+    poly-label(5, fill: col, stroke: 0.75pt + col, label-body: white-content)
+  } else if style == "hexagon" {
+    poly-label(6)
+  } else if style == "solid-hexagon" {
+    poly-label(6, fill: col, stroke: 0.75pt + col, label-body: white-content)
+  } else if style == "badge" {
+    box(fill: col.lighten(85%), stroke: 0.55pt + col, inset: (x: 5pt, y: 1.2pt), radius: 3pt)[#content]
+  } else {
+    text(weight: "bold", fill: col)[#label.]
+  }
+}
+
+#let _draft-box(lines: 5, title: [Nháp], accent: palette.accent) = block(
+  width: 100%,
+  fill: luma(252),
+  stroke: (paint: accent.lighten(45%), thickness: 0.7pt, dash: "dotted"),
+  inset: (x: 7pt, y: 6pt),
+  radius: 4pt,
+)[
+  #text(size: 8.5pt, weight: "bold", fill: accent)[#title]
+  #v(0.35em)
+  #for _ in range(lines) {
+    line(length: 100%, stroke: 0.35pt + luma(210))
+    v(0.72em)
+  }
+]
+
+#let _maybe-draft(body, draft: false, draft-width: 30%, draft-lines: 5, draft-title: [Nháp], accent: palette.accent) = {
+  if draft {
+    grid(
+      columns: (1fr, draft-width),
+      column-gutter: 10pt,
+      align: (left + top, left + top),
+      body,
+      _draft-box(lines: draft-lines, title: draft-title, accent: accent),
+    )
+  } else {
+    body
+  }
+}
+
+// ─────────────────────────────────────────────────────────
+// MCQ
+// Auto-col: đo text width vs 0.25L / 0.50L (chuẩn ex_test)
+// fig: / fig-pos: "right"|"left"|"center" / fig-width: / cols: 0|1|2|4
+// opt-fig: true  → 4 options là hình vẽ (cetz canvas…), bỏ qua measure()
+// opt-fig-cols:  → số cột khi options là hình (mặc định 2)
+// ─────────────────────────────────────────────────────────
+#let mcq(
+  stem,
+  options,
+  correct: (),
+  loigiai: none,
+  mode: "dethi",
+  accent: palette.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 35%,
+  cols: 0,
+  row-gutter: auto,
+  opt-fig: false,
+  opt-fig-cols: 2,
+  opt-style: "plain",
+  opt-label-color: auto,
+  lines: 0,
+  num: auto,
+  prefix: "Câu",
+  q-label-style: "plain",
+  tags: (),
+  show-tags: true,
+  draft: false,
+  draft-width: 30%,
+  draft-lines: 5,
+  draft-title: [Nháp],
+  boxed: false,
+  box-fill: white,
+  box-stroke: 0.6pt + palette.border,
+  box-inset: (x: 10pt, y: 8pt),
+  box-radius: 4pt,
+  ..args,
+) = context {
+  let loigiai = _resolve-loigiai(loigiai, args)
+  let q-state = _next-question-num(num: num)
+  let num = q-state.num
+  let labels = ("A", "B", "C", "D", "E", "F")
+
+  let render-label(i, col) = {
+    let label-col = if opt-label-color == auto { col } else { opt-label-color }
+    _option-label(labels.at(i), label-col, style: opt-style)
+  }
+
+  // Tìm đáp án đúng & lưu state
+  let ai = -1
+  let idx = 0
+  for opt in options {
+    let ok = if type(opt) == dictionary { opt.at("correct", default: false) } else { correct.contains(idx + 1) }
+    if ok { ai = idx }
+    idx += 1
+  }
+  // Mảng text và correct cho từng option
+  let opt-texts = options.map(o => if type(o) == dictionary { o.body } else { o })
+  let opt-oks = options
+    .enumerate()
+    .map(((i, o)) => if type(o) == dictionary { o.at("correct", default: false) } else { correct.contains(i + 1) })
+
+  // ── Phát hiện options là hình ────────────────────────────
+  // cetz canvas dùng layout() bên trong → measure() sẽ crash.
+  // Kiểm tra repr: nếu bất kỳ option nào chứa "layout(" thì coi là hình.
+  // Người dùng cũng có thể đặt opt-fig: true để ép chế độ hình.
+  let _is-fig = opt-fig or opt-texts.any(t => repr(t).contains("layout("))
+
+  let em-sz = text.size
+  let label-width = 1.6 * em-sz
+  let label-gap = 0.3 * em-sz
+  let option-top-gap = 0.16em
+  let option-indent = if _is-fig { 0pt } else { 1.1 * em-sz }
+
+  // Đo inline width và height — BỎ QUA nếu options là hình
+  let mw = 0pt
+  let max-inline-h = 0pt
+  let has-frac = false
+  if not _is-fig {
+    for t in opt-texts {
+      let sz = measure(box[#t])
+      if sz.width > mw { mw = sz.width }
+      if sz.height > max-inline-h { max-inline-h = sz.height }
+      let rt = repr(t)
+      if (
+        rt.contains("frac(")
+          or rt.contains("binom(")
+          or rt.contains("integral(")
+          or rt.contains("sum(")
+          or rt.contains("limits(")
+          or rt.contains("mat(")
+          or rt.contains("cases(")
+          or rt.contains("vec(")
+      ) {
+        has-frac = true
+      }
+    }
+  }
+  let has-tall-math = max-inline-h > 1.45 * em-sz or has-frac
+  let option-leading = if has-tall-math { 1.8em } else { 0.95em }
+
+  // ── Render options ──────────────────────────────────────
+  let opts-r = if _is-fig {
+    // Chế độ hình: thẻ card 2×2, label ở góc trên-trái, hình căn giữa
+    let is_arr = type(cols) == array
+    let nc = if is_arr { cols.len() } else if cols != 0 { cols } else { opt-fig-cols }
+    let grid-cols = if is_arr { cols } else { nc }
+    grid(
+      columns: grid-cols,
+      row-gutter: 8pt,
+      column-gutter: 8pt,
+      align: left + top,
+      ..opt-texts
+        .enumerate()
+        .map(((i, t)) => {
+          let hi = (mode == "loigiai" or mode == "solcolor") and opt-oks.at(i)
+          let col = if hi { rgb("#cc2200") } else { black }
+          let card-stroke = if hi {
+            (paint: col, thickness: 2pt)
+          } else {
+            0.7pt + luma(180)
+          }
+          block(
+            width: 100%,
+            stroke: card-stroke,
+            radius: 5pt,
+            inset: (x: 8pt, top: 6pt, bottom: 8pt),
+            fill: if hi { rgb("#fff5f5") } else { white },
+          )[
+            #render-label(i, col)
+            #v(0.3em)
+            #align(center)[#t]
+          ]
+        })
+    )
+  } else {
+    // Chế độ văn bản / toán — logic cũ
+    layout(sz => {
+      let lw = sz.width
+      let nc = if cols != 0 {
+        cols
+      } else {
+        let chosen = 1
+        for candidate in (4, 2) {
+          if chosen == 1 {
+            let gutter = if candidate == 4 { 11pt } else { 13pt }
+            let cell-width = (lw - gutter * (candidate - 1)) / candidate
+            let text-width = cell-width - label-width - label-gap
+            if text-width > 0pt and mw <= text-width * 0.95 {
+              chosen = candidate
+            }
+          }
+        }
+        chosen
+      }
+      let column-gutter = if nc == 1 { 0pt } else if nc == 4 { 11pt } else { 13pt }
+      let calc-row-gutter = if row-gutter != auto { row-gutter } else if nc == 4 { 0.45em } else {
+        option-leading
+      }
+      grid(
+        columns: if type(cols) == array { cols } else { (1fr,) * nc },
+        row-gutter: calc-row-gutter,
+        column-gutter: column-gutter,
+        align: left + top,
+        ..opt-texts
+          .enumerate()
+          .map(((i, t)) => {
+            let hi = (mode == "loigiai" or mode == "solcolor") and opt-oks.at(i)
+            let col = if hi { rgb("#cc2200") } else { black }
+            // Hanging indent giữ nhãn A/B/C/D cùng baseline với phương án,
+            // kể cả khi phương án bắt đầu bằng số mũ hoặc phân số cao.
+            par(
+              justify: false,
+              leading: option-leading,
+              hanging-indent: label-width + label-gap,
+            )[
+              #box(width: label-width)[#render-label(i, col)]#h(label-gap)#text(
+                fill: col,
+                weight: if hi { "bold" } else { "regular" },
+              )[#t]
+            ]
+          })
+      )
+    })
+  }
+
+  // ── Sinh Tags (Nếu có) ─────────────────────────────────
+  let _render-tags = if show-tags and tags.len() > 0 {
+    (
+      h(1fr)
+        + box[
+          #for t in tags {
+            box(fill: luma(240), inset: (x: 4pt, y: 3pt), radius: 2pt, text(
+              size: 0.7em,
+              fill: luma(80),
+              weight: "bold",
+              t,
+            ))
+            h(2pt)
+          }]
+    )
+  } else { none }
+
+  // Stem row: [Câu N.] [stem] [fig?]
+  let q-label = _q-label(prefix, num, accent, style: q-label-style)
+  let _stem-w-tags = [#stem #_render-tags]
+  let stem-row = if fig != none and (fig-pos == "right" or fig-pos == "left") {
+    if fig-pos == "right" {
+      grid(
+        columns: (1fr, fig-width),
+        column-gutter: 14pt,
+        align: (left + top, center + top),
+        [#q-label #_stem-w-tags], fig,
+      )
+    } else {
+      grid(
+        columns: (fig-width, 1fr),
+        column-gutter: 14pt,
+        align: (center + top, left + top),
+        fig, [#q-label #_stem-w-tags],
+      )
+    }
+  } else if fig != none and fig-pos == "center" {
+    [#q-label #_stem-w-tags]
+    v(0.4em)
+    _fig-scaled-center(fig, fig-width)
+  } else {
+    [#q-label #_stem-w-tags]
+  }
+
+  [
+    #q-state.markers
+    #_mcq-meta.update(m => (
+      m
+        + (
+          (
+            num: num,
+            id: args.named().at("id", default: none),
+            tags: tags,
+            ans: if ai >= 0 { labels.at(ai) } else { "?" },
+          ),
+        )
+    ))
+    #_question-frame(
+      [
+        #_maybe-draft(
+          [
+            #stem-row
+            #v(option-top-gap)
+            #pad(left: option-indent)[#opts-r]
+            #if lines > 0 { draw-lines(lines) }
+            #if mode == "loigiai" and loigiai != none {
+              v(0.7em)
+              _sol(loigiai, accent)
+            }
+          ],
+          draft: draft,
+          draft-width: draft-width,
+          draft-lines: draft-lines,
+          draft-title: draft-title,
+          accent: accent,
+        )
+      ],
+      below: 1.05em,
+      boxed: boxed,
+      fill: box-fill,
+      stroke: box-stroke,
+      inset: box-inset,
+      radius: box-radius,
+    )
+  ]
+}
+
+// ─────────────────────────────────────────────────────────
+// TF — True([...]) = đúng, [...] = sai
+// Bảng: Phát biểu | □Đ | □S
+// ─────────────────────────────────────────────────────────
+#let tf(
+  stem,
+  statements,
+  loigiai: none,
+  mode: "dethi",
+  accent: palette.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 30%,
+  ds-style: "table",
+  use-table: auto,
+  lines: 0,
+  num: auto,
+  prefix: "Câu",
+  q-label-style: "plain",
+  tags: (),
+  show-tags: true,
+  draft: false,
+  draft-width: 30%,
+  draft-lines: 5,
+  draft-title: [Nháp],
+  boxed: false,
+  box-fill: white,
+  box-stroke: 0.6pt + palette.border,
+  box-inset: (x: 10pt, y: 8pt),
+  box-radius: 4pt,
+  ..args,
+) = context {
+  let loigiai = _resolve-loigiai(loigiai, args)
+  let q-state = _next-question-num(num: num)
+  let num = q-state.num
+  let vis-ans = mode != "dethi"
+  let alpha = ("a", "b", "c", "d", "e", "f")
+  let legacy-table = args.named().at("table", default: auto)
+  let style = if use-table == false or legacy-table == false {
+    if ds-style == "table" { "list" } else { ds-style }
+  } else if use-table == true or legacy-table == true {
+    "table"
+  } else {
+    ds-style
+  }
+  let valid-styles = (
+    "table",
+    "list",
+    "pill",
+    "modern",
+    "minimal",
+    "bookmark",
+    "folder",
+    "diamond",
+    "gradient",
+    "checklist",
+  )
+  assert(
+    valid-styles.contains(style),
+    message: "ds-style không hợp lệ. Dùng: " + valid-styles.join(", "),
+  )
+
+  // Lưu state TF: mảng Đ/S cho từng phát biểu
+  let tf-row = statements.map(s => if type(s) == dictionary and s.at("correct", default: false) { "Đ" } else { "S" })
+
+  // Xây dựng các hàng của bảng Đ/S chuẩn.
+  let table-rows = statements
+    .enumerate()
+    .map(((i, s)) => {
+      let ok = if type(s) == dictionary { s.at("correct", default: false) } else { false }
+      let txt = if type(s) == dictionary { s.body } else { s }
+      let md = if vis-ans and ok { text(fill: palette.correct, weight: "bold")[✓] } else { none }
+      let ms = if vis-ans and not ok { text(fill: palette.wrong, weight: "bold")[✓] } else { none }
+      let fd = if vis-ans and ok { palette.correct.lighten(80%) } else { white }
+      let fs = if vis-ans and not ok { palette.wrong.lighten(85%) } else { white }
+      (
+        pad(x: 6pt, y: 4pt)[#text(weight: "bold")[#alpha.at(i))] #h(3pt) #txt],
+        align(center + horizon)[
+          #box(width: 1.8em, height: 1.8em, stroke: 0.6pt + palette.border, fill: fd, align(center + horizon)[#md])
+        ],
+        align(center + horizon)[
+          #box(width: 1.8em, height: 1.8em, stroke: 0.6pt + palette.border, fill: fs, align(center + horizon)[#ms])
+        ],
+      )
+    })
+    .flatten()
+
+  let tbl = table(
+    columns: (1fr, auto, auto),
+    stroke: 0.5pt + palette.border,
+    align: (left + horizon, center + horizon, center + horizon),
+    table.cell(fill: accent, align: center + horizon, pad(left: 6pt, y: 5pt)[#text(
+      fill: white,
+      weight: "bold",
+    )[Phát biểu]]),
+    table.cell(fill: accent, align: center + horizon, pad(x: 8pt, y: 5pt)[#text(fill: white, weight: "bold")[Đ]]),
+    table.cell(fill: accent, align: center + horizon, pad(x: 8pt, y: 5pt)[#text(fill: white, weight: "bold")[S]]),
+    ..table-rows,
+  )
+
+  // Các kiểu danh sách gọn. Ở mode "dethi" không để lộ đáp án;
+  // ở mode "loigiai"/"solcolor" mới hiện dấu và màu Đúng/Sai.
+  let list-rows = statements
+    .enumerate()
+    .map(((i, s)) => {
+      let ok = if type(s) == dictionary { s.at("correct", default: false) } else { false }
+      let txt = if type(s) == dictionary { s.body } else { s }
+      let answer-color = if ok { palette.correct } else { palette.wrong }
+      let answer-text = if ok { [✓ ĐÚNG] } else { [✗ SAI] }
+      let marker = if vis-ans {
+        text(fill: answer-color, weight: "bold", size: 0.82em)[#answer-text]
+      } else {
+        none
+      }
+      let label = alpha.at(i)
+      let row-fill = if vis-ans {
+        if ok { palette.correct.lighten(94%) } else { palette.wrong.lighten(95%) }
+      } else {
+        white
+      }
+      let row-border = if vis-ans { answer-color.lighten(45%) } else { palette.border }
+
+      if style == "list" {
+        grid(
+          columns: (auto, 1fr, auto),
+          column-gutter: 6pt,
+          align: (left + top, left + top, right + top),
+          text(weight: "bold", fill: accent)[#label)],
+          txt,
+          marker,
+        )
+      } else if style == "pill" {
+        block(
+          width: 100%,
+          fill: row-fill,
+          stroke: 0.7pt + row-border,
+          radius: 999pt,
+          inset: (x: 11pt, y: 6pt),
+        )[
+          #grid(
+            columns: (auto, 1fr, auto),
+            column-gutter: 8pt,
+            align: (center + horizon, left + horizon, right + horizon),
+            box(
+              width: 1.65em,
+              height: 1.65em,
+              fill: accent,
+              radius: 999pt,
+              align(center + horizon)[#text(fill: white, weight: "bold")[#label]],
+            ),
+            txt,
+            marker,
+          )
+        ]
+      } else if style == "modern" {
+        block(
+          width: 100%,
+          fill: row-fill,
+          stroke: (left: 3pt + accent, rest: 0.5pt + row-border),
+          radius: (right: 5pt),
+          inset: (x: 10pt, y: 7pt),
+        )[
+          #grid(
+            columns: (auto, 1fr, auto),
+            column-gutter: 8pt,
+            align: (left + top, left + top, right + top),
+            text(weight: "bold", fill: accent)[#label.],
+            txt,
+            marker,
+          )
+        ]
+      } else if style == "minimal" {
+        block(
+          width: 100%,
+          stroke: (bottom: 0.5pt + row-border),
+          inset: (x: 2pt, y: 6pt),
+        )[
+          #grid(
+            columns: (auto, 1fr, auto),
+            column-gutter: 7pt,
+            align: (left + top, left + top, right + top),
+            text(weight: "bold", fill: accent)[#label)],
+            txt,
+            marker,
+          )
+        ]
+      } else if style == "bookmark" {
+        block(
+          width: 100%,
+          fill: row-fill,
+          stroke: 0.6pt + row-border,
+          radius: 4pt,
+          inset: (left: 0pt, right: 9pt, y: 0pt),
+        )[
+          #grid(
+            columns: (auto, 1fr, auto),
+            column-gutter: 9pt,
+            align: (center + horizon, left + horizon, right + horizon),
+            box(
+              fill: accent,
+              inset: (x: 9pt, y: 8pt),
+              radius: (left: 4pt),
+            )[#text(fill: white, weight: "bold")[#label]],
+            txt,
+            marker,
+          )
+        ]
+      } else if style == "folder" {
+        block(width: 100%)[
+          #box(
+            fill: accent,
+            radius: (top: 5pt),
+            inset: (x: 10pt, y: 3pt),
+          )[#text(fill: white, weight: "bold", size: 0.85em)[Ý #label]]
+          #block(
+            width: 100%,
+            fill: row-fill,
+            stroke: 0.7pt + row-border,
+            radius: (top-right: 5pt, bottom: 5pt),
+            inset: (x: 10pt, y: 7pt),
+          )[
+            #grid(
+              columns: (1fr, auto),
+              column-gutter: 8pt,
+              align: (left + top, right + top),
+              txt,
+              marker,
+            )
+          ]
+        ]
+      } else if style == "diamond" {
+        block(
+          width: 100%,
+          fill: row-fill,
+          stroke: 0.6pt + row-border,
+          radius: 4pt,
+          inset: (x: 9pt, y: 7pt),
+        )[
+          #grid(
+            columns: (auto, 1fr, auto),
+            column-gutter: 8pt,
+            align: (center + horizon, left + horizon, right + horizon),
+            text(fill: accent, weight: "bold", size: 1.25em)[◆],
+            [#text(weight: "bold", fill: accent)[#label)] #txt],
+            marker,
+          )
+        ]
+      } else if style == "gradient" {
+        let grad = gradient.linear(
+          if vis-ans { answer-color.lighten(88%) } else { accent.lighten(88%) },
+          white,
+          angle: 0deg,
+        )
+        block(
+          width: 100%,
+          fill: grad,
+          radius: 7pt,
+          inset: (x: 9pt, y: 7pt),
+        )[
+          #grid(
+            columns: (auto, 1fr, auto),
+            column-gutter: 8pt,
+            align: (center + horizon, left + horizon, right + horizon),
+            box(
+              width: 1.6em,
+              height: 1.6em,
+              fill: gradient.linear(accent, accent.lighten(35%), angle: 0deg),
+              radius: 999pt,
+              align(center + horizon)[#text(fill: white, weight: "bold")[#label]],
+            ),
+            txt,
+            marker,
+          )
+        ]
+      } else {
+        // checklist
+        let mark-icon = if vis-ans {
+          text(fill: white, weight: "bold", size: 0.8em)[#if ok { [✓] } else { [✗] }]
+        } else {
+          none
+        }
+        let check-box = box(
+          width: 1.3em,
+          height: 1.3em,
+          fill: if vis-ans { answer-color } else { white },
+          stroke: if vis-ans { none } else { 0.8pt + palette.border },
+          radius: 3pt,
+          align(center + horizon)[#mark-icon],
+        )
+        block(
+          width: 100%,
+          stroke: (bottom: 0.5pt + luma(225)),
+          inset: (x: 3pt, y: 6pt),
+        )[
+          #grid(
+            columns: (auto, auto, 1fr),
+            column-gutter: 8pt,
+            align: (center + horizon, left + horizon, left + horizon),
+            check-box,
+            text(weight: "bold", fill: accent)[#label)],
+            txt,
+          )
+        ]
+      }
+    })
+  let statement-render = if style == "table" {
+    tbl
+  } else {
+    stack(
+      dir: ttb,
+      spacing: if style == "folder" { 10pt } else { 7pt },
+      ..list-rows,
+    )
+  }
+
+  // ── Sinh Tags (Nếu có) ─────────────────────────────────
+  let _render-tags = if show-tags and tags.len() > 0 {
+    (
+      h(1fr)
+        + box[
+          #for t in tags {
+            box(fill: luma(240), inset: (x: 4pt, y: 3pt), radius: 2pt, text(
+              size: 0.7em,
+              fill: luma(80),
+              weight: "bold",
+              t,
+            ))
+            h(2pt)
+          }]
+    )
+  } else { none }
+
+  let q-label = _q-label(prefix, num, accent, style: q-label-style)
+  let _stem-w-tags = [#stem #_render-tags]
+  let stem-row = if fig != none and (fig-pos == "right" or fig-pos == "left") {
+    if fig-pos == "right" {
+      grid(
+        columns: (1fr, fig-width),
+        column-gutter: 14pt,
+        align: (left + top, center + top),
+        [#q-label #_stem-w-tags], fig,
+      )
+    } else {
+      grid(
+        columns: (fig-width, 1fr),
+        column-gutter: 14pt,
+        align: (center + top, left + top),
+        fig, [#q-label #_stem-w-tags],
+      )
+    }
+  } else if fig != none and fig-pos == "center" {
+    [#q-label #_stem-w-tags]
+    v(0.4em)
+    _fig-scaled-center(fig, fig-width)
+  } else {
+    [#q-label #_stem-w-tags]
+  }
+
+  [
+    #q-state.markers
+    #_tf-meta.update(m => m + ((num: num, id: args.named().at("id", default: none), tags: tags, ans: tf-row),))
+    #_question-frame(
+      [
+        #_maybe-draft(
+          [
+            #stem-row
+            #v(0.6em)
+            #pad(left: if style == "table" { 1.5em } else { 1em })[#statement-render]
+            #if lines > 0 { draw-lines(lines) }
+            #if mode == "loigiai" and loigiai != none {
+              v(0.7em)
+              _sol(loigiai, accent)
+            }
+          ],
+          draft: draft,
+          draft-width: draft-width,
+          draft-lines: draft-lines,
+          draft-title: draft-title,
+          accent: accent,
+        )
+      ],
+      below: 1.4em,
+      boxed: boxed,
+      fill: box-fill,
+      stroke: box-stroke,
+      inset: box-inset,
+      radius: box-radius,
+    )
+  ]
+}
+#let hoac(..args) = math.cases(delim: "[", ..args.named(), ..args.pos().map(math.display))
+#let heva(..args) = math.cases(delim: "{", ..args.named(), ..args.pos().map(math.display))
+// tfrac: phân số cỡ inline — dùng trong math mode: $tfrac(1, 2)$
+#let tfrac(a, b) = {
+  show math.frac: f => f
+  scale(x: 72%, y: 72%, origin: center + horizon, reflow: true, math.inline(math.frac(a, b)))
+}
+// ── Hệ thống STEP — tô màu từng bước lời giải ─────────────────
+// Dùng: #step[Bước...] #step[Bước...] #reset-step()
+#let _step-colors = (
+  rgb("#1565c0"),
+  rgb("#e65100"),
+  rgb("#2e7d32"),
+  rgb("#6a1b9a"),
+  rgb("#00838f"),
+  rgb("#c62828"),
+)
+#let _step-cnt = counter("se-step")
+#let _step-reveal-config = state("se-step-reveal-config", (before_nonfirst: none))
+#let configure-step-reveal(before_nonfirst: none) = [
+  #_step-reveal-config.update((before_nonfirst: before_nonfirst))
+]
+#let step(
+  body,
+  color: auto,
+  before_nonfirst: auto,
+  above: 0.55em,
+  below: 0.45em,
+) = {
+  _step-cnt.step()
+  context {
+    let n = _step-cnt.get().first()
+    let c = _step-colors.at(calc.rem(n - 1, _step-colors.len()))
+    let text-color = if color != auto { color } else { c.darken(10%) }
+    let border-color = if color != auto { color } else { c }
+    let reveal = if before_nonfirst != auto {
+      before_nonfirst
+    } else if n > 1 {
+      _step-reveal-config.get().at("before_nonfirst", default: none)
+    } else {
+      none
+    }
+    let step-block = block(
+      width: 100%,
+      stroke: (left: 1.5pt + border-color),
+      inset: (left: 8pt, right: 0pt, top: 1.5pt, bottom: 1.5pt),
+      below: below,
+      above: above,
+    )[
+      #text(fill: text-color, weight: "bold")[Bước #n.] #h(0.3em) #body
+    ]
+    if reveal == none {
+      step-block
+    } else {
+      [#reveal #step-block]
+    }
+  }
+}
+#let reset-step() = [#_step-cnt.update(0)]
+// ─────────────────────────────────────────────────────────
+// SHORT — 4 ô trống / hiện đáp án
+// ─────────────────────────────────────────────────────────
+#let short(
+  stem,
+  answer,
+  loigiai: none,
+  mode: "dethi",
+  accent: palette.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 30%,
+  show-boxes: true,
+  lines: 0,
+  num: auto,
+  prefix: "Câu",
+  q-label-style: "plain",
+  tags: (),
+  show-tags: true,
+  draft: false,
+  draft-width: 30%,
+  draft-lines: 5,
+  draft-title: [Nháp],
+  box-count: 4,
+  boxed: false,
+  box-fill: white,
+  box-stroke: 0.6pt + palette.border,
+  box-inset: (x: 10pt, y: 8pt),
+  box-radius: 4pt,
+  ..args,
+) = context {
+  let loigiai = _resolve-loigiai(loigiai, args)
+  let q-state = _next-question-num(num: num)
+  let num = q-state.num
+
+  let widget = if mode == "dethi" {
+    stack(dir: ltr, spacing: 3pt, ..range(box-count).map(_ => box(width: 1.9em, height: 1.9em, stroke: 0.7pt + black)))
+  } else {
+    box(fill: palette.correct.lighten(85%), stroke: 1pt + palette.correct, inset: (x: 10pt, y: 3pt), radius: 3pt)[
+      #text(weight: "bold", fill: palette.correct, size: 1.05em)[#answer]
+    ]
+  }
+
+  // ── Sinh Tags (Nếu có) ─────────────────────────────────
+  let _render-tags = if show-tags and tags.len() > 0 {
+    (
+      h(1fr)
+        + box[
+          #for t in tags {
+            box(fill: luma(240), inset: (x: 4pt, y: 3pt), radius: 2pt, text(
+              size: 0.7em,
+              fill: luma(80),
+              weight: "bold",
+              t,
+            ))
+            h(2pt)
+          }]
+    )
+  } else { none }
+
+  let q-label = _q-label(prefix, num, accent, style: q-label-style)
+  let _stem-w-tags = [#stem #_render-tags]
+  let stem-row = if fig != none and (fig-pos == "right" or fig-pos == "left") {
+    if fig-pos == "right" {
+      grid(
+        columns: (1fr, fig-width),
+        column-gutter: 14pt,
+        align: (left + top, center + top),
+        [#q-label #_stem-w-tags], fig,
+      )
+    } else {
+      grid(
+        columns: (fig-width, 1fr),
+        column-gutter: 14pt,
+        align: (center + top, left + top),
+        fig, [#q-label #_stem-w-tags],
+      )
+    }
+  } else if fig != none and fig-pos == "center" {
+    [#q-label #_stem-w-tags]
+    v(0.4em)
+    _fig-scaled-center(fig, fig-width)
+  } else {
+    [#q-label #_stem-w-tags]
+  }
+
+  [
+    #q-state.markers
+    #_sh-meta.update(m => m + ((num: num, id: args.named().at("id", default: none), tags: tags, ans: answer),))
+    #_question-frame(
+      [
+        #_maybe-draft(
+          [
+            #stem-row
+            #if show-boxes {
+              v(0.6em)
+              pad(left: 1.5em)[
+                #stack(dir: ltr, spacing: 6pt, text(weight: "bold")[Đáp số:], widget)
+              ]
+            }
+            #if lines > 0 { draw-lines(lines) }
+            #if mode == "loigiai" and loigiai != none {
+              v(0.7em)
+              _sol(loigiai, accent)
+            }
+          ],
+          draft: draft,
+          draft-width: draft-width,
+          draft-lines: draft-lines,
+          draft-title: draft-title,
+          accent: accent,
+        )
+      ],
+      below: 1.4em,
+      boxed: boxed,
+      fill: box-fill,
+      stroke: box-stroke,
+      inset: box-inset,
+      radius: box-radius,
+    )
+  ]
+}
+
+#let tl(
+  stem,
+  loigiai: none,
+  mode: "dethi",
+  accent: palette.accent,
+  fig: none,
+  fig-pos: "right",
+  fig-width: 30%,
+  lines: 6,
+  num: auto,
+  prefix: "Câu",
+  q-label-style: "plain",
+  draft: false,
+  draft-width: 30%,
+  draft-lines: 6,
+  draft-title: [Nháp],
+  boxed: false,
+  box-fill: white,
+  box-stroke: 0.6pt + palette.border,
+  box-inset: (x: 10pt, y: 8pt),
+  box-radius: 4pt,
+  ..args,
+) = context {
+  let loigiai = _resolve-loigiai(loigiai, args)
+  let q-state = _next-question-num(num: num)
+  let num = q-state.num
+
+  let q-label = _q-label(prefix, num, accent, style: q-label-style)
+  let stem-row = if fig != none and (fig-pos == "right" or fig-pos == "left") {
+    if fig-pos == "right" {
+      grid(
+        columns: (1fr, fig-width),
+        column-gutter: 14pt,
+        align: (left + top, center + top),
+        [#q-label #stem], fig,
+      )
+    } else {
+      grid(
+        columns: (fig-width, 1fr),
+        column-gutter: 14pt,
+        align: (center + top, left + top),
+        fig, [#q-label #stem],
+      )
+    }
+  } else if fig != none and fig-pos == "center" {
+    [#q-label #stem]
+    v(0.4em)
+    _fig-scaled-center(fig, fig-width)
+  } else {
+    [#q-label #stem]
+  }
+
+  [
+    #q-state.markers
+    #_tl-meta.update(m => m + ((num: num, id: args.named().at("id", default: none)),))
+    #_question-frame(
+      [
+        #_maybe-draft(
+          [
+            #stem-row
+            #if lines > 0 { draw-lines(lines) }
+            #if mode == "loigiai" and loigiai != none {
+              v(0.7em)
+              _sol(loigiai, accent)
+            }
+          ],
+          draft: draft,
+          draft-width: draft-width,
+          draft-lines: draft-lines,
+          draft-title: draft-title,
+          accent: accent,
+        )
+      ],
+      below: 1.4em,
+      boxed: boxed,
+      fill: box-fill,
+      stroke: box-stroke,
+      inset: box-inset,
+      radius: box-radius,
+    )
+  ]
+}
+
+#let tn = mcq
+#let ds = tf
+#let tln = short
+
+// ── exam-mode ─────────────────────────────────────────────
+#let exam-mode(
+  mode: "dethi",
+  accent: palette.accent,
+  opt-style: "plain",
+  opt-label-color: auto,
+  q-label-style: "plain",
+  show-tags: true,
+  draft: false,
+  draft-width: 30%,
+  draft-lines: 5,
+  boxed: false,
+  box-fill: white,
+  box-stroke: 0.6pt + palette.border,
+  ..args
+) = {
+  let params = (
+    mode: mode,
+    accent: accent,
+    opt-style: opt-style,
+    opt-label-color: opt-label-color,
+    q-label-style: q-label-style,
+    show-tags: show-tags,
+    draft: draft,
+    draft-width: draft-width,
+    draft-lines: draft-lines,
+    boxed: boxed,
+    box-fill: box-fill,
+    box-stroke: box-stroke,
+    ..args.named()
+  )
+  
+  (
+    tn: tn.with(..params),
+    ds: ds.with(..params),
+    tln: tln.with(..params),
+    tl: tl.with(..params),
+    mcq: mcq.with(..params),
+    tf: tf.with(..params),
+    short: short.with(..params),
+  )
+}
+
+// ── het (HẾT ĐỀ) ───────────────────────────────────────────
+#let het = align(center)[
+  #v(2.5em)
+  #text(weight: "bold")[----------- HẾT -----------] <end-exam>
+  #v(0.4em)
+  #text(style: "italic", size: 11pt)[
+    Thí sinh không được sử dụng tài liệu. \
+    Giám thị không giải thích gì thêm.
+  ]
+  #v(1.5em)
+]
+
+// ── exam-part ─────────────────────────────────────────────
+// Mặc định `reset-counter: false` để số câu chạy liên tục toàn đề.
+// Nếu muốn một phần bắt đầu lại từ Câu 1, dùng `reset-counter: true`.
+#let exam-part(title, count: auto, reset-counter: false) = {
+  // In beamer mode: skip print-only section headers
+  if sys.inputs.at("beamer", default: "0") == "1" { return }
+  [
+    #if reset-counter {
+      [#metadata((kind: "question", current: 0)) <se-q-reset>]
+    }
+    #_part-cnt.step()
+    #metadata("part") <ep-marker>
+    #v(0.9em)
+    #block(
+      width: 100%,
+      fill: rgb("#e8f0fc"),
+      stroke: (left: 4pt + palette.accent),
+      inset: (left: 10pt, right: 8pt, top: 7pt, bottom: 7pt),
+      radius: (right: 4pt),
+    )[
+      #text(weight: "bold")[#title]
+      #context {
+        let c = count
+        if c == auto {
+          let markers = query(<ep-marker>)
+          let ends = query(<end-exam>)
+          let p-idx = query(selector(<ep-marker>).before(here())).len()
+          let current-marker = markers.at(p-idx - 1)
+
+          if p-idx < markers.len() {
+            c = query(selector(_q-marker).after(current-marker.location()).before(markers.at(p-idx).location())).len()
+          } else if ends.len() > 0 {
+            c = query(selector(_q-marker).after(current-marker.location()).before(ends.last().location())).len()
+          } else {
+            c = query(selector(_q-marker).after(current-marker.location())).len()
+          }
+        }
+        let title-str = repr(title)
+        let has-cau = title-str.contains("câu") or title-str.contains("câ u")
+        if c > 0 and not has-cau {
+          h(1fr)
+          text(style: "italic", fill: palette.muted)[(#c câu)]
+        }
+      }
+    ]
+    #v(0.5em)
+  ]
+}
+
+// ─────────────────────────────────────────────────────────
+// HEADER — Tiêu đề đề thi (v7 — nhiều tuỳ chọn)
+// ─────────────────────────────────────────────────────────
+#let thpt-school-exam(
+  body,
+  department: "BỘ GIÁO DỤC VÀ ĐÀO TẠO",
+  school: "SỞ GIÁO DỤC VÀ ĐÀO TẠO",
+  exam-title: "THI THỬ THPT QUỐC GIA 2026",
+  subject: "TOÁN - LỚP 12",
+  duration: "90 phút",
+  structure: auto, // auto = tự đếm từ exam-part
+  code: "101",
+  footer-left: none,
+  accent: palette.accent,
+  // ── Tuỳ chọn nâng cao ──
+  show-topbar: false, // thanh màu accent trên đỉnh trang
+  header-border: true, // đường kẻ dưới tiêu đề
+  header-font: "Times New Roman",
+  body-font: "Times New Roman",
+  body-size: 12pt,
+  // ── Font viết tay (tuỳ chọn) ──
+  // Truyền tên font để dùng #hw[...] trong nội dung
+  // Ví dụ: handwriting-font: "HP001 4 hàng"
+  //         handwriting-font: "Bradley Hand"
+  handwriting-font: none,
+  handwriting-size: 1em, // cỡ chữ tương đối so với body-size
+  q-style: "bold", // "bold" | "boxed" | "pill"
+  q-color: auto, // auto = accent
+  watermark: none, // Chữ in chìm phía sau bộ đề
+  watermark-opacity: 0.1,
+  watermark-angle: -30deg,
+  beamer: sys.inputs.at("beamer", default: "0") == "1", // auto-detect via --input beamer=1
+) = {
+  // In beamer mode: skip all page/header setup, just return body
+  if beamer { return body }
+
+  let _q-color = if q-color == auto { accent } else { q-color }
+
+  set page(
+    paper: "a4",
+    margin: (top: 2cm, bottom: 2cm, x: 1.5cm),
+    background: if watermark != none {
+      rotate(watermark-angle, text(
+        size: 60pt,
+        fill: luma(100).transparentize(100% - watermark-opacity * 100%),
+        weight: "bold",
+      )[#watermark])
+    } else { none },
+    footer: context {
+      set text(size: 9pt, fill: palette.muted)
+      line(length: 100%, stroke: 0.4pt + palette.border)
+      v(1pt)
+      let locs = query(<end-exam>)
+      let total = if locs.len() > 0 { locs.last().location().page() } else { counter(page).final().first() }
+      grid(
+        columns: (1fr, auto),
+        align: (left, right),
+        if footer-left != none { footer-left } else { [#exam-title — #subject] },
+        [Trang #counter(page).display() / #total #if code != "" [— Mã Đề: #code]],
+      )
+    },
+  )
+  set text(font: body-font, size: body-size, lang: "vi")
+  set par(justify: true, leading: 0.75em)
+  show math.frac: math.display
+
+  // ── Kích hoạt font viết tay toàn cục ─────────────────────
+  // Hàm #hw[...] đã được export ở đầu sang-exam.typ
+  // Chỉ cần update state để hw() đọc đúng font
+  _hw-font.update(handwriting-font)
+  _hw-size.update(handwriting-size)
+
+  // Thanh màu accent trên đỉnh (tuỳ chọn)
+  if show-topbar {
+    place(top + left, dx: -1.5cm, dy: -2cm, rect(width: 21cm, height: 5pt, fill: accent))
+  }
+
+  // Tự đếm structure nếu = auto
+  let struct-content = if structure != auto { structure } else {
+    context {
+      let mc = _mcq-meta.final().len()
+      let tf = _tf-meta.final().len()
+      let sh = _sh-meta.final().len()
+      let essay = _tl-meta.final().len()
+      let parts = ()
+      if mc > 0 { parts.push([#mc câu trắc nghiệm]) }
+      if tf > 0 { parts.push([#tf đúng/sai]) }
+      if sh > 0 { parts.push([#sh trả lời ngắn]) }
+      if essay > 0 { parts.push([#essay câu tự luận]) }
+      parts.join([, ])
+    }
+  }
+
+  // Header 2 cột
+  v(0.3em)
+  grid(
+    columns: (1fr, 1fr),
+    column-gutter: 8pt,
+    align(center)[
+      #set text(font: header-font)
+      #text(weight: "bold", size: 12pt)[#department] \
+      #text(weight: "bold", size: 12pt, fill: accent)[#school] \
+      #v(-3pt) #line(length: 35%, stroke: 1pt + accent) #v(1pt)
+      #text(style: "italic", size: 10pt)[
+        (Đề thi có #context {
+          let locs = query(<end-exam>)
+          if locs.len() > 0 { locs.last().location().page() } else { counter(page).final().first() }
+        } trang)
+      ]
+    ],
+    align(center)[
+      #set text(font: header-font)
+      #text(weight: "bold", size: 13.5pt, fill: accent)[#upper(exam-title)] \
+      #text(weight: "bold", size: 12pt)[MÔN #upper(subject)] \
+      #text(style: "italic", size: 10.5pt)[Thời gian làm bài: #duration] \
+      #text(style: "italic", size: 10pt)[(Đề có #struct-content)]
+    ],
+  )
+
+  v(1.4em)
+  grid(
+    columns: (1fr, auto),
+    column-gutter: 14pt,
+    align: (left + bottom, center + bottom),
+    {
+      set text(size: 11.5pt)
+      grid(
+        columns: (auto, 1fr),
+        row-gutter: 9pt,
+        column-gutter: 3pt,
+        align: (left + bottom, left + bottom),
+        text(weight: "bold")[Họ và tên thí sinh:],
+        line(length: 100%, stroke: (paint: black, thickness: 0.6pt, dash: "dotted")),
+
+        text(weight: "bold")[Số Báo Danh:],
+        line(length: 100%, stroke: (paint: black, thickness: 0.6pt, dash: "dotted")),
+      )
+    },
+    if code != "" {
+      box(stroke: 0.8pt + black, inset: (x: 12pt, y: 7pt))[
+        #text(weight: "bold", size: 12pt)[Mã đề thi #code]
+      ]
+    },
+  )
+  v(0.9em)
+  if header-border { line(length: 100%, stroke: 0.8pt + black) }
+  v(1em)
+  body
+}
+
+
+// ─────────────────────────────────────────────────────────
+// PRINT-ANSWER-KEY — 3 bảng đáp án: MCQ / TF / Short
+// ─────────────────────────────────────────────────────────
+#let _chunk(arr, n) = {
+  let out = ()
+  let cur = ()
+  for x in arr {
+    cur.push(x)
+    if cur.len() == n {
+      out.push(cur)
+      cur = ()
+    }
+  }
+  if cur.len() > 0 { out.push(cur) }
+  out
+}
+
+#let print-answer-key() = context {
+  let mcq-ans = _mcq-meta.get()
+  let tf-ans = _tf-meta.get()
+  let sh-ans = _sh-meta.get()
+
+  v(1.5em)
+
+  // ── Bảng 1: Trắc nghiệm ──────────────────────────────
+  if mcq-ans.len() > 0 {
+    v(0.8em)
+    align(center)[
+      #text(weight: "bold", size: 12pt, fill: palette.accent)[BẢNG ĐÁP ÁN — TRẮC NGHIỆM]
+    ]
+    v(0.3em)
+    align(center, table(
+      columns: (1fr,) * 5,
+      stroke: 0.5pt + rgb("#cbd5e1"),
+      align: center + horizon,
+      inset: (x: 8pt, y: 6pt),
+      ..mcq-ans.map(it => [
+        #text(weight: "bold", fill: rgb("#475569"))[#it.num.]
+        #h(0.3em)
+        #text(weight: "bold", fill: palette.accent)[#it.ans]
+      ])
+    ))
+    v(1em)
+  }
+
+  // ── Bảng 2: Đúng/Sai ─────────────────────────────────
+  if tf-ans.len() > 0 {
+    v(0.8em)
+    align(center)[
+      #text(weight: "bold", size: 12pt, fill: palette.accent)[BẢNG ĐÁP ÁN — ĐÚNG/SAI]
+    ]
+    v(0.3em)
+    align(center, table(
+      columns: (1.5fr, 1fr, 1fr, 1fr, 1fr),
+      stroke: 0.5pt + rgb("#cbd5e1"),
+      align: center + horizon,
+      inset: (x: 8pt, y: 6pt),
+      table.cell(fill: rgb("#f1f5f9"), pad(y: 4pt)[#text(weight: "bold", fill: rgb("#334155"))[Câu]]),
+      ..(
+        ("a", "b", "c", "d").map(l => {
+          table.cell(fill: rgb("#f1f5f9"), pad(y: 4pt)[#text(weight: "bold", fill: rgb("#334155"))[#l)]])
+        })
+      ),
+      ..tf-ans
+        .map(item => {
+          let cells = (
+            table.cell(fill: rgb("#f8fafc"), pad(y: 4pt)[#text(weight: "bold", fill: rgb("#475569"))[Câu #item.num]]),
+          )
+          for vv in item.ans {
+            let col = if vv == "Đ" { palette.correct } else { palette.wrong }
+            cells = cells + (pad(y: 4pt)[#text(weight: "bold", fill: col)[#vv]],)
+          }
+          cells
+        })
+        .flatten(),
+    ))
+    v(1em)
+  }
+
+  // ── Bảng 3: Điền số ───────────────────────────────────
+  if sh-ans.len() > 0 {
+    v(0.8em)
+    align(center)[
+      #text(weight: "bold", size: 12pt, fill: palette.accent)[BẢNG ĐÁP ÁN — ĐIỀN SỐ]
+    ]
+    v(0.3em)
+    align(center, table(
+      columns: (1fr,) * 5,
+      stroke: 0.5pt + rgb("#cbd5e1"),
+      align: center + horizon,
+      inset: (x: 8pt, y: 6pt),
+      ..sh-ans.map(it => [
+        #text(weight: "bold", fill: rgb("#475569"))[#it.num.]
+        #h(0.3em)
+        #text(weight: "bold", fill: palette.accent)[#it.ans]
+      ])
+    ))
+  }
+}
+
+// ─────────────────────────────────────────────────────────
+// CÔNG CỤ TOÁN HỌC (MATH TOOLS)
+// ─────────────────────────────────────────────────────────
+// vect(AB) → dấu mũi tên chuẩn LaTeX \overrightarrow
+#let vect(..args) = {
+  let body = args.pos().map(a => if type(a) == str { math.upright(a) } else { a }).join()
+  math.accent(body, math.arrow.r)
+}

--- a/packages/preview/sang-math/1.0.5/typst.toml
+++ b/packages/preview/sang-math/1.0.5/typst.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sang-math"
+version = "1.0.5"
+entrypoint = "lib.typ"
+authors = ["Sang Nguyen <sangnhc87@gmail.com>"]
+compiler = "0.14.0"
+license = "MIT"
+description = "Bộ macro đề thi THPT chuẩn BGD 2025 (Toán, Lý, Hóa), sách chuyên đề, BBT và hình học CeTZ"
+keywords = ["math", "exam", "vietnam", "thpt", "bbt", "physics", "chemistry"]
+homepage = "https://hdsd-conictypst.pages.dev"
+repository = "https://github.com/sangnhc87/conictypst"


### PR DESCRIPTION
I am submitting
- [ ] a new package
- [x] an update for a package

Description: This patch release fixes parameter pass-through in `exam-mode`, standardizes Vietnamese math limit notation, adds multi-discipline science symbols, and expands documentation for Physics and Chemistry exam preparation.

### What changed

- Fixes `exam-mode` parameter forwarding by passing through `..args.named()` into question constructors (`tn`, `ds`, `mcq`), allowing advanced options like `opt-style: "circle"`, `prefix`, and `box-inset` to take effect as documented.
- Standardizes `lim` in `math-sym.typ` using `math.limits(math.lim, inline: true)` to match Vietnamese high-school mathematics typography.
- Adds convenient science symbols for multidisciplinary exam typesetting in `math-sym.typ`: `#doC` / `#celsius`, `#ohm`, `#pu-tn` (reversible reaction), and `#pu-nhiet` (thermal reaction arrow).
- Documents integration with `@preview/typsium:0.3.2` for high-school Chemistry exam writing.
- Adds structured AI prompting guidelines for generating 100% compliant `sang-math:1.0.5` exam sources.
- Updates package metadata and import examples to 1.0.5.

### Verification

- Successfully compiled the full test suite with `typst 0.14.2` (`tests/*.typ`, exam and book demos, all copy-ready examples).
- Verified package compile under `packages/preview/sang-math/1.0.5/lib.typ`.
- Maintained clean package tree (19 files, no generated PDFs, caches, or `.DS_Store`).