### PR TITLE
cgreet:0.2.1

### DIFF
--- a/packages/preview/cgreet/0.2.1/LICENSES/Apache-2.0.txt
+++ b/packages/preview/cgreet/0.2.1/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/preview/cgreet/0.2.1/LICENSES/MIT.txt
+++ b/packages/preview/cgreet/0.2.1/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Julian Y. Richard Corbet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/cgreet/0.2.1/README.md
+++ b/packages/preview/cgreet/0.2.1/README.md
@@ -1,0 +1,57 @@
+# cgreet
+
+Compose formal German salutations for Switzerland, Liechtenstein, Germany,
+and Austria from explicitly supplied recipient details.
+
+```typst
+#import "@preview/cgreet:0.2.1": de-salutation, salutation-titles
+
+#de-salutation("Frau Dr. Müller", region: "ch")
+// Sehr geehrte Frau Dr. Müller
+
+#de-salutation("Herr Professor Dr. Schmidt", region: "de")
+// Sehr geehrter Herr Professor Schmidt,
+
+#assert.eq(salutation-titles("Herr Dipl.-Ing. Müller"), ("Dipl.-Ing.",))
+```
+
+`de-salutation(name, region: "ch")` returns a string. German (`de`) and Austrian
+(`at`) salutations end with a comma; Swiss (`ch`) and Liechtenstein (`li`)
+salutations do not. Region codes must be lowercase. An unsupported region raises
+an assertion; `parse-region` lets callers check one first.
+
+Missing honorifics or surnames produce the generic salutation
+`Sehr geehrte Damen und Herren` with the region's punctuation. The helper reads
+supplied `Herr`/`Herrn` or `Frau`; it does not infer gender from a person's name.
+Professor takes precedence over other recognized titles. Surname extraction
+selects the last significant token, so callers should review compound names.
+
+## Helpers
+
+Import any of these functions with an explicit `@preview/cgreet:0.2.1` import.
+All `name`, `token`, `code`, `region`, and `location` arguments are strings.
+
+| Function | Result |
+| --- | --- |
+| `de-salutation(name, region: "ch")` | Complete salutation string. |
+| `parse-region(code)` | `ch`, `li`, `de`, or `at`; `none` for unsupported input. |
+| `region-uses-comma(region)` | Whether a supported region requires a comma. |
+| `salutation-last-name(name)` | Last whitespace-separated token, or an empty string. |
+| `salutation-honorific(name)` | `herr`, `frau`, or an empty string. |
+| `salutation-title-kind(token)` | Normalized recognized title, or an empty string. |
+| `salutation-titles(name)` | Array of distinct recognized titles, with precedence applied. |
+| `salutation-surname(name)` | Last token after ignoring honorifics, titles, and post-nominal grades. |
+| `recipient-salutation-warning(location, name)` | Advisory string for a missing name, otherwise `none`. |
+| `de-honorific-warning(location, name)` | Advisory string for incomplete German address details, otherwise `none`. |
+
+Token lookup strips leading and trailing periods and lowercases ASCII A–Z.
+Names retain their spelling. The bundled [German correspondence table](tables/de.json)
+is shared with cgreet's Rust, JavaScript, and Python implementations. Diagnostic
+strings retain the `job.cl_recipient.name` field label used by the originating
+application; callers can present their own wording around these advisories.
+
+## License
+
+Copyright © 2026 Julian Y. Richard Corbet. Use this release under either
+[MIT](LICENSES/MIT.txt) or [Apache-2.0](LICENSES/Apache-2.0.txt), at your option.
+Both license texts are included in the package.

--- a/packages/preview/cgreet/0.2.1/tables/de.json
+++ b/packages/preview/cgreet/0.2.1/tables/de.json
@@ -1,0 +1,51 @@
+{
+  "locale": "de",
+  "source_norms": "SN 010130 for ch/li, DIN 5008 for de/at (at follows DIN since ÖNORM A 1080 was withdrawn in 2018)",
+  "honorifics": {
+    "frau": "frau",
+    "herr": "herr",
+    "herrn": "herr"
+  },
+  "titles": {
+    "dr": "Dr.",
+    "prof": "Professor",
+    "professor": "Professor",
+    "dipl-ing": "Dipl.-Ing.",
+    "dipling": "Dipl.-Ing.",
+    "mag": "Mag.",
+    "magister": "Mag.",
+    "dipl.-ing": "Dipl.-Ing.",
+    "dipl.ing": "Dipl.-Ing."
+  },
+  "sole_titles": [
+    "Professor"
+  ],
+  "filler": [
+    "herr",
+    "herrn",
+    "frau",
+    "mr",
+    "mrs",
+    "ms",
+    "miss",
+    "dr",
+    "prof",
+    "professor",
+    "dipl-ing",
+    "dipling",
+    "mag",
+    "magister",
+    "phd",
+    "ma",
+    "ba",
+    "bsc",
+    "msc",
+    "dipl.-ing",
+    "dipl.ing"
+  ],
+  "comma_regions": [
+    "de",
+    "at"
+  ],
+  "generic": "Sehr geehrte Damen und Herren"
+}

--- a/packages/preview/cgreet/0.2.1/typst.toml
+++ b/packages/preview/cgreet/0.2.1/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cgreet"
+version = "0.2.1"
+entrypoint = "typst/greet.typ"
+authors = ["Julian Y. Richard Corbet <@julian-corbet>"]
+license = "MIT OR Apache-2.0"
+description = "Compose formal German salutations with titles."
+repository = "https://github.com/corbet-labs/cgreet"
+keywords = ["salutation", "greeting", "german", "correspondence", "letter"]
+categories = ["text", "languages", "office"]

--- a/packages/preview/cgreet/0.2.1/typst.toml
+++ b/packages/preview/cgreet/0.2.1/typst.toml
@@ -5,6 +5,5 @@ entrypoint = "typst/greet.typ"
 authors = ["Julian Y. Richard Corbet <@julian-corbet>"]
 license = "MIT OR Apache-2.0"
 description = "Compose formal German salutations with titles."
-repository = "https://github.com/corbet-labs/cgreet"
 keywords = ["salutation", "greeting", "german", "correspondence", "letter"]
 categories = ["text", "languages", "office"]

--- a/packages/preview/cgreet/0.2.1/typst/greet.typ
+++ b/packages/preview/cgreet/0.2.1/typst/greet.typ
@@ -1,0 +1,66 @@
+/// Deterministic salutation helpers, sharing the canonical Rust/TS/Python table.
+#let de-table = json("../tables/de.json")
+
+#let tokens(name) = name.trim().split(regex("\\s+")).filter(token => token != "")
+
+/// Strip leading/trailing periods and lowercase ASCII A-Z only.
+#let norm(token) = {
+  token.trim(".").clusters().map(char => if char >= "A" and char <= "Z" { lower(char) } else { char }).fold("", (result, char) => result + char)
+}
+
+#let parse-region(code) = if code in ("ch", "li", "de", "at") { code } else { none }
+
+#let region-uses-comma(region) = {
+  assert(parse-region(region) != none, message: "region must be ch, li, de, or at")
+  region in de-table.comma_regions
+}
+
+#let salutation-last-name(name) = tokens(name).at(-1, default: "")
+
+#let salutation-honorific(name) = {
+  de-table.honorifics.at(norm(tokens(name).at(0, default: "")), default: "")
+}
+
+#let salutation-title-kind(token) = de-table.titles.at(norm(token), default: "")
+
+#let salutation-titles(name) = {
+  let kept = ()
+  for token in tokens(name) {
+    let title = salutation-title-kind(token)
+    if title != "" and title not in kept { kept.push(title) }
+  }
+  let sole = kept.filter(title => title in de-table.sole_titles)
+  if sole.len() > 0 { (sole.first(),) } else { kept }
+}
+
+#let salutation-surname(name) = {
+  tokens(name).filter(token => norm(token) not in de-table.filler).at(-1, default: "")
+}
+
+#let de-salutation(name, region: "ch") = {
+  let comma = if region-uses-comma(region) { "," } else { "" }
+  let honorific = salutation-honorific(name)
+  let surname = salutation-surname(name)
+  if honorific == "" or surname == "" {
+    de-table.generic + comma
+  } else {
+    let titles = salutation-titles(name)
+    let title-part = if titles.len() == 0 { "" } else { " " + titles.join(" ") }
+    let address = if honorific == "frau" { "Sehr geehrte Frau" } else { "Sehr geehrter Herr" }
+    address + title-part + " " + surname + comma
+  }
+}
+
+#let recipient-salutation-warning(location, name) = {
+  if salutation-last-name(name) == "" {
+    location + ": job.cl_recipient.name is empty; using generic salutation (provide a name for tailored opportunities)"
+  } else { none }
+}
+
+#let de-honorific-warning(location, name) = {
+  if salutation-last-name(name) == "" {
+    none
+  } else if salutation-honorific(name) == "" or salutation-surname(name) == "" {
+    location + ": job.cl_recipient.name has no parsable Herr/Frau honorific; using generic salutation (provide e.g. \"Frau Dr. Müller\" for tailored opportunities)"
+  } else { none }
+}


### PR DESCRIPTION
I am submitting

- [x] a new package
- [ ] an update for a package

cgreet composes formal German salutations from explicitly supplied honorifics,
academic titles, and surnames, with the punctuation used in Switzerland,
Liechtenstein, Germany, and Austria. It also exposes title/name helpers and
advisories for incomplete recipient details, so letter templates can share one
implementation.

- [x] Selected a distinctive name: cgreet is the established Corbet Labs product
  name, with its family prefix; it does not reserve generic names such as
  `greeting`, `salutation`, or `letter`.
- [x] Added a manifest with the required metadata.
- [x] Added a README with versioned `@preview` imports and public API documentation.
- [x] Included both license texts and linked them from the README.
- [x] Tested the exact preview package with Typst 0.15.0: the README examples
  and salutation assertions compiled successfully through
  `@preview/cgreet:0.2.1` imports.
- [x] Included only the runtime, table, manifest, README, and license texts;
  there are no PDF or image documentation assets to exclude.

The complete runtime, canonical table, documentation, manifest, and license
texts are included in this submission.
