### PR TITLE
qualitree:0.1.0

### DIFF
--- a/packages/preview/qualitree/0.1.0/CONTEXT.md
+++ b/packages/preview/qualitree/0.1.0/CONTEXT.md
@@ -1,0 +1,9 @@
+# Public example context
+
+This repository demonstrates a reusable native Typst QFD library through a fictional coffee-at-home study. It contains no private source documents or imported private datasets. Numerical weights, relationships, targets, and revision decisions are illustrative workshop inputs.
+
+The intended substitution is coffee made at home instead of buying a coffee at the local café. Taste, serving temperature, and household safety are independent acceptance gates. Other needs cover a sequence of two or three drinks, easy setup and cleaning, preground coffee six months after roasting, and a small footprint.
+
+The provisional scope includes machine, sealed dose, and protective packaging. The first matrix maps needs to functions; the second maps those functions to components with unrounded inherited priorities. Technologies remain candidate implementations. The example does not establish a validated recipe, shelf life, safety outcome, or competitive ranking.
+
+See [the coffee study notes](examples/COFFEE.md) for the system boundary, validation questions, source attribution, and example map. See [the design brief](DESIGN.md) for the package responsibilities and behavior.

--- a/packages/preview/qualitree/0.1.0/CONTRIBUTING.md
+++ b/packages/preview/qualitree/0.1.0/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Maintaining Qualitree
+
+The library uses native Typst and has no runtime package dependencies. Python scripts use only the standard library. Keep semantic computation independent from rendering.
+
+## Module boundaries
+
+| Module | Responsibility |
+| --- | --- |
+| `lib.typ` | Explicit public exports |
+| `model.typ` | Matrix/series normalization and validation |
+| `calculations.typ` | Priority arithmetic and public roof coordinates |
+| `stages.typ` | Stable identities and propagation to the next stage |
+| `revisions.typ` | ID alignment, edit status and historical data |
+| `theme.typ`, `labels.typ` | Visual defaults and translatable text |
+| `figure-data.typ` | Resolve visibility and basement once per figure |
+| `layout.typ`, `text.typ` | Measure natural geometry and fit constrained content |
+| `profile-layout.typ` | Pure score-preserving displacement algorithm |
+| `symbols.typ`, `profile-symbols.typ` | Shared native vector primitives |
+| `roof.typ`, `matrix-panel.typ`, `comparison-panel.typ`, `legend.typ` | Render one region from shared data and geometry |
+| `draw.typ` | Public argument boundary and composition |
+
+Panel modules must not recompute priorities or infer identities. Revision history must never enter current-priority arithmetic. Measurements use the same decorated labels that are drawn. Lines and competitive markers use the same displaced points.
+
+## Comments
+
+Follow [Salvatore Sanfilippo's guidance](https://antirez.com/news/124): function comments specify contracts, module comments describe design, and local comments explain reasons or domain knowledge that would otherwise require reconstruction. Keep comments adjacent to the code they describe. Avoid redundant narration, commented-out implementations, and unexplained debt markers.
+
+A useful comment here explains why a removed relation has a visible historical symbol but zero current value. An unhelpful comment merely says that a loop visits rows.
+
+## Verify a change
+
+```sh
+python3 tools/test.py
+python3 tools/build_examples.py
+python3 tools/build_docs.py --check
+python3 tools/package.py
+```
+
+Use small numerical assertions for semantics; use rendered fixtures for layout. Add regression cases that would fail under the old behavior. For geometry changes, inspect the espresso, component, revision and overlapping-profile outputs. Check at natural size and when fitted into a report. Tests compile with the bundled fonts and ignore system fonts, exposing undocumented font dependencies.
+
+`docs/site/` contains source-controlled HTML/CSS/JS and rendered examples. `tools/build_docs.py` validates local links, anchors and image alternatives before copying it to `build/site/`. `tools/build_examples.py` refreshes the actual diagram assets. Edit the Typst example, not its SVG output.
+
+## Release
+
+1. Update the manifest version, documented imports and examples together.
+2. Run the checks above and inspect rendered output.
+3. Build `build/packages/preview/qualitree/VERSION/` using `tools/package.py`.
+4. Check the bundle contains the README, license, manifest, library and public examples. It deliberately omits build tools, fonts and documentation images.
+5. Push the repository. The Pages workflow validates and publishes the guide; it grants write access only to the deploy job.
+6. Submit the versioned directory to [typst/packages](https://github.com/typst/packages) with a PR. Keep the source repository and homepage in the manifest.
+7. Use `@preview` in the quickstart only after the package PR is merged and available.
+
+Published versions are immutable in normal circumstances. Ship a new version for fixes.

--- a/packages/preview/qualitree/0.1.0/CONTRIBUTING.md
+++ b/packages/preview/qualitree/0.1.0/CONTRIBUTING.md
@@ -51,3 +51,24 @@ Use small numerical assertions for semantics; use rendered fixtures for layout. 
 7. Use `@preview` in the quickstart only after the package PR is merged and available.
 
 Published versions are immutable in normal circumstances. Ship a new version for fixes.
+
+
+## Bilingual documentation and highlighting
+
+The English guide is `docs/site/index.html`; its French counterpart is
+`docs/site/fr/index.html`. Keep section IDs identical so language links preserve
+the reading position. Translate prose, alternative text, and interface messages;
+API parameter names stay unchanged. French diagrams in `examples/fr/` translate
+labels from the shared model, preserving its identities and numerical data.
+Detailed English-only references are explicitly labeled in the French guide.
+
+Mark Typst blocks with `<code class="language-typst">`. The documentation build
+uses the installed Typst compiler to highlight raw text, and writes static spans
+into `build/site/`. It never evaluates the snippet as Typst code. No browser
+highlighter or CDN script is needed. `tools/highlight.py` isolates the experimental
+HTML-export interface; CI pins Typst 0.15.1 and checks that highlighting preserves
+Unicode and escaped HTML exactly. Copy controls read the resulting text content.
+
+Run `python3 -m unittest discover -s tools/tests`, then the example and documentation
+builds. Requires Python 3.11+ and Typst 0.15.1+. Inspect the rendered French diagrams
+when changing their labels, since translations can alter header dimensions.

--- a/packages/preview/qualitree/0.1.0/LICENSE
+++ b/packages/preview/qualitree/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 QFD contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/qualitree/0.1.0/README.md
+++ b/packages/preview/qualitree/0.1.0/README.md
@@ -1,12 +1,12 @@
-<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
 
 # Qualitree
 
 Draw, connect, and compare Houses of Quality in native Typst. Map **needs → functions → components**, carry priorities between stages, and show design revisions with readable green/red/yellow backgrounds.
 
-[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/API.md)
+[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/API.md)
 
-![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/site/assets/hero.png)
+![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/hero.png)
 
 ## Start in five minutes
 
@@ -86,7 +86,11 @@ Stable IDs identify entities; labels are editable text. Relations remain one-bas
 
 Additions have pale green backgrounds, removals pale red, and changes pale yellow. Dark symbols and +/−/~ annotations supplement color. Reordering IDs creates no false edits. Removed relationships remain visible but contribute zero to current priorities. Diff views do not currently support competitive profiles or custom basements; compare source stages without those options.
 
-![Revision comparison](https://raw.githubusercontent.com/tychota/qfd-typst/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/site/assets/revisions.svg)
+The worked revision adds refrigerated milk storage and automatic steaming to the capsule-coffee baseline. Read existing and new needs row by row, then follow the revised functions into shared and added components. See the [change rationale](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/examples/COFFEE.md#deploying-a-new-capability-milk-drinks).
+
+![Milk drinks: needs to functions revision](https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/revisions.svg)
+
+![Milk drinks: functions to components revision](https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/revision-components.svg)
 
 ## Typography and layout
 
@@ -102,7 +106,7 @@ Correlation signs use bold vector +/− and circled strong signs. Choose `correl
 python3 tools/install_local.py
 ```
 
-Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/API.md#installation).
+Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/API.md#installation).
 
 **Typst Universe:** [submission PR #5808](https://github.com/typst/packages/pull/5808) is open. Use relative or `@local` imports until it is accepted; `@preview/qualitree:0.1.0` is not available yet.
 
@@ -119,12 +123,12 @@ Tests execute Typst assertions, 128 visibility combinations and other layout cas
 
 ## Documentation map
 
-- [Vocabulary](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/CONTEXT.md): needs, functions, components, technologies and thresholds.
-- [Coffee study](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
-- [API](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/API.md): inputs, styling, calculations and revision limitations.
-- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/CONTRIBUTING.md): module boundaries, comments, checks and releases.
-- [Methodology](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
-- [Design](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/PLAN.md).
+- [Vocabulary](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/CONTEXT.md): needs, functions, components, technologies and thresholds.
+- [Coffee study](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
+- [API](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/API.md): inputs, styling, calculations and revision limitations.
+- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/CONTRIBUTING.md): module boundaries, comments, checks and releases.
+- [Methodology](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
+- [Design](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/PLAN.md).
 
 ## Credits
 

--- a/packages/preview/qualitree/0.1.0/README.md
+++ b/packages/preview/qualitree/0.1.0/README.md
@@ -104,7 +104,7 @@ python3 tools/install_local.py
 
 Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/main/docs/API.md#installation).
 
-**Typst Universe:** this repository is prepared for submission. Use relative or `@local` imports until the submission is accepted; `@preview/qualitree:0.1.0` is not promised available yet.
+**Typst Universe:** [submission PR #5808](https://github.com/typst/packages/pull/5808) is open. Use relative or `@local` imports until it is accepted; `@preview/qualitree:0.1.0` is not available yet.
 
 ## Develop and verify
 
@@ -125,6 +125,10 @@ Tests execute Typst assertions, 128 visibility combinations and other layout cas
 - [Maintaining the package](https://github.com/tychota/qfd-typst/blob/main/CONTRIBUTING.md): module boundaries, comments, checks and releases.
 - [Methodology](https://github.com/tychota/qfd-typst/blob/main/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
 - [Design](https://github.com/tychota/qfd-typst/blob/main/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/main/PLAN.md).
+
+## Credits
+
+Tycho Tatitscheff and Julien Calixte.
 
 ## License
 

--- a/packages/preview/qualitree/0.1.0/README.md
+++ b/packages/preview/qualitree/0.1.0/README.md
@@ -1,12 +1,12 @@
-<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
 
 # Qualitree
 
 Draw, connect, and compare Houses of Quality in native Typst. Map **needs → functions → components**, carry priorities between stages, and show design revisions with readable green/red/yellow backgrounds.
 
-[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/API.md)
+[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/API.md)
 
-![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/hero.png)
+![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/hero.png)
 
 ## Start in five minutes
 
@@ -86,11 +86,13 @@ Stable IDs identify entities; labels are editable text. Relations remain one-bas
 
 Additions have pale green backgrounds, removals pale red, and changes pale yellow. Dark symbols and +/−/~ annotations supplement color. Reordering IDs creates no false edits. Removed relationships remain visible but contribute zero to current priorities. Diff views do not currently support competitive profiles or custom basements; compare source stages without those options.
 
-The worked revision adds refrigerated milk storage and automatic steaming to the capsule-coffee baseline. Read existing and new needs row by row, then follow the revised functions into shared and added components. See the [change rationale](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/examples/COFFEE.md#deploying-a-new-capability-milk-drinks).
+The compact walkthrough adds a steam wand to a coffee-only baseline: one new milk-drink need, two new functions, and effects on existing cleaning, space, and safety responsibilities. A second option adds automatic metering and refrigerated milk storage. Both use the same compact baseline; the full coffee study remains a separate detailed example. See the [option comparison](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/examples/COFFEE.md#compact-walkthrough-two-milk-options).
 
-![Milk drinks: needs to functions revision](https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/revisions.svg)
+![Steam wand: needs to functions revision](https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/revisions.svg)
 
-![Milk drinks: functions to components revision](https://raw.githubusercontent.com/tychota/qfd-typst/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/site/assets/revision-components.svg)
+![Steam wand: functions to components revision](https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/revision-components.svg)
+
+See the [profile palette reference](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/PALETTE.md) for color provenance, contrast values, and customization.
 
 ## Typography and layout
 
@@ -106,7 +108,7 @@ Correlation signs use bold vector +/− and circled strong signs. Choose `correl
 python3 tools/install_local.py
 ```
 
-Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/API.md#installation).
+Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/API.md#installation).
 
 **Typst Universe:** [submission PR #5808](https://github.com/typst/packages/pull/5808) is open. Use relative or `@local` imports until it is accepted; `@preview/qualitree:0.1.0` is not available yet.
 
@@ -123,12 +125,12 @@ Tests execute Typst assertions, 128 visibility combinations and other layout cas
 
 ## Documentation map
 
-- [Vocabulary](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/CONTEXT.md): needs, functions, components, technologies and thresholds.
-- [Coffee study](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
-- [API](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/API.md): inputs, styling, calculations and revision limitations.
-- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/CONTRIBUTING.md): module boundaries, comments, checks and releases.
-- [Methodology](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
-- [Design](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/8cb5edc677e47faee7d02b631fd5503236556f0d/PLAN.md).
+- [Vocabulary](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/CONTEXT.md): needs, functions, components, technologies and thresholds.
+- [Coffee study](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
+- [API](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/API.md): inputs, styling, calculations and revision limitations.
+- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/CONTRIBUTING.md): module boundaries, comments, checks and releases.
+- [Methodology](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
+- [Design](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/PLAN.md).
 
 ## Credits
 

--- a/packages/preview/qualitree/0.1.0/README.md
+++ b/packages/preview/qualitree/0.1.0/README.md
@@ -1,12 +1,14 @@
-<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/006448730a3086aae1259f99e02078630f9951f6/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
 
 # Qualitree
 
+[Documentation française](https://tychota.github.io/qfd-typst/fr/) · [English documentation](https://tychota.github.io/qfd-typst/)
+
 Draw, connect, and compare Houses of Quality in native Typst. Map **needs → functions → components**, carry priorities between stages, and show design revisions with readable green/red/yellow backgrounds.
 
-[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/API.md)
+[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/docs/API.md)
 
-![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/hero.png)
+![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/006448730a3086aae1259f99e02078630f9951f6/docs/site/assets/hero.png)
 
 ## Start in five minutes
 
@@ -86,13 +88,13 @@ Stable IDs identify entities; labels are editable text. Relations remain one-bas
 
 Additions have pale green backgrounds, removals pale red, and changes pale yellow. Dark symbols and +/−/~ annotations supplement color. Reordering IDs creates no false edits. Removed relationships remain visible but contribute zero to current priorities. Diff views do not currently support competitive profiles or custom basements; compare source stages without those options.
 
-The compact walkthrough adds a steam wand to a coffee-only baseline: one new milk-drink need, two new functions, and effects on existing cleaning, space, and safety responsibilities. A second option adds automatic metering and refrigerated milk storage. Both use the same compact baseline; the full coffee study remains a separate detailed example. See the [option comparison](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/examples/COFFEE.md#compact-walkthrough-two-milk-options).
+The compact walkthrough adds a steam wand to a coffee-only baseline: one new milk-drink need, two new functions, and effects on existing cleaning, space, and safety responsibilities. A second option adds automatic metering and refrigerated milk storage. Both use the same compact baseline; the full coffee study remains a separate detailed example. See the [option comparison](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/examples/COFFEE.md#compact-walkthrough-two-milk-options).
 
-![Steam wand: needs to functions revision](https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/revisions.svg)
+![Steam wand: needs to functions revision](https://raw.githubusercontent.com/tychota/qfd-typst/006448730a3086aae1259f99e02078630f9951f6/docs/site/assets/revisions.svg)
 
-![Steam wand: functions to components revision](https://raw.githubusercontent.com/tychota/qfd-typst/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/site/assets/revision-components.svg)
+![Steam wand: functions to components revision](https://raw.githubusercontent.com/tychota/qfd-typst/006448730a3086aae1259f99e02078630f9951f6/docs/site/assets/revision-components.svg)
 
-See the [profile palette reference](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/PALETTE.md) for color provenance, contrast values, and customization.
+See the [profile palette reference](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/docs/PALETTE.md) for color provenance, contrast values, and customization.
 
 ## Typography and layout
 
@@ -108,7 +110,7 @@ Correlation signs use bold vector +/− and circled strong signs. Choose `correl
 python3 tools/install_local.py
 ```
 
-Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/API.md#installation).
+Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/docs/API.md#installation).
 
 **Typst Universe:** [submission PR #5808](https://github.com/typst/packages/pull/5808) is open. Use relative or `@local` imports until it is accepted; `@preview/qualitree:0.1.0` is not available yet.
 
@@ -125,12 +127,12 @@ Tests execute Typst assertions, 128 visibility combinations and other layout cas
 
 ## Documentation map
 
-- [Vocabulary](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/CONTEXT.md): needs, functions, components, technologies and thresholds.
-- [Coffee study](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
-- [API](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/API.md): inputs, styling, calculations and revision limitations.
-- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/CONTRIBUTING.md): module boundaries, comments, checks and releases.
-- [Methodology](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
-- [Design](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/18034efa23b8299de1932ce1210ca06ca19c7f14/PLAN.md).
+- [Vocabulary](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/CONTEXT.md): needs, functions, components, technologies and thresholds.
+- [Coffee study](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
+- [API](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/docs/API.md): inputs, styling, calculations and revision limitations.
+- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/CONTRIBUTING.md): module boundaries, comments, checks and releases.
+- [Methodology](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
+- [Design](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/006448730a3086aae1259f99e02078630f9951f6/PLAN.md).
 
 ## Credits
 

--- a/packages/preview/qualitree/0.1.0/README.md
+++ b/packages/preview/qualitree/0.1.0/README.md
@@ -1,0 +1,131 @@
+<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/main/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
+
+# Qualitree
+
+Draw, connect, and compare Houses of Quality in native Typst. Map **needs → functions → components**, carry priorities between stages, and show design revisions with readable green/red/yellow backgrounds.
+
+[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/main/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/main/docs/API.md)
+
+![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/main/docs/site/assets/hero.png)
+
+## Start in five minutes
+
+Install [Typst 0.15.1 or newer](https://github.com/typst/typst/releases). On macOS:
+
+```sh
+brew install typst
+git clone https://github.com/tychota/qfd-typst.git
+cd qfd-typst
+mkdir -p build
+typst compile --root . --font-path fonts examples/espresso.typ build/espresso.pdf
+```
+
+Open `build/espresso.pdf`. For automatic recompilation while editing:
+
+```sh
+typst watch --root . --font-path fonts examples/espresso.typ build/espresso.pdf
+```
+
+On Windows/Linux, download the CLI from the official releases page and put the executable on your PATH. Verify with `typst --version`. No LaTeX installation is needed.
+
+In the [Typst web app](https://typst.app/), upload `lib.typ`, `src/`, and an example, preserving their folder structure. Upload the bundled Plex fonts too if those families are unavailable. Relative imports work without publishing a package.
+
+## A first matrix
+
+Create `main.typ` beside `lib.typ`:
+
+```typst
+#import "lib.typ": qfd
+#set page(width: auto, height: auto, margin: 6mm)
+
+#qfd(
+  whats: ("Enjoy good coffee", "Prepare drinks quickly"),
+  hows: ("Heat water", "Channel water"),
+  importance: (10, 7),
+  matrix: ((9, 3), (3, 9)),
+  targets: ("92 °C*", [Recipe target]),
+  directions: ("target", "maximize"),
+  correlations: ((1, 2, "-"),),
+  width: auto,
+)
+```
+
+Compile with `typst compile --font-path fonts main.typ`. The temperature is an illustrative recipe hypothesis, not a universal recommendation.
+
+## Connect stages
+
+Stable IDs identify entities; labels are editable text. Relations remain one-based positions within each stage.
+
+```typst
+#import "lib.typ": qfd, qfd-stage, qfd-deploy
+#let needs = qfd-stage(
+  rows: ((id: "taste", label: "Good taste", weight: 10),),
+  columns: ((id: "heat", label: "Heat water", direction: "target"),),
+  matrix: ((9,),),
+)
+#let components = qfd-deploy(needs,
+  columns: ((id: "heater", label: "Heater"),),
+  matrix: ((9,),), labels: (whats: [Functions], hows: [Components]),
+)
+#qfd(..components)
+```
+
+`qfd-deploy` carries **unrounded relative weights** forward. Only displayed values are rounded. Priorities are engineering judgments; they do not replace acceptance thresholds for taste, temperature, or safety.
+
+## Compare revisions
+
+```typst
+#import "lib.typ": qfd, qfd-stage, qfd-diff
+#let before = qfd-stage(
+  rows: ((id: "taste", label: "Good taste", weight: 10),),
+  columns: ((id: "heat", label: "Heat water"),), matrix: ((3,),),
+)
+#let after = before + (matrix: ((9,),))
+#qfd(..qfd-diff(before, after))
+```
+
+Additions have pale green backgrounds, removals pale red, and changes pale yellow. Dark symbols and +/−/~ annotations supplement color. Reordering IDs creates no false edits. Removed relationships remain visible but contribute zero to current priorities. Diff views do not currently support competitive profiles or custom basements; compare source stages without those options.
+
+![Revision comparison](https://raw.githubusercontent.com/tychota/qfd-typst/main/docs/site/assets/revisions.svg)
+
+## Typography and layout
+
+Plex Sans labels and Plex Serif headings are the defaults, with built-in fallback families. The repository includes the fonts under their SIL Open Font License. The library does not install fonts or change your page settings.
+
+Header and row sizes are measured automatically. Override `header-height`, `row-height`, `cell-size`, `label-padding`, `header-padding`, or `cell-padding` independently. `font`, `serif-font`, `font-size`, `grid-thickness`, `frame-thickness`, and `theme` control appearance. `width: auto` preserves natural dimensions; `width: 100%` scales a figure to a finite container. Scaling a dense chart into a small space also shrinks its text.
+
+Correlation signs use bold vector +/− and circled strong signs. Choose `correlation-style: "text"` for ++/--. Direction indicators are ↑ maximize, ↓ minimize, and a bullseye for a target. Competitive markers stagger vertically by default, preserving score positions; `marker-stagger: false` restores centered markers. Dense ties may shrink markers, and crossings forced by score order cannot always be avoided.
+
+## Named local installation
+
+```sh
+python3 tools/install_local.py
+```
+
+Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/main/docs/API.md#installation).
+
+**Typst Universe:** this repository is prepared for submission. Use relative or `@local` imports until the submission is accepted; `@preview/qualitree:0.1.0` is not promised available yet.
+
+## Develop and verify
+
+```sh
+python3 tools/test.py
+python3 tools/build_examples.py
+python3 tools/build_docs.py
+python3 tools/package.py
+```
+
+Tests execute Typst assertions, 128 visibility combinations and other layout cases, invalid inputs, stage propagation, ID-based revisions, and profile placement. All public examples compile with bundled fonts and without system fonts. Source files drive the documentation previews; `build_examples.py` refreshes them.
+
+## Documentation map
+
+- [Vocabulary](https://github.com/tychota/qfd-typst/blob/main/CONTEXT.md): needs, functions, components, technologies and thresholds.
+- [Coffee study](https://github.com/tychota/qfd-typst/blob/main/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
+- [API](https://github.com/tychota/qfd-typst/blob/main/docs/API.md): inputs, styling, calculations and revision limitations.
+- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/main/CONTRIBUTING.md): module boundaries, comments, checks and releases.
+- [Methodology](https://github.com/tychota/qfd-typst/blob/main/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
+- [Design](https://github.com/tychota/qfd-typst/blob/main/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/main/PLAN.md).
+
+## License
+
+MIT for source and documentation. Bundled IBM Plex fonts retain their adjacent SIL Open Font License notices. The hero is an AI-generated decorative illustration; the examples are native Typst diagrams with explicit illustrative assumptions.

--- a/packages/preview/qualitree/0.1.0/README.md
+++ b/packages/preview/qualitree/0.1.0/README.md
@@ -1,12 +1,12 @@
-<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/main/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/tychota/qfd-typst/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/site/assets/logo.svg" width="72" alt="Qualitree logo"></p>
 
 # Qualitree
 
 Draw, connect, and compare Houses of Quality in native Typst. Map **needs → functions → components**, carry priorities between stages, and show design revisions with readable green/red/yellow backgrounds.
 
-[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/main/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/main/docs/API.md)
+[Documentation](https://tychota.github.io/qfd-typst/) · [Coffee example](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/examples/COFFEE.md) · [API reference](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/API.md)
 
-![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/main/docs/site/assets/hero.png)
+![House of Quality and coffee-machine illustration](https://raw.githubusercontent.com/tychota/qfd-typst/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/site/assets/hero.png)
 
 ## Start in five minutes
 
@@ -35,7 +35,7 @@ In the [Typst web app](https://typst.app/), upload `lib.typ`, `src/`, and an exa
 Create `main.typ` beside `lib.typ`:
 
 ```typst
-#import "lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #set page(width: auto, height: auto, margin: 6mm)
 
 #qfd(
@@ -57,7 +57,7 @@ Compile with `typst compile --font-path fonts main.typ`. The temperature is an i
 Stable IDs identify entities; labels are editable text. Relations remain one-based positions within each stage.
 
 ```typst
-#import "lib.typ": qfd, qfd-stage, qfd-deploy
+#import "@preview/qualitree:0.1.0": qfd, qfd-stage, qfd-deploy
 #let needs = qfd-stage(
   rows: ((id: "taste", label: "Good taste", weight: 10),),
   columns: ((id: "heat", label: "Heat water", direction: "target"),),
@@ -75,7 +75,7 @@ Stable IDs identify entities; labels are editable text. Relations remain one-bas
 ## Compare revisions
 
 ```typst
-#import "lib.typ": qfd, qfd-stage, qfd-diff
+#import "@preview/qualitree:0.1.0": qfd, qfd-stage, qfd-diff
 #let before = qfd-stage(
   rows: ((id: "taste", label: "Good taste", weight: 10),),
   columns: ((id: "heat", label: "Heat water"),), matrix: ((3,),),
@@ -86,7 +86,7 @@ Stable IDs identify entities; labels are editable text. Relations remain one-bas
 
 Additions have pale green backgrounds, removals pale red, and changes pale yellow. Dark symbols and +/−/~ annotations supplement color. Reordering IDs creates no false edits. Removed relationships remain visible but contribute zero to current priorities. Diff views do not currently support competitive profiles or custom basements; compare source stages without those options.
 
-![Revision comparison](https://raw.githubusercontent.com/tychota/qfd-typst/main/docs/site/assets/revisions.svg)
+![Revision comparison](https://raw.githubusercontent.com/tychota/qfd-typst/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/site/assets/revisions.svg)
 
 ## Typography and layout
 
@@ -102,7 +102,7 @@ Correlation signs use bold vector +/− and circled strong signs. Choose `correl
 python3 tools/install_local.py
 ```
 
-Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/main/docs/API.md#installation).
+Then use `#import "@local/qualitree:0.1.0": qfd`. This only installs the library for the local CLI; fonts are separate. See [installation paths](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/API.md#installation).
 
 **Typst Universe:** [submission PR #5808](https://github.com/typst/packages/pull/5808) is open. Use relative or `@local` imports until it is accepted; `@preview/qualitree:0.1.0` is not available yet.
 
@@ -119,12 +119,12 @@ Tests execute Typst assertions, 128 visibility combinations and other layout cas
 
 ## Documentation map
 
-- [Vocabulary](https://github.com/tychota/qfd-typst/blob/main/CONTEXT.md): needs, functions, components, technologies and thresholds.
-- [Coffee study](https://github.com/tychota/qfd-typst/blob/main/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
-- [API](https://github.com/tychota/qfd-typst/blob/main/docs/API.md): inputs, styling, calculations and revision limitations.
-- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/main/CONTRIBUTING.md): module boundaries, comments, checks and releases.
-- [Methodology](https://github.com/tychota/qfd-typst/blob/main/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
-- [Design](https://github.com/tychota/qfd-typst/blob/main/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/main/PLAN.md).
+- [Vocabulary](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/CONTEXT.md): needs, functions, components, technologies and thresholds.
+- [Coffee study](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/examples/COFFEE.md): scope, assumptions, candidate technologies, evidence and validation work.
+- [API](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/API.md): inputs, styling, calculations and revision limitations.
+- [Maintaining the package](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/CONTRIBUTING.md): module boundaries, comments, checks and releases.
+- [Methodology](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/docs/METHODOLOGY.md): functional analysis and classic QFD terminology.
+- [Design](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/DESIGN.md) and [implementation plan](https://github.com/tychota/qfd-typst/blob/a02adcdc8b7e6bd07d537cdac3f41a81931c5969/PLAN.md).
 
 ## Credits
 

--- a/packages/preview/qualitree/0.1.0/examples/COFFEE.md
+++ b/packages/preview/qualitree/0.1.0/examples/COFFEE.md
@@ -48,7 +48,48 @@ Both pages were consulted on 9 September 2026. Sources inform the discussion onl
 - `espresso.typ`: needs → functions, with provisional targets and illustrative roof interactions.
 - `components.typ`: functions → components, inheriting unrounded priorities.
 - `report.typ`: a two-page A3 report with both deployments and the decision context.
-- `revisions.typ`: a separate, deliberately small revision exercise. It reorders stable IDs, renames a need, changes relationships, adds protection, and removes a decorative-light requirement. Removed relations and roof signs remain reviewable; they contribute nothing to current priorities.
+- `revisions.typ`: add milk drinks to the original capsule machine; compare needs → functions row by row.
+- `revision-components.typ`: continue the same change through functions → components, with priorities inherited from the revised first stage.
+- `milk-data.typ`: both revised stages and their baseline comparisons.
 - `minimal.typ`: a two-by-two introduction to the positional API.
 
 Revision comparison is different from competitive comparison. No café or competing appliance scores are supplied: they have not been measured. A future comparison should identify the particular café beverage and candidate concepts, use consistent conditions and scales, retain missing observations as `none`, and separate observed values from assumptions.
+
+
+## Deploying a new capability: milk drinks
+
+The revision asks what adding milk drinks implies for the whole existing product. The baseline is the capsule-coffee concept above. The provisional extension has integrated refrigerated milk storage feeding an automatic steam/frothing path. This is a concept assumption, not a description of an actual Nespresso product. A removable jug with a manual steam wand would produce a different deployment, particularly for refrigeration, handling, and user protection.
+
+Two new needs are **enjoy warm milk drinks with suitable texture** and **keep milk ready between drink sessions**. “Store refrigerated milk,” “heat milk,” and “generate steam and texture milk” are functions serving those needs. Five added functions cover cold storage, milk metering/transport, controlled heating, steam/texturing, and cleaning milk-contact paths. The second stage allocates them to four proposed component groups: refrigerated reservoir/sensor, milk pump/valves/tubing, steam generator/protection, and mixer/outlet. The cooling principle, steam-generation technology, and sensing implementation remain open technology choices.
+
+### Read the needs comparison row by row
+
+| Existing or new need | Consequence of the milk extension | What the team must resolve |
+| --- | --- | --- |
+| Café-worthy taste | Milk preparation and residues can affect the drink and coffee experience. | Agree milk recipes, sensory acceptance, and cleaning effectiveness. |
+| Acceptable drink temperature | The final result now depends on milk heating and mixing as well as coffee temperature. | Define measurement conditions for the combined drink. |
+| Two to three consecutive drinks | Milk capacity, steam recovery, shared heat demand, and rinsing become contributors. | Evaluate a mixed coffee/milk drink sequence with refill and cleanup. |
+| Easy setup and cleaning | This existing need expands to milk-contact surfaces and the cold reservoir. | Establish a feasible cleaning procedure and validate it. |
+| Six-month grounds preservation | The original sealed-dose preservation function remains unchanged. | Retain the existing coffee validation; do not confuse it with milk storage. |
+| Small footprint | The reservoir, cooling system, tubing, and service clearances consume space. | Revisit the full installation and maintenance envelope. |
+| Safe household use | Steam, added power demand, milk handling, and cleaning add interfaces to assess. | Revisit protection and acceptance gates with appropriate specialists. |
+| **New: warm milk drinks with suitable texture** | Requires metering, controlled heating, and texturing. | Agree drink volume, texture, temperature, and reproducibility criteria. |
+| **New: milk ready between sessions** | Requires controlled storage and a workable cleaning/storage routine. | Define and validate storage and hygiene conditions; targets remain TBD. |
+
+### Follow each function into components
+
+The first twelve rows preserve the original function identities. The last five are the new milk functions. Read the changes across each row before reading the totals:
+
+- **Convert electrical energy into heat:** the proposed steam module adds demand; controller and power-protection relationships strengthen from 3 to 9 to represent coordinated operation.
+- **Channel water and serve drinks:** the water circuit gains a steam supply interface; the cup interface must accommodate the milk outlet.
+- **Collect waste:** retain the existing coffee-drip relationship and add milk-rinse collection. The tray/capacity definition changes; no arbitrary removal is introduced.
+- **Guide operation:** the existing controller now coordinates coffee, milk, storage, and cleaning sequences.
+- **Contain hazards:** the housing and protection functions extend to the cold module, milk circuit, steam generator, and hot outlet.
+- **Store milk:** allocate controlled storage to the refrigerated reservoir and sensing, with controller and housing interfaces.
+- **Meter milk:** allocate transport/dosing to the milk circuit and controller, with reservoir and outlet interfaces.
+- **Heat and texture milk:** allocate energy transfer and texture formation to the steam module and mixer, while retaining shared water, power, and control interfaces.
+- **Clean milk-contact paths:** allocate access/flushability across reservoir, tubing, mixer, controller, and waste collector. A new dedicated cleaning device is not assumed.
+
+All strengths are illustrative engineering judgments. A strong need/function relationship means the function matters to that need; it does **not** mean adding it improves satisfaction. Refrigeration can strongly affect footprint while making the size constraint harder to satisfy. The proposed roof tensions flag simultaneous heat demand and cold/hot integration for investigation.
+
+Each revised deployment is calculated independently from the actual revised stage, then compared against its baseline. Do not deploy the diff display itself. Relative priorities can move because new needs/functions change the normalization denominator: a yellow inherited weight alone does not establish a physical hardware modification. Existing IDs, relations, and labels let the reviewer distinguish these cases. This additive concept has no deleted component; removal rendering is covered by the library tests rather than an invented product deletion.

--- a/packages/preview/qualitree/0.1.0/examples/COFFEE.md
+++ b/packages/preview/qualitree/0.1.0/examples/COFFEE.md
@@ -1,0 +1,54 @@
+# Coffee at home: a worked QFD example
+
+The use case is replacing a coffee from the local café with a drink prepared at home. The numerical example is a fictional workshop, not a benchmark of an existing appliance. Every weight, relationship, and roof correlation is an illustrative judgment. The matrices help organize decisions and expose dependencies; they do not provide empirical evidence of product quality.
+
+The provisional system boundary includes the machine, sealed preground dose, and protective packaging. That boundary makes preservation a function the team can influence. If the scope becomes machine-only, remove preservation from its functional deployment and treat supplied-dose freshness as an external interface requirement. This assumption remains open for confirmation.
+
+## Needs and acceptance gates
+
+| Need | What to establish before acceptance |
+| --- | --- |
+| Café-worthy taste | Agree a minimum acceptable result against a selected café reference, using a documented blind tasting protocol. No numerical cutoff has yet been agreed. |
+| Acceptable drink temperature | Agree a minimum and acceptable range at a stated time after serving in a specified cup. Brewing-water temperature is a different measurement. |
+| Two to three consecutive drinks | Test three drinks, including initial warm-up, recovery between drinks, reservoir capacity, dose replacement, and waste capacity. Specify rinse volume and beverage size. |
+| Little setup and cleaning effort | Observe an untrained adult completing setup, brewing, refill, and cleanup; record time, actions, errors, and wet/dirty handling. |
+| Preground coffee six months after roasting | Validate sealed doses of known roast date under defined storage conditions. Compare taste with a suitable fresh reference; record sealing delay, roast, grind, barrier construction, and storage. |
+| Small footprint | Set a countertop envelope, including refill access, lid opening, ventilation, and clearance to remove the tray. |
+| Low danger in ordinary household use | Establish acceptance gates for foreseeable heat, pressure, electrical, stability, and accessible-part hazards, including a child nearby; specialist assessment and applicable requirements remain to be identified. |
+
+Taste, drink temperature, and safety are acceptance gates. Their presence in the weighted matrix helps allocate effort but does not turn a failed gate into an acceptable concept. There is no claim of safety certification, six-month shelf life, or café-equivalent taste.
+
+## Functions, components, and technologies
+
+The first deployment contains seven needs and twelve functions. The function groups are:
+
+- Store water and convert electrical energy into controlled thermal delivery.
+- Pressurize and channel water, open the dose flow path, and control contact with grounds.
+- Preserve grounds before extraction, deliver coffee to the cup, and collect drips and spent doses.
+- Guide the sequence and contain thermal, pressure, and electrical hazards.
+
+These names describe transformations, storage, transport, and protection. Components implement them: reservoir, heater and sensor, pump and pressure-limiting path, flowmeter and circuit, dose chamber/opener/seals, sealed dose and packaging, outlet/cup support, waste collectors, controller/interface, and housing/protection.
+
+A turbine is one candidate flowmeter principle. A vibration pump or thermoblock is a possible realization, not a requirement derived by this example. A stepper motor has no established need here. Each technology choice needs its own trade study once flow, pressure, temperature, noise, cost, lifetime, and control requirements are defined.
+
+`qfd-deploy` uses the preceding column priorities as the next stage’s row weights. It preserves full-precision relative values; rounding is only for display. These two matrices share exactly the same function IDs, so changes to prose labels do not break identity.
+
+## Provisional targets and sources
+
+The example uses **92 ± 2 °C brewing water** and **about 25 seconds contact** as starting hypotheses. Earlier ranges of 85–95 °C and 10–20 seconds are also hypotheses to investigate, not standards. Timing needs a defined start/end event, and capsule geometry, coffee dose, grind, recipe, and beverage yield can change an appropriate operating window.
+
+The Specialty Coffee Association article recounts a historical espresso definition with brewing water at 90.5–96.1 °C and extraction lasting 20–30 seconds, and discusses variation in surveyed practice. It provides context for an initial recipe, not proof that these values apply to this capsule concept. [SCA, “Defining the Ever-Changing Espresso”](https://sca.coffee/sca-news/25-magazine/issue-3/defining-ever-changing-espresso-25-magazine-issue-3-zyx36).
+
+Nespresso describes sealed capsules and storage practices as ways to protect coffee freshness. This manufacturer information supports considering a protective barrier and controlled storage. It does not validate our proposed construction or establish acceptable taste six months after the roast date. [Nespresso, “How to store your coffee pods”](https://www.nespresso.com/nz/en/news/how-to-store-your-coffee-pods).
+
+Both pages were consulted on 9 September 2026. Sources inform the discussion only; the need weights and relationships were not extracted from them.
+
+## How to read the examples
+
+- `espresso.typ`: needs → functions, with provisional targets and illustrative roof interactions.
+- `components.typ`: functions → components, inheriting unrounded priorities.
+- `report.typ`: a two-page A3 report with both deployments and the decision context.
+- `revisions.typ`: a separate, deliberately small revision exercise. It reorders stable IDs, renames a need, changes relationships, adds protection, and removes a decorative-light requirement. Removed relations and roof signs remain reviewable; they contribute nothing to current priorities.
+- `minimal.typ`: a two-by-two introduction to the positional API.
+
+Revision comparison is different from competitive comparison. No café or competing appliance scores are supplied: they have not been measured. A future comparison should identify the particular café beverage and candidate concepts, use consistent conditions and scales, retain missing observations as `none`, and separate observed values from assumptions.

--- a/packages/preview/qualitree/0.1.0/examples/COFFEE.md
+++ b/packages/preview/qualitree/0.1.0/examples/COFFEE.md
@@ -48,15 +48,35 @@ Both pages were consulted on 9 September 2026. Sources inform the discussion onl
 - `espresso.typ`: needs → functions, with provisional targets and illustrative roof interactions.
 - `components.typ`: functions → components, inheriting unrounded priorities.
 - `report.typ`: a two-page A3 report with both deployments and the decision context.
-- `revisions.typ`: add milk drinks to the original capsule machine; compare needs → functions row by row.
-- `revision-components.typ`: continue the same change through functions → components, with priorities inherited from the revised first stage.
+- `revisions.typ`: compact manual-wand walkthrough, with five needs and five functions.
+- `revision-components.typ`: continue the compact manual-wand change into five component groups.
+- `milk-options.typ`: a shared compact coffee-only baseline and two alternatives (manual jug/wand or automatic refrigerated milk).
+- `milk-automatic.typ`: two-page compact report for the automatic alternative.
+- `milk-detailed.typ`: the complete integrated-milk revision of the original twelve-function coffee study.
 - `milk-data.typ`: both revised stages and their baseline comparisons.
 - `minimal.typ`: a two-by-two introduction to the positional API.
 
 Revision comparison is different from competitive comparison. No café or competing appliance scores are supplied: they have not been measured. A future comparison should identify the particular café beverage and candidate concepts, use consistent conditions and scales, retain missing observations as `none`, and separate observed values from assumptions.
 
 
-## Deploying a new capability: milk drinks
+## Compact walkthrough: two milk options
+
+The documentation starts with a five-by-five matrix so the reader can follow one change. `milk-options.typ` is a separate teaching model with a shared coffee-only baseline: four needs, three functions, and three component groups. It deliberately aggregates the detailed coffee study; its numerical priorities must not be mixed with that study.
+
+**Option A — manual wand and removable jug.** Add the need “enjoy warm, textured milk” and the functions “heat milk” and “texture milk.” Existing cleaning and hazard-containment responsibilities expand. Add steam generation and a wand/jug group; revise the controller and housing/protection. Milk refrigeration stays outside the appliance. The user supplies, positions, and cleans the jug.
+
+**Option B — automatic preparation with refrigerated storage.** Start from the same coffee-only baseline. Add the same milk-drink need plus “keep milk ready between sessions,” with refrigerated storage and automatic milk metering as additional functions. Proposed hardware includes a refrigerated reservoir, milk pump/valves/tubing, and an automatic mixer in addition to steam generation and revised controls/protection.
+
+| Question | Manual wand + jug | Automatic + refrigeration |
+| --- | --- | --- |
+| Who meters and positions milk? | The user handles the jug. | The machine meters milk into a mixer. |
+| Where is milk stored? | Outside the appliance, between sessions. | In an integrated refrigerated reservoir. |
+| What must be cleaned? | Jug and accessible wand, alongside coffee paths. | Reservoir, milk circuit, and mixer, alongside coffee paths. |
+| What happens to existing constraints? | Reassess steam handling, cleanup effort, and jug space. | Reassess cleaning access, cold storage, shared power, and the installation envelope. |
+
+The diagrams show relevance and design responsibility, not which option is superior. Establish requirements, observe user handling, and assess both concepts before assigning satisfaction scores or selecting a technology. No numerical milk-storage or hygiene target has been asserted. Both alternatives carry their own recalculated function priorities into their component matrices.
+
+## Deploying a new capability: detailed milk study
 
 The revision asks what adding milk drinks implies for the whole existing product. The baseline is the capsule-coffee concept above. The provisional extension has integrated refrigerated milk storage feeding an automatic steam/frothing path. This is a concept assumption, not a description of an actual Nespresso product. A removable jug with a manual steam wand would produce a different deployment, particularly for refrigeration, handling, and user protection.
 

--- a/packages/preview/qualitree/0.1.0/examples/coffee-data.typ
+++ b/packages/preview/qualitree/0.1.0/examples/coffee-data.typ
@@ -79,19 +79,3 @@
   show-roof: false,
   labels: (whats: [Functions · inherited priorities], hows: [Components], importance: [Rel. %]),
 )
-
-// A deliberately small editorial example isolates revision semantics from the
-// café-substitution study. Relationship changes have no measured justification.
-#let revision-before = qfd-stage(
-  rows: (needs.at(0), needs.at(3), (id: "decor", label: [Offer a decorative light], weight: 2)),
-  columns: (functions.at(2), functions.at(6), (id: "light", label: [Illuminate the worktop])),
-  matrix: ((9, 9, 0), (1, 3, 1), (0, 0, 9)),
-  correlations: ((1, 2, "+"), (2, 3, "-")),
-)
-#let revision-after = qfd-stage(
-  rows: (needs.at(3) + (label: [Clean with fewer handling steps],), needs.at(0), needs.at(6)),
-  columns: (functions.at(6), functions.at(2), functions.at(11)),
-  matrix: ((9, 0, 1), (9, 9, 0), (1, 3, 9)),
-  correlations: ((1, 2, "++"), (1, 3, "+")),
-)
-#let revision-view = qfd-diff(revision-before, revision-after)

--- a/packages/preview/qualitree/0.1.0/examples/coffee-data.typ
+++ b/packages/preview/qualitree/0.1.0/examples/coffee-data.typ
@@ -1,0 +1,97 @@
+// A fictional design workshop, not a product benchmark. Need weights and every
+// relationship are illustrative judgments. Thresholds are separate pass/fail
+// gates; a high aggregate priority never establishes taste or safety acceptance.
+#import "../lib.typ": qfd-stage, qfd-deploy, qfd-diff
+
+#let needs = (
+  (id: "taste", label: [Enjoy a café-worthy taste], weight: 10),
+  (id: "temperature", label: [Drink coffee at an acceptable temperature], weight: 9),
+  (id: "sequence", label: [Make 2–3 coffees consecutively], weight: 7),
+  (id: "routine", label: [Set up and clean with little effort], weight: 7),
+  (id: "freshness", label: [Use preground coffee six months after roasting], weight: 6),
+  (id: "space", label: [Keep the kitchen footprint small], weight: 4),
+  (id: "safety", label: [Use safely without training, with a child nearby], weight: 10),
+)
+
+// Functions describe transformations, storage, transport, and protection. The
+// provisional system includes machine, sealed dose, and protective packaging.
+#let functions = (
+  (id: "store-water", label: [Store water for consecutive drinks], direction: "maximize", target: [3 cups \ + rinse]),
+  (id: "make-heat", label: [Convert electrical energy into heat], direction: "minimize", target: [Warm-up \ TBD]),
+  (id: "control-heat", label: [Deliver water at controlled temperature], direction: "target", target: [92 ± 2 \ °C\*]),
+  (id: "pressurize", label: [Pressurize water for extraction], direction: "target", target: [Recipe \ TBD]),
+  (id: "channel", label: [Channel and meter water to the dose], direction: "target", target: [Volume \ TBD]),
+  (id: "open-dose", label: [Open the dose flow path], direction: "minimize", target: [1 dose \ insert]),
+  (id: "extract", label: [Control water–grounds contact], direction: "target", target: [≈25 s\*]),
+  (id: "preserve", label: [Preserve grounds before extraction], direction: "maximize", target: [6 mo.\*]),
+  (id: "serve", label: [Deliver coffee into the cup], direction: "minimize", target: [Heat loss \ TBD]),
+  (id: "collect", label: [Collect drips and spent doses], direction: "maximize", target: [3 spent \ doses]),
+  (id: "guide", label: [Guide setup and the brewing sequence], direction: "minimize", target: [Steps \ TBD]),
+  (id: "protect", label: [Contain heat, pressure, and electrical hazards], direction: "minimize", target: [Risk \ gates \ TBD]),
+)
+
+#let needs-functions = qfd-stage(
+  rows: needs, columns: functions,
+  matrix: (
+    (0, 1, 9, 3, 9, 3, 9, 9, 3, 0, 1, 0),
+    (0, 9, 9, 0, 1, 0, 3, 0, 9, 0, 1, 1),
+    (9, 9, 3, 3, 3, 3, 3, 0, 1, 9, 3, 1),
+    (3, 0, 0, 0, 1, 9, 1, 3, 3, 9, 9, 1),
+    (0, 0, 0, 0, 0, 1, 1, 9, 0, 0, 0, 0),
+    (9, 3, 0, 3, 1, 1, 0, 1, 1, 9, 0, 3),
+    (1, 3, 3, 9, 3, 9, 1, 1, 3, 3, 9, 9),
+  ),
+  correlations: ((2, 3, "++"), (3, 9, "+"), (4, 12, "-"), (6, 12, "--"), (6, 11, "+")),
+  labels: (whats: [Household needs], hows: [Functions], target: [Provisional target\*]),
+)
+
+// Components implement the functions above. Pump type, heater technology, and
+// sensor principle remain candidate choices, not requirements disguised as HOWs.
+#let components = (
+  (id: "tank", label: [Water tank and refill interface]),
+  (id: "heater", label: [Heater and thermal sensor]),
+  (id: "pump", label: [Pump and pressure-limiting path]),
+  (id: "meter", label: [Flowmeter and water circuit]),
+  (id: "chamber", label: [Dose chamber, opener, and seals]),
+  (id: "dose", label: [Sealed dose and barrier packaging]),
+  (id: "outlet", label: [Coffee outlet and cup support]),
+  (id: "collector", label: [Drip tray and spent-dose container]),
+  (id: "controller", label: [Controller and user interface]),
+  (id: "housing", label: [Housing, interlocks, and power protection]),
+)
+
+#let functions-components = qfd-deploy(needs-functions,
+  columns: components,
+  matrix: (
+    (9, 0, 0, 1, 0, 0, 0, 0, 1, 1),
+    (0, 9, 0, 0, 0, 0, 0, 0, 3, 3),
+    (0, 9, 1, 3, 1, 0, 0, 0, 9, 1),
+    (0, 0, 9, 3, 3, 0, 0, 0, 3, 3),
+    (1, 0, 3, 9, 3, 1, 0, 0, 9, 0),
+    (0, 0, 1, 0, 9, 9, 0, 0, 1, 3),
+    (0, 3, 3, 9, 9, 9, 1, 0, 9, 0),
+    (0, 0, 0, 0, 0, 9, 0, 0, 0, 0),
+    (0, 0, 0, 1, 3, 0, 9, 0, 1, 1),
+    (0, 0, 0, 0, 3, 1, 3, 9, 0, 1),
+    (3, 0, 0, 0, 3, 1, 1, 3, 9, 3),
+    (1, 3, 9, 3, 9, 1, 3, 3, 9, 9),
+  ),
+  show-roof: false,
+  labels: (whats: [Functions · inherited priorities], hows: [Components], importance: [Rel. %]),
+)
+
+// A deliberately small editorial example isolates revision semantics from the
+// café-substitution study. Relationship changes have no measured justification.
+#let revision-before = qfd-stage(
+  rows: (needs.at(0), needs.at(3), (id: "decor", label: [Offer a decorative light], weight: 2)),
+  columns: (functions.at(2), functions.at(6), (id: "light", label: [Illuminate the worktop])),
+  matrix: ((9, 9, 0), (1, 3, 1), (0, 0, 9)),
+  correlations: ((1, 2, "+"), (2, 3, "-")),
+)
+#let revision-after = qfd-stage(
+  rows: (needs.at(3) + (label: [Clean with fewer handling steps],), needs.at(0), needs.at(6)),
+  columns: (functions.at(6), functions.at(2), functions.at(11)),
+  matrix: ((9, 0, 1), (9, 9, 0), (1, 3, 9)),
+  correlations: ((1, 2, "++"), (1, 3, "+")),
+)
+#let revision-view = qfd-diff(revision-before, revision-after)

--- a/packages/preview/qualitree/0.1.0/examples/coffee-data.typ
+++ b/packages/preview/qualitree/0.1.0/examples/coffee-data.typ
@@ -1,7 +1,7 @@
 // A fictional design workshop, not a product benchmark. Need weights and every
 // relationship are illustrative judgments. Thresholds are separate pass/fail
 // gates; a high aggregate priority never establishes taste or safety acceptance.
-#import "../lib.typ": qfd-stage, qfd-deploy, qfd-diff
+#import "@preview/qualitree:0.1.0": qfd-stage, qfd-deploy, qfd-diff
 
 #let needs = (
   (id: "taste", label: [Enjoy a café-worthy taste], weight: 10),

--- a/packages/preview/qualitree/0.1.0/examples/components.typ
+++ b/packages/preview/qualitree/0.1.0/examples/components.typ
@@ -1,0 +1,11 @@
+#import "../lib.typ": qfd
+#import "coffee-data.typ": functions-components
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[Coffee at home · functions → components]
+#v(2mm)
+#block(width: 220mm)[Row priorities are the preceding stage’s unrounded relative priorities. Relationships are illustrative engineering judgments; component choices remain provisional.]
+#v(3mm)
+#qfd(..functions-components, width: auto, what-width: 64mm)
+#v(3mm)
+#block(width: 220mm)[A turbine flowmeter, vibration pump, or thermoblock are candidate realizations. The matrix does not establish a preferred technology or certify acceptance gates.]

--- a/packages/preview/qualitree/0.1.0/examples/components.typ
+++ b/packages/preview/qualitree/0.1.0/examples/components.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #import "coffee-data.typ": functions-components
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)

--- a/packages/preview/qualitree/0.1.0/examples/espresso.typ
+++ b/packages/preview/qualitree/0.1.0/examples/espresso.typ
@@ -1,0 +1,11 @@
+#import "../lib.typ": qfd
+#import "coffee-data.typ": needs-functions
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[Coffee at home · needs → functions]
+#v(2mm)
+#block(width: 235mm)[Illustrative workshop priorities. Provisional scope: machine + sealed dose + packaging. Taste, drink temperature, and safety remain acceptance gates.]
+#v(3mm)
+#qfd(..needs-functions, width: auto)
+#v(3mm)
+#block(width: 235mm)[\*Targets are hypotheses for validation, including 92 ± 2 °C brewing water, about 25 s contact, and six-month freshness. Brewing-water temperature is not a drink-temperature acceptance threshold. See COFFEE.md.]

--- a/packages/preview/qualitree/0.1.0/examples/espresso.typ
+++ b/packages/preview/qualitree/0.1.0/examples/espresso.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #import "coffee-data.typ": needs-functions
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)

--- a/packages/preview/qualitree/0.1.0/examples/fr/milk-automatic.typ
+++ b/packages/preview/qualitree/0.1.0/examples/fr/milk-automatic.typ
@@ -1,0 +1,15 @@
+#import "@preview/qualitree:0.1.0": qfd
+#import "milk-data.typ": automatic-diff, automatic-component-diff
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt, lang: "fr")
+#text(size: 16pt, weight: "bold")[Option B · lait réfrigéré et préparation automatique]
+#v(2mm)
+#block(width: 200mm)[Comparaison avec la même machine à café initiale. Disposer de lait entre les utilisations ajoute le stockage froid et le dosage automatique. Nettoyage et encombrement doivent être réévalués.]
+#v(3mm)
+#qfd(..automatic-diff, width: auto, what-width: 58mm)
+#pagebreak()
+#text(size: 16pt, weight: "bold")[Option B · conséquences sur les composants]
+#v(2mm)
+#block(width: 200mm)[Le réservoir réfrigéré, le circuit lait et le mélangeur demandent des commandes coordonnées, un accès pour le nettoyage et une protection adaptée. Les deux options sont des concepts à étudier, pas un classement de performances mesurées.]
+#v(3mm)
+#qfd(..automatic-component-diff, width: auto, what-width: 58mm)

--- a/packages/preview/qualitree/0.1.0/examples/fr/milk-data.typ
+++ b/packages/preview/qualitree/0.1.0/examples/fr/milk-data.typ
@@ -1,0 +1,48 @@
+// Traduire les libellés conserve les identifiants, les relations et les poids
+// du modèle pédagogique commun. Les données numériques ne sont pas dupliquées.
+#import "@preview/qualitree:0.1.0": qfd-diff
+#import "../milk-options.typ": baseline, manual, automatic, baseline-components, manual-components, automatic-components
+#let labels-fr = (
+  whats: [Besoins], hows: [Fonctions], importance: [Poids],
+  relation: [Relation], strong: [Forte (9)], medium: [Moyenne (3)], weak: [Faible (1)],
+  changes: [Modifications], added: [Ajout], removed: [Suppression], changed: [Modification],
+  absolute: [Σ abs.], relative: [Rel. %], target: [Cible],
+)
+#let needs = (
+  taste: [Savourer un bon café], clean: [Nettoyer facilement],
+  space: [Occuper peu de place], safe: [Utiliser sans danger à la maison],
+  milk: [Savourer un lait chaud et texturé], ready: [Disposer de lait entre les utilisations],
+)
+#let functions-before = (coffee: [Préparer le café], clean: [Nettoyer les circuits], protect: [Contenir les dangers])
+#let functions-after = functions-before + (
+  clean: [Nettoyer les circuits café et lait], protect: [Contenir les dangers du café et de la vapeur],
+  heat-milk: [Chauffer le lait], texture: [Texturer le lait],
+  cold: [Stocker le lait au froid], meter: [Doser le lait automatiquement],
+)
+#let parts-before = (coffee: [Module de préparation du café], control: [Commande et interface], housing: [Boîtier et protection])
+#let parts-manual = parts-before + (
+  control: [Commande avec mode vapeur], housing: [Boîtier et protection vapeur],
+  steam: [Générateur de vapeur], wand: [Buse vapeur et pichet amovible],
+)
+#let parts-automatic = parts-before + (
+  control: [Commande du cycle lait automatique], housing: [Boîtier et protection de puissance],
+  steam: [Générateur de vapeur], mixer: [Mélangeur vapeur–lait],
+  cold: [Réservoir réfrigéré], circuit: [Pompe, vannes et tuyaux de lait],
+)
+#let translate(stage, rows, columns, components: false) = stage + (
+  whats: stage.row-ids.map(id => rows.at(id)),
+  hows: stage.column-ids.map(id => columns.at(id)),
+  labels: labels-fr + if components {
+    (whats: [Fonctions · priorités transmises], hows: [Composants], importance: [Rel. %])
+  } else { (:) },
+)
+#let manual-diff = qfd-diff(translate(baseline, needs, functions-before), translate(manual, needs, functions-after))
+#let automatic-diff = qfd-diff(translate(baseline, needs, functions-before), translate(automatic, needs, functions-after))
+#let manual-component-diff = qfd-diff(
+  translate(baseline-components, functions-before, parts-before, components: true),
+  translate(manual-components, functions-after, parts-manual, components: true),
+)
+#let automatic-component-diff = qfd-diff(
+  translate(baseline-components, functions-before, parts-before, components: true),
+  translate(automatic-components, functions-after, parts-automatic, components: true),
+)

--- a/packages/preview/qualitree/0.1.0/examples/fr/revision-components.typ
+++ b/packages/preview/qualitree/0.1.0/examples/fr/revision-components.typ
@@ -1,0 +1,11 @@
+#import "@preview/qualitree:0.1.0": qfd
+#import "milk-data.typ": manual-component-diff
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt, lang: "fr")
+#text(size: 16pt, weight: "bold")[Suivre le changement jusqu’aux composants]
+#v(2mm)
+#block(width: 180mm)[Ajoutez un générateur de vapeur, une buse et un pichet amovible. Adaptez les commandes et la protection existantes. Les priorités proviennent de la matrice des besoins.]
+#v(3mm)
+#qfd(..manual-component-diff, width: auto, what-width: 58mm)
+#v(3mm)
+#block(width: 180mm)[Suivez d’abord le nettoyage et la protection : les pièces ajoutées affectent aussi les responsabilités existantes. Un poids jaune peut changer par simple normalisation ; les cellules colorées indiquent les changements de relations.]

--- a/packages/preview/qualitree/0.1.0/examples/fr/revisions.typ
+++ b/packages/preview/qualitree/0.1.0/examples/fr/revisions.typ
@@ -1,0 +1,11 @@
+#import "@preview/qualitree:0.1.0": qfd
+#import "milk-data.typ": manual-diff
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt, lang: "fr")
+#text(size: 16pt, weight: "bold")[Ajouter une buse vapeur]
+#v(2mm)
+#block(width: 165mm)[Un nouveau besoin : savourer un lait chaud et texturé. Deux fonctions supplémentaires : chauffer et texturer le lait. Les besoins de nettoyage, de place et de sécurité restent applicables.]
+#v(3mm)
+#qfd(..manual-diff, width: auto, what-width: 52mm)
+#v(3mm)
+#block(width: 165mm)[Lisez chaque ligne de gauche à droite. Le vert montre les ajouts ; les libellés jaunes signalent des responsabilités élargies. La sécurité dépend aussi du chauffage et de la texturation du lait. Les poids et relations sont illustratifs.]

--- a/packages/preview/qualitree/0.1.0/examples/milk-automatic.typ
+++ b/packages/preview/qualitree/0.1.0/examples/milk-automatic.typ
@@ -1,0 +1,15 @@
+#import "@preview/qualitree:0.1.0": qfd
+#import "milk-options.typ": automatic-diff, automatic-component-diff
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[Option B · automatic refrigerated milk]
+#v(2mm)
+#block(width: 190mm)[Compared with the same coffee-only baseline. In addition to milk drinks, keeping milk ready between sessions introduces cold storage and automatic metering. Cleaning and space requirements gain new interfaces.]
+#v(3mm)
+#qfd(..automatic-diff, width: auto, what-width: 52mm)
+#pagebreak()
+#text(size: 16pt, weight: "bold")[Option B · component consequences]
+#v(2mm)
+#block(width: 190mm)[A refrigerated reservoir, milk circuit, and automatic mixer require coordinated controls, cleaning access, and power/protection. Compare this architecture with the manual option; these are alternative concepts, not measured performance rankings.]
+#v(3mm)
+#qfd(..automatic-component-diff, width: auto, what-width: 52mm)

--- a/packages/preview/qualitree/0.1.0/examples/milk-data.typ
+++ b/packages/preview/qualitree/0.1.0/examples/milk-data.typ
@@ -1,0 +1,88 @@
+// Deploy one product change across both existing stages. All strengths and
+// weights are workshop hypotheses; unchanged IDs preserve the baseline history.
+#import "@preview/qualitree:0.1.0": qfd-stage, qfd-deploy, qfd-diff
+#import "coffee-data.typ": needs, functions, components, needs-functions, functions-components
+
+#let milk-needs = needs.map(item => if item.id == "routine" {
+  item + (label: [Set up and clean coffee and milk paths easily],)
+} else { item }) + (
+  (id: "milk-drink", label: [Enjoy warm milk drinks with suitable texture], weight: 8),
+  (id: "milk-ready", label: [Keep milk ready between drink sessions], weight: 6),
+)
+#let milk-functions = functions.map(item => if item.id == "guide" {
+  item + (label: [Guide coffee, milk, and cleaning sequences],)
+} else if item.id == "protect" {
+  item + (label: [Contain hot-water, steam, and electrical hazards],)
+} else if item.id == "collect" {
+  item + (label: [Collect doses, drips, and milk rinse waste],)
+} else { item }) + (
+  (id: "store-milk", label: [Store milk under controlled refrigeration], target: [Storage gate\ TBD]),
+  (id: "meter-milk", label: [Channel and meter milk to the cup], target: [Dose\ TBD]),
+  (id: "heat-milk", label: [Transfer controlled heat into milk], target: [Serving temp.\ TBD]),
+  (id: "texture-milk", label: [Generate steam and texture milk], target: [Texture\ TBD]),
+  (id: "clean-milk", label: [Flush and clean milk-contact paths], target: [Hygiene gate\ TBD]),
+)
+
+// Each existing need gets five new relationships in the function order above.
+// A positive strength means relevance, not a beneficial impact: refrigeration
+// can strongly affect footprint while making the footprint harder to satisfy.
+#let extensions = (
+  (1, 1, 3, 3, 9), // Taste: residues and milk preparation can affect the result.
+  (0, 1, 9, 3, 0), // Temperature now depends on the combined drink.
+  (3, 9, 9, 9, 3), // Consecutive drinks consume milk, heat, and rinse capacity.
+  (3, 3, 1, 3, 9), // The original cleaning need extends to the milk circuit.
+  (0, 0, 0, 0, 0), // Grounds preservation is unchanged by the added capability.
+  (9, 3, 3, 3, 3), // Cold storage and plumbing consume the existing space budget.
+  (3, 3, 9, 9, 9), // Steam, food-contact paths, and cooling add hazard interfaces.
+)
+#let milk-needs-functions = qfd-stage(
+  rows: milk-needs, columns: milk-functions,
+  matrix: needs-functions.matrix.enumerate().map(((i, row)) => row + extensions.at(i)) + (
+    (1, 3, 3, 0, 1, 0, 1, 0, 3, 1, 3, 3, 3, 9, 9, 9, 3),
+    (0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 9, 1, 0, 0, 9),
+  ),
+  correlations: needs-functions.correlations + ((2, 16, "-"), (13, 15, "-"), (14, 17, "+")),
+  labels: (whats: [Existing and new household needs], hows: [Functions · milk extension]),
+)
+
+#let milk-components = components.map(item => if item.id == "heater" {
+  item + (label: [Coffee heater and coordinated thermal sensing],)
+} else if item.id == "collector" {
+  item + (label: [Drip tray, dose container, and rinse capacity],)
+} else if item.id == "controller" {
+  item + (label: [Controller, milk sequence, and cleaning interface],)
+} else if item.id == "housing" {
+  item + (label: [Housing, steam protection, and shared power budget],)
+} else { item }) + (
+  (id: "cold-module", label: [Refrigerated milk reservoir and sensor]),
+  (id: "milk-circuit", label: [Milk pump, valves, and removable tubing]),
+  (id: "steam-module", label: [Steam generator and thermal protection]),
+  (id: "frother", label: [Steam–milk mixer and outlet]),
+)
+
+// Explicitly revise shared interfaces as well as adding hardware. Cleaning
+// participates in the inherited waste collector and controller; no standalone
+// "cleaner" component is assumed. Cooling technology is deliberately undecided.
+#let shared = functions-components.matrix.enumerate().map(((i, original)) => {
+  let row = original
+  if i == 1 { row.at(8) = 9; row.at(9) = 9 } // Coordinate heat demand and power.
+  row + (
+    (0, 0, 0, 0), (0, 0, 9, 0), (0, 0, 1, 0), (0, 0, 0, 0),
+    (0, 0, 3, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0),
+    (0, 0, 0, 3), (0, 1, 1, 3), (3, 3, 3, 3), (3, 3, 9, 9),
+  ).at(i)
+})
+#let milk-functions-components = qfd-deploy(milk-needs-functions,
+  columns: milk-components,
+  matrix: shared + (
+    (0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 9, 1, 0, 0),
+    (0, 0, 0, 0, 0, 0, 1, 1, 9, 1, 3, 9, 0, 3),
+    (1, 1, 0, 3, 0, 0, 0, 0, 9, 3, 0, 3, 9, 9),
+    (3, 1, 3, 3, 0, 0, 0, 1, 9, 3, 0, 3, 9, 9),
+    (3, 0, 0, 1, 0, 0, 0, 9, 9, 1, 9, 9, 3, 9),
+  ),
+  show-roof: false,
+  labels: (whats: [Functions · redeployed priorities], hows: [Existing and new components], importance: [Rel. %]),
+)
+#let revision-view = qfd-diff(needs-functions, milk-needs-functions)
+#let component-revision-view = qfd-diff(functions-components, milk-functions-components)

--- a/packages/preview/qualitree/0.1.0/examples/milk-detailed.typ
+++ b/packages/preview/qualitree/0.1.0/examples/milk-detailed.typ
@@ -1,0 +1,13 @@
+#import "@preview/qualitree:0.1.0": qfd
+#import "milk-data.typ": revision-view, component-revision-view
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[Detailed coffee study · integrated milk extension]
+#v(2mm)
+#block(width: 240mm)[This full deployment extends coffee-data.typ. It is separate from the compact teaching model in milk-options.typ. All judgments and targets remain provisional.]
+#v(3mm)
+#qfd(..revision-view, width: auto, what-width: 64mm)
+#pagebreak()
+#text(size: 16pt, weight: "bold")[Detailed deployment · component consequences]
+#v(3mm)
+#qfd(..component-revision-view, width: auto, what-width: 64mm)

--- a/packages/preview/qualitree/0.1.0/examples/milk-options.typ
+++ b/packages/preview/qualitree/0.1.0/examples/milk-options.typ
@@ -1,0 +1,105 @@
+// A compact teaching model, independent of the detailed coffee deployment.
+// Both options are compared against the same coffee-only baseline. Scores are
+// illustrative relevance judgments, not measured option performance.
+#import "@preview/qualitree:0.1.0": qfd-stage, qfd-deploy, qfd-diff
+
+#let needs = (
+  (id: "taste", label: [Enjoy good coffee], weight: 10),
+  (id: "clean", label: [Clean up easily], weight: 7),
+  (id: "space", label: [Use little counter space], weight: 4),
+  (id: "safe", label: [Use safely at home], weight: 10),
+)
+#let functions = (
+  (id: "coffee", label: [Prepare coffee]),
+  (id: "clean", label: [Clean fluid paths]),
+  (id: "protect", label: [Contain hazards]),
+)
+#let baseline = qfd-stage(rows: needs, columns: functions,
+  matrix: ((9, 3, 0), (3, 9, 1), (3, 3, 1), (3, 3, 9)),
+  show-roof: false,
+  labels: (whats: [Needs], hows: [Functions]),
+)
+#let milk-need = (id: "milk", label: [Enjoy warm, textured milk], weight: 8)
+#let milk-functions = (
+  (id: "heat-milk", label: [Heat milk]),
+  (id: "texture", label: [Texture milk]),
+)
+#let manual = qfd-stage(rows: needs + (milk-need,),
+  columns: functions.slice(0, 1) + (
+    functions.at(1) + (label: [Clean coffee and milk paths],),
+    functions.at(2) + (label: [Contain coffee and steam hazards],),
+  ) + milk-functions,
+  matrix: (
+    (9, 3, 0, 1, 1),
+    (3, 9, 1, 3, 3),
+    (3, 3, 1, 3, 3),
+    (3, 3, 9, 9, 9),
+    (1, 3, 3, 9, 9),
+  ),
+  show-roof: false,
+  labels: (whats: [Existing needs + milk drinks], hows: [Functions]),
+)
+#let automatic = qfd-stage(
+  rows: needs + (milk-need, (id: "ready", label: [Keep milk ready between sessions], weight: 6)),
+  columns: manual.column-ids.enumerate().map(((i, id)) => (id: id, label: manual.hows.at(i))) + (
+    (id: "cold", label: [Store refrigerated milk]),
+    (id: "meter", label: [Meter milk automatically]),
+  ),
+  matrix: manual.matrix.enumerate().map(((i, row)) => row + (
+    (1, 1), (9, 9), (9, 3), (3, 3), (3, 9),
+  ).at(i)) + ((0, 9, 3, 0, 0, 9, 3),),
+  show-roof: false,
+  labels: (whats: [Existing needs + milk convenience], hows: [Functions]),
+)
+#let components = (
+  (id: "coffee", label: [Coffee brewing module]),
+  (id: "control", label: [Controller and interface]),
+  (id: "housing", label: [Housing and protection]),
+)
+#let baseline-components = qfd-deploy(baseline, columns: components,
+  matrix: ((9, 3, 3), (9, 3, 1), (3, 3, 9)),
+  show-roof: false,
+  labels: (whats: [Functions], hows: [Components], importance: [Rel. %]),
+)
+#let manual-components = qfd-deploy(manual,
+  columns: (components.at(0),
+    components.at(1) + (label: [Controller with steam mode],),
+    components.at(2) + (label: [Housing and steam protection],),
+    (id: "steam", label: [Steam generator]),
+    (id: "wand", label: [Steam wand and removable jug]),
+  ),
+  matrix: (
+    (9, 3, 3, 0, 0),
+    (9, 3, 1, 1, 9),
+    (3, 9, 9, 9, 9),
+    (1, 9, 3, 9, 9),
+    (0, 3, 3, 9, 9),
+  ),
+  show-roof: false,
+  labels: (whats: [Functions · inherited priorities], hows: [Components], importance: [Rel. %]),
+)
+#let automatic-components = qfd-deploy(automatic,
+  columns: (components.at(0),
+    components.at(1) + (label: [Controller with automatic milk cycle],),
+    components.at(2) + (label: [Housing and shared power protection],),
+    (id: "steam", label: [Steam generator]),
+    (id: "mixer", label: [Automatic steam–milk mixer]),
+    (id: "cold", label: [Refrigerated reservoir]),
+    (id: "circuit", label: [Milk pump, valves, and tubing]),
+  ),
+  matrix: (
+    (9, 3, 3, 0, 0, 0, 0),
+    (9, 9, 1, 1, 9, 9, 9),
+    (3, 9, 9, 9, 9, 3, 3),
+    (1, 9, 3, 9, 9, 0, 3),
+    (0, 9, 3, 9, 9, 0, 3),
+    (0, 3, 3, 0, 0, 9, 1),
+    (0, 9, 1, 0, 3, 3, 9),
+  ),
+  show-roof: false,
+  labels: (whats: [Functions · inherited priorities], hows: [Components], importance: [Rel. %]),
+)
+#let manual-diff = qfd-diff(baseline, manual)
+#let manual-component-diff = qfd-diff(baseline-components, manual-components)
+#let automatic-diff = qfd-diff(baseline, automatic)
+#let automatic-component-diff = qfd-diff(baseline-components, automatic-components)

--- a/packages/preview/qualitree/0.1.0/examples/minimal.typ
+++ b/packages/preview/qualitree/0.1.0/examples/minimal.typ
@@ -1,0 +1,16 @@
+#import "../lib.typ": qfd
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[A first House of Quality]
+#v(3mm)
+#qfd(
+  whats: ([Easy to prepare], [Easy to clean]),
+  hows: ([Guide the sequence], [Collect the drips]),
+  importance: (5, 3), relations: ((1, 1, "S"), (1, 2, "W"), (2, 2, "S")),
+  directions: ("minimize", "maximize"),
+  targets: ([Few steps], [Three drinks]),
+  correlations: ((1, 2, "+"),),
+  width: auto,
+)
+#v(2mm)
+Illustrative judgments: S = 9, M = 3, W = 1.

--- a/packages/preview/qualitree/0.1.0/examples/minimal.typ
+++ b/packages/preview/qualitree/0.1.0/examples/minimal.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
 #text(size: 16pt, weight: "bold")[A first House of Quality]

--- a/packages/preview/qualitree/0.1.0/examples/profiles.typ
+++ b/packages/preview/qualitree/0.1.0/examples/profiles.typ
@@ -1,0 +1,15 @@
+#import "../lib.typ": qfd
+#set page(width: auto, height: auto, margin: 6mm)
+#set text(font: "IBM Plex Sans", size: 10pt)
+= Overlapping observations
+Synthetic scores demonstrate vertical staggering; x remains the reported score.
+#v(4mm)
+#qfd(whats: ("First observation", "Second observation", "Third observation", "Fourth observation"),
+ hows: ("Example function",), show-roof: false, show-basement: false, show-rel-legend: false,
+ alternatives: (
+  (label: "A", scores: (4,3,4,3)),
+  (label: "B", scores: (3,3,1,2)),
+  (label: "C", scores: (3,1,1,3)),
+  (label: "D", scores: (1,1,4,4)),
+  (label: "E", scores: (3,1,1,3)),
+ ), row-height: 18mm, comparison-width: 42mm, width: auto)

--- a/packages/preview/qualitree/0.1.0/examples/profiles.typ
+++ b/packages/preview/qualitree/0.1.0/examples/profiles.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #set page(width: auto, height: auto, margin: 6mm)
 #set text(font: "IBM Plex Sans", size: 10pt)
 = Overlapping observations

--- a/packages/preview/qualitree/0.1.0/examples/report.typ
+++ b/packages/preview/qualitree/0.1.0/examples/report.typ
@@ -1,0 +1,44 @@
+#import "../lib.typ": qfd
+#import "coffee-data.typ": needs-functions, functions-components
+#set page(paper: "a3", margin: 15mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 10pt)
+#set par(leading: 0.6em)
+#text(font: ("IBM Plex Serif", "Libertinus Serif"), size: 22pt)[Coffee at home]
+#v(1mm)
+#text(size: 12pt)[A worked deployment from household needs to components]
+#v(4mm)
+#block(width: 100%)[
+  The intended substitution is a coffee prepared at home instead of a visit to the local café.
+  The provisional system boundary includes the machine, a sealed preground dose, and its packaging.
+  All weights, relations, and roof signs below are illustrative workshop judgments.
+
+  *Acceptance comes first.* Taste, drink temperature, and household safety require separate
+  pass/fail checks. Their thresholds and validation protocols must be agreed before a concept
+  is accepted. Relative priority cannot compensate for failing one of these gates.
+]
+#v(4mm)
+#text(size: 16pt, weight: "bold")[1 · Translate needs into functions]
+#v(2mm)
+#qfd(..needs-functions, width: 100%)
+#v(3mm)
+#block(width: 100%)[
+  Function groups cover water storage and energy conversion; pressure, flow, and extraction;
+  preservation of grounds; serving and waste collection; guidance and protection.
+  Brewing-water temperature of 92 ± 2 °C, about 25 s of contact, and six months of freshness
+  are provisional targets. They are not measured results or universal capsule specifications.
+]
+#pagebreak()
+#text(size: 16pt, weight: "bold")[2 · Deploy priorities into components]
+#v(2mm)
+#qfd(..functions-components, width: 100%, what-width: 64mm)
+#v(3mm)
+#block(width: 100%)[
+  The row weights are inherited from stage 1 without rounding. The proposed components organize
+  possible implementations; a turbine flowmeter or a particular pump technology still requires
+  selection and testing. No stepper motor is assumed.
+
+  *Next evidence:* compare blind taste and temperature at serving with the chosen café reference;
+  repeat a three-drink sequence; observe setup and cleanup; test stored sealed doses; assess footprint
+  and foreseeable household misuse. No competitive scores have been measured in this example.
+  See COFFEE.md for protocols, limitations, and sources.
+]

--- a/packages/preview/qualitree/0.1.0/examples/report.typ
+++ b/packages/preview/qualitree/0.1.0/examples/report.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #import "coffee-data.typ": needs-functions, functions-components
 #set page(paper: "a3", margin: 15mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 10pt)

--- a/packages/preview/qualitree/0.1.0/examples/revision-components.typ
+++ b/packages/preview/qualitree/0.1.0/examples/revision-components.typ
@@ -1,0 +1,11 @@
+#import "@preview/qualitree:0.1.0": qfd
+#import "milk-data.typ": component-revision-view
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[Adding milk drinks · functions → components]
+#v(2mm)
+#block(width: 240mm)[The same revision continues into hardware. Existing function rows come first; the five new milk functions follow. Row priorities are recalculated from the revised needs → functions stage, preserving full precision.]
+#v(3mm)
+#qfd(..component-revision-view, width: auto, what-width: 64mm)
+#v(3mm)
+#block(width: 240mm)[*Reuse still requires redesign.* The controller coordinates brewing, cooling, steaming, and cleaning; the housing carries the shared power and protection requirements; the tray collects milk-rinse waste. Yellow weights can change through priority normalization even when a row’s relationships stay unchanged.]

--- a/packages/preview/qualitree/0.1.0/examples/revision-components.typ
+++ b/packages/preview/qualitree/0.1.0/examples/revision-components.typ
@@ -1,11 +1,11 @@
 #import "@preview/qualitree:0.1.0": qfd
-#import "milk-data.typ": component-revision-view
+#import "milk-options.typ": manual-component-diff
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
-#text(size: 16pt, weight: "bold")[Adding milk drinks · functions → components]
+#text(size: 16pt, weight: "bold")[Follow the change into components]
 #v(2mm)
-#block(width: 240mm)[The same revision continues into hardware. Existing function rows come first; the five new milk functions follow. Row priorities are recalculated from the revised needs → functions stage, preserving full precision.]
+#block(width: 170mm)[Add a steam generator, wand, and removable jug. Expand the existing controls and protection. Function priorities come from the preceding needs matrix.]
 #v(3mm)
-#qfd(..component-revision-view, width: auto, what-width: 64mm)
+#qfd(..manual-component-diff, width: auto, what-width: 52mm)
 #v(3mm)
-#block(width: 240mm)[*Reuse still requires redesign.* The controller coordinates brewing, cooling, steaming, and cleaning; the housing carries the shared power and protection requirements; the tray collects milk-rinse waste. Yellow weights can change through priority normalization even when a row’s relationships stay unchanged.]
+#block(width: 170mm)[Read the cleaning and protection rows first: adding the new parts also changes existing responsibilities. Yellow row weights can change through normalization alone; highlighted cells show the relationship edits.]

--- a/packages/preview/qualitree/0.1.0/examples/revisions.typ
+++ b/packages/preview/qualitree/0.1.0/examples/revisions.typ
@@ -1,0 +1,11 @@
+#import "../lib.typ": qfd
+#import "coffee-data.typ": revision-view
+#set page(width: auto, height: auto, margin: 8mm)
+#set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
+#text(size: 16pt, weight: "bold")[Reviewing a design revision]
+#v(2mm)
+#block(width: 180mm)[A small fictional revision demonstrates stable IDs, reordered entities, additions, removals, and modifications. It compares two design records; it is separate from comparison with a local café.]
+#v(3mm)
+#qfd(..revision-view, width: auto, what-width: 58mm, cell-size: 11mm)
+#v(3mm)
+#block(width: 180mm)[Removed relations and roof signs remain visible for review. Removed rows show their historical weights, while their current importance is zero. Removed relationships contribute zero to current priorities.]

--- a/packages/preview/qualitree/0.1.0/examples/revisions.typ
+++ b/packages/preview/qualitree/0.1.0/examples/revisions.typ
@@ -1,11 +1,11 @@
 #import "@preview/qualitree:0.1.0": qfd
-#import "coffee-data.typ": revision-view
+#import "milk-data.typ": revision-view
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
-#text(size: 16pt, weight: "bold")[Reviewing a design revision]
+#text(size: 16pt, weight: "bold")[Adding milk drinks · needs → functions]
 #v(2mm)
-#block(width: 180mm)[A small fictional revision demonstrates stable IDs, reordered entities, additions, removals, and modifications. It compares two design records; it is separate from comparison with a local café.]
+#block(width: 240mm)[Before: the capsule-coffee machine. After: an integrated refrigerated milk supply and automatic steaming/frothing. Read each existing need across its new relationships, then the two new needs at the bottom. All judgments remain provisional.]
 #v(3mm)
-#qfd(..revision-view, width: auto, what-width: 58mm, cell-size: 11mm)
+#qfd(..revision-view, width: auto, what-width: 64mm)
 #v(3mm)
-#block(width: 180mm)[Removed relations and roof signs remain visible for review. Removed rows show their historical weights, while their current importance is zero. Removed relationships contribute zero to current priorities.]
+#block(width: 240mm)[*Existing needs still apply.* Milk changes taste, drink temperature, throughput, cleanup, footprint, and safety. Grounds preservation stays unchanged. Strong relationships identify design responsibility, not proof of improvement. The roof records proposed heating/power and cold/hot integration tensions.]

--- a/packages/preview/qualitree/0.1.0/examples/revisions.typ
+++ b/packages/preview/qualitree/0.1.0/examples/revisions.typ
@@ -1,11 +1,11 @@
 #import "@preview/qualitree:0.1.0": qfd
-#import "milk-data.typ": revision-view
+#import "milk-options.typ": manual-diff
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)
-#text(size: 16pt, weight: "bold")[Adding milk drinks · needs → functions]
+#text(size: 16pt, weight: "bold")[Add a steam wand]
 #v(2mm)
-#block(width: 240mm)[Before: the capsule-coffee machine. After: an integrated refrigerated milk supply and automatic steaming/frothing. Read each existing need across its new relationships, then the two new needs at the bottom. All judgments remain provisional.]
+#block(width: 155mm)[One new need: enjoy warm, textured milk. Two added functions: heat milk and texture it. The existing cleaning, space, and safety needs still apply.]
 #v(3mm)
-#qfd(..revision-view, width: auto, what-width: 64mm)
+#qfd(..manual-diff, width: auto, what-width: 46mm)
 #v(3mm)
-#block(width: 240mm)[*Existing needs still apply.* Milk changes taste, drink temperature, throughput, cleanup, footprint, and safety. Grounds preservation stays unchanged. Strong relationships identify design responsibility, not proof of improvement. The roof records proposed heating/power and cold/hot integration tensions.]
+#block(width: 155mm)[Read across each row. Green bands show additions; yellow labels show expanded responsibilities. For example, the safety row now also relates strongly to milk heating and texturing. Scores are illustrative.]

--- a/packages/preview/qualitree/0.1.0/examples/revisions.typ
+++ b/packages/preview/qualitree/0.1.0/examples/revisions.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": qfd
+#import "@preview/qualitree:0.1.0": qfd
 #import "coffee-data.typ": revision-view
 #set page(width: auto, height: auto, margin: 8mm)
 #set text(font: ("IBM Plex Sans", "New Computer Modern"), size: 9pt)

--- a/packages/preview/qualitree/0.1.0/lib.typ
+++ b/packages/preview/qualitree/0.1.0/lib.typ
@@ -1,7 +1,8 @@
 // Public API. Internal panels remain private to the package structure.
 #import "src/model.typ": qfd-matrix
 #import "src/calculations.typ": qfd-weights, qfd-correlation-point
-#import "src/theme.typ": qfd-palette, qfd-theme
+#import "src/theme.typ": qfd-theme
+#import "src/palette.typ": qfd-palette
 #import "src/stages.typ": qfd-stage, qfd-deploy
 #import "src/revisions.typ": qfd-diff
 #import "src/draw.typ": house-of-quality

--- a/packages/preview/qualitree/0.1.0/lib.typ
+++ b/packages/preview/qualitree/0.1.0/lib.typ
@@ -1,0 +1,8 @@
+// Public API. Internal panels remain private to the package structure.
+#import "src/model.typ": qfd-matrix
+#import "src/calculations.typ": qfd-weights, qfd-correlation-point
+#import "src/theme.typ": qfd-palette, qfd-theme
+#import "src/stages.typ": qfd-stage, qfd-deploy
+#import "src/revisions.typ": qfd-diff
+#import "src/draw.typ": house-of-quality
+#let qfd = house-of-quality

--- a/packages/preview/qualitree/0.1.0/src/calculations.typ
+++ b/packages/preview/qualitree/0.1.0/src/calculations.typ
@@ -1,0 +1,33 @@
+#import "model.typ": _dense, _nonnegative, _correlation-point
+
+// Absolute weights: sum_i importance[i] * relation[i][j].
+// Relative weights are percentages in 0..100, not Typst ratio values.
+// Independent rounding is deliberate: rounded percentages may not sum to 100.
+#let qfd-weights(importance, matrix, digits: 0) = {
+  assert(type(matrix) == array and matrix.len() > 0,
+    message: "qfd: matrix must not be empty")
+  assert(type(matrix.first()) == array and matrix.first().len() > 0,
+    message: "qfd: matrix must have at least one column")
+  let rows = matrix.len()
+  let columns = matrix.first().len()
+  let matrix = _dense(matrix, rows, columns)
+  assert(type(importance) == array and importance.len() == rows,
+    message: "qfd: importance must have one number per WHAT")
+  assert(importance.all(_nonnegative),
+    message: "qfd: importance values must be finite, nonnegative numbers")
+  assert(type(digits) == int and digits >= 0 and digits <= 10,
+    message: "qfd: digits must be an integer from 0 to 10")
+  let absolute = range(columns).map(c =>
+    range(rows).map(r => importance.at(r) * matrix.at(r).at(c)).sum())
+  let total = absolute.sum()
+  let relative = absolute.map(v => if total == 0 { 0 } else { 100 * v / total })
+  (
+    absolute: absolute,
+    total: total,
+    relative: relative,
+    rounded: relative.map(v => calc.round(v, digits: digits)),
+  )
+}
+
+// Public geometry helper shares validation with normalized roof records.
+#let qfd-correlation-point = _correlation-point

--- a/packages/preview/qualitree/0.1.0/src/change-display.typ
+++ b/packages/preview/qualitree/0.1.0/src/change-display.typ
@@ -16,3 +16,16 @@
   let fill = change-fill(status, style)
   if fill != none { place(top + left, dx: x, dy: y, rect(width: width, height: height, fill: fill, stroke: none)) }
 }
+
+// Structural additions/removals color the whole band, including empty cells.
+// An added-row/removed-column intersection existed in neither revision; keep
+// it neutral instead of implying a relationship was added or removed there.
+#let cell-background-status(data, row, column) = {
+  let status = cell-status(data, row, column)
+  if status != "unchanged" { return status }
+  let axes = (row-status(data, row), column-status(data, column))
+  if "added" in axes and "removed" in axes { "unchanged" }
+  else if "added" in axes { "added" }
+  else if "removed" in axes { "removed" }
+  else { "unchanged" }
+}

--- a/packages/preview/qualitree/0.1.0/src/change-display.typ
+++ b/packages/preview/qualitree/0.1.0/src/change-display.typ
@@ -1,0 +1,18 @@
+// Revision colors indicate edit operations, never relationship strength. Dark
+// symbols and explicit +/−/~ marks keep the meaning available without color.
+#import "text.typ": _as-content
+
+#let change-fill(status, style) = if status == "unchanged" { none } else { style.at(status + "-fill") }
+#let change-mark(status) = (unchanged: "", added: "+", removed: "−", changed: "~").at(status)
+#let changed-label(label, status) = if status == "unchanged" { _as-content(label) } else {
+  [#strong(change-mark(status)) #_as-content(label)]
+}
+#let row-status(data, index) = if data.changes == none { "unchanged" } else { data.changes.rows.at(index) }
+#let column-status(data, index) = if data.changes == none { "unchanged" } else { data.changes.columns.at(index) }
+#let cell-status(data, row, column) = if data.changes == none { "unchanged" } else {
+  data.changes.cells.at(row).at(column)
+}
+#let fill-cell(x, y, width, height, status, style) = {
+  let fill = change-fill(status, style)
+  if fill != none { place(top + left, dx: x, dy: y, rect(width: width, height: height, fill: fill, stroke: none)) }
+}

--- a/packages/preview/qualitree/0.1.0/src/comparison-panel.typ
+++ b/packages/preview/qualitree/0.1.0/src/comparison-panel.typ
@@ -1,0 +1,54 @@
+// The series panel consumes one set of displaced points for BOTH lines and
+// markers. Missing scores split paths, avoiding invented interpolated evidence.
+#import "symbols.typ": _polyline
+#import "profile-symbols.typ": _profile-pen, _profile-marker
+#import "profile-layout.typ": stagger-profiles
+#import "text.typ": _cell, _as-content
+
+#let draw-comparison(data, g, style) = {
+  if not data.show-competitive { return [] }
+  let (minimum, maximum) = data.score-range
+  let tick-width = g.cw / (maximum - minimum + 1)
+  let score-x(score) = g.mx + g.mw + (score - minimum + 0.5) * tick-width
+  let tick-height = calc.min(4.5mm, g.header / 4)
+  let title-height = calc.min(11mm, g.header - tick-height)
+  _cell(g.mx + g.mw, g.my - tick-height - title-height, g.cw, title-height,
+    strong(_as-content(data.labels.comparison)), wrap: true, inset: g.cell-padding)
+  for tick in range(minimum, maximum + 1) {
+    _cell(score-x(tick) - tick-width / 2, g.my - tick-height,
+      tick-width, tick-height, tick, inset: 0pt)
+  }
+  let sizes = data.alternatives.map(item => calc.min(item.marker-size * (style.symbol-size / 7pt),
+    tick-width * 0.75, g.row * 0.40))
+  let diameter = if sizes.len() == 0 { 0 } else { calc.max(..sizes) / g.row + 0.035 }
+  let points = stagger-profiles(data.alternatives.map(a => a.scores),
+    enabled: style.marker-stagger, spread: style.marker-spread, diameter: diameter, x-step: tick-width / g.row)
+  for (s, item) in data.alternatives.enumerate() {
+    let run = ()
+    for point in points.at(s) {
+      if point == none { _polyline(run, _profile-pen(item)); run = () }
+      else { run.push((score-x(point.x), g.my + point.y * g.row)) }
+    }
+    _polyline(run, _profile-pen(item))
+  }
+  for (s, item) in data.alternatives.enumerate() {
+    for (r, point) in points.at(s).enumerate() {
+      if point == none { continue }
+      // For large tie groups, shrink just the tied markers enough to fit their
+      // available vertical lanes. The data x-coordinate remains untouched.
+      let gaps = points.enumerate().filter(((i, p)) => i != s and p.at(r) != none and
+        calc.abs(p.at(r).x - point.x) * tick-width < sizes.at(s))
+        .map(((i, p)) => calc.abs(p.at(r).y - point.y) * g.row)
+        .filter(gap => gap > 0pt)
+      let size = if style.marker-stagger and gaps.len() > 0 {
+        calc.min(sizes.at(s), calc.min(..gaps) * 0.88)
+      } else { sizes.at(s) }
+      place(top + left, dx: score-x(point.x) - size / 2, dy: g.my + point.y * g.row - size / 2,
+        _profile-marker(item, size))
+    }
+  }
+  _cell(g.mx + g.mw, g.my + g.mh, g.cw / 2, 5mm, emph(_as-content(data.labels.poor)),
+    anchor: left + horizon, inset: 0.5mm)
+  _cell(g.mx + g.mw + g.cw / 2, g.my + g.mh, g.cw / 2, 5mm, emph(_as-content(data.labels.excellent)),
+    anchor: right + horizon, inset: 0.5mm)
+}

--- a/packages/preview/qualitree/0.1.0/src/draw.typ
+++ b/packages/preview/qualitree/0.1.0/src/draw.typ
@@ -1,0 +1,77 @@
+// Public rendering boundary: normalize once, measure once, then compose panels.
+// The package does not set page size or load fonts. Dimensions below describe
+// the natural figure; width controls a single final uniform scale.
+#import "theme.typ": qfd-theme
+#import "figure-data.typ": prepare-figure
+#import "layout.typ": figure-layout, fit-figure
+#import "legend.typ": _legend
+#import "roof.typ": draw-roof
+#import "matrix-panel.typ": draw-matrix, draw-basement, draw-grid
+#import "comparison-panel.typ": draw-comparison
+
+// Render one House of Quality. Plain arrays use one-based positional relations;
+// qfd-stage/qfd-diff supply the same arguments plus stable IDs and change data.
+// Explicit font/line arguments take precedence over theme; auto uses its default.
+#let house-of-quality(
+  whats: (), hows: (), relations: (), matrix: none, importance: none,
+  correlations: (), targets: none, difficulty: none, directions: none, basement: auto,
+  alternatives: (), score-range: (0, 5), legend-order: auto, labels: (:),
+  row-ids: none, column-ids: none, changes: none,
+  show-roof: true, show-importance: auto, show-basement: true,
+  show-competitive: auto, show-legend: true,
+  show-rel-legend: true, show-corr-legend: true, show-eval-legend: true,
+  width: 100%, cell-size: 9mm, row-height: auto, what-width: 54mm,
+  importance-width: 8mm, comparison-width: 38mm, header-height: auto,
+  basement-height: auto, legend-width: 43mm, legend-gap: 5mm,
+  cell-padding: 1mm, label-padding: 2mm, header-padding: 1.5mm,
+  theme: (:), font: auto, serif-font: auto, font-size: auto,
+  ink: auto, grid-thickness: auto, frame-thickness: auto, symbol-size: auto,
+  correlation-style: "circled", marker-stagger: true, marker-spread: 0.30,
+  relative-digits: 0, weight-digits: 1,
+) = context {
+  assert(type(theme) == dictionary, message: "qfd: theme must be a dictionary")
+  for key in theme.keys() { assert(key in qfd-theme, message: "qfd: unknown theme key: " + key) }
+  let style = qfd-theme + theme
+  let overrides = (font: font, serif-font: serif-font, font-size: font-size,
+    ink: ink, grid-thickness: grid-thickness, frame-thickness: frame-thickness, symbol-size: symbol-size)
+  for (key, value) in overrides { if value != auto { style.insert(key, value) } }
+  assert(type(style.ink) == color, message: "qfd: ink must be a Typst color")
+  assert(correlation-style in ("circled", "text"), message: "qfd: correlation-style must be circled or text")
+  assert(type(marker-stagger) == bool, message: "qfd: marker-stagger must be boolean")
+  assert(type(marker-spread) in (int, float) and marker-spread >= 0 and marker-spread <= 0.30,
+    message: "qfd: marker-spread must be between 0 and 0.30")
+  assert(type(weight-digits) == int and weight-digits >= 0 and weight-digits <= 10,
+    message: "qfd: weight-digits must be an integer from 0 to 10")
+  style += (weight-digits: weight-digits, thin: (paint: style.ink, thickness: style.grid-thickness),
+    frame: (paint: style.ink, thickness: style.frame-thickness), correlation-style: correlation-style,
+    marker-stagger: marker-stagger, marker-spread: marker-spread)
+  let data = prepare-figure(whats, hows, relations, matrix, importance, correlations,
+    targets, difficulty, directions, basement, alternatives, score-range, legend-order,
+    labels, show-roof, show-importance, show-basement, show-competitive, show-legend,
+    show-rel-legend, show-corr-legend, show-eval-legend, relative-digits, changes)
+  set text(font: style.font, size: style.font-size, fill: style.ink, weight: "regular", style: "normal", hyphenate: false)
+  set par(justify: false, leading: 0.3em, spacing: 0pt, first-line-indent: 0pt)
+  set block(above: 0pt, below: 0pt)
+  set align(left)
+  let legend = if data.show-legend {
+    _legend(data.labels, data.alternatives, data.legend-order, data.score-range,
+      legend-width, style.thin, style.frame, style.ink, style.symbol-size,
+      symbol-thickness: style.symbol-thickness, correlation-style: correlation-style, changes: changes != none,
+      change-fills: (added: style.added-fill, removed: style.removed-fill, changed: style.changed-fill),
+      relation: data.show-rel-legend, correlation: data.show-roof and data.show-corr-legend,
+      evaluation: data.show-competitive and data.show-eval-legend and data.alternatives.len() > 0)
+  } else { none }
+  let legend-size = if legend == none { (width: 0pt, height: 0pt) } else { measure(legend) }
+  let g = figure-layout(data, style, cell-size, row-height, what-width, importance-width,
+    comparison-width, header-height, basement-height, legend-width, legend-gap,
+    cell-padding, label-padding, header-padding, legend-size)
+  let drawing = box(width: g.width, height: g.height, {
+    draw-roof(data, g, style)
+    draw-matrix(data, g, style)
+    draw-basement(data, g, style)
+    draw-comparison(data, g, style)
+    draw-grid(data, g, style)
+    if legend != none { place(top + left, dx: g.legend-x, dy: g.roof-base, legend) }
+  })
+  fit-figure(drawing, g.width, width)
+}

--- a/packages/preview/qualitree/0.1.0/src/figure-data.typ
+++ b/packages/preview/qualitree/0.1.0/src/figure-data.typ
@@ -1,0 +1,102 @@
+// Validate figure semantics before measuring or drawing anything. The returned
+// record is shared by panels; they never reinterpret weights or visibility.
+#import "model.typ": qfd-matrix, _dense, _correlations, _alternatives
+#import "calculations.typ": qfd-weights
+#import "labels.typ": _labels
+
+#let prepare-figure(
+  whats, hows, relations, matrix, importance, correlations, targets, difficulty,
+  directions, basement, alternatives, score-range, legend-order, labels,
+  show-roof, show-importance, show-basement, show-competitive, show-legend,
+  show-rel-legend, show-corr-legend, show-eval-legend, relative-digits, changes,
+) = {
+  assert(type(whats) == array and whats.len() > 0,
+    message: "qfd: whats must be a nonempty array")
+  assert(type(hows) == array and hows.len() > 0,
+    message: "qfd: hows must be a nonempty array")
+  let nr = whats.len()
+  let nc = hows.len()
+  let rel = if matrix == none {
+    qfd-matrix(nr, nc, relations: relations)
+  } else {
+    assert(type(relations) == array and relations.len() == 0,
+      message: "qfd: pass either matrix or relations, not both")
+    _dense(matrix, nr, nc)
+  }
+  let corr = _correlations(correlations, nc)
+  let weights = if importance == none { none } else {
+    qfd-weights(importance, rel, digits: relative-digits)
+  }
+  if targets != none {
+    assert(type(targets) == array and targets.len() == nc,
+      message: "qfd: targets must have one entry per HOW")
+  }
+  assert(type(labels) == dictionary, message: "qfd: labels must be a dictionary")
+  for key in labels.keys() {
+    assert(key in _labels, message: "qfd: unknown label key: " + key)
+  }
+  let labels = _labels + labels
+  assert(type(score-range) == array and score-range.len() == 2,
+    message: "qfd: score-range must contain two integer endpoints")
+  let (score-min, score-max) = score-range
+  assert(type(score-min) == int and type(score-max) == int and score-min < score-max,
+    message: "qfd: score-range must contain increasing integer endpoints")
+  let alternatives = _alternatives(alternatives, nr, score-range)
+  let show-importance = if show-importance == auto { importance != none } else { show-importance }
+  let show-competitive = if show-competitive == auto { alternatives.len() > 0 } else { show-competitive }
+  assert(not show-importance or importance != none,
+    message: "qfd: show-importance requires importance data")
+  for flag in (show-roof, show-importance, show-basement, show-competitive,
+    show-legend, show-rel-legend, show-corr-legend, show-eval-legend) {
+    assert(type(flag) == bool, message: "qfd: visibility flags must be booleans")
+  }
+  let order = if legend-order == auto { range(1, alternatives.len() + 1) } else { legend-order }
+  assert(type(order) == array and order.sorted() == range(1, alternatives.len() + 1),
+    message: "qfd: legend-order must be a permutation of the 1-based alternative indices")
+
+  if difficulty != none {
+    assert(type(difficulty) == array and difficulty.len() == nc,
+      message: "qfd: difficulty must have one entry per HOW")
+  }
+  let directions = if directions == none { range(nc).map(_ => none) } else { directions }
+  assert(type(directions) == array and directions.len() == nc and
+    directions.all(d => d == none or d in ("maximize", "minimize", "target", "none")),
+    message: "qfd: directions must contain one maximize/minimize/target/none per HOW")
+  let basement = if basement == auto {
+    let rows = ()
+    if targets != none and targets.any(v => v != none) { rows.push((label: labels.target, values: targets)) }
+    if difficulty != none { rows.push((label: labels.difficulty, values: difficulty)) }
+    if weights != none {
+      rows.push((label: labels.absolute, values: weights.absolute, computed: true))
+      rows.push((label: labels.relative, values: weights.rounded, bold: true))
+    }
+    rows
+  } else { basement }
+  assert(type(basement) == array, message: "qfd: basement must be auto or an array of rows")
+  for row in basement {
+    assert(type(row) == dictionary and "label" in row and "values" in row,
+      message: "qfd: each basement row requires label and values")
+    assert(type(row.values) == array and row.values.len() == nc,
+      message: "qfd: each basement row must have one value per HOW")
+  }
+  let basement = if show-basement { basement } else { () }
+
+  if changes != none {
+    let statuses = ("unchanged", "added", "removed", "changed")
+    assert(type(changes) == dictionary, message: "qfd: changes must be a revision dictionary")
+    assert(changes.rows.len() == nr and changes.columns.len() == nc,
+      message: "qfd: revision dimensions must match the figure")
+    assert(changes.rows.all(s => s in statuses) and changes.columns.all(s => s in statuses),
+      message: "qfd: unknown revision status")
+    assert(changes.cells.len() == nr and changes.cells.all(r => r.len() == nc and r.all(s => s in statuses)),
+      message: "qfd: revision cells must match the matrix")
+    let previous = _dense(changes.previous-matrix, nr, nc)
+  }
+  (whats: whats, hows: hows, nr: nr, nc: nc, matrix: rel, importance: importance,
+   correlations: corr, targets: targets, directions: directions, basement: basement,
+   alternatives: alternatives, score-range: score-range, legend-order: order,
+   labels: labels, changes: changes, weights: weights,
+   show-roof: show-roof, show-importance: show-importance, show-competitive: show-competitive,
+   show-legend: show-legend, show-rel-legend: show-rel-legend,
+   show-corr-legend: show-corr-legend, show-eval-legend: show-eval-legend)
+}

--- a/packages/preview/qualitree/0.1.0/src/labels.typ
+++ b/packages/preview/qualitree/0.1.0/src/labels.typ
@@ -1,0 +1,13 @@
+// English defaults are data, allowing each matrix level to name its axes.
+#let _labels = (
+  whats: [Customer needs], importance: [Weight],
+  comparison: [Comparative evaluation], poor: [poor], excellent: [excellent],
+  relation: [Relation], correlation: [Correlation], evaluation: [Evaluation],
+  strong: [Strong (9)], medium: [Medium (3)], weak: [Weak (1)],
+  very-positive: [very positive], positive: [positive],
+  negative: [negative], very-negative: [very negative],
+  target: [Target], absolute: [Σ abs], relative: [Rel. %],
+  score-note: auto, hows: [Functions], difficulty: [Difficulty], direction: [Direction],
+  changes: [Changes], added: [Added], removed: [Removed], changed: [Changed],
+)
+

--- a/packages/preview/qualitree/0.1.0/src/layout.typ
+++ b/packages/preview/qualitree/0.1.0/src/layout.typ
@@ -1,0 +1,62 @@
+// Measure text at natural size before allocating the figure. Rendering panels
+// consume this geometry without measuring again, so every shared edge agrees.
+#import "text.typ": _as-content
+#import "change-display.typ": changed-label, row-status, column-status
+
+#let figure-layout(data, style, cell-size, row-height, what-width, importance-width,
+  comparison-width, header-height, basement-height, legend-width, legend-gap,
+  cell-padding, label-padding, header-padding, legend-size) = {
+  for value in (cell-size, what-width, importance-width, comparison-width,
+    legend-width, style.font-size, style.symbol-size, style.grid-thickness, style.frame-thickness) {
+    assert(type(value) == length and value > 0pt, message: "qfd: dimensions and thicknesses must be positive lengths")
+  }
+  for value in (cell-padding, label-padding, header-padding, legend-gap) {
+    assert(type(value) == length and value >= 0pt, message: "qfd: padding and gaps must be nonnegative lengths")
+  }
+  assert(what-width > 2 * label-padding, message: "qfd: label padding leaves no room for text")
+  let direction-height = if data.directions.any(d => d != none and d != "none") { 5mm } else { 0pt }
+  let header-height = if header-height == auto {
+    calc.max(12mm, ..data.hows.enumerate().map(((c, label)) => measure(box(changed-label(label, column-status(data, c)))).width + 2 * header-padding)) + direction-height
+  } else { header-height }
+  let row-height = if row-height == auto {
+    calc.max(style.symbol-size + 2 * cell-padding, 7mm,
+      ..data.whats.enumerate().map(((r, label)) => measure(block(width: what-width - 2 * label-padding,
+        breakable: false, changed-label(label, row-status(data, r)))).height + 2 * label-padding))
+  } else { row-height }
+  let basement-height = if basement-height == auto { 7mm } else { basement-height }
+  for value in (header-height, row-height, basement-height) {
+    assert(type(value) == length and value > 0pt, message: "qfd: resolved dimensions must be positive lengths")
+  }
+  assert(header-height > direction-height, message: "qfd: header must leave room above direction indicators")
+  let pad = calc.max(1.5mm, style.frame-thickness)
+  let iw = if data.show-importance { importance-width } else { 0pt }
+  let cw = if data.show-competitive { comparison-width } else { 0pt }
+  let mx = pad + what-width + iw
+  let mw = data.nc * cell-size
+  let roof-base = pad + if data.show-roof { mw / 2 } else { 0pt }
+  let my = roof-base + header-height
+  let mh = data.nr * row-height
+  let right-edge = mx + mw + cw
+  let legend-x = right-edge + legend-gap
+  let canvas-width = if legend-size.width == 0pt { right-edge + pad } else { legend-x + legend-size.width + pad }
+  let under-body = calc.max(data.basement.len() * basement-height, if data.show-competitive { 6mm } else { 0pt })
+  let canvas-height = calc.max(my + mh + under-body, roof-base + legend-size.height) + pad
+  (pad: pad, cell: cell-size, row: row-height, what: what-width, iw: iw, cw: cw,
+   header: header-height, basement: basement-height, direction: direction-height,
+   mx: mx, mw: mw, my: my, mh: mh, roof-base: roof-base, right: right-edge,
+   legend-x: legend-x, width: canvas-width, height: canvas-height,
+   cell-padding: cell-padding, label-padding: label-padding, header-padding: header-padding)
+}
+
+// Uniform final scaling is explicit: natural width is safe on auto-sized pages;
+// a ratio needs a finite layout region. It never silently paginates a matrix.
+#let fit-figure(drawing, natural-width, width) = layout(region => {
+  let requested = if width == auto { natural-width }
+    else if type(width) == length { width }
+    else if type(width) == ratio { width * region.width }
+    else if type(width) == relative { width.length + width.ratio * region.width }
+    else { panic("qfd: width must be auto, a length, a ratio, or a relative length") }
+  assert(requested > 0pt and requested < calc.inf * 1pt,
+    message: "qfd: width must resolve to a finite positive length; use width: auto on auto-width pages")
+  scale(requested / natural-width * 100%, reflow: true, drawing)
+})

--- a/packages/preview/qualitree/0.1.0/src/legend.typ
+++ b/packages/preview/qualitree/0.1.0/src/legend.typ
@@ -1,0 +1,49 @@
+// Legend height follows its visible sections and actual series labels.
+#import "symbols.typ": _relation, _sign
+#import "profile-symbols.typ": _sample
+#import "text.typ": _as-content
+
+#let _legend(labels, alternatives, order, limits, width, thin, frame, ink,
+  symbol-size, symbol-thickness: 1.1pt, correlation-style: "circled", changes: false, change-fills: (:), relation: true, correlation: true, evaluation: true) = {
+  let row(sample, label) = grid(
+    columns: (0.65cm, 1fr), column-gutter: 0.1cm, align: left + horizon,
+    align(center, sample), _as-content(label),
+  )
+  let section(title, entries) = stack(dir: ttb, spacing: 0.15cm,
+    strong(_as-content(title)), line(length: 100%, stroke: thin), ..entries)
+  let sections = ()
+  if relation {
+    sections.push(section(labels.relation, (
+      row(_relation(9, symbol-size, ink, thickness: symbol-thickness), labels.strong),
+      row(_relation(3, symbol-size, ink, thickness: symbol-thickness), labels.medium),
+      row(_relation(1, symbol-size, ink, thickness: symbol-thickness), labels.weak),
+    )))
+  }
+  if correlation {
+    sections.push(section(labels.correlation, (
+      row(_sign("++", style: correlation-style, size: symbol-size, ink: ink, thickness: symbol-thickness), labels.very-positive), row(_sign("+", style: correlation-style, size: symbol-size, ink: ink, thickness: symbol-thickness), labels.positive),
+      row(_sign("-", style: correlation-style, size: symbol-size, ink: ink, thickness: symbol-thickness), labels.negative), row(_sign("--", style: correlation-style, size: symbol-size, ink: ink, thickness: symbol-thickness), labels.very-negative),
+    )))
+  }
+  if evaluation {
+    let entries = order.map(index => {
+      let item = alternatives.at(index - 1)
+      let label = _as-content(item.label)
+      if item.at("emphasize", default: false) { label = strong(label) }
+      row(_sample(item, item.marker-size * (symbol-size / 7pt)), label)
+    })
+    let note = if labels.score-note == auto {
+      [#(limits.at(0)) = #labels.poor, #(limits.at(1)) = #labels.excellent]
+    } else { _as-content(labels.score-note) }
+    entries.push(emph(note))
+    sections.push(section(labels.evaluation, entries))
+  }
+  if changes {
+    sections.push(section(labels.changes, ("added", "removed", "changed").map(status =>
+      row(rect(width: 0.45cm, height: 0.3cm, fill: change-fills.at(status), stroke: thin), labels.at(status)))))
+  }
+  if sections.len() == 0 { return none }
+  rect(width: width, inset: 0.15cm, radius: 2pt, stroke: frame, fill: none,
+    stack(dir: ttb, spacing: 0.4cm, ..sections))
+}
+

--- a/packages/preview/qualitree/0.1.0/src/matrix-panel.typ
+++ b/packages/preview/qualitree/0.1.0/src/matrix-panel.typ
@@ -1,0 +1,90 @@
+// The central panel displays current relationships, or historical symbols for
+// removed cells. Historical values are display-only; figure-data owns totals.
+#import "symbols.typ": _segment, _frame, _relation, _direction
+#import "text.typ": _cell, _as-content
+#import "change-display.typ": fill-cell, row-status, column-status, cell-status, changed-label, change-mark
+
+#let draw-matrix(data, g, style) = {
+  _cell(g.pad, g.roof-base, g.what, g.header,
+    stack(spacing: 2mm, text(font: style.serif-font, size: style.font-size * 1.2,
+      weight: "bold", _as-content(data.labels.whats)),
+      text(size: style.font-size * 0.85, [→ #data.labels.hows])),
+    wrap: true, inset: g.label-padding)
+  for (c, label) in data.hows.enumerate() {
+    let status = column-status(data, c)
+    fill-cell(g.mx + c * g.cell, g.roof-base, g.cell, g.header, status, style)
+    _cell(g.mx + c * g.cell, g.roof-base, g.cell, g.header - g.direction,
+      rotate(-90deg, reflow: true, box(changed-label(label, status))),
+      anchor: center + bottom, inset: g.header-padding)
+    if g.direction > 0pt {
+      _cell(g.mx + c * g.cell, g.my - g.direction, g.cell, g.direction,
+        text(size: style.font-size * 1.3, weight: "bold", _direction(data.directions.at(c))), inset: 0pt)
+    }
+  }
+  if data.show-importance {
+    _cell(g.pad + g.what, g.roof-base, g.iw, g.header,
+      rotate(-90deg, reflow: true, box(strong(_as-content(data.labels.importance)))),
+      anchor: center + bottom, inset: g.header-padding)
+  }
+  for (r, label) in data.whats.enumerate() {
+    let status = row-status(data, r)
+    fill-cell(g.pad, g.my + r * g.row, g.what + g.iw, g.row, status, style)
+    _cell(g.pad, g.my + r * g.row, g.what, g.row, changed-label(label, status),
+      anchor: left + horizon, wrap: true, inset: g.label-padding)
+    if data.show-importance {
+      _cell(g.pad + g.what, g.my + r * g.row, g.iw, g.row,
+        if status == "removed" { calc.round(data.changes.previous-importance.at(r), digits: style.weight-digits) }
+        else { calc.round(data.importance.at(r), digits: style.weight-digits) }, inset: g.cell-padding)
+    }
+    for c in range(data.nc) {
+      let status = cell-status(data, r, c)
+      fill-cell(g.mx + c * g.cell, g.my + r * g.row, g.cell, g.row, status, style)
+      let current = data.matrix.at(r).at(c)
+      let value = if status == "removed" { data.changes.previous-matrix.at(r).at(c) } else { current }
+      _cell(g.mx + c * g.cell, g.my + r * g.row, g.cell, g.row,
+        _relation(value, style.symbol-size, style.ink, thickness: style.symbol-thickness), inset: g.cell-padding)
+      if status != "unchanged" {
+        _cell(g.mx + (c + 0.65) * g.cell, g.my + r * g.row, g.cell * 0.35, g.row * 0.35,
+          text(size: 5pt, weight: "bold", change-mark(status)), inset: 0pt)
+        if status == "changed" {
+          _cell(g.mx + c * g.cell, g.my + (r + 0.70) * g.row, g.cell, g.row * 0.30,
+            text(size: 5pt, [#(data.changes.previous-matrix.at(r).at(c))→#current]), inset: 0pt)
+        }
+      }
+    }
+  }
+}
+
+#let draw-basement(data, g, style) = {
+  for (b, row) in data.basement.enumerate() {
+    _cell(g.pad, g.my + g.mh + b * g.basement, g.what + g.iw, g.basement,
+      emph(_as-content(row.label)), anchor: right + horizon, inset: g.label-padding)
+    for (c, value) in row.values.enumerate() {
+      let value = if row.at("computed", default: false) { calc.round(value, digits: style.weight-digits) } else { value }
+      let body = _as-content(value)
+      if row.at("bold", default: false) { body = strong(body) }
+      _cell(g.mx + c * g.cell, g.my + g.mh + b * g.basement,
+        g.cell, g.basement, body, inset: g.cell-padding)
+    }
+  }
+}
+
+// Grid strokes are drawn after fills. Every neighboring panel shares the same
+// boundaries, including when importance or competitive assessment is hidden.
+#let draw-grid(data, g, style) = {
+  for r in range(1, data.nr) { _segment(g.pad, g.my + r * g.row, g.right, g.my + r * g.row, style.thin) }
+  for c in range(1, data.nc) {
+    _segment(g.mx + c * g.cell, g.roof-base, g.mx + c * g.cell,
+      g.my + g.mh + data.basement.len() * g.basement, style.thin)
+  }
+  for b in range(1, data.basement.len()) {
+    _segment(g.mx, g.my + g.mh + b * g.basement, g.mx + g.mw,
+      g.my + g.mh + b * g.basement, style.thin)
+  }
+  _frame(g.pad, g.my, g.what + g.iw + g.mw, g.mh, style.frame)
+  _segment(g.mx, g.my, g.mx, g.my + g.mh, style.frame)
+  if data.show-importance { _segment(g.pad + g.what, g.my, g.pad + g.what, g.my + g.mh, style.frame) }
+  _frame(g.mx, g.roof-base, g.mw, g.header, style.frame)
+  if data.basement.len() > 0 { _frame(g.mx, g.my + g.mh, g.mw, data.basement.len() * g.basement, style.frame) }
+  if data.show-competitive { _frame(g.mx + g.mw, g.my, g.cw, g.mh, style.frame) }
+}

--- a/packages/preview/qualitree/0.1.0/src/matrix-panel.typ
+++ b/packages/preview/qualitree/0.1.0/src/matrix-panel.typ
@@ -2,7 +2,7 @@
 // removed cells. Historical values are display-only; figure-data owns totals.
 #import "symbols.typ": _segment, _frame, _relation, _direction
 #import "text.typ": _cell, _as-content
-#import "change-display.typ": fill-cell, row-status, column-status, cell-status, changed-label, change-mark
+#import "change-display.typ": fill-cell, row-status, column-status, cell-status, cell-background-status, changed-label, change-mark
 
 #let draw-matrix(data, g, style) = {
   _cell(g.pad, g.roof-base, g.what, g.header,
@@ -38,7 +38,7 @@
     }
     for c in range(data.nc) {
       let status = cell-status(data, r, c)
-      fill-cell(g.mx + c * g.cell, g.my + r * g.row, g.cell, g.row, status, style)
+      fill-cell(g.mx + c * g.cell, g.my + r * g.row, g.cell, g.row, cell-background-status(data, r, c), style)
       let current = data.matrix.at(r).at(c)
       let value = if status == "removed" { data.changes.previous-matrix.at(r).at(c) } else { current }
       _cell(g.mx + c * g.cell, g.my + r * g.row, g.cell, g.row,

--- a/packages/preview/qualitree/0.1.0/src/model.typ
+++ b/packages/preview/qualitree/0.1.0/src/model.typ
@@ -1,4 +1,4 @@
-#import "theme.typ": qfd-palette
+#import "palette.typ": qfd-palette
 // QFD data normalization. All public row/column indices are ONE-BASED.
 // Internal helpers intentionally have an underscore prefix.
 

--- a/packages/preview/qualitree/0.1.0/src/model.typ
+++ b/packages/preview/qualitree/0.1.0/src/model.typ
@@ -1,0 +1,116 @@
+#import "theme.typ": qfd-palette
+// QFD data normalization. All public row/column indices are ONE-BASED.
+// Internal helpers intentionally have an underscore prefix.
+
+#let _number(x) = type(x) == int or type(x) == float
+#let _nonnegative(x) = _number(x) and x >= 0 and x < calc.inf
+
+#let relation-value(value) = {
+  if value == none or value == "" { return 0 }
+  if type(value) == str {
+    let values = (S: 9, M: 3, W: 1)
+    let key = upper(value)
+    assert(key in values, message: "qfd: relation must be S, M, W, 9, 3, 1, 0, none, or an empty string")
+    return values.at(key)
+  }
+  assert(_number(value) and value in (0, 1, 3, 9),
+    message: "qfd: numeric relation must be 0, 1, 3, or 9")
+  value
+}
+
+// Convert sparse (row, column, strength) triples to a dense numeric matrix.
+#let qfd-matrix(rows, columns, relations: ()) = {
+  assert(type(rows) == int and rows > 0,
+    message: "qfd: row count must be a positive integer")
+  assert(type(columns) == int and columns > 0,
+    message: "qfd: column count must be a positive integer")
+  assert(type(relations) == array, message: "qfd: relations must be an array")
+  let cells = (:)
+  for entry in relations {
+    assert(type(entry) == array and entry.len() == 3,
+      message: "qfd: each relation must be a (row, column, strength) triple")
+    let (r, c, value) = entry
+    assert(type(r) == int and r >= 1 and r <= rows,
+      message: "qfd: relation row index out of bounds (indices start at 1)")
+    assert(type(c) == int and c >= 1 and c <= columns,
+      message: "qfd: relation column index out of bounds (indices start at 1)")
+    let key = str(r) + ":" + str(c)
+    assert(not (key in cells), message: "qfd: duplicate relation at " + key)
+    cells.insert(key, relation-value(value))
+  }
+  range(rows).map(r => range(columns).map(c =>
+    cells.at(str(r + 1) + ":" + str(c + 1), default: 0)))
+}
+
+#let _dense(matrix, rows, columns) = {
+  assert(type(matrix) == array and matrix.len() == rows,
+    message: "qfd: matrix must have one row per WHAT")
+  matrix.map(row => {
+    assert(type(row) == array and row.len() == columns,
+      message: "qfd: matrix must have one column per HOW")
+    row.map(relation-value)
+  })
+}
+
+// Logical coordinates relative to the lower-left corner of the roof.
+// The drawing converts y-up here to Typst's y-down coordinates.
+#let _correlation-point(i, j, columns: none) = {
+  assert(type(i) == int and type(j) == int and i >= 1 and j >= 1,
+    message: "qfd: correlation indices must be positive integers")
+  assert(i != j, message: "qfd: a HOW cannot correlate with itself")
+  if columns != none {
+    assert(type(columns) == int and columns > 0,
+      message: "qfd: column count must be a positive integer")
+    assert(i <= columns and j <= columns,
+      message: "qfd: correlation column index out of bounds")
+  }
+  let a = calc.min(i, j)
+  let b = calc.max(i, j)
+  (x: (a + b - 1) / 2, y: (b - a) / 2)
+}
+
+#let _correlations(values, columns) = {
+  assert(type(values) == array, message: "qfd: correlations must be an array")
+  let seen = (:)
+  let result = ()
+  for entry in values {
+    assert(type(entry) == array and entry.len() == 3,
+      message: "qfd: each correlation must be an (i, j, sign) triple")
+    let (i, j, sign) = entry
+    let point = _correlation-point(i, j, columns: columns)
+    assert(sign in ("++", "+", "-", "--"),
+      message: "qfd: correlation sign must be ++, +, -, or --")
+    let a = calc.min(i, j)
+    let b = calc.max(i, j)
+    let key = str(a) + ":" + str(b)
+    assert(not (key in seen), message: "qfd: duplicate correlation at " + key)
+    seen.insert(key, true)
+    result.push((i: a, j: b, sign: sign, point: point))
+  }
+  result
+}
+
+#let _alternatives(values, rows, limits) = {
+  assert(type(values) == array, message: "qfd: alternatives must be an array")
+  values.enumerate().map(((index, item)) => {
+    assert(type(item) == dictionary and "label" in item and "scores" in item,
+      message: "qfd: an alternative requires label and scores fields")
+    assert(type(item.scores) == array and item.scores.len() == rows,
+      message: "qfd: each alternative needs one score per WHAT")
+    for score in item.scores {
+      assert(score == none or (_number(score) and score >= limits.at(0) and score <= limits.at(1)),
+        message: "qfd: scores must lie within score-range; use none for missing data")
+    }
+    let result = qfd-palette.at(calc.rem(index, qfd-palette.len())) + item
+    assert(result.marker in ("circle", "triangle", "square", "diamond", "pentagon"),
+      message: "qfd: unknown alternative marker")
+    assert(type(result.color) == color, message: "qfd: alternative color must be a Typst color")
+    for value in (result.thickness, result.marker-size, result.marker-thickness) {
+      assert(type(value) == length and value > 0pt,
+        message: "qfd: alternative sizes and thicknesses must be positive lengths")
+    }
+    assert(type(result.fill-lighten) == ratio and result.fill-lighten >= 0% and result.fill-lighten <= 100%,
+      message: "qfd: fill-lighten must be a ratio from 0% to 100%")
+    result
+  })
+}

--- a/packages/preview/qualitree/0.1.0/src/palette.typ
+++ b/packages/preview/qualitree/0.1.0/src/palette.typ
@@ -1,0 +1,22 @@
+// Profile colors identify alternatives, not good/bad values or revision states.
+// The earlier defaults used five Okabe–Ito hues (https://jfly.uni-koeln.de/color/).
+// This custom adaptation keeps its blue, darkens the warm/green/purple families,
+// and replaces the second blue with ochre for white-paper contrast. It is not
+// the original palette or a claim of universal color-vision distinguishability.
+// See docs/PALETTE.md for provenance, measured contrast, and visual previews.
+
+#let _profile(color, marker, dash, size: 6.5pt) = (
+  color: rgb(color), marker: marker, dash: dash,
+  thickness: 1pt, marker-size: size, marker-thickness: 1.1pt,
+  fill-lighten: 80%,
+)
+
+// Equal strokes avoid implying that the first alternative is more important.
+// Shape sizes compensate for differing areas; staggering may shrink dense ties.
+#let qfd-palette = (
+  _profile("0072B2", "circle", "solid"),
+  _profile("B34700", "triangle", "dashed", size: 7pt),
+  _profile("007A59", "square", "dotted", size: 5.5pt),
+  _profile("815A9B", "diamond", "dash-dotted", size: 7pt),
+  _profile("8A6500", "pentagon", (4pt, 2pt, 0.8pt, 2pt, 0.8pt, 2pt)),
+)

--- a/packages/preview/qualitree/0.1.0/src/profile-layout.typ
+++ b/packages/preview/qualitree/0.1.0/src/profile-layout.typ
@@ -1,0 +1,78 @@
+// Competitive scores are data: only y may move. This module works in row units,
+// independent of Typst drawing, colors and fonts. The renderer maps x back to
+// score ticks and y back to physical rows. Missing observations remain holes.
+
+#let _cross(a, b, c) = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+#let _intersects(a, b, c, d) = {
+  _cross(a, b, c) * _cross(a, b, d) < 0 and _cross(c, d, a) * _cross(c, d, b) < 0
+}
+
+// Count crossings adjacent to one row, using both incoming and outgoing edges.
+// Touching endpoints are intentional ties, not crossings. A deterministic local
+// search avoids factorial permutations when a chart contains many alternatives.
+#let _cost(points, row) = {
+  let cost = 0
+  for edge in (row - 1, row) {
+    if edge < 0 or edge + 1 >= points.first().len() { continue }
+    for a in range(points.len()) {
+      for b in range(a + 1, points.len()) {
+        let p = (points.at(a).at(edge), points.at(a).at(edge + 1),
+          points.at(b).at(edge), points.at(b).at(edge + 1))
+        if p.any(v => v == none) { continue }
+        if _intersects(..p) { cost += 1 }
+      }
+    }
+  }
+  cost
+}
+
+// Return an array per series of (x: original-score, y: row-center + offset).
+// Nearby scores are grouped using diameter/x-step. Offsets never exceed spread
+// (at most 0.3 row); ties get distinct lanes. This reduces avoidable crossings,
+// but cannot remove crossings forced by reversals in the observed scores.
+#let stagger-profiles(scores, enabled: true, spread: 0.30, diameter: 0.22, x-step: 1) = {
+  assert(type(enabled) == bool, message: "qfd: marker-stagger must be boolean")
+  assert(spread >= 0 and spread <= 0.30, message: "qfd: marker spread must be between 0 and 0.30 rows")
+  if scores.len() == 0 { return () }
+  assert(scores.all(s => s.len() == scores.first().len()), message: "qfd: profiles must have equal lengths")
+  let points = scores.map(s => s.enumerate().map(((r, v)) =>
+    if v == none { none } else { (x: v, y: r + 0.5) }))
+  if not enabled or spread == 0 { return points }
+  for r in range(scores.first().len()) {
+    let indices = range(scores.len()).filter(s => scores.at(s).at(r) != none)
+      .sorted(key: s => scores.at(s).at(r))
+    let groups = ()
+    for s in indices {
+      if groups.len() == 0 or calc.abs(scores.at(s).at(r) - scores.at(groups.last().last()).at(r)) * x-step >= diameter {
+        groups.push((s,))
+      } else {
+        let group = groups.pop()
+        group.push(s)
+        groups.push(group)
+      }
+    }
+    for group in groups {
+      if group.len() < 2 { continue }
+      let span = calc.min(spread, diameter * (group.len() - 1) / 2)
+      for (lane, s) in group.enumerate() {
+        points.at(s).at(r).y += (2 * lane / (group.len() - 1) - 1) * span
+      }
+      // Pair swaps improve the neighboring segments without changing the lane
+      // set. Equal costs keep input order, preventing arbitrary visual churn.
+      for pass in range(2) {
+        for a in range(group.len()) {
+          for b in range(a + 1, group.len()) {
+            let i = group.at(a)
+            let j = group.at(b)
+            let candidate = points
+            let y = candidate.at(i).at(r).y
+            candidate.at(i).at(r).y = candidate.at(j).at(r).y
+            candidate.at(j).at(r).y = y
+            if _cost(candidate, r) < _cost(points, r) { points = candidate }
+          }
+        }
+      }
+    }
+  }
+  points
+}

--- a/packages/preview/qualitree/0.1.0/src/profile-symbols.typ
+++ b/packages/preview/qualitree/0.1.0/src/profile-symbols.typ
@@ -1,0 +1,18 @@
+// Series styles are shared by the comparison panel and its legend.
+#import "symbols.typ": _marker, _segment
+
+#let _profile-pen(item) = (
+  paint: item.color, thickness: item.thickness, dash: item.dash,
+  cap: "round", join: "round",
+)
+
+#let _profile-marker(item, size) = _marker(
+  item.marker, size, item.color, fill: item.color.lighten(item.fill-lighten), thickness: item.marker-thickness,
+)
+
+#let _sample(item, size) = box(width: 0.6cm, height: 0.4cm, {
+  _segment(0.02cm, 0.2cm, 0.58cm, 0.2cm, _profile-pen(item))
+  place(top + left, dx: 0.3cm - size / 2, dy: 0.2cm - size / 2,
+    _profile-marker(item, size))
+})
+

--- a/packages/preview/qualitree/0.1.0/src/revisions.typ
+++ b/packages/preview/qualitree/0.1.0/src/revisions.typ
@@ -1,0 +1,130 @@
+#import "stages.typ": _check-stage
+#import "model.typ": _correlations
+
+#let _indices(ids) = {
+  let result = (:)
+  for (i, id) in ids.enumerate() { result.insert(id, i) }
+  result
+}
+#let _union(before, after) = after + before.filter(id => not (id in after))
+#let _status(old, current, empty: none) = {
+  if old == current { "unchanged" }
+  else if old == empty { "added" }
+  else if current == empty { "removed" }
+  else { "changed" }
+}
+#let _aligned(values, ids, index, absent: none) = {
+  if values == none { return none }
+  ids.map(id => if id in index { values.at(index.at(id)) } else { absent })
+}
+#let _matrix-at(stage, rows, columns, row, column) = {
+  if row in rows and column in columns { stage.matrix.at(rows.at(row)).at(columns.at(column)) }
+  else { 0 }
+}
+
+// Compare current entities by stable ID, preserving after-order and appending
+// removals in before-order. Historical cells are kept separately so removed
+// rows/columns cannot influence current priority totals. Drawing options come
+// from after; only labels, weights, targets, directions, relations and roof
+// correlations participate in change detection. Positional custom basements
+// and competitive profiles must be removed before diffing, rather than silently
+// misaligning their data. A diff result is a display view, not another revision.
+#let qfd-diff(before, after) = {
+  let old = _check-stage(before)
+  let current = _check-stage(after)
+  for stage in (before, after) {
+    assert(not ("changes" in stage), message: "qfd: compare source stages, not existing diffs")
+    assert(stage.at("alternatives", default: ()).len() == 0,
+      message: "qfd: revision comparison does not support competitive alternatives")
+    assert(stage.at("basement", default: auto) == auto,
+      message: "qfd: revision comparison requires automatic basement rows")
+  }
+  assert((old.importance == none) == (current.importance == none),
+    message: "qfd: revision comparison requires weights on both stages or neither")
+  let rows = _union(old.row-ids, current.row-ids)
+  let columns = _union(old.column-ids, current.column-ids)
+  let old-rows = _indices(old.row-ids)
+  let new-rows = _indices(current.row-ids)
+  let old-cols = _indices(old.column-ids)
+  let new-cols = _indices(current.column-ids)
+  let old-matrix = rows.map(row => columns.map(col => _matrix-at(old, old-rows, old-cols, row, col)))
+  let matrix = rows.map(row => columns.map(col => _matrix-at(current, new-rows, new-cols, row, col)))
+  let row-status = rows.map(id => {
+    if not (id in old-rows) { return "added" }
+    if not (id in new-rows) { return "removed" }
+    let a = old-rows.at(id)
+    let b = new-rows.at(id)
+    if (old.whats.at(a) != current.whats.at(b) or
+      (old.importance != none and old.importance.at(a) != current.importance.at(b))) { "changed" }
+    else { "unchanged" }
+  })
+  let column-status = columns.map(id => {
+    if not (id in old-cols) { return "added" }
+    if not (id in new-cols) { return "removed" }
+    let a = old-cols.at(id)
+    let b = new-cols.at(id)
+    if ((old.hows.at(a), old.targets.at(a), old.directions.at(a)) !=
+      (current.hows.at(b), current.targets.at(b), current.directions.at(b))) { "changed" }
+    else { "unchanged" }
+  })
+  let display(values-old, values-current, ids, index-old, index-current) = ids.map(id =>
+    if id in index-current { values-current.at(index-current.at(id)) }
+    else { values-old.at(index-old.at(id)) })
+  let importance = _aligned(current.importance, rows, new-rows, absent: 0)
+  let global-cols = _indices(columns)
+  let roof(stage) = {
+    let result = (:)
+    for item in _correlations(stage.at("correlations", default: ()), stage.column-ids.len()) {
+      let i = global-cols.at(stage.column-ids.at(item.i - 1)) + 1
+      let j = global-cols.at(stage.column-ids.at(item.j - 1)) + 1
+      let a = calc.min(i, j)
+      let b = calc.max(i, j)
+      result.insert(str(a) + ":" + str(b), (i: a, j: b, sign: item.sign))
+    }
+    result
+  }
+  let old-roof = roof(old)
+  let new-roof = roof(current)
+  let correlation-changes = _union(old-roof.keys(), new-roof.keys()).map(key => {
+    let previous = old-roof.at(key, default: none)
+    let current = new-roof.at(key, default: none)
+    let position = if current == none { previous } else { current }
+    let a = if previous == none { none } else { previous.sign }
+    let b = if current == none { none } else { current.sign }
+    (i: position.i, j: position.j, status: _status(a, b), previous: a, current: b)
+  })
+  let difficulty = (before.at("difficulty", default: none), after.at("difficulty", default: none))
+  for (i, values) in difficulty.enumerate() {
+    if values != none {
+      assert(type(values) == array and values.len() == (old, current).at(i).column-ids.len(),
+        message: "qfd: difficulty must align with column IDs")
+    }
+  }
+  let aligned-difficulty = if difficulty.all(v => v == none) { none } else {
+    let a = if difficulty.at(0) == none { old.column-ids.map(_ => none) } else { difficulty.at(0) }
+    let b = if difficulty.at(1) == none { current.column-ids.map(_ => none) } else { difficulty.at(1) }
+    display(a, b, columns, old-cols, new-cols)
+  }
+  after + (
+    difficulty: aligned-difficulty,
+    row-ids: rows, column-ids: columns,
+    whats: display(old.whats, current.whats, rows, old-rows, new-rows),
+    hows: display(old.hows, current.hows, columns, old-cols, new-cols),
+    importance: importance, matrix: matrix,
+    targets: display(old.targets, current.targets, columns, old-cols, new-cols),
+    directions: display(old.directions, current.directions, columns, old-cols, new-cols),
+    correlations: new-roof.values().map(item => (item.i, item.j, item.sign)),
+    changes: (
+      rows: row-status, columns: column-status,
+      cells: range(rows.len()).map(r => range(columns.len()).map(c =>
+        _status(old-matrix.at(r).at(c), matrix.at(r).at(c), empty: 0))),
+      previous-matrix: old-matrix,
+      previous-whats: _aligned(old.whats, rows, old-rows),
+      previous-hows: _aligned(old.hows, columns, old-cols),
+      previous-importance: _aligned(old.importance, rows, old-rows),
+      previous-targets: _aligned(old.targets, columns, old-cols),
+      previous-directions: _aligned(old.directions, columns, old-cols),
+      correlations: correlation-changes,
+    ),
+  )
+}

--- a/packages/preview/qualitree/0.1.0/src/roof.typ
+++ b/packages/preview/qualitree/0.1.0/src/roof.typ
@@ -1,0 +1,45 @@
+// Roof correlations belong to column pairs. The lattice geometry is shared with
+// the calculation API; revision overlays must use the same diamond centers.
+#import "symbols.typ": _segment, _sign
+#import "text.typ": _cell
+#import "change-display.typ": change-fill, change-mark
+
+#let draw-roof(data, g, style) = {
+  if not data.show-roof { return [] }
+  if data.changes != none {
+    for entry in data.changes.at("correlations", default: ()) {
+      if entry.status != "unchanged" {
+        let x = g.mx + (entry.i + entry.j - 1) / 2 * g.cell
+        let y = g.roof-base - calc.abs(entry.j - entry.i) / 2 * g.cell
+        place(top + left, dx: x - g.cell / 2, dy: y - g.cell / 2,
+          polygon((g.cell / 2, 0pt), (g.cell, g.cell / 2), (g.cell / 2, g.cell), (0pt, g.cell / 2),
+            fill: change-fill(entry.status, style), stroke: none))
+        let sign = if entry.current == none { entry.previous } else { entry.current }
+        _cell(x - g.cell / 4, y - g.cell / 4, g.cell / 2, g.cell / 2,
+          _sign(sign, style: style.correlation-style, size: style.symbol-size,
+            ink: style.ink, thickness: style.symbol-thickness), inset: 0pt)
+        _cell(x + g.cell / 8, y - g.cell / 4, g.cell / 4, g.cell / 4,
+          text(size: 5pt, weight: "bold", change-mark(entry.status)), inset: 0pt)
+      }
+    }
+  }
+  for k in range(1, data.nc) {
+    _segment(g.mx + k * g.cell, g.roof-base,
+      g.mx + (k + data.nc) * g.cell / 2, g.roof-base - (data.nc - k) * g.cell / 2, style.thin)
+    _segment(g.mx + k * g.cell, g.roof-base,
+      g.mx + k * g.cell / 2, g.roof-base - k * g.cell / 2, style.thin)
+  }
+  _segment(g.mx, g.roof-base, g.mx + g.mw / 2, g.pad, style.frame)
+  _segment(g.mx + g.mw / 2, g.pad, g.mx + g.mw, g.roof-base, style.frame)
+  for item in data.correlations {
+    let edited = data.changes != none and data.changes.at("correlations", default: ()).any(e =>
+      e.i == item.i and e.j == item.j and e.status != "unchanged")
+    if not edited {
+      let x = g.mx + item.point.x * g.cell
+      let y = g.roof-base - item.point.y * g.cell
+      _cell(x - g.cell / 4, y - g.cell / 4, g.cell / 2, g.cell / 2,
+        _sign(item.sign, style: style.correlation-style, size: style.symbol-size,
+          ink: style.ink, thickness: style.symbol-thickness), inset: 0pt)
+    }
+  }
+}

--- a/packages/preview/qualitree/0.1.0/src/stages.typ
+++ b/packages/preview/qualitree/0.1.0/src/stages.typ
@@ -1,0 +1,103 @@
+#import "model.typ": qfd-matrix, _dense, _nonnegative, _correlations
+#import "calculations.typ": qfd-weights
+
+// IDs are nonempty strings scoped to an axis. Labels remain native Typst content.
+#let _records(records, axis, fields) = {
+  assert(type(records) == array and records.len() > 0,
+    message: "qfd: " + axis + " must be a nonempty array of records")
+  let ids = ()
+  for item in records {
+    assert(type(item) == dictionary and "id" in item and "label" in item,
+      message: "qfd: each " + axis + " record needs id and label")
+    assert(item.keys().all(key => key in fields),
+      message: "qfd: unsupported " + axis + " record field")
+    assert(type(item.id) == str and item.id != "",
+      message: "qfd: stable IDs must be nonempty strings")
+    assert(not (item.id in ids), message: "qfd: duplicate " + axis + " ID: " + item.id)
+    ids.push(item.id)
+  }
+  ids
+}
+
+// The return value is directly spreadable into qfd. Sparse relations use the
+// same one-based indices as qfd-matrix; identities are for deployment/revision.
+// Missing weights remain absent: manufacturing invented priorities is unsafe.
+#let qfd-stage(rows: (), columns: (), relations: (), matrix: none,
+  importance: auto, ..options) = {
+  assert(options.pos().len() == 0, message: "qfd: stage options must be named")
+  let options = options.named()
+  let reserved = ("whats", "hows", "row-ids", "column-ids", "targets", "directions", "changes")
+  assert(options.keys().all(key => not (key in reserved)),
+    message: "qfd: stage identity, target, and direction fields must come from records")
+  let row-ids = _records(rows, "row", ("id", "label", "weight"))
+  let column-ids = _records(columns, "column", ("id", "label", "direction", "target"))
+  let weights = rows.map(item => item.at("weight", default: none))
+  assert(weights.all(value => value == none or _nonnegative(value)),
+    message: "qfd: row weights must be finite, nonnegative numbers")
+  if importance == auto {
+    assert(weights.all(value => value == none) or weights.all(value => value != none),
+      message: "qfd: supply all row weights or an explicit importance array")
+    importance = if weights.all(value => value == none) { none } else { weights }
+  }
+  if importance != none {
+    assert(type(importance) == array and importance.len() == rows.len() and importance.all(_nonnegative),
+      message: "qfd: importance must contain one finite nonnegative number per row")
+  }
+  let directions = columns.map(item => item.at("direction", default: "none"))
+  assert(directions.all(value => value in ("maximize", "minimize", "target", "none")),
+    message: "qfd: direction must be maximize, minimize, target, or none")
+  assert(type(relations) == array, message: "qfd: relations must be an array")
+  assert(matrix == none or relations.len() == 0,
+    message: "qfd: provide matrix or relations, not both")
+  let matrix = if matrix == none { qfd-matrix(rows.len(), columns.len(), relations: relations) }
+    else { _dense(matrix, rows.len(), columns.len()) }
+  let correlations = options.at("correlations", default: ())
+  let validated = _correlations(correlations, columns.len())
+  options + (
+    row-ids: row-ids, column-ids: column-ids,
+    whats: rows.map(item => item.label), hows: columns.map(item => item.label),
+    importance: importance, matrix: matrix,
+    targets: columns.map(item => item.at("target", default: none)),
+    directions: directions,
+  )
+}
+
+// Validate the public, transparent stage dictionary before indexing it. This
+// also supports a caller editing its values between construction and use.
+#let _check-stage(stage) = {
+  assert(type(stage) == dictionary, message: "qfd: expected a stage dictionary")
+  for key in ("row-ids", "column-ids", "whats", "hows", "matrix", "importance", "targets", "directions") {
+    assert(key in stage, message: "qfd: stage is missing " + key)
+  }
+  assert(type(stage.row-ids) == array and type(stage.column-ids) == array,
+    message: "qfd: stage IDs must be arrays")
+  for (ids, labels) in ((stage.row-ids, stage.whats), (stage.column-ids, stage.hows)) {
+    assert(type(labels) == array and ids.len() == labels.len(), message: "qfd: IDs and labels must align")
+  }
+  assert(type(stage.targets) == array and stage.targets.len() == stage.column-ids.len(),
+    message: "qfd: targets must align with column IDs")
+  assert(type(stage.directions) == array and stage.directions.len() == stage.column-ids.len(),
+    message: "qfd: directions must align with column IDs")
+  let normalized = qfd-stage(
+    rows: stage.row-ids.enumerate().map(((i, id)) => (id: id, label: stage.whats.at(i))),
+    columns: stage.column-ids.enumerate().map(((i, id)) =>
+      (id: id, label: stage.hows.at(i), target: stage.targets.at(i), direction: stage.directions.at(i))),
+    matrix: stage.matrix, importance: stage.importance,
+    correlations: stage.at("correlations", default: ()),
+  )
+  normalized
+}
+
+// Propagate full-precision relative priorities. Rounding belongs to display;
+// even a small early rounding error would otherwise compound across stages.
+#let qfd-deploy(previous-stage, columns: (), relations: (), matrix: none, ..options) = {
+  let previous = _check-stage(previous-stage)
+  assert(previous.importance != none,
+    message: "qfd: deployment needs explicit importance in the previous stage")
+  assert(not ("importance" in options.named()),
+    message: "qfd: deployment importance is derived from the previous stage")
+  let weights = qfd-weights(previous.importance, previous.matrix).relative
+  let rows = previous.column-ids.enumerate().map(((i, id)) =>
+    (id: id, label: previous.hows.at(i), weight: weights.at(i)))
+  qfd-stage(rows: rows, columns: columns, relations: relations, matrix: matrix, ..options)
+}

--- a/packages/preview/qualitree/0.1.0/src/symbols.typ
+++ b/packages/preview/qualitree/0.1.0/src/symbols.typ
@@ -1,0 +1,76 @@
+// Native vector primitives. Coordinates are canvas-local lengths; helpers
+// reserve their own bounds so placed strokes never change surrounding flow.
+
+// Every segment has a nonnegative local bounding box, including roof diagonals.
+#let _segment(x1, y1, x2, y2, pen) = {
+  let x = calc.min(x1, x2)
+  let y = calc.min(y1, y2)
+  place(top + left, dx: x, dy: y,
+    line(start: (x1 - x, y1 - y), end: (x2 - x, y2 - y), stroke: pen))
+}
+
+// A single path per contiguous profile preserves dash phase and line joins.
+#let _polyline(points, pen) = {
+  if points.len() < 2 { return [] }
+  let x = calc.min(..points.map(p => p.at(0)))
+  let y = calc.min(..points.map(p => p.at(1)))
+  let local = points.map(p => (p.at(0) - x, p.at(1) - y))
+  place(top + left, dx: x, dy: y,
+    curve(stroke: pen, fill: none, curve.move(local.first()),
+      ..local.slice(1).map(p => curve.line(p))))
+}
+
+#let _frame(x, y, w, h, pen) = place(top + left, dx: x, dy: y,
+  rect(width: w, height: h, inset: 0pt, stroke: pen, fill: none))
+
+#let _marker(shape, size, paint, fill: none, thickness: 0.7pt) = {
+  let pen = (paint: paint, thickness: thickness, join: "round")
+  let drawing = if shape == "circle" {
+    circle(radius: size / 2, fill: fill, stroke: pen)
+  } else if shape == "square" {
+    rect(width: size, height: size, inset: 0pt, fill: fill, stroke: pen)
+  } else if shape == "diamond" {
+    polygon((size / 2, 0pt), (size, size / 2), (size / 2, size), (0pt, size / 2),
+      fill: fill, stroke: pen)
+  } else {
+    let n = if shape == "triangle" { 3 } else { 5 }
+    let vertices = range(n).map(k => {
+      let angle = -90deg + k * 360deg / n
+      (size / 2 + size / 2 * calc.cos(angle), size / 2 + size / 2 * calc.sin(angle))
+    })
+    polygon(..vertices, fill: fill, stroke: pen)
+  }
+  box(width: size, height: size, place(top + left, drawing))
+}
+
+#let _relation(value, size, ink, thickness: 0.8pt) = {
+  if value == 9 { _marker("circle", size, ink, fill: ink, thickness: thickness) }
+  else if value == 3 { _marker("circle", size, ink, fill: none, thickness: thickness) }
+  else if value == 1 { _marker("triangle", size * 1.2, ink, fill: none, thickness: thickness) }
+  else { [] }
+}
+
+// Strong signs use a circle to stay distinct at small print sizes.
+#let _sign(value, style: "circled", size: 9pt, ink: black, thickness: 0.9pt) = {
+  let strong-sign = value in ("++", "--")
+  let positive = value in ("+", "++")
+  if style == "text" {
+    text(size: size, weight: "bold", fill: ink,
+      if value == "-" { "−" } else if value == "--" { "−−" } else { value })
+  } else {
+    box(width: size, height: size, {
+      let pen = (paint: ink, thickness: thickness, cap: "round")
+      if strong-sign { circle(radius: size / 2, stroke: pen) }
+      _segment(size * 0.2, size / 2, size * 0.8, size / 2, pen)
+      if positive { _segment(size / 2, size * 0.2, size / 2, size * 0.8, pen) }
+    })
+  }
+}
+
+#let _direction(value) = {
+  if value == "maximize" { [↑] }
+  else if value == "minimize" { [↓] }
+  else if value == "target" { [◎] } else { [] }
+}
+
+

--- a/packages/preview/qualitree/0.1.0/src/text.typ
+++ b/packages/preview/qualitree/0.1.0/src/text.typ
@@ -1,0 +1,21 @@
+// Text fitting is the last resort for explicitly constrained dimensions.
+// Automatic layout measures unscaled content first; strings remain literal.
+
+#let _as-content(value) = if value == none { [] } else { [#value] }
+
+// Constrain content to a cell without clipping or evaluating user strings.
+// WHATs wrap first; short values and rotated labels shrink only when necessary.
+#let _fit(body, w, h, anchor: center + horizon, wrap: false) = context {
+  let body = if wrap { block(width: w, breakable: false, body) } else { box(body) }
+  let extent = measure(body)
+  let factor = calc.min(1, w / calc.max(0.01pt, extent.width), h / calc.max(0.01pt, extent.height))
+  block(width: w, height: h, breakable: false, above: 0pt, below: 0pt,
+    align(anchor, scale(factor * 100%, reflow: true, body)))
+}
+
+#let _cell(x, y, w, h, body, anchor: center + horizon, wrap: false, inset: 0.1cm) = {
+  let inset = calc.min(inset, w / 2 - 0.01pt, h / 2 - 0.01pt)
+  place(top + left, dx: x + inset, dy: y + inset,
+    _fit(_as-content(body), w - 2 * inset, h - 2 * inset, anchor: anchor, wrap: wrap))
+}
+

--- a/packages/preview/qualitree/0.1.0/src/theme.typ
+++ b/packages/preview/qualitree/0.1.0/src/theme.typ
@@ -8,14 +8,3 @@
   added-fill: rgb("E4F2E5"), removed-fill: rgb("F8E3E3"),
   changed-fill: rgb("FFF2CE"),
 )
-
-// Five source-palette styles. Additional alternatives cycle these defaults;
-// callers can provide explicit color, marker, dash, and thickness per series.
-#let qfd-palette = (
-  (color: rgb("0072B2"), marker: "circle", dash: "solid", thickness: 1.2pt, marker-size: 6.5pt, marker-thickness: 1.1pt, fill-lighten: 45%),
-  (color: rgb("D55E00"), marker: "triangle", dash: "dashed", thickness: 0.8pt, marker-size: 7pt, marker-thickness: 0.9pt, fill-lighten: 45%),
-  (color: rgb("009E73"), marker: "square", dash: "dotted", thickness: 0.8pt, marker-size: 5.5pt, marker-thickness: 0.9pt, fill-lighten: 45%),
-  (color: rgb("CC79A7"), marker: "diamond", dash: "dash-dotted", thickness: 0.8pt, marker-size: 7pt, marker-thickness: 1pt, fill-lighten: 50%),
-  (color: rgb("56B4E9"), marker: "pentagon", dash: (4pt, 2pt, 0.8pt, 2pt, 0.8pt, 2pt), thickness: 0.7pt, marker-size: 5.5pt, marker-thickness: 0.8pt, fill-lighten: 60%),
-)
-

--- a/packages/preview/qualitree/0.1.0/src/theme.typ
+++ b/packages/preview/qualitree/0.1.0/src/theme.typ
@@ -1,0 +1,21 @@
+// Shared visual defaults; callers can override individual drawing arguments.
+#let qfd-theme = (
+  font: ("IBM Plex Sans", "New Computer Modern"),
+  serif-font: ("IBM Plex Serif", "Libertinus Serif"),
+  font-size: 9pt, ink: rgb("20252A"),
+  grid-thickness: 0.35pt, frame-thickness: 0.7pt,
+  symbol-size: 7pt, symbol-thickness: 1.1pt,
+  added-fill: rgb("E4F2E5"), removed-fill: rgb("F8E3E3"),
+  changed-fill: rgb("FFF2CE"),
+)
+
+// Five source-palette styles. Additional alternatives cycle these defaults;
+// callers can provide explicit color, marker, dash, and thickness per series.
+#let qfd-palette = (
+  (color: rgb("0072B2"), marker: "circle", dash: "solid", thickness: 1.2pt, marker-size: 6.5pt, marker-thickness: 1.1pt, fill-lighten: 45%),
+  (color: rgb("D55E00"), marker: "triangle", dash: "dashed", thickness: 0.8pt, marker-size: 7pt, marker-thickness: 0.9pt, fill-lighten: 45%),
+  (color: rgb("009E73"), marker: "square", dash: "dotted", thickness: 0.8pt, marker-size: 5.5pt, marker-thickness: 0.9pt, fill-lighten: 45%),
+  (color: rgb("CC79A7"), marker: "diamond", dash: "dash-dotted", thickness: 0.8pt, marker-size: 7pt, marker-thickness: 1pt, fill-lighten: 50%),
+  (color: rgb("56B4E9"), marker: "pentagon", dash: (4pt, 2pt, 0.8pt, 2pt, 0.8pt, 2pt), thickness: 0.7pt, marker-size: 5.5pt, marker-thickness: 0.8pt, fill-lighten: 60%),
+)
+

--- a/packages/preview/qualitree/0.1.0/typst.toml
+++ b/packages/preview/qualitree/0.1.0/typst.toml
@@ -1,0 +1,12 @@
+[package]
+name = "qualitree"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Tycho Tatitscheff", "Julien Calixte"]
+license = "MIT"
+description = "Draw and compare cascading Houses of Quality."
+compiler = "0.15.1"
+repository = "https://github.com/tychota/qfd-typst"
+homepage = "https://tychota.github.io/qfd-typst/"
+keywords = ["qfd", "house-of-quality", "requirements", "matrix", "functional-analysis"]
+exclude = ["/tests", "/tools", "/build", "/.github", "/docs", "/fonts", "/PLAN.md", "/DESIGN.md"]


### PR DESCRIPTION
I am submitting
- [x] a new package
- [ ] an update for a package

Description: Qualitree draws native Houses of Quality, deploys full-precision priorities across needs → functions → components, and compares named design revisions by stable IDs. It provides measured automatic layout, configurable styling, readable change backgrounds, direction indicators, and bounded staggering for overlapping competitive observations. The package has no runtime dependencies.

Source and documentation: https://github.com/tychota/qfd-typst · https://tychota.github.io/qfd-typst/

The public coffee example separates illustrative priorities and provisional performance targets from measured evidence. A compact walkthrough compares a manual steam wand and an automatic refrigerated-milk option against the same baseline; a separate detailed revision retains the full coffee deployment. Both trace needs → functions → components. Profile styling uses a documented custom darker adaptation of the earlier Okabe–Ito subset, with consistent strokes and redundant shapes/dashes. Added/removed rows and columns use continuous background bands, with individual relationship changes kept visible. The source repository includes calculation, stage, revision, layout, invalid-input and rendered-example checks. Tested with Typst 0.15.1, including a named @preview import against this exact local submission bundle. GitHub CI is passing.

I have read and followed the submission guidelines and, in particular, I
- [x] selected a name that is not the canonical name for this functionality
  - Explanation: Qualitree combines quality with the branching structure of deployment; it is a coined name rather than QFD or House of Quality.
- [x] added a typst.toml file with all required keys
- [x] added a README.md documenting the package
- [x] chose the MIT license and included LICENSE
- [x] tested the package locally and it worked
- [x] excluded PDFs, documentation images, fonts and build tools from the runtime bundle, while retaining LICENSE

This is a library package, not a template. The README links to source-hosted previews. IBM Plex fonts are available in the source repository under the SIL Open Font License; the library names them with built-in fallback families and does not install fonts.
